### PR TITLE
Enable React 19 on 10% of Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-10pct-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-10pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable the React 19 experiment on 10% of Atomic sites, and skip more incompatible themes and plugins.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -22,8 +22,12 @@ class Jetpack_Mu_Wpcom {
 	const BASE_FILE       = __FILE__;
 
 	// Themes (by template slug) and plugins (by basename) known to break with React 19.
-	const REACT_19_INCOMPATIBLE_THEMES  = array( 'divi' );
-	const REACT_19_INCOMPATIBLE_PLUGINS = array( 'wp-table-builder/wp-table-builder.php' );
+	const REACT_19_INCOMPATIBLE_THEMES  = array( 'divi', 'woodmart' );
+	const REACT_19_INCOMPATIBLE_PLUGINS = array(
+		'wp-table-builder/wp-table-builder.php',
+		'ultimate-blocks/ultimate-blocks.php',
+		'beehive-analytics/beehive-analytics.php',
+	);
 
 	/**
 	 * Initialize the class.
@@ -899,7 +903,7 @@ class Jetpack_Mu_Wpcom {
 			} elseif ( self::has_react_19_incompatible_extension() ) {
 				$is_enabled = false;
 			} else {
-				$current_segment = 5; // Segment of Atomic sites in the experiment, in %.
+				$current_segment = 10; // Segment of Atomic sites in the experiment, in %.
 				$site_segment    = $site_id % 100;
 
 				/*

--- a/projects/plugins/wpcomsh/changelog/update-react-19-on-10pct-atomic
+++ b/projects/plugins/wpcomsh/changelog/update-react-19-on-10pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin JS error reporting on 10% of sites, to keep up with the React 19 experiment rollout.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -222,7 +222,7 @@ function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
 		return false;
 	}
 
-	$current_segment = 5; // Segment of sites that get error reporting, in %.
+	$current_segment = 10; // Segment of sites that get error reporting, in %.
 	$site_segment    = $site_id % 100;
 
 	// Sites whose id ends in digits < $current_segment are in the segment.


### PR DESCRIPTION
Raise the Gutenberg React 19 experiment segment from 5% to 10%, and the wpcomsh JS error reporting segment along with it, so that every site in the experiment keeps reporting errors.

Also exclude the Woodmart theme, and the Ultimate Blocks and Beehive Analytics plugins, from the rollout. These are known to fail with React 19.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Install the Jetpack build from this PR on your Atomic site and verify it doesn't crash.