### PR TITLE
Jetpack AI: stop the Overview activity-log test polling an expensive role query

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -389,7 +389,11 @@ describe( 'AI admin page (main.jsx)', () => {
 		render( <App /> );
 
 		// Landing view is Overview; the row renders there and nowhere else.
-		const rows = await screen.findAllByRole( 'link', { name: /Activity log/ } );
+		// Wait on the cheap text query: polling a role+name query re-computes
+		// accessible names on every mutation and starves the 1s budget on a
+		// loaded CI runner.
+		await expect( screen.findByText( 'Activity log', IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+		const rows = screen.getAllByRole( 'link', { name: /Activity log/ } );
 		expect( rows ).toHaveLength( 1 );
 		expect( rows[ 0 ] ).toHaveAttribute( 'href', 'https://example.com/activity' );
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-main-test-flake
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-main-test-flake
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Jetpack AI: stabilize the admin page test for the Overview activity log row under CI load.
+
+


### PR DESCRIPTION
## Proposed changes
* Stops the `overview tab: gate on` test in `_inc/client/ai/test/main.jsx` from polling `findAllByRole( 'link', { name } )`. That query recomputes accessible names on every DOM mutation and costs ~50ms per run under jsdom, so on a loaded CI runner it exhausts the 1s `findBy` budget before the row is checked (trunk run 33098886013).
* The test now waits on the cheap text query and asserts the link role and `href` once.

## Related product discussion/links
*  p1787853274213119-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `cd projects/plugins/jetpack && pnpm run test-gui -- _inc/client/ai/test/main.jsx` passes.
