### PR TITLE
AI Assistant banner: send standard context props on its Tracks events

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-dashboard-assistant-banner-events-props
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-dashboard-assistant-banner-events-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Assistant banner: send the standard context props (channel, surface, screen, site_type, product_slug, is_test, is_a11n) on its Tracks events.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/ai-assistant-banner.php
@@ -8,6 +8,13 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
+use Automattic\Jetpack\Status\Host;
+
+// The audience helpers live in the AI Launchpad feature, loaded by a different
+// loader method; require them directly so the props can never silently degrade.
+require_once __DIR__ . '/../ai-launchpad/helpers.php';
+
 /**
  * Determines whether the AI assistant banner should be shown to the current user.
  *
@@ -52,6 +59,37 @@ function wpcom_should_show_ai_assistant_banner() {
 	}
 
 	return true;
+}
+
+/**
+ * Tracks props shared by the banner's three events, per the AI events standard.
+ *
+ * @param string $screen_id The current admin screen id.
+ * @return array<string,string>
+ */
+function wpcom_ai_assistant_banner_tracks_props( $screen_id ) {
+	$purchases = function_exists( 'wpcom_expiry_get_purchases' ) ? wpcom_expiry_get_purchases() : array();
+	// Real plan bundles only: the expiry picker's slug fallback would also match
+	// add-ons such as Professional Email Premium ("premium" substring).
+	$bundles  = wp_list_filter( (array) $purchases, array( 'product_type' => 'bundle' ) );
+	$plan     = class_exists( Expiry_Data::class ) ? Expiry_Data::pick_primary_plan_purchase( $bundles ) : null;
+	$has_slug = $plan && isset( $plan->product_slug ) && is_string( $plan->product_slug ) && '' !== $plan->product_slug;
+
+	return array(
+		'channel'      => 'web',
+		'surface'      => 'dashboard',
+		// Deliberately the WP screen id, not $pagenow — AI Launchpad's hardcoded
+		// 'admin.php' uses the other vocabulary for the same standard prop.
+		'screen'       => (string) $screen_id,
+		// Two buckets, mirroring AI Launchpad: this package ships only on Simple and
+		// Atomic (wpcomsh, mu-wpcom-plugin). Add a self-hosted branch if the banner
+		// ever moves into the Jetpack plugin.
+		'site_type'    => ( new Host() )->is_wpcom_simple() ? 'simple' : 'atomic',
+		// The AI events standard wants the string "none" over an empty value.
+		'product_slug' => $has_slug ? $plan->product_slug : 'none',
+		'is_test'      => function_exists( 'wpcom_ai_launchpad_is_test' ) && wpcom_ai_launchpad_is_test() ? 'true' : 'false',
+		'is_a11n'      => function_exists( 'wpcom_ai_launchpad_is_a11n' ) && wpcom_ai_launchpad_is_a11n() ? 'true' : 'false',
+	);
 }
 
 /**
@@ -158,7 +196,12 @@ function wpcom_maybe_add_ai_assistant_banner() {
 
 	add_action( 'admin_notices', 'wpcom_render_ai_assistant_banner', 1 );
 
-	jetpack_mu_wpcom_enqueue_assets( 'ai-assistant-banner', array( 'js' ) );
+	$asset_handle = jetpack_mu_wpcom_enqueue_assets( 'ai-assistant-banner', array( 'js' ) );
+	wp_localize_script(
+		$asset_handle,
+		'wpcomAiAssistantBanner',
+		array( 'trackProps' => wpcom_ai_assistant_banner_tracks_props( $screen->id ) )
+	);
 }
 add_action( 'current_screen', 'wpcom_maybe_add_ai_assistant_banner' );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-assistant-banner/js/ai-assistant-banner.js
@@ -7,16 +7,20 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		return;
 	}
 
-	wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression' );
+	// Shared context props, computed server-side. Defensive fallback so the
+	// events still fire prop-less if the global is ever absent.
+	const trackProps = window.wpcomAiAssistantBanner?.trackProps || {};
+
+	wpcomTrackEvent( 'jetpack_ai_assistant_banner_impression', trackProps );
 
 	const ctaBtn = banner.querySelector( '.button-secondary' );
 	ctaBtn?.addEventListener( 'click', () => {
-		wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click' );
+		wpcomTrackEvent( 'jetpack_ai_assistant_banner_cta_click', trackProps );
 	} );
 
 	const attachDismissHandler = btn => {
 		btn.addEventListener( 'click', () => {
-			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss' );
+			wpcomTrackEvent( 'jetpack_ai_assistant_banner_dismiss', trackProps );
 
 			const body = new FormData();
 			body.append( 'action', 'dismiss_ai_assistant_banner' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-assistant-banner/AI_Assistant_Banner_Tracks_Props_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-assistant-banner/AI_Assistant_Banner_Tracks_Props_Test.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for the AI Assistant banner Tracks props.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/helpers.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-assistant-banner/ai-assistant-banner.php';
+
+/**
+ * Test class for the AI Assistant banner Tracks props.
+ */
+class AI_Assistant_Banner_Tracks_Props_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		Constants::clear_constants();
+		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * The constant props, and the screen id passing through unchanged.
+	 */
+	public function test_constant_props_and_screen() {
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'web', $props['channel'] );
+		$this->assertSame( 'dashboard', $props['surface'] );
+		$this->assertSame( 'dashboard', $props['screen'] );
+	}
+
+	/**
+	 * The site_type prop reports the hosting platform.
+	 */
+	public function test_site_type_follows_the_platform() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->assertSame( 'simple', wpcom_ai_assistant_banner_tracks_props( 'dashboard' )['site_type'] );
+
+		Constants::set_constant( 'IS_WPCOM', false );
+		$this->assertSame( 'atomic', wpcom_ai_assistant_banner_tracks_props( 'dashboard' )['site_type'] );
+	}
+
+	/**
+	 * The primary plan purchase supplies product_slug.
+	 */
+	public function test_product_slug_from_primary_plan() {
+		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
+			(object) array(
+				'product_slug' => 'business-bundle',
+				'product_type' => 'bundle',
+				'expiry_date'  => '2027-01-01T00:00:00+00:00',
+			),
+		);
+
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'business-bundle', $props['product_slug'] );
+	}
+
+	/**
+	 * Non-bundle purchases never supply the slug, even when they expire later and
+	 * their slug would pass the expiry picker's substring inference.
+	 */
+	public function test_product_slug_ignores_non_plan_purchases() {
+		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
+			(object) array(
+				'product_slug' => 'wp_titan_mail_premium_yearly',
+				'product_type' => 'mailbox',
+				'expiry_date'  => '2028-01-01T00:00:00+00:00',
+			),
+			(object) array(
+				'product_slug' => 'business-bundle',
+				'product_type' => 'bundle',
+				'expiry_date'  => '2027-01-01T00:00:00+00:00',
+			),
+		);
+
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'business-bundle', $props['product_slug'] );
+	}
+
+	/**
+	 * Without a plan purchase the prop is the string "none", never empty or null.
+	 */
+	public function test_product_slug_defaults_to_none() {
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'none', $props['product_slug'] );
+	}
+
+	/**
+	 * The audience flags travel as literal strings, false by default in this environment.
+	 */
+	public function test_audience_props_are_false_strings_by_default() {
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'false', $props['is_test'] );
+		$this->assertSame( 'false', $props['is_a11n'] );
+	}
+
+	/**
+	 * The a11n flag follows the shared launchpad helper: the Atomic proxy signal flips it.
+	 */
+	public function test_is_a11n_follows_proxied_request() {
+		Constants::set_constant( 'AT_PROXIED_REQUEST', true );
+
+		$props = wpcom_ai_assistant_banner_tracks_props( 'dashboard' );
+
+		$this->assertSame( 'true', $props['is_a11n'] );
+	}
+}


### PR DESCRIPTION
## Proposed changes

The wp-admin AI Assistant banner records its three Tracks events (`jetpack_ai_assistant_banner_impression`, `jetpack_ai_assistant_banner_cta_click`, `jetpack_ai_assistant_banner_dismiss`) with no properties at all, so impressions and clicks cannot be split by site type, plan, or screen, and internal traffic cannot be filtered out of the rates.

* Send shared context props on all three events: `channel`, `surface`, `screen`, `site_type`, `product_slug`, `is_test`, and `is_a11n`. No new events, and the firing behaviour is unchanged.
* The props are computed server-side in the banner's feature file and handed to its script with `wp_localize_script`. The JS reads the payload once and passes the same object to the three existing calls; an absent payload degrades to today's prop-less events rather than throwing.
* `product_slug` reports the site's primary plan bundle, picked from the purchases the expiry-notices feature already reads, pre-filtered to `product_type === 'bundle'` so an add-on purchase with a plan-like slug cannot be misreported. Without a plan purchase the prop is the string `none`.
* `is_test` and `is_a11n` reuse the AI Launchpad's audience helpers — host-based test detection, and Automattician identity on Simple or a request behind the Automattic proxy on Atomic — and travel as the literal strings `true`/`false`.
* `site_type` mirrors the AI Launchpad's derivation (`simple`/`atomic`; this package ships only on WordPress.com platforms). `screen` is the WP screen id.
* Unit tests cover the props builder: the constant props, screen passthrough, platform-driven `site_type`, plan-vs-add-on selection, the `none` fallback, and both audience flags.

## Related product discussion/links

* NA

## Does this pull request change what data or activity we track or use?

Yes — it adds seven properties to the three existing banner events: the environment (`channel`, `surface`, `screen`, `site_type`, `is_test`), the requester (`is_a11n`: Automattician, or a request behind the Automattic proxy), and the site's plan (`product_slug`). This classifies existing fires so internal traffic can be separated from customer traffic; it adds no new events, no content data, and no personal data beyond what the events already carry.

## Testing instructions

1. Sync this Jetpack to an Atomic or Simple site.
2. Go to the site's settings and disable all agent access.
3. Open DevTools → Network, filter for `t.gif`, and tick "Preserve log" (the CTA navigates away).
4. Go to wp-admin → Dashboard and look for the events in the filtered requests — `jetpack_ai_assistant_banner_impression` on load, `_cta_click` on the "Enable AI assistant" button, `_dismiss` on the X. Validate each carries the new props:

Sample impression captured on a Simple site (`pixel.wp.com/t.gif` query string, identifiers replaced with dummies; `_cta_click` and `_dismiss` carry the same props):

```
channel=web
&surface=dashboard
&screen=dashboard
&site_type=simple
&product_slug=business-bundle
&is_test=false
&is_a11n=true
&blog_id=123456789
&_en=jetpack_ai_assistant_banner_impression
&_ui=12345678
&_ut=wpcom%3Auser_id
&_ul=exampleuser
&_ts=1787926821183
&_tz=-1
&_lg=en-GB
&_pf=MacIntel
&_ht=1440&_wd=2560&_sx=0&_sy=0
&_dl=https%3A%2F%2Fexample.wordpress.com%2Fwp-admin%2F
&_dr=
&blog_tz=1
&user_lang=en-gb
&blog_lang=en
&_rt=1787926821185
&_=_
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
