### PR TITLE
VideoPress: give the empty Library an upload dropzone empty state

### DIFF
--- a/projects/packages/videopress/changelog/add-library-dropzone-empty-state
+++ b/projects/packages/videopress/changelog/add-library-dropzone-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: Give the empty Library an upload dropzone empty state.

--- a/projects/packages/videopress/routes/library/package.json
+++ b/projects/packages/videopress/routes/library/package.json
@@ -13,6 +13,10 @@
 		"@wordpress/route": "0.19.0",
 		"@wordpress/ui": "0.20.0"
 	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@testing-library/user-event": "^14.5.2"
+	},
 	"route": {
 		"path": "/",
 		"page": "jetpack-videopress-dashboard"

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -4,7 +4,7 @@ import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
-import { Button } from '@wordpress/ui';
+import { Button, Card } from '@wordpress/ui';
 import CaptionManagerModal from '../../src/client/components/caption-manager-modal/lazy';
 import DashboardLayout from '../../src/dashboard/components/dashboard-layout';
 import FetchErrorNotice from '../../src/dashboard/components/fetch-error-notice';
@@ -15,6 +15,7 @@ import { buildLibraryActions } from '../../src/dashboard/components/library/acti
 import { libraryFields } from '../../src/dashboard/components/library/fields';
 import { UploadActionsProvider } from '../../src/dashboard/components/library/upload-actions-context';
 import QueryClientWrapper from '../../src/dashboard/components/query-client-wrapper';
+import UploadDropzone from '../../src/dashboard/components/upload-dropzone';
 import { DeleteVideosError, useDeleteVideo } from '../../src/dashboard/hooks/use-delete-video';
 import { useFreeTier } from '../../src/dashboard/hooks/use-free-tier';
 import { useLibrary } from '../../src/dashboard/hooks/use-library';
@@ -66,6 +67,20 @@ const defaultLayouts: SupportedLayouts = {
 	table: { layout: { density: 'balanced' } },
 };
 
+// The whole library, unfiltered — `paginationInfo` on the user's own view is
+// scoped to their filters and search, so it cannot answer "is there anything
+// at all". A perPage=1 read keeps it cheap, and the shape is stable so the
+// query caches across screens.
+const TOTAL_COUNT_VIEW: View = {
+	type: 'table',
+	page: 1,
+	perPage: 1,
+	fields: [],
+	filters: [],
+	search: '',
+	sort: { field: 'date', direction: 'desc' },
+};
+
 const StageInner = () => {
 	const [ initialView, persistView ] = usePersistedView( DEFAULT_VIEW );
 	const [ view, setView ] = useState< View >( initialView );
@@ -92,6 +107,7 @@ const StageInner = () => {
 		refetch,
 	} = useLibrary( view );
 	const { uploadQueue, startUpload, retryUpload } = useUpload();
+	const { paginationInfo: totalPagination } = useLibrary( TOTAL_COUNT_VIEW );
 	const { mutateAsync: deleteVideo } = useDeleteVideo();
 	const { mutateAsync: setPrivacyAsync } = useSetPrivacy();
 	const { mutateAsync: uploadFromLibrary } = useUploadFromLibrary();
@@ -404,6 +420,84 @@ const StageInner = () => {
 
 	const getItemId = useCallback( ( item: LibraryItem ) => item.id, [] );
 
+	// The library holds nothing at all — not "this filter matched nothing".
+	// Strict `=== 0` so an unsettled or failed count request reads as "show
+	// the listing", never as an empty library; a non-empty queue means rows
+	// are already being spliced into the listing, which then owns the surface.
+	const isLibraryEmpty =
+		totalPagination?.totalItems === 0 &&
+		uploadQueue.length === 0 &&
+		items.length === 0 &&
+		! isError;
+
+	// The viewport's three mutually exclusive surfaces, flattened out of
+	// nested ternaries so each branch can say why it exists.
+	const renderViewport = () => {
+		// A failed listing request would otherwise render as DataViews'
+		// "No results" — indistinguishable from an empty library. Surface
+		// the error explicitly with a Retry that refetches. Only when the
+		// QUERY has nothing valid to show: a failed *background* refresh
+		// keeps its cached rows (grid stays, self-heals on the next
+		// poll), while a failed view change / first load leaves data
+		// undefined (react-query drops keepPreviousData placeholders on
+		// error), so it lands here. Deliberately `items`, not
+		// `renderedItems` — the latter splices in in-flight upload rows,
+		// which must not mask a failed listing.
+		if ( isError && items.length === 0 ) {
+			return (
+				<FetchErrorNotice
+					className="vp-library__error"
+					message={ __( 'We couldn’t load your video library.', 'jetpack-videopress-pkg' ) }
+					error={ libraryError }
+					onRetry={ () => void refetch() }
+				/>
+			);
+		}
+
+		// An empty library gets an upload dropzone instead of DataViews'
+		// "No results" — a first-video invitation rather than a failed
+		// search. Dropping or picking files lands in the same
+		// `handleFilesSelected` pipeline as the page-wide DropZone and the
+		// header button, so the listing (with its spliced in-flight rows)
+		// takes over the moment anything enters the queue.
+		if ( isLibraryEmpty ) {
+			return (
+				<div className="vp-library__empty-state">
+					<Card.Root className="vp-library__empty-card">
+						<Card.Header>
+							<Card.Title render={ <h2 /> }>
+								{ __( 'Upload your first video', 'jetpack-videopress-pkg' ) }
+							</Card.Title>
+						</Card.Header>
+						<Card.Content>
+							<UploadDropzone
+								onFiles={ handleFilesSelected }
+								disabled={ isAtLimit }
+								allowMultiple={ ! isFree || isUnlimited }
+							/>
+						</Card.Content>
+					</Card.Root>
+				</div>
+			);
+		}
+
+		return (
+			<DataViews< LibraryItem >
+				data={ renderedItems }
+				fields={ libraryFields }
+				actions={ actions }
+				view={ view }
+				onChangeView={ onChangeView }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ getItemId }
+				paginationInfo={ paginationInfo }
+				isLoading={ isLoading }
+				defaultLayouts={ defaultLayouts }
+			/>
+		);
+	};
+
 	const onCaptionTracksChange = useCallback( () => {
 		void refetch();
 	}, [ refetch ] );
@@ -455,38 +549,7 @@ const StageInner = () => {
 						label={ __( 'Drop videos to upload', 'jetpack-videopress-pkg' ) }
 						onFilesDrop={ handleFilesSelected }
 					/>
-					{ isError && items.length === 0 ? (
-						// A failed listing request would otherwise render as DataViews'
-						// "No results" — indistinguishable from an empty library. Surface
-						// the error explicitly with a Retry that refetches. Only when the
-						// QUERY has nothing valid to show: a failed *background* refresh
-						// keeps its cached rows (grid stays, self-heals on the next
-						// poll), while a failed view change / first load leaves data
-						// undefined (react-query drops keepPreviousData placeholders on
-						// error), so it lands here. Deliberately `items`, not
-						// `renderedItems` — the latter splices in in-flight upload rows,
-						// which must not mask a failed listing.
-						<FetchErrorNotice
-							className="vp-library__error"
-							message={ __( 'We couldn’t load your video library.', 'jetpack-videopress-pkg' ) }
-							error={ libraryError }
-							onRetry={ () => void refetch() }
-						/>
-					) : (
-						<DataViews< LibraryItem >
-							data={ renderedItems }
-							fields={ libraryFields }
-							actions={ actions }
-							view={ view }
-							onChangeView={ onChangeView }
-							selection={ selection }
-							onChangeSelection={ setSelection }
-							getItemId={ getItemId }
-							paginationInfo={ paginationInfo }
-							isLoading={ isLoading }
-							defaultLayouts={ defaultLayouts }
-						/>
-					) }
+					{ renderViewport() }
 				</div>
 			</UploadActionsProvider>
 			{ captionVideo && (

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -1,10 +1,10 @@
 import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
-import { DropZone, Tooltip } from '@wordpress/components';
+import { DropZone, Spinner, Tooltip } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
-import { Button, Card } from '@wordpress/ui';
+import { Button, Card, VisuallyHidden } from '@wordpress/ui';
 import CaptionManagerModal from '../../src/client/components/caption-manager-modal/lazy';
 import DashboardLayout from '../../src/dashboard/components/dashboard-layout';
 import FetchErrorNotice from '../../src/dashboard/components/fetch-error-notice';
@@ -420,18 +420,26 @@ const StageInner = () => {
 
 	const getItemId = useCallback( ( item: LibraryItem ) => item.id, [] );
 
-	// The library holds nothing at all — not "this filter matched nothing".
-	// Strict `=== 0` so an unsettled or failed count request reads as "show
-	// the listing", never as an empty library; a non-empty queue means rows
-	// are already being spliced into the listing, which then owns the surface.
-	const isLibraryEmpty =
-		totalPagination?.totalItems === 0 &&
-		uploadQueue.length === 0 &&
-		items.length === 0 &&
-		! isError;
+	const renderDataViews = () => (
+		<DataViews< LibraryItem >
+			data={ renderedItems }
+			fields={ libraryFields }
+			actions={ actions }
+			view={ view }
+			onChangeView={ onChangeView }
+			selection={ selection }
+			onChangeSelection={ setSelection }
+			getItemId={ getItemId }
+			paginationInfo={ paginationInfo }
+			isLoading={ isLoading }
+			defaultLayouts={ defaultLayouts }
+		/>
+	);
 
-	// The viewport's three mutually exclusive surfaces, flattened out of
-	// nested ternaries so each branch can say why it exists.
+	// The viewport's four mutually exclusive surfaces, flattened out of
+	// nested ternaries so each branch can say why it exists. Order matters:
+	// error first, then anything already listable, then the undecided wait,
+	// then the empty-vs-listing verdict.
 	const renderViewport = () => {
 		// A failed listing request would otherwise render as DataViews'
 		// "No results" — indistinguishable from an empty library. Surface
@@ -454,13 +462,34 @@ const StageInner = () => {
 			);
 		}
 
+		// Anything to list — fetched rows or in-flight uploads being spliced
+		// in — and the listing owns the surface, whatever the count says.
+		if ( items.length > 0 || uploadQueue.length > 0 ) {
+			return renderDataViews();
+		}
+
+		// The initial state: the unfiltered count hasn't answered yet, so
+		// whether this library is empty is genuinely unknown. Painting the
+		// grid skeleton and then swapping in the dropzone (or vice versa)
+		// reads as the page loading twice; an explicit wait reads as loading
+		// once. `undefined` rather than `isLoading` so a background refetch
+		// of a settled count never re-shows the wait.
+		if ( totalPagination === undefined ) {
+			return (
+				<div className="vp-library__deciding" role="status">
+					<Spinner />
+					<VisuallyHidden>{ __( 'Loading…', 'jetpack-videopress-pkg' ) }</VisuallyHidden>
+				</div>
+			);
+		}
+
 		// An empty library gets an upload dropzone instead of DataViews'
 		// "No results" — a first-video invitation rather than a failed
 		// search. Dropping or picking files lands in the same
 		// `handleFilesSelected` pipeline as the page-wide DropZone and the
 		// header button, so the listing (with its spliced in-flight rows)
 		// takes over the moment anything enters the queue.
-		if ( isLibraryEmpty ) {
+		if ( totalPagination.totalItems === 0 ) {
 			return (
 				<div className="vp-library__empty-state">
 					<Card.Root className="vp-library__empty-card">
@@ -481,21 +510,9 @@ const StageInner = () => {
 			);
 		}
 
-		return (
-			<DataViews< LibraryItem >
-				data={ renderedItems }
-				fields={ libraryFields }
-				actions={ actions }
-				view={ view }
-				onChangeView={ onChangeView }
-				selection={ selection }
-				onChangeSelection={ setSelection }
-				getItemId={ getItemId }
-				paginationInfo={ paginationInfo }
-				isLoading={ isLoading }
-				defaultLayouts={ defaultLayouts }
-			/>
-		);
+		// A non-empty library whose current view matched nothing is a filter
+		// story, and DataViews' own "No results" tells it.
+		return renderDataViews();
 	};
 
 	const onCaptionTracksChange = useCallback( () => {

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -20,6 +20,16 @@
 		margin: 24px 24px 0;
 	}
 
+	// Stands in for the whole viewport while the empty-vs-listing decision is
+	// pending (the unfiltered count hasn't answered yet), so the initial
+	// state reads as loading rather than a page that loaded empty.
+	&__deciding {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-block-size: 240px;
+	}
+
 	// The empty library's upload invitation: one centered card, sized to the
 	// Settings tab's content measure so adjacent screens share a width. The
 	// viewport's `> *` flex rule stretches it; `overflow-y` keeps the card

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -20,6 +20,23 @@
 		margin: 24px 24px 0;
 	}
 
+	// The empty library's upload invitation: one centered card, sized to the
+	// Settings tab's content measure so adjacent screens share a width. The
+	// viewport's `> *` flex rule stretches it; `overflow-y` keeps the card
+	// reachable on short windows.
+	&__empty-state {
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding: 24px;
+		overflow-y: auto;
+	}
+
+	&__empty-card {
+		inline-size: 100%;
+		max-inline-size: 718px;
+	}
+
 	&__viewport {
 		display: flex;
 		flex-direction: column;

--- a/projects/packages/videopress/routes/library/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/library/test/stage.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react';
+import { makeVideoFile } from '../../../src/dashboard/test-utils/video-file';
+import { stage as Stage } from '../stage';
+import type { LibraryItem } from '../../../src/dashboard/types/library';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockNavigate = jest.fn();
+jest.mock( '@wordpress/route', () => ( {
+	__esModule: true,
+	useNavigate: () => mockNavigate,
+} ) );
+
+// The grid itself is not under test; a stand-in marks whether the listing owns
+// the viewport.
+jest.mock( '@wordpress/dataviews', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@wordpress/dataviews' ),
+	DataViews: () => <div data-testid="dataviews" />,
+} ) );
+
+jest.mock( '../../../src/dashboard/components/dashboard-layout', () => ( {
+	__esModule: true,
+	default: ( { children, actions }: { children: ReactNode; actions?: ReactNode } ) => (
+		<div>
+			{ actions }
+			{ children }
+		</div>
+	),
+} ) );
+jest.mock( '../../../src/dashboard/components/query-client-wrapper', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+} ) );
+jest.mock( '../../../src/client/components/caption-manager-modal/lazy', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+let mockLibraryTotal = 3;
+let mockItems: LibraryItem[] = [];
+let mockIsError = false;
+jest.mock( '../../../src/dashboard/hooks/use-library', () => ( {
+	LIBRARY_QUERY_KEY: 'videopress-library',
+	useLibrary: () => ( {
+		items: mockItems,
+		isLoading: false,
+		isError: mockIsError,
+		error: null,
+		paginationInfo: { totalItems: mockLibraryTotal, totalPages: 1 },
+		refetch: jest.fn(),
+	} ),
+} ) );
+
+let mockQueue: Array< { id: string; status: string; progress: number; file: File } > = [];
+const mockStartUpload = jest.fn();
+jest.mock( '../../../src/dashboard/hooks/use-upload', () => ( {
+	useUpload: () => ( {
+		uploadQueue: mockQueue,
+		startUpload: ( ...args: unknown[] ) => mockStartUpload( ...args ),
+		retryUpload: jest.fn(),
+		cancelUpload: jest.fn(),
+		acknowledgeUpload: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '../../../src/dashboard/hooks/use-delete-video', () => ( {
+	...jest.requireActual( '../../../src/dashboard/hooks/use-delete-video' ),
+	useDeleteVideo: () => ( { mutateAsync: jest.fn() } ),
+} ) );
+let mockFreeTier = {
+	isAtLimit: false,
+	isFree: false,
+	isUnlimited: true,
+	videoCount: 0,
+	limit: 1,
+};
+jest.mock( '../../../src/dashboard/hooks/use-free-tier', () => ( {
+	useFreeTier: () => mockFreeTier,
+} ) );
+jest.mock( '../../../src/dashboard/hooks/use-set-privacy', () => ( {
+	useSetPrivacy: () => ( { mutateAsync: jest.fn() } ),
+} ) );
+jest.mock( '../../../src/dashboard/hooks/use-upload-from-library', () => ( {
+	useUploadFromLibrary: () => ( { mutateAsync: jest.fn() } ),
+} ) );
+jest.mock( '../../../src/dashboard/hooks/use-videopress-upgrade', () => ( {
+	useVideoPressUpgrade: () => jest.fn(),
+} ) );
+jest.mock( '../../../src/dashboard/hooks/use-persisted-view', () => ( {
+	usePersistedView: ( fallback: unknown ) => [ fallback, jest.fn() ],
+} ) );
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		createInfoNotice: jest.fn(),
+	} ),
+} ) );
+
+describe( 'library stage empty state', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockItems = [];
+		mockQueue = [];
+		mockLibraryTotal = 3;
+		mockIsError = false;
+		mockFreeTier = { isAtLimit: false, isFree: false, isUnlimited: true, videoCount: 0, limit: 1 };
+	} );
+
+	it( 'renders the upload dropzone instead of the grid when the library is empty', () => {
+		mockLibraryTotal = 0;
+
+		render( <Stage /> );
+
+		expect( screen.getByText( 'Upload your first video' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Drag and drop your videos here' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'dataviews' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the listing while videos exist', () => {
+		render( <Stage /> );
+
+		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hands the surface to the listing the moment an upload is queued', () => {
+		// The listing splices in-flight queue rows in at the top, so it owns
+		// the viewport as soon as anything is uploading — even though the
+		// persisted count still reads zero.
+		mockLibraryTotal = 0;
+		mockQueue = [
+			{ id: 'q1', status: 'uploading', progress: 0.4, file: makeVideoFile( 'a.mp4' ) },
+		];
+
+		render( <Stage /> );
+
+		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+	} );
+
+	it( 'never masks a failed listing request with the empty state', () => {
+		// A failed count/listing read is indistinguishable from an empty
+		// library by numbers alone; the error surface must win.
+		mockLibraryTotal = 0;
+		mockIsError = true;
+
+		render( <Stage /> );
+
+		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'We couldn’t load your video library.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers a single-file picker on the capped free tier', () => {
+		mockLibraryTotal = 0;
+		mockFreeTier = { isAtLimit: false, isFree: true, isUnlimited: false, videoCount: 0, limit: 1 };
+
+		render( <Stage /> );
+
+		// The dropzone's copy follows `allowMultiple`, which follows the plan.
+		expect( screen.getByText( 'Drag and drop your video here' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/videopress/routes/library/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/library/test/stage.test.tsx
@@ -41,17 +41,20 @@ jest.mock( '../../../src/client/components/caption-manager-modal/lazy', () => ( 
 	default: () => null,
 } ) );
 
-let mockLibraryTotal = 3;
+// `null` models the in-flight count: useLibrary reports no paginationInfo
+// until the request answers.
+let mockLibraryTotal: number | null = 3;
 let mockItems: LibraryItem[] = [];
 let mockIsError = false;
 jest.mock( '../../../src/dashboard/hooks/use-library', () => ( {
 	LIBRARY_QUERY_KEY: 'videopress-library',
 	useLibrary: () => ( {
 		items: mockItems,
-		isLoading: false,
+		isLoading: mockLibraryTotal === null,
 		isError: mockIsError,
 		error: null,
-		paginationInfo: { totalItems: mockLibraryTotal, totalPages: 1 },
+		paginationInfo:
+			mockLibraryTotal === null ? undefined : { totalItems: mockLibraryTotal, totalPages: 1 },
 		refetch: jest.fn(),
 	} ),
 } ) );
@@ -110,6 +113,18 @@ describe( 'library stage empty state', () => {
 		mockLibraryTotal = 3;
 		mockIsError = false;
 		mockFreeTier = { isAtLimit: false, isFree: false, isUnlimited: true, videoCount: 0, limit: 1 };
+	} );
+
+	it( 'starts in a loading state while the count request is in flight', () => {
+		// The initial render must not guess: neither the grid skeleton nor the
+		// dropzone paints until the unfiltered count answers.
+		mockLibraryTotal = null;
+
+		render( <Stage /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'dataviews' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the upload dropzone instead of the grid when the library is empty', () => {

--- a/projects/packages/videopress/src/dashboard/components/free-tier-notice/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/free-tier-notice/index.tsx
@@ -20,6 +20,13 @@ export const FREE_TIER_AT_LIMIT_MESSAGE = __(
 	'jetpack-videopress-pkg'
 );
 
+// Stable id for the at-limit toast, so a user who keeps dropping files at the
+// limit refreshes one notice instead of stacking a column of identical black
+// bars: the notices store drops an existing notice with the same id on create.
+// Shared across surfaces on purpose — the plan is one fact, and only one of
+// these surfaces is on screen at a time.
+export const FREE_TIER_AT_LIMIT_NOTICE_ID = 'vp-upload-at-limit';
+
 /**
  * Permanent (non-dismissible) free-plan upgrade Notice. The Overview tab
  * renders it for every free-tier user with the default free-plan copy; the

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/index.tsx
@@ -1,0 +1,269 @@
+import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import { Button, Tooltip } from '@wordpress/components';
+import { useCallback, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { upload } from '@wordpress/icons';
+import { EmptyState, Text } from '@wordpress/ui';
+import { useVideoPressUpgrade } from '../../hooks/use-videopress-upgrade';
+import { FREE_TIER_AT_LIMIT_MESSAGE, FREE_TIER_AT_LIMIT_NOTICE_ID } from '../free-tier-notice';
+import {
+	describeRefusal,
+	filterVideoFiles,
+	INVALID_FILE_NOTICE_ID,
+	videoFileAccept,
+} from './video-files';
+import './style.scss';
+import type { MouseEvent } from 'react';
+
+/**
+ * The drag-and-drop upload surface: dashed-SVG outline, drop handling, hint
+ * and sub copy, a picker button, and the hidden file input behind it.
+ * Extracted from the /upload flow's UploadCard so Home's emptied-library
+ * state can offer the same target instead of a button that bounces to
+ * another page.
+ *
+ * Free-plan gating is split with the caller: `disabled` marks the surface and
+ * its button as refusing, while the caller keeps the FreeTierNotice and the
+ * slicing of a multi-file drop down to the plan — `dataTransfer` can carry
+ * several files regardless of `allowMultiple`, so `onFiles` must always expect
+ * an array.
+ *
+ * REFUSING is this component's job, though, not the caller's. A drop the plan
+ * or the file type can't accept used to be dropped on the floor here — the
+ * handlers were simply unbound while `disabled`, so at the free-plan limit a
+ * file dragged onto a surface that still read "Drag and drop your video here"
+ * vanished with no error, no toast and no state change. Both refusals now go
+ * out as the same error notice the Library's DropZone raises, from the one
+ * place that sees every drop, click and pick.
+ *
+ * @param props               - Component props.
+ * @param props.onFiles       - Called with the dropped/selected files, already
+ *                            filtered to types the backend accepts.
+ * @param props.disabled      - Whether the free-tier limit blocks uploading.
+ * @param props.allowMultiple - Whether the picker input accepts several files.
+ * @param props.copyVariant   - Copy override. Defaults to follow
+ *                            `allowMultiple`; Home's emptied-library state
+ *                            passes 'single' even on multi-file plans because
+ *                            it is inviting the (new) first video.
+ * @param props.subCopy       - Sub-copy override. The default sells the
+ *                            product (captions, owned player) for /upload's
+ *                            marketing shape; Home's emptied-library state
+ *                            passes the quieter "it will show up here"
+ *                            promise instead.
+ * @return The dropzone element.
+ */
+const UploadDropzone = ( {
+	onFiles,
+	disabled = false,
+	allowMultiple = false,
+	copyVariant,
+	subCopy,
+}: {
+	onFiles: ( files: File[] ) => void;
+	disabled?: boolean;
+	allowMultiple?: boolean;
+	copyVariant?: 'single' | 'multiple';
+	subCopy?: string;
+} ) => {
+	const inputRef = useRef< HTMLInputElement >( null );
+	const [ dragging, setDragging ] = useState( false );
+	const { createErrorNotice } = useGlobalNotices();
+	const runUpgrade = useVideoPressUpgrade();
+	const plural = ( copyVariant ?? ( allowMultiple ? 'multiple' : 'single' ) ) === 'multiple';
+	const dropzoneClassName = `vp-upload-dropzone${ dragging ? ' is-dragging' : '' }${
+		disabled ? ' is-disabled' : ''
+	}`;
+
+	// The at-limit refusal, in the same shape the Library's DropZone uses: the
+	// short form of the plan sentence, plus the upgrade route the persistent
+	// notice above the dropzone already offers. The stable id is what keeps a
+	// fourth blocked drop from stacking a fourth identical black bar.
+	const rejectAtLimit = useCallback( () => {
+		createErrorNotice( FREE_TIER_AT_LIMIT_MESSAGE, {
+			id: FREE_TIER_AT_LIMIT_NOTICE_ID,
+			actions: [ { label: __( 'Upgrade', 'jetpack-videopress-pkg' ), onClick: runUpgrade } ],
+		} );
+	}, [ createErrorNotice, runUpgrade ] );
+
+	// Everything that arrives as files — a drop, or the picker's change —
+	// lands here so the type filter and the limit are enforced once. Rejecting
+	// a `.txt` renamed `.mp4` at this point is what stops it consuming the free
+	// plan's single slot and settling into a permanently broken video.
+	//
+	// Async because the type filter now reads the file's leading bytes; nothing
+	// blocks while it does, and the notice below is the only thing waiting on it.
+	const acceptFiles = useCallback(
+		async ( files: File[] ) => {
+			// Nothing offered, nothing to refuse — a cancelled file dialog fires
+			// a change event with an empty list.
+			if ( ! files.length ) {
+				return;
+			}
+			// The file check runs BEFORE the plan gate, and the order is the fix:
+			// with the limit first, dropping a renamed `.txt` at the cap was
+			// answered with "You've reached the free plan's 1-video limit" — a
+			// fact about the plan standing in for the answer to a question about
+			// the file, which sent both testers off to check their plan.
+			const videos = await filterVideoFiles( files );
+			if ( ! videos.length ) {
+				// The message is derived, not fixed: a real `.webm` is a video we
+				// can't take, and saying "Only video files can be uploaded" to
+				// someone holding one is simply untrue.
+				createErrorNotice( await describeRefusal( files ), {
+					id: INVALID_FILE_NOTICE_ID,
+				} );
+				return;
+			}
+			if ( disabled ) {
+				rejectAtLimit();
+				return;
+			}
+			onFiles( videos );
+		},
+		[ createErrorNotice, disabled, onFiles, rejectAtLimit ]
+	);
+
+	const openPicker = useCallback( () => {
+		if ( disabled ) {
+			rejectAtLimit();
+			return;
+		}
+		inputRef.current?.click();
+	}, [ disabled, rejectAtLimit ] );
+
+	const onSurfaceClick = useCallback(
+		( event: MouseEvent< HTMLDivElement > ) => {
+			// The picker button lives inside this surface and opens the picker
+			// itself, so its click has to stop here or the file dialog would be
+			// asked for twice.
+			if ( ( event.target as HTMLElement ).closest( 'button' ) ) {
+				return;
+			}
+			openPicker();
+		},
+		[ openPicker ]
+	);
+
+	const pickerButton = (
+		<Button
+			className="vp-upload-dropzone__button"
+			variant="primary"
+			__next40pxDefaultSize
+			onClick={ openPicker }
+			aria-disabled={ disabled }
+		>
+			{ plural
+				? __( 'Select videos to upload', 'jetpack-videopress-pkg' )
+				: __( 'Select a video to upload', 'jetpack-videopress-pkg' ) }
+		</Button>
+	);
+
+	return (
+		<>
+			{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- the picker button inside this surface is the keyboard (and screen-reader) path; the surface click is a redundant pointer affordance for people who aim at the big target rather than the button. */ }
+			<div
+				className={ dropzoneClassName }
+				aria-disabled={ disabled }
+				onClick={ onSurfaceClick }
+				onDragOver={ e => {
+					e.preventDefault();
+					// No brand highlight while disabled — the surface must not
+					// promise a drop it is about to refuse — but the handler
+					// still runs, because only a bound handler gets a `drop`
+					// event to answer with.
+					setDragging( ! disabled );
+				} }
+				onDragLeave={ () => setDragging( false ) }
+				onDrop={ e => {
+					e.preventDefault();
+					setDragging( false );
+					// `void`: the refusal (or the hand-off to onFiles) settles a
+					// microtask later, after the header read; nothing here waits.
+					void acceptFiles( Array.from( e.dataTransfer.files ) );
+				} }
+			>
+				<svg className="vp-upload-dropzone__outline" aria-hidden="true" focusable="false">
+					<rect className="vp-upload-dropzone__outline-rect" />
+				</svg>
+				{ /*
+				 * The design system's own empty-state treatment — the circled
+				 * icon Jetpack Social and the rest of the dashboard use — rather
+				 * than a bare glyph. `EmptyState.Icon` stands alone without its
+				 * Root; the Root would impose its own centred column layout on
+				 * top of the one this surface already has.
+				 */ }
+				<EmptyState.Icon icon={ upload } className="vp-upload-dropzone__icon" />
+				<Text variant="body-lg" className="vp-upload-dropzone__hint">
+					{ plural
+						? __( 'Drag and drop your videos here', 'jetpack-videopress-pkg' )
+						: __( 'Drag and drop your video here', 'jetpack-videopress-pkg' ) }
+				</Text>
+				<Text variant="body-sm" className="vp-upload-dropzone__sub">
+					{ subCopy ??
+						( plural
+							? __(
+									'Add one or several. Each upload gets automatic captions, a player you fully own, and a link to share anywhere. No ads, no algorithm.',
+									'jetpack-videopress-pkg'
+							  )
+							: __(
+									'Add one video. Each upload gets automatic captions, a player you fully own, and a link to share anywhere. No ads, no algorithm.',
+									'jetpack-videopress-pkg'
+							  ) ) }
+				</Text>
+				{ /*
+				 * `aria-disabled`, not `disabled`. The two halves of this one
+				 * control have to answer the same way, and a `disabled` button
+				 * is unfocusable and fires nothing — it could neither be
+				 * reached by keyboard nor say why it was refusing, which is
+				 * how the surface and the button came to disagree in the first
+				 * place. (`accessibleWhenDisabled` is not enough: it adds the
+				 * attribute but then swallows the click.)
+				 *
+				 * What `aria-disabled` does NOT buy is the look: the DS dims
+				 * `:disabled`, not the ARIA attribute, so at the plan limit
+				 * this sat in full brand blue with a plain pointer and read as
+				 * completely live until you clicked it — while the header
+				 * "Upload video" button one screen away was dimmed, refusing
+				 * and tooltipped. Two contradicting conventions for the same
+				 * state. The stylesheet dims this one to match, and the
+				 * Tooltip below gives the same sentence on hover that the
+				 * click raises as a notice. Both, not either: hover is what a
+				 * mouse user gets before committing, and the click-to-explain
+				 * is the only path a touch user has.
+				 */ }
+				{ disabled ? (
+					// Only at the limit. An enabled tooltip here would just
+					// restate the button's own label; the header needs one
+					// because it is refusing from a toolbar with no copy
+					// around it.
+					<Tooltip text={ FREE_TIER_AT_LIMIT_MESSAGE }>{ pickerButton }</Tooltip>
+				) : (
+					pickerButton
+				) }
+			</div>
+			<input
+				ref={ inputRef }
+				type="file"
+				// The allow-list, not `video/*`. Under `video/*` the OS dialog
+				// offered `.webm` and `.mkv` — real videos this backend refuses —
+				// and both testers picked one and were told their video wasn't a
+				// video. A drop can't be narrowed this way, so it leans on
+				// `describeRefusal` instead; this just stops the picker from
+				// setting the trap in the first place.
+				accept={ videoFileAccept() }
+				multiple={ allowMultiple }
+				className="vp-upload-dropzone__input"
+				onChange={ e => {
+					// Both reads happen before the await inside acceptFiles: the
+					// input is cleared synchronously so picking the same file twice
+					// in a row still fires a change event.
+					const input = e.currentTarget;
+					void acceptFiles( Array.from( e.target.files ?? [] ) );
+					input.value = '';
+				} }
+			/>
+		</>
+	);
+};
+
+export default UploadDropzone;

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/select-files.ts
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/select-files.ts
@@ -1,0 +1,57 @@
+import { _n, sprintf } from '@wordpress/i18n';
+
+// Tags the first-run flow's uploads in the shared queue. The queue outlives
+// any component, so the tag is the hand-off contract: the /upload stage
+// re-finds its own items by it after a mid-flight remount, and Home's
+// emptied-library dropzone starts uploads under it so the /upload stage
+// adopts them on arrival. Lives here (not in a route) so both routes can
+// import it without pulling each other's bundles.
+export const UPLOAD_ONBOARDING_CONTEXT = 'upload-onboarding';
+
+// The same flow's MULTI-file drops, which behave nothing like the single one:
+// they navigate to the Library and are carried by its in-flight rows and the
+// upload pill, with no surface of their own. Separating them is what keeps
+// the single-upload moments — the /upload bridge's adoption, and the one-time
+// "Your video is live" notice on /video/:id — from firing once per file
+// of a batch.
+export const UPLOAD_BATCH_CONTEXT = 'upload-batch';
+
+export type PlanFileSelection = {
+	files: File[];
+	/**
+	 * Set when the plan slice dropped files. Must be surfaced (a notice) —
+	 * silently missing uploads read as a bug.
+	 */
+	discardedNotice?: string;
+};
+
+/**
+ * Apply the plan's allowance to a file selection. The free tier includes one
+ * video, so everything past the first is dropped by the slice; the notice
+ * naming the dropped count rides along so every caller surfaces the same
+ * message.
+ *
+ * @param selected      - The files the user dropped or picked.
+ * @param allowMultiple - Whether the plan allows several files at once.
+ * @return The files to upload, plus the notice when any were dropped.
+ */
+export function selectFilesForPlan( selected: File[], allowMultiple: boolean ): PlanFileSelection {
+	const files = allowMultiple ? selected : selected.slice( 0, 1 );
+	if ( files.length === selected.length ) {
+		return { files };
+	}
+	const discarded = selected.length - files.length;
+	return {
+		files,
+		discardedNotice: sprintf(
+			/* translators: %d: number of selected videos not uploaded on the free plan. */
+			_n(
+				'The free plan includes one video — uploading your first. Upgrade to add %d more.',
+				'The free plan includes one video — uploading your first. Upgrade to add the other %d.',
+				discarded,
+				'jetpack-videopress-pkg'
+			),
+			discarded
+		),
+	};
+}

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/style.scss
@@ -1,0 +1,121 @@
+// The drag-and-drop upload surface. Extracted from routes/upload/style.scss
+// (`.vp-onboarding__dropzone*`) so Home's emptied-library state renders the
+// same target; the rules are a straight port under the component's own block.
+// The dashed outline is drawn by an SVG <rect> overlay (not a CSS `dashed`
+// border) so the dash length + gap are controllable — CSS can't space out
+// `border-style: dashed`. Stroke color is still the card's neutral-stroke
+// token.
+.vp-upload-dropzone {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--wpds-dimension-gap-sm);
+	padding: var(--wpds-dimension-padding-3xl) var(--wpds-dimension-padding-2xl);
+	text-align: center;
+	background: var(--wpds-color-background-surface-neutral-strong); // white
+	border-radius: var(--wpds-border-radius-lg);
+	// The whole surface opens the file picker, not just the button inside it.
+	cursor: var(--wpds-cursor-control);
+	transition: background var(--wpds-motion-duration-sm) var(--wpds-motion-easing-subtle);
+
+	// Very subtle grayer fill on hover.
+	&:hover {
+		background: var(--wpds-color-background-surface-neutral-weak);
+	}
+
+	// That fill is close enough to the resting stroke that the dotted outline
+	// disappeared into it, which is why the first-run screen — where the
+	// pointer lands on the dropzone straight off the welcome modal's CTA — was
+	// reported as having no dashed border at all, while the same control at the
+	// plan limit (hover fill suppressed) plainly had one. Darken the dots by
+	// the same amount the fill darkens. Excluded rather than merely overridden
+	// for the other two states, so neither depends on source order: dragging
+	// owns the outline while a file is over the surface, and a refusing surface
+	// must not light up at all.
+	&:hover:not(.is-dragging, .is-disabled) .vp-upload-dropzone__outline-rect {
+		stroke: var(--wpds-color-stroke-surface-neutral-strong);
+	}
+
+	&.is-dragging {
+		background: var(--wpds-color-background-surface-brand);
+
+		.vp-upload-dropzone__outline-rect {
+			stroke: var(--wpds-color-stroke-interactive-brand);
+		}
+	}
+
+	// At the plan limit the surface still answers a drop or a click — with a
+	// notice saying why — but it must not look like a live target while doing
+	// it, so the hover fill goes and the cursor says no.
+	&.is-disabled,
+	&.is-disabled:hover {
+		background: var(--wpds-color-background-surface-neutral-strong);
+		// Matches the refusing picker button beside it (the DS gives an
+		// aria-disabled button `not-allowed`); there is no disabled-cursor
+		// token to reach for.
+		cursor: not-allowed;
+	}
+
+	// The refusing picker button. `aria-disabled` keeps it focusable and lets
+	// it explain itself on click (see index.tsx), but the DS only dims
+	// `:disabled`, so on the ARIA attribute alone this stayed solid brand blue
+	// with a plain pointer — a button that looked entirely live at the plan
+	// limit. These are the same two declarations the header "Upload video"
+	// buttons use (routes/home/style.scss, routes/library/style.scss), so the
+	// product has one disabled-button convention rather than two contradicting
+	// ones.
+	&__button[aria-disabled="true"] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	&__outline {
+		position: absolute;
+		inset: 0;
+		inline-size: 100%;
+		block-size: 100%;
+		pointer-events: none;
+		overflow: visible;
+	}
+
+	&__outline-rect {
+		x: 0.5px;
+		y: 0.5px;
+		width: calc(100% - 1px);
+		height: calc(100% - 1px);
+		rx: var(--wpds-border-radius-lg);
+		fill: none;
+		stroke: var(--wpds-color-stroke-surface-neutral);
+		stroke-width: var(--wpds-border-width-xs);
+		// Round dots (round caps on ~1px dashes), ~5px apart — reads as dots,
+		// more of them and tighter than the earlier long dashes.
+		stroke-linecap: round;
+		stroke-dasharray: 1 5;
+	}
+
+	// The circle, border and fill come from `EmptyState.Icon`, which is where
+	// the rest of the dashboard gets this treatment — so does the colour, hence
+	// nothing about the glyph is restated here. Only the trailing margin is
+	// dropped: that spacing is meant for the design system's own empty-state
+	// column, and this surface already sets its rhythm with the flex `gap`
+	// above. Left in, the two stack and the icon floats away from its heading.
+	&__icon {
+		margin-block-end: 0;
+	}
+
+	&__hint {
+		color: var(--wpds-color-foreground-content-neutral);
+	}
+
+	&__sub {
+		max-inline-size: 48ch;
+		margin-bottom: var(--wpds-dimension-gap-sm);
+		color: var(--wpds-color-foreground-content-neutral-weak);
+	}
+
+	&__input {
+		display: none;
+	}
+}

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/index.test.tsx
@@ -1,0 +1,361 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { makeRenamedTextFile, makeVideoFile } from '../../../test-utils/video-file';
+import UploadDropzone from '../index';
+import { selectFilesForPlan } from '../select-files';
+
+const mockCreateErrorNotice = jest.fn();
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: ( ...args: unknown[] ) => mockCreateErrorNotice( ...args ),
+		createInfoNotice: jest.fn(),
+	} ),
+} ) );
+
+// The real hook pulls in the connection package's checkout workflow, which
+// wants an initial state this component test has no business hydrating.
+const mockRunUpgrade = jest.fn();
+jest.mock( '../../../hooks/use-videopress-upgrade', () => ( {
+	useVideoPressUpgrade: () => mockRunUpgrade,
+} ) );
+
+const AT_LIMIT_MESSAGE = 'You’ve reached the free plan’s 1-video limit. Upgrade to upload more.';
+
+// Real container bytes, not `[ 'x' ]`: the filter these files pass through
+// reads the header and checks it against the extension.
+const makeFile = ( name: string, type = 'video/mp4' ) => makeVideoFile( name, type );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'UploadDropzone', () => {
+	it( 'renders the single-file copy by default', () => {
+		render( <UploadDropzone onFiles={ jest.fn() } /> );
+
+		expect( screen.getByText( 'Drag and drop your video here' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Select a video to upload' } ) ).toBeEnabled();
+	} );
+
+	it( 'follows allowMultiple into the plural copy and a multi-file input', () => {
+		const { container } = render( <UploadDropzone onFiles={ jest.fn() } allowMultiple /> );
+
+		expect( screen.getByText( 'Drag and drop your videos here' ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the picker input is visually hidden with no label; no accessible query reaches it.
+		const input = container.querySelector( 'input[type="file"]' ) as HTMLInputElement;
+		expect( input ).toHaveAttribute( 'multiple' );
+	} );
+
+	it( 'keeps the single-file copy when copyVariant overrides a multi-file plan', () => {
+		render( <UploadDropzone onFiles={ jest.fn() } allowMultiple copyVariant="single" /> );
+
+		expect( screen.getByText( 'Drag and drop your video here' ) ).toBeInTheDocument();
+	} );
+
+	it( 'lets subCopy replace the default sub-copy line', () => {
+		render( <UploadDropzone onFiles={ jest.fn() } subCopy="It will show up here." /> );
+
+		expect( screen.getByText( 'It will show up here.' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /automatic captions/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'fires onFiles with the picked files on input change', async () => {
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the picker input is visually hidden with no label; no accessible query reaches it.
+		const input = container.querySelector( 'input[type="file"]' ) as HTMLInputElement;
+		const file = makeFile( 'one.mp4' );
+		await userEvent.upload( input, file );
+
+		await waitFor( () => expect( onFiles ).toHaveBeenCalledWith( [ file ] ) );
+	} );
+
+	it( 'fires onFiles from a drop and never while disabled', async () => {
+		const onFiles = jest.fn();
+		const { container, rerender } = render( <UploadDropzone onFiles={ onFiles } /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'one.mp4' ) ] } } );
+		await waitFor( () => expect( onFiles ).toHaveBeenCalledTimes( 1 ) );
+
+		rerender( <UploadDropzone onFiles={ onFiles } disabled /> );
+		expect( dropzone ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( screen.getByRole( 'button', { name: 'Select a video to upload' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'two.mp4' ) ] } } );
+		await waitFor( () => expect( mockCreateErrorNotice ).toHaveBeenCalled() );
+		expect( onFiles ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'answers a drop it cannot accept instead of swallowing the file', async () => {
+		// The plan-limit bug: the surface still read "Drag and drop your video
+		// here", the drop handler was simply unbound, and the file vanished
+		// with no error, no toast and no state change.
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } disabled /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'two.mp4' ) ] } } );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				AT_LIMIT_MESSAGE,
+				expect.objectContaining( {
+					actions: [ expect.objectContaining( { label: 'Upgrade' } ) ],
+				} )
+			)
+		);
+		expect( onFiles ).not.toHaveBeenCalled();
+	} );
+
+	it( 'refreshes one at-limit notice rather than stacking a black bar per attempt', async () => {
+		// Both testers dropped repeatedly at the limit and got a column of
+		// identical notices. A stable id makes the store replace the existing
+		// one instead.
+		const { container } = render( <UploadDropzone onFiles={ jest.fn() } disabled /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'a.mp4' ) ] } } );
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'b.mp4' ) ] } } );
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'c.mp4' ) ] } } );
+
+		await waitFor( () => expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 3 ) );
+		const ids = mockCreateErrorNotice.mock.calls.map(
+			( [ , options ] ) => ( options as { id?: string } )?.id
+		);
+		expect( ids ).toEqual( [ 'vp-upload-at-limit', 'vp-upload-at-limit', 'vp-upload-at-limit' ] );
+	} );
+
+	it( 'offers the upgrade route from the rejected-drop notice', async () => {
+		const { container } = render( <UploadDropzone onFiles={ jest.fn() } disabled /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'two.mp4' ) ] } } );
+
+		await waitFor( () => expect( mockCreateErrorNotice ).toHaveBeenCalled() );
+		const [ , options ] = mockCreateErrorNotice.mock.calls[ 0 ] as [
+			string,
+			{ actions: { onClick: () => void }[] },
+		];
+		options.actions[ 0 ].onClick();
+		expect( mockRunUpgrade ).toHaveBeenCalled();
+	} );
+
+	it( 'refuses from the picker button in the same voice as the surface', async () => {
+		// The two halves of one control used to disagree: the button was
+		// `disabled` (silent, unfocusable) while the surface quietly ate the
+		// file. Both now say the same thing.
+		render( <UploadDropzone onFiles={ jest.fn() } disabled /> );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Select a video to upload' } ) );
+
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith( AT_LIMIT_MESSAGE, expect.anything() );
+	} );
+
+	it( 'explains the refusal on hover too, not only on click', async () => {
+		// The button was `aria-disabled` (so it could answer a click) but still
+		// rendered live and said nothing on hover, while the header "Upload
+		// video" button was dimmed with a tooltip carrying this same sentence.
+		// Hover is what a mouse user gets BEFORE committing to a click.
+		render( <UploadDropzone onFiles={ jest.fn() } disabled /> );
+
+		await userEvent.hover( screen.getByRole( 'button', { name: 'Select a video to upload' } ) );
+
+		await expect(
+			screen.findByText( AT_LIMIT_MESSAGE, {}, { timeout: 3000 } )
+		).resolves.toBeVisible();
+	} );
+
+	it( 'leaves the enabled button untooltipped', async () => {
+		render( <UploadDropzone onFiles={ jest.fn() } /> );
+
+		await userEvent.hover( screen.getByRole( 'button', { name: 'Select a video to upload' } ) );
+
+		expect( screen.queryByText( AT_LIMIT_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'rejects a file that only looks like a video', async () => {
+		// A `.txt` renamed `.mp4` used to upload 0→100%, register, consume the
+		// free plan's one slot and settle into a permanently broken video. It
+		// REPORTS `video/mp4` — Chromium derives the type from the extension —
+		// so only its bytes give it away.
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } /> );
+
+		const impostor = makeRenamedTextFile( 'not-a-video.mp4' );
+		expect( impostor.type ).toBe( 'video/mp4' );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ impostor ] } } );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith( 'Only video files can be uploaded.', {
+				id: 'vp-upload-invalid-file',
+			} )
+		);
+		expect( onFiles ).not.toHaveBeenCalled();
+	} );
+
+	it( 'tells the owner of a real WebM what to do instead of denying it is a video', async () => {
+		// Both testers hit this: `.webm` is not on the server allow-list, so the
+		// refusal is right, but "Only video files can be uploaded." about a
+		// genuine video is false and leaves nowhere to go.
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } /> );
+
+		// Real EBML bytes — the refusal has to be about the CONTAINER, not about
+		// the file being an impostor.
+		const webm = new File(
+			[ new Uint8Array( [ 0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00 ] ) ],
+			'holiday.webm',
+			{ type: 'video/webm' }
+		);
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ webm ] } } );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'WEBM files can’t be uploaded. Convert your video to MP4 or MOV, then try again.',
+				{ id: 'vp-upload-invalid-file' }
+			)
+		);
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalledWith(
+			'Only video files can be uploaded.',
+			expect.anything()
+		);
+		expect( onFiles ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stops the picker offering formats the drop handler would refuse', async () => {
+		// `accept="video/*"` is what put `.webm` and `.mkv` in the OS dialog in
+		// the first place. The picker must offer only the allow-list.
+		const { container } = render( <UploadDropzone onFiles={ jest.fn() } /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the picker input is visually hidden with no label; no accessible query reaches it.
+		const input = container.querySelector( 'input[type="file"]' ) as HTMLInputElement;
+		const accept = input.getAttribute( 'accept' ) ?? '';
+		expect( accept ).not.toBe( 'video/*' );
+		expect( accept.split( ',' ) ).toContain( '.mp4' );
+		expect( accept.split( ',' ) ).not.toContain( '.webm' );
+	} );
+
+	it( 'rejects an impostor picked through the file dialog, not just dropped', async () => {
+		// The picker is a separate entry point into the same guard; testers
+		// reproduced the upload through both.
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the picker input is visually hidden with no label; no accessible query reaches it.
+		const input = container.querySelector( 'input[type="file"]' ) as HTMLInputElement;
+		await userEvent.upload( input, makeRenamedTextFile( 'not-a-video.mp4' ) );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+				'Only video files can be uploaded.',
+				expect.objectContaining( { id: 'vp-upload-invalid-file' } )
+			)
+		);
+		expect( onFiles ).not.toHaveBeenCalled();
+	} );
+
+	it( 'names the real reason at the plan limit instead of blaming the plan', async () => {
+		// Ordering: the limit gate used to fire first, so a renamed `.txt`
+		// dropped at the cap was told "You've reached the free plan's 1-video
+		// limit" — a fact about the plan answering a question about the file.
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } disabled /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, {
+			dataTransfer: { files: [ makeRenamedTextFile( 'not-a-video.mp4' ) ] },
+		} );
+
+		await waitFor( () => expect( mockCreateErrorNotice ).toHaveBeenCalled() );
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+			'Only video files can be uploaded.',
+			expect.anything()
+		);
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalledWith( AT_LIMIT_MESSAGE, expect.anything() );
+		expect( onFiles ).not.toHaveBeenCalled();
+	} );
+
+	it( 'still reports the plan when a real video arrives at the limit', async () => {
+		// The other half of that ordering: a genuine video at the cap is a plan
+		// problem, and must still say so.
+		const { container } = render( <UploadDropzone onFiles={ jest.fn() } disabled /> );
+
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, { dataTransfer: { files: [ makeFile( 'real.mp4' ) ] } } );
+
+		await waitFor( () =>
+			expect( mockCreateErrorNotice ).toHaveBeenCalledWith( AT_LIMIT_MESSAGE, expect.anything() )
+		);
+	} );
+
+	it( 'passes the real videos through and drops the rest of a mixed selection', async () => {
+		const onFiles = jest.fn();
+		const { container } = render( <UploadDropzone onFiles={ onFiles } allowMultiple /> );
+
+		const clip = makeFile( 'clip.mp4' );
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the dropzone is a styled div with no accessible role; no query reaches it.
+		const dropzone = container.querySelector( '.vp-upload-dropzone' ) as HTMLElement;
+		fireEvent.drop( dropzone, {
+			dataTransfer: { files: [ clip, makeFile( 'notes.pdf', 'application/pdf' ) ] },
+		} );
+
+		await waitFor( () => expect( onFiles ).toHaveBeenCalledWith( [ clip ] ) );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'opens the picker from the surface without double-firing on the button', async () => {
+		render( <UploadDropzone onFiles={ jest.fn() } /> );
+
+		const clicks: Event[] = [];
+		// eslint-disable-next-line testing-library/no-node-access -- the picker input is visually hidden with no label; no accessible query reaches it.
+		const input = document.querySelector( 'input[type="file"]' ) as HTMLInputElement;
+		input.addEventListener( 'click', event => {
+			event.preventDefault();
+			clicks.push( event );
+		} );
+
+		await userEvent.click( screen.getByText( 'Drag and drop your video here' ) );
+		expect( clicks ).toHaveLength( 1 );
+
+		// The button opens the picker itself; its click must not also bubble up
+		// to the surface and ask for a second file dialog.
+		await userEvent.click( screen.getByRole( 'button', { name: 'Select a video to upload' } ) );
+		expect( clicks ).toHaveLength( 2 );
+	} );
+} );
+
+describe( 'selectFilesForPlan', () => {
+	it( 'passes a multi-file plan through untouched', () => {
+		const files = [ makeFile( 'a.mp4' ), makeFile( 'b.mp4' ) ];
+		expect( selectFilesForPlan( files, true ) ).toEqual( { files } );
+	} );
+
+	it( 'slices the free plan to one file and names the dropped count', () => {
+		const files = [ makeFile( 'a.mp4' ), makeFile( 'b.mp4' ), makeFile( 'c.mp4' ) ];
+		const result = selectFilesForPlan( files, false );
+
+		expect( result.files ).toEqual( [ files[ 0 ] ] );
+		expect( result.discardedNotice ).toBe(
+			'The free plan includes one video — uploading your first. Upgrade to add the other 2.'
+		);
+	} );
+
+	it( 'returns an empty selection without a notice', () => {
+		expect( selectFilesForPlan( [], false ) ).toEqual( { files: [] } );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/style.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/style.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The at-limit look is pure CSS, and jsdom neither compiles nor applies
+ * stylesheets (jest stubs `.scss` imports out entirely), so the rule is read
+ * from source — the same technique routes/upload/test/style.test.ts uses. Worth
+ * guarding because the failure is invisible to every other test: the button
+ * kept answering a click correctly while rendering in full brand blue, so it
+ * read as completely live at the very moment it was refusing.
+ */
+
+describe( 'at-limit dropzone styling', () => {
+	const { readFileSync } = jest.requireActual< {
+		readFileSync: ( path: string, encoding: string ) => string;
+	} >( 'fs' );
+	/**
+	 * The stylesheet under test. Located from jest's own state rather than
+	 * `__dirname`: `@types/node` isn't a dependency of this package (nothing in
+	 * the client touches the filesystem), and a second ambient
+	 * `declare const __dirname` would collide with the one in
+	 * routes/upload/test/style.test.ts — both files are global scripts to
+	 * TypeScript, having no imports of their own.
+	 *
+	 * @return The stylesheet source.
+	 */
+	const readStylesheet = (): string =>
+		readFileSync(
+			expect.getState().testPath?.replace( /test[/\\]style\.test\.ts$/, 'style.scss' ) ?? '',
+			'utf8'
+		);
+
+	/**
+	 * Read one declaration block out of the stylesheet by its selector.
+	 *
+	 * @param selector - The selector text as written in the source.
+	 * @return Everything between that selector's braces.
+	 */
+	const block = ( selector: string ): string => {
+		const stylesheet = readStylesheet();
+		const start = stylesheet.indexOf( `${ selector } {` );
+		expect( start ).toBeGreaterThan( -1 );
+		const open = stylesheet.indexOf( '{', start );
+		return stylesheet.slice( open + 1, stylesheet.indexOf( '}', open ) );
+	};
+
+	it( 'dims and refuses the picker button, matching the header buttons', () => {
+		// `aria-disabled` keeps the button focusable so it can explain itself on
+		// click, but the DS only dims `:disabled` — so without these two lines it
+		// sat at the plan limit in full brand blue with a plain pointer, while
+		// the header "Upload video" button one screen away was dimmed and
+		// `not-allowed`. Two contradicting conventions for one state.
+		const button = block( '&__button[aria-disabled="true"]' );
+
+		expect( button ).toContain( 'opacity: 0.5' );
+		expect( button ).toContain( 'cursor: not-allowed' );
+	} );
+
+	it( 'keeps the same refusal on the surface around it', () => {
+		// The two halves of the control have to look the same way they behave.
+		const surface = block( '&.is-disabled,\n\t&.is-disabled:hover' );
+
+		expect( surface ).toContain( 'cursor: not-allowed' );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/video-files.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/test/video-files.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for the shared accepted-video-file filter. Moved here from
+ * routes/library/test/upload-drop.test.ts when the filter moved out of the
+ * Library route so /upload and Home could reject the same files.
+ */
+
+import { makeRenamedTextFile, makeVideoFile } from '../../../test-utils/video-file';
+import { describeRefusal, filterVideoFiles, videoFileAccept } from '../video-files';
+
+// A file whose BYTES are a real container header, so only the name/type under
+// test decides the outcome. `[ 'x' ]` won't do any more: the filter reads the
+// leading bytes and checks them against the container the extension claims.
+const file = ( name: string, type = '' ): File => makeVideoFile( name, type );
+
+// The ISO-BMFF family shares one signature, so .mov/.m4v/.3gp use the header
+// above too; these are the other two containers the filter knows.
+const ebmlFile = ( name: string, type = '' ): File =>
+	new File( [ new Uint8Array( [ 0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x00, 0x00, 0x00 ] ) ], name, {
+		type,
+	} );
+// 'OggS' plus the version and header-type bytes of a real first page (BOS).
+// Written as bytes rather than pasted into a string literal: the raw NULs made
+// git treat this whole file as binary, so every diff of it read "Bin 7499 ->
+// 11987 bytes" instead of showing the tests.
+const oggFile = ( name: string, type = '' ): File =>
+	new File( [ new Uint8Array( [ 0x4f, 0x67, 0x67, 0x53, 0x00, 0x02, 0x00, 0x00 ] ) ], name, {
+		type,
+	} );
+
+const setAllowedVideoExtensions = ( map: Record< string, string > | undefined ) => {
+	( window as unknown as { JPVIDEOPRESS_INITIAL_STATE?: unknown } ).JPVIDEOPRESS_INITIAL_STATE = map
+		? { allowedVideoExtensions: map }
+		: undefined;
+};
+
+// Clear the initial state between tests so cases that don't set it fall back to
+// the static (server-mirroring) extension list deterministically.
+afterEach( () => {
+	setAllowedVideoExtensions( undefined );
+} );
+
+describe( 'filterVideoFiles', () => {
+	it( 'keeps only files with an allowed video extension', async () => {
+		const result = await filterVideoFiles( [
+			file( 'clip.mp4' ),
+			file( 'photo.jpg' ),
+			file( 'movie.MOV' ), // case-insensitive
+			file( 'doc.pdf' ),
+		] );
+		expect( result.map( f => f.name ) ).toEqual( [ 'clip.mp4', 'movie.MOV' ] );
+	} );
+
+	it( 'accepts .mov files (regression: video/quicktime must pass)', async () => {
+		expect(
+			( await filterVideoFiles( [ file( 'clip.mov', 'video/quicktime' ) ] ) ).map( f => f.name )
+		).toEqual( [ 'clip.mov' ] );
+		// And via the extension fallback when the browser leaves the type empty.
+		expect( ( await filterVideoFiles( [ file( 'clip.mov' ) ] ) ).map( f => f.name ) ).toEqual( [
+			'clip.mov',
+		] );
+	} );
+
+	it( 'rejects extensions the backend does not accept (e.g. .webm/.mkv)', async () => {
+		// `.webm`/`.mkv` are valid video MIME types but absent from the server
+		// allow-list, so the drop filter rejects them rather than starting an
+		// upload the backend would fail.
+		await expect( filterVideoFiles( [ ebmlFile( 'clip.webm', 'video/webm' ) ] ) ).resolves.toEqual(
+			[]
+		);
+		await expect(
+			filterVideoFiles( [ ebmlFile( 'clip.mkv', 'video/x-matroska' ) ] )
+		).resolves.toEqual( [] );
+	} );
+
+	it( 'sources the accepted extensions from the server allow-list', async () => {
+		// A site whose backend advertises `.flv` accepts it; one that omits
+		// `.mp4` rejects it — proving the list comes from the initial state.
+		setAllowedVideoExtensions( { flv: 'video/x-flv' } );
+		expect(
+			( await filterVideoFiles( [ file( 'a.flv', 'video/x-flv' ) ] ) ).map( f => f.name )
+		).toEqual( [ 'a.flv' ] );
+		await expect( filterVideoFiles( [ file( 'a.mp4', 'video/mp4' ) ] ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'rejects non-video MIME types', async () => {
+		await expect( filterVideoFiles( [ file( 'photo.jpg', 'image/jpeg' ) ] ) ).resolves.toEqual(
+			[]
+		);
+	} );
+
+	it( 'does not accept a non-video MIME type just because the name ends in a video extension', async () => {
+		// A reported MIME type is authoritative when it contradicts the name: a
+		// PDF renamed to `.mp4` must not slip through the extension fallback.
+		await expect( filterVideoFiles( [ file( 'evil.mp4', 'application/pdf' ) ] ) ).resolves.toEqual(
+			[]
+		);
+		await expect(
+			filterVideoFiles( [ file( 'not-a-video.mp4', 'text/plain' ) ] )
+		).resolves.toEqual( [] );
+	} );
+
+	it( 'rejects a renamed text file that REPORTS video/mp4', async () => {
+		// The bug both testers reproduced, and the reason the MIME check above
+		// isn't enough on its own: Chromium derives `File.type` from the
+		// extension, so a `.txt` renamed `.mp4` reports `video/mp4` exactly like
+		// a real one. It then uploaded end to end, landed on a real edit screen,
+		// sat at "Processing" forever and consumed the free plan's only slot.
+		// Only the bytes tell the two apart.
+		const renamed = makeRenamedTextFile( 'not-a-video.mp4' );
+		expect( renamed.type ).toBe( 'video/mp4' );
+		await expect( filterVideoFiles( [ renamed ] ) ).resolves.toEqual( [] );
+	} );
+
+	it( 'rejects renamed text across the whole ISO-BMFF family', async () => {
+		await expect(
+			filterVideoFiles( [
+				makeRenamedTextFile( 'a.mov', 'video/quicktime' ),
+				makeRenamedTextFile( 'b.m4v', 'video/x-m4v' ),
+				makeRenamedTextFile( 'c.3gp', 'video/3gpp' ),
+			] )
+		).resolves.toEqual( [] );
+	} );
+
+	it( 'keeps the real video out of a mixed drop with a renamed impostor', async () => {
+		const real = makeVideoFile( 'holiday.mp4' );
+		const result = await filterVideoFiles( [ makeRenamedTextFile( 'fake.mp4' ), real ] );
+		expect( result ).toEqual( [ real ] );
+	} );
+
+	it( 'accepts a QuickTime .mov that does not open with an ftyp box', async () => {
+		// Older QuickTime files legitimately start with another top-level atom.
+		// Insisting on `ftyp` would refuse a real video, which is the one
+		// outcome this check must never produce.
+		const mdatFirst = new File(
+			[ new Uint8Array( [ 0x00, 0x00, 0x10, 0x00, 0x6d, 0x64, 0x61, 0x74 ] ) ],
+			'legacy.mov',
+			{ type: 'video/quicktime' }
+		);
+		expect( ( await filterVideoFiles( [ mdatFirst ] ) ).map( f => f.name ) ).toEqual( [
+			'legacy.mov',
+		] );
+	} );
+
+	it( 'checks WebM and Ogg against their own signatures', async () => {
+		setAllowedVideoExtensions( { webm: 'video/webm', ogv: 'video/ogg' } );
+
+		expect(
+			(
+				await filterVideoFiles( [
+					ebmlFile( 'real.webm', 'video/webm' ),
+					oggFile( 'real.ogv', 'video/ogg' ),
+				] )
+			).map( f => f.name )
+		).toEqual( [ 'real.webm', 'real.ogv' ] );
+
+		await expect(
+			filterVideoFiles( [
+				makeRenamedTextFile( 'fake.webm', 'video/webm' ),
+				makeRenamedTextFile( 'fake.ogv', 'video/ogg' ),
+			] )
+		).resolves.toEqual( [] );
+	} );
+
+	it( 'fails open on a format it holds no signature for', async () => {
+		// `.avi` is on the allow-list but has no verifier, so it rides on its
+		// extension. Deliberate: a signature we half-remember would refuse real
+		// videos, and a false accept is only ever a failed upload — a false
+		// reject is someone's footage turned away.
+		const avi = makeRenamedTextFile( 'clip.avi', 'video/x-msvideo' );
+		expect( ( await filterVideoFiles( [ avi ] ) ).map( f => f.name ) ).toEqual( [ 'clip.avi' ] );
+	} );
+
+	it( 'fails open when the file cannot be read at all', async () => {
+		const unreadable = makeRenamedTextFile( 'unreadable.mp4' );
+		// A file that has moved or been unmounted since the drop throws here.
+		jest.spyOn( unreadable, 'slice' ).mockImplementation( () => {
+			throw new Error( 'NotReadableError' );
+		} );
+
+		expect( ( await filterVideoFiles( [ unreadable ] ) ).map( f => f.name ) ).toEqual( [
+			'unreadable.mp4',
+		] );
+	} );
+
+	it( 'does not match an extension that is merely a substring', async () => {
+		// "notmp4" ends with "mp4" but not ".mp4" — the dot guards against it.
+		await expect( filterVideoFiles( [ file( 'video.notmp4' ) ] ) ).resolves.toEqual( [] );
+	} );
+} );
+
+describe( 'describeRefusal', () => {
+	const NOT_A_VIDEO = 'Only video files can be uploaded.';
+
+	it( 'does not tell someone their real WebM is not a video', async () => {
+		// The bug both testers found independently. `.webm` is genuinely refused —
+		// it is not on the server allow-list, so the upload would fail — but the
+		// answer they got was "Only video files can be uploaded." about a real
+		// video, with nothing to do about it.
+		const real = ebmlFile( 'holiday.webm', 'video/webm' );
+
+		await expect( filterVideoFiles( [ real ] ) ).resolves.toEqual( [] );
+		await expect( describeRefusal( [ real ] ) ).resolves.toBe(
+			'WEBM files can’t be uploaded. Convert your video to MP4 or MOV, then try again.'
+		);
+	} );
+
+	it( 'names Matroska the same way', async () => {
+		await expect( describeRefusal( [ ebmlFile( 'clip.mkv', 'video/x-matroska' ) ] ) ).resolves.toBe(
+			'MKV files can’t be uploaded. Convert your video to MP4 or MOV, then try again.'
+		);
+	} );
+
+	it( 'keeps the plain message for something that never was a video', async () => {
+		// A `.txt` renamed `.mp4` is on the allow-list and fails the byte check:
+		// "that isn't a video" is the true sentence there, and must not be
+		// replaced by advice about converting formats.
+		await expect( describeRefusal( [ makeRenamedTextFile( 'not-a-video.mp4' ) ] ) ).resolves.toBe(
+			NOT_A_VIDEO
+		);
+		await expect( describeRefusal( [ file( 'doc.pdf', 'application/pdf' ) ] ) ).resolves.toBe(
+			NOT_A_VIDEO
+		);
+	} );
+
+	it( 'uses the bytes, not the name, to decide which sentence is true', async () => {
+		// A `.txt` wearing a `.webm` name reports `video/webm` in Chromium, so
+		// only the EBML signature separates it from the real thing. This is the
+		// job the `webm`/`mkv`/`ogg` entries in CONTAINER_CHECKS do today, and the
+		// reason they are not dead code.
+		const impostor = makeRenamedTextFile( 'fake.webm', 'video/webm' );
+		expect( impostor.type ).toBe( 'video/webm' );
+		await expect( describeRefusal( [ impostor ] ) ).resolves.toBe( NOT_A_VIDEO );
+	} );
+
+	it( 'falls back to the reported type for a container it holds no signature for', async () => {
+		// `.flv` has no verifier here, so the only evidence is the type the
+		// browser derived from the extension. Wrong guesses only change the
+		// wording of a refusal that stands either way.
+		await expect( describeRefusal( [ file( 'clip.flv', 'video/x-flv' ) ] ) ).resolves.toBe(
+			'FLV files can’t be uploaded. Convert your video to MP4 or MOV, then try again.'
+		);
+	} );
+
+	it( 'answers a mixed drop about the video, not the junk beside it', async () => {
+		// The `.webm` is the file the user meant to upload and the only one with
+		// anything to do about it.
+		await expect(
+			describeRefusal( [
+				file( 'notes.pdf', 'application/pdf' ),
+				ebmlFile( 'clip.webm', 'video/webm' ),
+			] )
+		).resolves.toBe(
+			'WEBM files can’t be uploaded. Convert your video to MP4 or MOV, then try again.'
+		);
+	} );
+
+	it( 'still says what to do when there is no extension to name', async () => {
+		await expect( describeRefusal( [ file( 'clip', 'video/webm' ) ] ) ).resolves.toBe(
+			'That video format can’t be uploaded. Convert your video to MP4 or MOV, then try again.'
+		);
+	} );
+
+	it( 'does not offer advice about a format the site actually accepts', async () => {
+		// A backend that advertises `.webm` accepts it, so there is nothing to
+		// convert — and nothing refused to describe.
+		setAllowedVideoExtensions( { webm: 'video/webm' } );
+		const real = ebmlFile( 'holiday.webm', 'video/webm' );
+		expect( ( await filterVideoFiles( [ real ] ) ).map( f => f.name ) ).toEqual( [
+			'holiday.webm',
+		] );
+	} );
+} );
+
+describe( 'videoFileAccept', () => {
+	it( 'offers exactly the extensions the backend accepts', () => {
+		setAllowedVideoExtensions( { mp4: 'video/mp4', mov: 'video/quicktime' } );
+		expect( videoFileAccept() ).toBe( '.mp4,.mov' );
+	} );
+
+	it( 'never widens back to video/*', () => {
+		// `accept="video/*"` was the trap: the OS dialog offered `.webm` and
+		// `.mkv`, which the drop handler then had to refuse. A MIME pattern in
+		// this attribute re-opens it.
+		const accept = videoFileAccept();
+		expect( accept ).not.toContain( 'video/' );
+		expect( accept ).not.toContain( '*' );
+		// The server's default list, so `.webm` is absent and `.mov` present.
+		expect( accept.split( ',' ) ).toContain( '.mov' );
+		expect( accept.split( ',' ) ).not.toContain( '.webm' );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/video-files.ts
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/video-files.ts
@@ -1,0 +1,420 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+// Fallback accepted-upload extensions, used only when the server-provided
+// allow-list is absent (unit tests, or a render before the initial state is
+// inlined). Mirrors the server's `Admin_UI::get_allowed_video_extensions()`
+// keys so behaviour matches the backend even on the fallback path. The live
+// list is read from `JPVIDEOPRESS_INITIAL_STATE.allowedVideoExtensions`.
+const FALLBACK_VIDEO_EXTENSIONS = [
+	'3g2',
+	'3gp',
+	'3gp2',
+	'3gpp',
+	'avi',
+	'm4v',
+	'mov',
+	'mp4',
+	'mpe',
+	'mpeg',
+	'mpg',
+	'ogv',
+	'wmv',
+];
+
+// Stable id for every "that isn't a video" notice, so a user who drops four
+// bad files in a row is told once rather than handed four identical black
+// bars: the notices store replaces an existing notice with the same id instead
+// of stacking a second one. Same technique as the delete notices in
+// routes/video/stage.tsx and routes/library/stage.tsx. Shared across surfaces
+// deliberately — /upload, Home and the Library are all saying the same thing,
+// and only one of them is on screen at a time.
+export const INVALID_FILE_NOTICE_ID = 'vp-upload-invalid-file';
+
+// The sentence that goes with that id when the file simply is not a video.
+// Lives here, next to the check that decides it, because two surfaces raise it
+// — the shared dropzone and the Library's DropZone — and both used to carry
+// their own copy of the string. See `describeRefusal` for when it is NOT the
+// right sentence.
+export const NOT_A_VIDEO_MESSAGE = __(
+	'Only video files can be uploaded.',
+	'jetpack-videopress-pkg'
+);
+
+// How much of the file to read for the container check. Every signature below
+// lives in the first 12 bytes; 64 leaves headroom without pulling any real
+// amount of a video into memory. `File.slice()` doesn't read the disk, so the
+// cost is one read of this many bytes per dropped file.
+const HEADER_BYTES = 64;
+
+/**
+ * The set of accepted upload extensions, sourced from the server's
+ * authoritative allow-list (`Admin_UI::get_allowed_video_extensions()`, inlined
+ * as `JPVIDEOPRESS_INITIAL_STATE.allowedVideoExtensions`). Falls back to the
+ * static list when the initial state isn't present (tests / pre-hydration).
+ * Read lazily so it always reflects the current initial state.
+ *
+ * @return Lower-cased accepted extensions (without the leading dot).
+ */
+function getAllowedExtensions(): Set< string > {
+	const map =
+		typeof JPVIDEOPRESS_INITIAL_STATE !== 'undefined'
+			? JPVIDEOPRESS_INITIAL_STATE?.allowedVideoExtensions
+			: undefined;
+	const extensions =
+		map && Object.keys( map ).length ? Object.keys( map ) : FALLBACK_VIDEO_EXTENSIONS;
+	return new Set( extensions.map( extension => extension.toLowerCase() ) );
+}
+
+/**
+ * The `accept` value for a video file input, built from the same allow-list the
+ * filter enforces.
+ *
+ * `accept="video/*"` was the bug: the OS dialog offered every container the
+ * system knows is a video — `.webm` and `.mkv` prominently — and both testers
+ * picked one, only to be told the file they had just been offered could not be
+ * uploaded. A picker must not offer what the drop handler will refuse. Dotted
+ * extensions rather than MIME types, because the allow-list is keyed by
+ * extension and that is what the backend checks; `video/webm` in this attribute
+ * would re-open the same hole.
+ *
+ * Called at render (not computed once at import) so it tracks the same lazily
+ * read initial state as {@link getAllowedExtensions}.
+ *
+ * @return A comma-joined `accept` list, e.g. `.mp4,.mov,…`.
+ */
+export function videoFileAccept(): string {
+	return [ ...getAllowedExtensions() ].map( extension => `.${ extension }` ).join( ',' );
+}
+
+/**
+ * Read a fixed-width ASCII field out of a header.
+ *
+ * @param bytes - The file's leading bytes.
+ * @param start - First byte of the field.
+ * @param end   - One past the last byte of the field.
+ * @return The field as an ASCII string (empty when the header is too short).
+ */
+function ascii( bytes: Uint8Array, start: number, end: number ): string {
+	return String.fromCharCode( ...bytes.subarray( start, end ) );
+}
+
+/**
+ * Test a header against a literal byte signature.
+ *
+ * @param bytes     - The file's leading bytes.
+ * @param signature - The expected leading bytes.
+ * @return Whether the header opens with that signature.
+ */
+function startsWith( bytes: Uint8Array, signature: number[] ): boolean {
+	return (
+		bytes.length >= signature.length &&
+		signature.every( ( byte, index ) => bytes[ index ] === byte )
+	);
+}
+
+// Top-level ISO-BMFF / QuickTime atom types. The modern brand box is `ftyp`,
+// but QuickTime-era `.mov` files legitimately open with another top-level atom
+// (a `wide`/`free` pad, or `mdat` outright), and refusing those would be a
+// false reject on a real video — the one outcome this check must never
+// produce. Anything in this set counts as "this really is that container".
+const ISO_BMFF_ATOMS = new Set( [
+	'ftyp',
+	'moov',
+	'mdat',
+	'free',
+	'skip',
+	'wide',
+	'pnot',
+	'junk',
+	'uuid',
+	'pict',
+] );
+
+/**
+ * ISO base media file format — mp4, m4v, mov, and the 3gp family. The 4-byte
+ * atom type sits at offset 4, after the atom's big-endian size.
+ *
+ * @param bytes - The file's leading bytes.
+ * @return Whether the header is an ISO-BMFF/QuickTime container.
+ */
+function isIsoBmff( bytes: Uint8Array ): boolean {
+	return bytes.length >= 8 && ISO_BMFF_ATOMS.has( ascii( bytes, 4, 8 ) );
+}
+
+/**
+ * Matroska / WebM — the EBML header magic every file of either type opens with.
+ *
+ * @param bytes - The file's leading bytes.
+ * @return Whether the header is an EBML (Matroska/WebM) container.
+ */
+function isMatroska( bytes: Uint8Array ): boolean {
+	return startsWith( bytes, [ 0x1a, 0x45, 0xdf, 0xa3 ] );
+}
+
+/**
+ * Ogg — the 'OggS' capture pattern that opens every page, including the first.
+ *
+ * @param bytes - The file's leading bytes.
+ * @return Whether the header is an Ogg container.
+ */
+function isOgg( bytes: Uint8Array ): boolean {
+	return ascii( bytes, 0, 4 ) === 'OggS';
+}
+
+// Extension → the container its bytes must actually be. This table does two
+// jobs. For an extension the backend ACCEPTS it is the impostor check (a `.txt`
+// renamed `.mp4`). For one it REFUSES it is how we tell a genuine video we
+// cannot take from a file that was never a video at all — which is the whole
+// difference between "convert this to MP4" and "that isn't a video".
+//
+// Only formats we can identify with confidence appear here: an accepted
+// extension with no entry (`.avi`, `.wmv`, `.mpg`, `.mpeg`) is taken on its
+// extension alone. That asymmetry is the point — a signature we half-remember
+// would reject real videos, and a false reject on someone's holiday footage is
+// far worse than the false accept the backend will catch anyway. The same gap
+// applies on the refusal side: a REFUSED extension with no entry (`.flv`,
+// `.ts`…) has no byte evidence either way, so the reported MIME type is all
+// `verdictFor` has to decide the wording with.
+//
+// `mkv`/`webm`/`ogg` read as dead code against the default allow-list, which
+// omits all three, and they are not. The keys are matched against whatever
+// `allowedVideoExtensions` carries, so a backend that advertises `.webm` gets it
+// verified like any other (covered in the tests) — and on the refusal path all
+// three are load-bearing today: they are exactly the containers a customer is
+// most likely to have and this backend most likely to turn away.
+const CONTAINER_CHECKS: Record< string, ( bytes: Uint8Array ) => boolean > = {
+	'3g2': isIsoBmff,
+	'3gp': isIsoBmff,
+	'3gp2': isIsoBmff,
+	'3gpp': isIsoBmff,
+	m4v: isIsoBmff,
+	mov: isIsoBmff,
+	mp4: isIsoBmff,
+	mkv: isMatroska,
+	webm: isMatroska,
+	ogg: isOgg,
+	ogv: isOgg,
+};
+
+/**
+ * Read a slice's bytes, preferring `Blob.arrayBuffer()` and falling back to
+ * `FileReader`. The fallback is not theoretical: `Blob.arrayBuffer` is absent
+ * from the jsdom build these tests run under (and from Safari before 14), while
+ * `FileReader` has been everywhere for a decade.
+ *
+ * @param blob - The slice to read.
+ * @return Its bytes.
+ */
+function readBytes( blob: Blob ): Promise< ArrayBuffer > {
+	if ( typeof blob.arrayBuffer === 'function' ) {
+		return blob.arrayBuffer();
+	}
+	return new Promise( ( resolve, reject ) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve( reader.result as ArrayBuffer );
+		reader.onerror = () => reject( reader.error );
+		reader.readAsArrayBuffer( blob );
+	} );
+}
+
+/**
+ * Read the leading bytes of a file.
+ *
+ * @param file - The dropped or picked file.
+ * @return The header, or null when the file could not be read — in which case the caller must let it through.
+ */
+async function readHeader( file: File ): Promise< Uint8Array | null > {
+	// Nothing here is worth assuming, and every failure ends the same way: a
+	// `File` we cannot read — an older engine without these APIs, a test
+	// double, a file moved or unmounted between the drop and this read — has to
+	// be accepted rather than refused, because "we couldn't look" is not
+	// evidence. Hence one try/catch around the whole read.
+	try {
+		if ( typeof file.slice !== 'function' ) {
+			return null;
+		}
+		const head = file.slice( 0, HEADER_BYTES );
+		if ( typeof head.arrayBuffer !== 'function' && typeof FileReader === 'undefined' ) {
+			return null;
+		}
+		return new Uint8Array( await readBytes( head ) );
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * The extension of a file name, lower-cased and without the leading dot.
+ *
+ * @param file - The dropped or picked file.
+ * @return The extension, or '' when the name has none.
+ */
+function extensionOf( file: File ): string {
+	const name = file.name.toLowerCase();
+	const dot = name.lastIndexOf( '.' );
+	return dot === -1 ? '' : name.slice( dot + 1 );
+}
+
+/**
+ * What one file is, as far as this dropzone is concerned.
+ *
+ * `unsupported-format` exists only so the refusal can be true. It is still a
+ * refusal — the backend would fail the upload — but both testers dropped a
+ * genuine `.webm` and were answered "Only video files can be uploaded", which is
+ * false, and false in the most discouraging way available: it tells someone
+ * their video isn't a video and gives them nothing to do about it.
+ */
+type FileVerdict = 'accepted' | 'unsupported-format' | 'not-a-video';
+
+/**
+ * Decide what one file is: accepted, a real video in a container this backend
+ * refuses, or not a video.
+ *
+ * @param file    - The dropped or picked file.
+ * @param allowed - The accepted extensions for this site.
+ * @return The verdict.
+ */
+async function verdictFor( file: File, allowed: Set< string > ): Promise< FileVerdict > {
+	// A reported MIME type must be a video type — cheap, and it blocks the
+	// honest cases (an `application/pdf` dragged in by mistake) before any read.
+	// It is NOT sufficient on its own: see filterVideoFiles.
+	if ( file.type && ! file.type.startsWith( 'video/' ) ) {
+		return 'not-a-video';
+	}
+
+	const extension = extensionOf( file );
+	const check = CONTAINER_CHECKS[ extension ];
+
+	if ( ! allowed.has( extension ) ) {
+		// Refused either way; all that is left to settle is which sentence is
+		// true. The bytes when we hold the signature — that is the confident
+		// answer, and it is why the `webm`/`mkv`/`ogg` entries above are worth
+		// keeping. Otherwise the type the browser derived FROM the extension,
+		// which is the OS's own extension→container map: not evidence about the
+		// contents (see filterVideoFiles), but the best available guide to what
+		// kind of file the user believes they picked, and a wrong guess here
+		// changes only the wording of a refusal that stands regardless.
+		if ( check ) {
+			const header = await readHeader( file );
+			return header === null || check( header ) ? 'unsupported-format' : 'not-a-video';
+		}
+		return file.type.startsWith( 'video/' ) ? 'unsupported-format' : 'not-a-video';
+	}
+
+	if ( ! check ) {
+		// A format we hold no signature for. Accept: see CONTAINER_CHECKS.
+		return 'accepted';
+	}
+
+	const header = await readHeader( file );
+	if ( header === null ) {
+		return 'accepted';
+	}
+
+	// From here we DO know what this container has to look like, so a mismatch
+	// is a confident "not that format" — including a file too short to hold the
+	// header it claims.
+	return check( header ) ? 'accepted' : 'not-a-video';
+}
+
+/**
+ * Verdicts for a whole selection, in the order the files were given.
+ *
+ * @param files - The files dropped onto (or picked for) a dropzone.
+ * @return One verdict per file.
+ */
+function verdictsFor( files: File[] ): Promise< FileVerdict[] > {
+	const allowed = getAllowedExtensions();
+	// In parallel: a multi-file drop shouldn't pay for one header read after
+	// another, and each file's verdict is independent of the rest.
+	return Promise.all( files.map( file => verdictFor( file, allowed ) ) );
+}
+
+/**
+ * Filter a dropped file set down to the video types the VideoPress backend
+ * accepts. A file qualifies when its extension is in the server's allow-list
+ * (so we accept exactly what the backend supports — e.g. `.mov`, but not
+ * `.webm`, rather than guessing client-side), its reported MIME type doesn't
+ * contradict that, AND its leading bytes are the container the extension
+ * claims. Keeps the drop handler from trying to upload images, PDFs, or
+ * unsupported video containers.
+ *
+ * The byte check is the load-bearing part, and it is why this is async.
+ * `File.type` cannot do this job: Chromium derives it FROM THE EXTENSION, so a
+ * text file renamed `something.mp4` reports `video/mp4` and satisfies any
+ * MIME-only guard. Two testers proved it — the file uploaded end to end, landed
+ * on a real edit screen, sat at "Processing" forever and burned the free plan's
+ * only video slot. Reading the first {@link HEADER_BYTES} bytes off the file
+ * settles it before the upload starts.
+ *
+ * The check FAILS OPEN by design: an extension we hold no signature for, or a
+ * file we could not read, is accepted. A false reject on someone's real video
+ * is a far worse outcome than a false accept the backend will refuse anyway.
+ *
+ * Lives beside the dropzone rather than in a route so /upload, Home's
+ * emptied-library state and the Library's DropZone all reject the same set of
+ * files, without any of them importing another route's bundle.
+ *
+ * Says only WHICH files survive. When none do, {@link describeRefusal} says why
+ * — the two are separate because the message needs a distinction the upload
+ * decision does not.
+ *
+ * @param files - The files dropped onto (or picked for) a dropzone.
+ * @return Only the files the backend accepts.
+ */
+export async function filterVideoFiles( files: File[] ): Promise< File[] > {
+	const verdicts = await verdictsFor( files );
+	return files.filter( ( _, index ) => verdicts[ index ] === 'accepted' );
+}
+
+/**
+ * The notice for a selection {@link filterVideoFiles} accepted nothing from.
+ *
+ * Two sentences are possible and choosing between them is the entire job. A
+ * genuine video in a container this backend refuses is NAMED and told what to do
+ * instead; anything else gets the plain "that isn't a video". The picker no
+ * longer offers `.webm` (see {@link videoFileAccept}), but a DROP has no
+ * `accept` to lean on, so this path stays the one that has to be right.
+ *
+ * MP4 and MOV rather than the whole allow-list: thirteen extensions including
+ * `.3gp2` and `.mpe` in a snackbar is noise, and these two are what every phone,
+ * camera and converter produces. Both are in the server list and in the fallback
+ * above, so the advice cannot be wrong about them on any site.
+ *
+ * Reads the same headers `filterVideoFiles` just read, rather than having that
+ * function return a richer result. Deliberate: this only ever runs after a
+ * refusal, `File.slice()` doesn't touch the disk, and one shared verdict
+ * function is cheaper to keep honest than a wider return type threaded through
+ * both dropzones and the Library's drop planner.
+ *
+ * @param files - The files that were refused.
+ * @return The message to show.
+ */
+export async function describeRefusal( files: File[] ): Promise< string > {
+	const verdicts = await verdictsFor( files );
+	// The first genuine-but-unsupported video in the selection. A mixed drop of
+	// a `.webm` and a PDF is answered about the `.webm`: it is the file the user
+	// meant to upload, and the only one with anything to do about it.
+	const unsupported = files.find( ( _, index ) => verdicts[ index ] === 'unsupported-format' );
+	if ( ! unsupported ) {
+		return NOT_A_VIDEO_MESSAGE;
+	}
+
+	const extension = extensionOf( unsupported );
+	if ( ! extension ) {
+		// A video with no extension at all to name.
+		return __(
+			'That video format can’t be uploaded. Convert your video to MP4 or MOV, then try again.',
+			'jetpack-videopress-pkg'
+		);
+	}
+
+	return sprintf(
+		/* translators: %s: an upper-cased video file extension, e.g. "WEBM". */
+		__(
+			'%s files can’t be uploaded. Convert your video to MP4 or MOV, then try again.',
+			'jetpack-videopress-pkg'
+		),
+		extension.toUpperCase()
+	);
+}

--- a/projects/packages/videopress/src/dashboard/test-utils/video-file.ts
+++ b/projects/packages/videopress/src/dashboard/test-utils/video-file.ts
@@ -1,0 +1,75 @@
+/**
+ * File builders for anything that goes through the dropzone's accepted-file
+ * filter (`components/upload-dropzone/video-files`). That filter reads a file's
+ * leading bytes and checks them against the container its extension claims, so
+ * a test file built from `[ 'x' ]` is no longer a video no matter what MIME
+ * type it is given — the byte content has to be right.
+ */
+
+import { act } from '@testing-library/react';
+
+// A minimal ISO-BMFF header: a 24-byte `ftyp` box branded `isom`. Enough for
+// the container check, which reads the box type at offset 4; the rest of a real
+// mp4 (moov/mdat) is irrelevant to it. Covers .mp4, .m4v, .mov and the 3gp
+// family, which share the format.
+const ISO_BMFF_HEADER = new Uint8Array( [
+	0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+	0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
+] );
+
+/**
+ * A file that really is the video its name claims: correct container bytes,
+ * so it survives the dropzone filter end to end.
+ *
+ * @param name - File name, including the extension.
+ * @param type - Reported MIME type. Defaults to `video/mp4`.
+ * @return The file.
+ */
+export function makeVideoFile( name: string, type = 'video/mp4' ): File {
+	return new File( [ ISO_BMFF_HEADER ], name, { type } );
+}
+
+/**
+ * The bug both testers reproduced: a text file renamed to a video extension.
+ * Chromium derives `File.type` from the extension, so this reports `video/mp4`
+ * exactly as the real thing does — which is why the default type here is
+ * `video/mp4` and not `text/plain`. Only the bytes give it away.
+ *
+ * @param name - File name, including the (video) extension.
+ * @param type - Reported MIME type. Defaults to the `video/mp4` a browser
+ *             would report for a `.mp4` name.
+ * @return The file.
+ */
+export function makeRenamedTextFile( name: string, type = 'video/mp4' ): File {
+	return new File(
+		[ 'This is a plain text file that somebody renamed. It is not a video.\n' ],
+		name,
+		{ type }
+	);
+}
+
+/**
+ * Let the accepted-file filter settle after a drop or a pick. It reads each
+ * file's header, so the hand-off to `onFiles` — or the refusal notice — lands a
+ * task after the event rather than during it.
+ *
+ * Four ticks, not two. A REFUSAL now reads the headers twice: once to decide
+ * which files survive (`filterVideoFiles`) and once to decide which sentence is
+ * true about the ones that didn't (`describeRefusal`). Under jsdom the read goes
+ * through `FileReader`, so each pass costs its own macrotask, and a caller that
+ * adds an await of its own on top — the Library's `planVideoDrop` — needed more
+ * than the two this used to give. Waiting longer than necessary is free; waiting
+ * too little is a flake that only shows up on a loaded CI box.
+ *
+ * Assertions that a notice appeared are still better written with `waitFor`.
+ * This is for the tests that want a settled tree before looking at it at all.
+ *
+ * @return Resolves once the pending file checks have run.
+ */
+export async function settleFileCheck(): Promise< void > {
+	await act( async () => {
+		for ( let tick = 0; tick < 4; tick++ ) {
+			await new Promise( resolve => setTimeout( resolve, 0 ) );
+		}
+	} );
+}

--- a/projects/plugins/jetpack/changelog/add-library-dropzone-empty-state
+++ b/projects/plugins/jetpack/changelog/add-library-dropzone-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: Invite the first upload with a dropzone when the video library is empty.

--- a/projects/plugins/videopress/changelog/add-library-dropzone-empty-state
+++ b/projects/plugins/videopress/changelog/add-library-dropzone-empty-state
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Invite the first upload with a dropzone when the video library is empty.


### PR DESCRIPTION
## Proposed changes

Split out of #51521 as a small, independently-landable slice: **only** the Library's empty state, replaced with an upload dropzone UI.

* The viewport's initial state is an explicit **loading UI**: until the unfiltered count request answers, neither the grid skeleton nor the dropzone paints, so the page never guesses a surface and then swaps it.
* With no videos at all (count answered zero, nothing uploading, no fetch error), the Library renders a centered "Upload your first video" card with a drag-and-drop surface — the empty state. With anything listable, DataViews renders as before.
* Drops and picks feed the same `handleFilesSelected` pipeline the page-wide DropZone and the header button already use, so the listing — with its spliced in-flight rows — takes over the moment anything enters the queue. No new upload machinery.
* The dropzone is a shared, self-contained component (`upload-dropzone/`) with honest refusals: file types are checked by reading each file's header (a `.txt` renamed `.mp4` is refused as "not a video", a real `.webm` as "a video we can't take"), and at-limit drops raise the upgrade notice instead of vanishing. The picker's `accept` uses the backend's allow-list rather than `video/*`.
* A failed listing request still shows the error surface — numbers alone never get to claim the library is empty.

#51521 (the full upload onboarding flow) will be rebased on top of this, shrinking to the flow itself.

## Related product discussion/links

* Split out of #51521; follows the #51520 → #51521 → #51522 → #51523 stack.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build with `jetpack build plugins/jetpack --deps`, use a Jetpack-connected site with no VideoPress videos.
* **Jetpack → VideoPress → Library**: on a cold load a brief loading spinner shows first (the initial state), then the empty state shows the dropzone card. Drop a video: the listing appears with the in-flight row. Delete it again: the dropzone card returns.
* Drop a non-video (try a `.txt` renamed to `.mp4`): a refusal notice appears, nothing is queued. On a free plan at its limit, the surface dims and drops raise the upgrade notice.
* With videos present, the Library renders exactly as before.
* `jetpack test js packages/videopress` — all suites pass.
