### PR TITLE
jetpack-mu-wpcom: fix a one-second race in the expiry-banner test fixture

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-expiry-banner-test-race
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-expiry-banner-test-race
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix a one-second race in the expiry-banner test's purchase fixture; test-only change
+
+

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -62,7 +62,14 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 			(object) array(
 				'product_slug'           => $slug,
 				'product_type'           => 'bundle',
-				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) ),
+				// Half a day of slack on top of the whole days: the banner
+				// computes `floor( ( expiry - now ) / DAY_IN_SECONDS )` at
+				// render time, so an expiry set to exactly N days collapses to
+				// N-1 the moment a single second elapses between this call and
+				// render() — which is a race this test loses on a slow runner.
+				// The cushion keeps every case in its intended day bucket for
+				// twelve hours instead of one second.
+				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
 				'user_allows_auto_renew' => $auto_renew,
 			),
 		);


### PR DESCRIPTION
## Proposed changes

* Fix a one-second race in `Admin_Banner_Test`'s purchase fixture. `set_purchase( $days )` put the expiry at exactly `now + N * DAY_IN_SECONDS`, while the banner computes `floor( ( expiry - now ) / DAY_IN_SECONDS )` at render time — so the moment a single second elapses between the fixture call and `render()`, "N days out" reads as N−1. The 8-day cases sit right on the 7-day escalation boundary, so on a slow runner they flip expectations and the suite fails (seen on PR #51717's `PHP tests: PHP 8.5 WP latest` job, in a PR that doesn't touch this package).
* Half a day of slack on the fixture keeps every case in its intended day bucket for twelve hours instead of one second. Test-only change; no production behavior is affected. (`Expiry_Data_Test` already uses a frozen `FIXED_NOW` and has no such race.)

## Related product discussion/links

* Surfaced by the CI failure on #51717.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jetpack test php packages/jetpack-mu-wpcom` — passes.
* The race is visible in the old code by inserting `sleep( 1 )` between `set_purchase( 8, … )` and `render()`: the "expected no notice … at 8 days" assertions fail. With this fix they pass.
