### PR TITLE
WordPress Agent credits: proxy self-hosted allowance status

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -518,7 +518,7 @@ class Jetpack_AI_Helper {
 		$period_start       = strtotime( $allowance['period-start'] );
 		$resets_at          = strtotime( $allowance['resets-at'] );
 
-		return $allowance['credit-limit'] > 0
+		return $allowance['credit-limit'] >= 0
 			&& $allowance['credits-used'] >= 0
 			&& $expected_remaining === $allowance['credits-remaining']
 			&& ( 0 === $allowance['credits-remaining'] ) === $allowance['is-exhausted']

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -67,6 +67,13 @@ class Jetpack_AI_Helper {
 	public static $ai_assistant_feature_error_cache_timeout = 10;
 
 	/**
+	 * Limit forced AI-assistant feature refreshes to one every five seconds.
+	 *
+	 * @var int
+	 */
+	public static $ai_assistant_feature_refresh_cooldown = 5;
+
+	/**
 	 * Stores the number of JetpackAI calls in case we want to mark AI-assisted posts some way.
 	 *
 	 * @var int
@@ -215,6 +222,16 @@ class Jetpack_AI_Helper {
 	 */
 	public static function transient_name_for_ai_assistance_feature( $blog_id ) {
 		return 'jetpack_openai_ai_assistance_feature_' . $blog_id;
+	}
+
+	/**
+	 * Get the name of the transient that limits forced AI-assistant feature refreshes.
+	 *
+	 * @param int $blog_id Blog ID to get the transient name for.
+	 * @return string
+	 */
+	public static function transient_name_for_ai_assistance_feature_refresh( $blog_id ) {
+		return 'jetpack_openai_ai_assistance_feature_refresh_' . $blog_id;
 	}
 
 	/**
@@ -417,6 +434,100 @@ class Jetpack_AI_Helper {
 	}
 
 	/**
+	 * Return usable AI-assistant feature data for a supported usage contract.
+	 *
+	 * Legacy responses expose a request count. The cost-based contract is additive
+	 * and versioned so existing WordPress.com responses keep their current meaning.
+	 * A malformed additive allowance is removed from an otherwise usable legacy
+	 * response so it cannot poison the cache or confuse newer clients. Credit-only
+	 * responses must be gated to Jetpack versions that support their schema.
+	 *
+	 * @param mixed $data Response data.
+	 * @return array|false
+	 */
+	private static function get_usable_ai_assistance_feature_data( $data ) {
+		if ( ! is_array( $data ) ) {
+			return false;
+		}
+
+		$has_legacy_contract = array_key_exists( 'requests-count', $data );
+		$allowance           = $data['ai-credit-allowance'] ?? null;
+		$has_credit_contract = self::is_usable_ai_credit_allowance( $allowance );
+
+		if ( $has_legacy_contract ) {
+			if ( array_key_exists( 'ai-credit-allowance', $data ) && ! $has_credit_contract ) {
+				unset( $data['ai-credit-allowance'] );
+			}
+
+			return $data;
+		}
+
+		return $has_credit_contract ? $data : false;
+	}
+
+	/**
+	 * Whether an allowance matches the supported cost-credit contract.
+	 *
+	 * @param mixed $allowance Allowance data.
+	 * @return bool
+	 */
+	private static function is_usable_ai_credit_allowance( $allowance ) {
+		if ( ! is_array( $allowance ) ) {
+			return false;
+		}
+
+		$required = array(
+			'schema-version',
+			'metering-model',
+			'policy',
+			'plan-kind',
+			'authoritative',
+			'credit-limit',
+			'credits-used',
+			'credits-remaining',
+			'period-start',
+			'resets-at',
+			'rollover',
+			'is-exhausted',
+		);
+
+		foreach ( $required as $key ) {
+			if ( ! array_key_exists( $key, $allowance ) ) {
+				return false;
+			}
+		}
+
+		if (
+			1 !== $allowance['schema-version']
+			|| 'provider-cost-v1' !== $allowance['metering-model']
+			|| 'jetpack-ai-self-hosted-monthly-v1' !== $allowance['policy']
+			|| ! in_array( $allowance['plan-kind'], array( 'free', 'paid' ), true )
+			|| true !== $allowance['authoritative']
+			|| ! is_int( $allowance['credit-limit'] )
+			|| ! is_int( $allowance['credits-used'] )
+			|| ! is_int( $allowance['credits-remaining'] )
+			|| ! is_string( $allowance['period-start'] )
+			|| ! is_string( $allowance['resets-at'] )
+			|| false !== $allowance['rollover']
+			|| ! is_bool( $allowance['is-exhausted'] )
+		) {
+			return false;
+		}
+
+		$expected_remaining = max( 0, $allowance['credit-limit'] - $allowance['credits-used'] );
+		$period_start       = strtotime( $allowance['period-start'] );
+		$resets_at          = strtotime( $allowance['resets-at'] );
+
+		return $allowance['credit-limit'] > 0
+			&& $allowance['credits-used'] >= 0
+			&& $expected_remaining === $allowance['credits-remaining']
+			&& ( 0 === $allowance['credits-remaining'] ) === $allowance['is-exhausted']
+			&& false !== $period_start
+			&& false !== $resets_at
+			&& $period_start < $resets_at;
+	}
+
+	/**
 	 * Get an object with useful data about the requests made to the AI.
 	 *
 	 * @param bool $skip_cache Whether to fetch fresh data from WordPress.com.
@@ -475,15 +586,36 @@ class Jetpack_AI_Helper {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 
 		// Try to pick the AI Assistant feature from cache.
-		$transient_name   = self::transient_name_for_ai_assistance_feature( $blog_id );
-		$cache            = get_transient( $transient_name );
-		$has_usable_cache = is_array( $cache ) && array_key_exists( 'requests-count', $cache );
+		$transient_name         = self::transient_name_for_ai_assistance_feature( $blog_id );
+		$refresh_transient_name = self::transient_name_for_ai_assistance_feature_refresh( $blog_id );
+		$cached_data            = get_transient( $transient_name );
+		$cache                  = self::get_usable_ai_assistance_feature_data( $cached_data );
+		$has_usable_cache       = false !== $cache;
 		if ( ! $skip_cache && $cache ) {
 			return $cache;
+		}
+		if ( ! $skip_cache && is_wp_error( $cached_data ) ) {
+			return $cached_data;
 		}
 
 		if ( ! $skip_cache && null !== static::$ai_assistant_failed_request ) {
 			return static::$ai_assistant_failed_request;
+		}
+
+		if ( $skip_cache && get_transient( $refresh_transient_name ) ) {
+			if ( $has_usable_cache ) {
+				return $cache;
+			}
+
+			return new WP_Error(
+				'ai_assistance_feature_refresh_rate_limited',
+				esc_html__( 'Jetpack AI status was refreshed too recently.', 'jetpack' ),
+				array( 'status' => 429 )
+			);
+		}
+
+		if ( $skip_cache ) {
+			set_transient( $refresh_transient_name, true, self::$ai_assistant_feature_refresh_cooldown );
 		}
 
 		$request_path = sprintf( '/sites/%d/jetpack-ai/ai-assistant-feature', $blog_id );
@@ -505,17 +637,29 @@ class Jetpack_AI_Helper {
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 === $response_code ) {
 			$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
-			$has_requests_count        = is_array( $ai_assistant_feature_data )
-				&& array_key_exists( 'requests-count', $ai_assistant_feature_data );
+			$usable_response_data      = self::get_usable_ai_assistance_feature_data( $ai_assistant_feature_data );
 
-			if ( $skip_cache && $has_usable_cache && ! $has_requests_count ) {
-				return $cache;
+			if ( false === $usable_response_data ) {
+				if ( $skip_cache && $has_usable_cache ) {
+					return $cache;
+				}
+
+				$error = new WP_Error(
+					'invalid_ai_assistance_feature_response',
+					esc_html__( 'The Jetpack AI status response was invalid.', 'jetpack' ),
+					array( 'status' => 502 )
+				);
+
+				static::$ai_assistant_failed_request = $error;
+				set_transient( $transient_name, $error, self::$ai_assistant_feature_error_cache_timeout );
+
+				return $error;
 			}
 
 			// Cache the AI Assistant feature, for Jetpack sites.
-			set_transient( $transient_name, $ai_assistant_feature_data, self::$ai_assistant_feature_cache_timeout );
+			set_transient( $transient_name, $usable_response_data, self::$ai_assistant_feature_cache_timeout );
 
-			return $ai_assistant_feature_data;
+			return $usable_response_data;
 		}
 
 		$error = new WP_Error(

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -419,9 +419,10 @@ class Jetpack_AI_Helper {
 	/**
 	 * Get an object with useful data about the requests made to the AI.
 	 *
+	 * @param bool $skip_cache Whether to fetch fresh data from WordPress.com.
 	 * @return mixed
 	 */
-	public static function get_ai_assistance_feature() {
+	public static function get_ai_assistance_feature( $skip_cache = false ) {
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 			// On WPCOM, we can get the ID from the site.
 			$blog_id                  = get_current_blog_id();
@@ -474,13 +475,14 @@ class Jetpack_AI_Helper {
 		$blog_id = Jetpack_Options::get_option( 'id' );
 
 		// Try to pick the AI Assistant feature from cache.
-		$transient_name = self::transient_name_for_ai_assistance_feature( $blog_id );
-		$cache          = get_transient( $transient_name );
-		if ( $cache ) {
+		$transient_name   = self::transient_name_for_ai_assistance_feature( $blog_id );
+		$cache            = get_transient( $transient_name );
+		$has_usable_cache = is_array( $cache ) && array_key_exists( 'requests-count', $cache );
+		if ( ! $skip_cache && $cache ) {
 			return $cache;
 		}
 
-		if ( null !== static::$ai_assistant_failed_request ) {
+		if ( ! $skip_cache && null !== static::$ai_assistant_failed_request ) {
 			return static::$ai_assistant_failed_request;
 		}
 
@@ -503,27 +505,37 @@ class Jetpack_AI_Helper {
 		$response_code = wp_remote_retrieve_response_code( $wpcom_request );
 		if ( 200 === $response_code ) {
 			$ai_assistant_feature_data = json_decode( wp_remote_retrieve_body( $wpcom_request ), true );
+			$has_requests_count        = is_array( $ai_assistant_feature_data )
+				&& array_key_exists( 'requests-count', $ai_assistant_feature_data );
+
+			if ( $skip_cache && $has_usable_cache && ! $has_requests_count ) {
+				return $cache;
+			}
 
 			// Cache the AI Assistant feature, for Jetpack sites.
 			set_transient( $transient_name, $ai_assistant_feature_data, self::$ai_assistant_feature_cache_timeout );
 
 			return $ai_assistant_feature_data;
-		} else {
-			$error = new WP_Error(
-				'failed_to_fetch_data',
-				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
-				array(
-					'status' => $response_code,
-					'ts'     => time(),
-				)
-			);
-
-			// Cache the AI Assistant feature error, for Jetpack sites, avoid API hammering.
-			set_transient( $transient_name, $error, self::$ai_assistant_feature_error_cache_timeout );
-
-			static::$ai_assistant_failed_request = $error;
-
-			return $error;
 		}
+
+		$error = new WP_Error(
+			'failed_to_fetch_data',
+			esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
+			array(
+				'status' => $response_code,
+				'ts'     => time(),
+			)
+		);
+
+		if ( $skip_cache && $has_usable_cache ) {
+			return $cache;
+		}
+
+		static::$ai_assistant_failed_request = $error;
+
+		// Cache the AI Assistant feature error, for Jetpack sites, avoid API hammering.
+		set_transient( $transient_name, $error, self::$ai_assistant_feature_error_cache_timeout );
+
+		return $error;
 	}
 }

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -196,6 +196,14 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 					'callback'            => array( $this, 'request_get_ai_assistance_feature' ),
 					'permission_callback' => array( 'Jetpack_AI_Helper', 'get_status_permission_check' ),
 				),
+				'args' => array(
+					'skip_cache' => array(
+						'required'    => false,
+						'type'        => 'boolean',
+						'default'     => false,
+						'description' => 'Whether to skip the cache and fetch fresh data',
+					),
+				),
 			)
 		);
 	}
@@ -312,9 +320,11 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	/**
 	 * Collect and provide relevat data about the AI feature,
 	 * such as the number of requests made.
+	 *
+	 * @param WP_REST_Request $request The request.
 	 */
-	public function request_get_ai_assistance_feature() {
-		return Jetpack_AI_Helper::get_ai_assistance_feature();
+	public function request_get_ai_assistance_feature( $request ) {
+		return Jetpack_AI_Helper::get_ai_assistance_feature( $request['skip_cache'] );
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -318,7 +318,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 	}
 
 	/**
-	 * Collect and provide relevat data about the AI feature,
+	 * Collect and provide relevant data about the AI feature,
 	 * such as the number of requests made.
 	 *
 	 * @param WP_REST_Request $request The request.

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php
@@ -201,7 +201,7 @@ class WPCOM_REST_API_V2_Endpoint_AI extends WP_REST_Controller {
 						'required'    => false,
 						'type'        => 'boolean',
 						'default'     => false,
-						'description' => 'Whether to skip the cache and fetch fresh data',
+						'description' => 'Whether to request fresh data, rate-limited by site',
 					),
 				),
 			)

--- a/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
+++ b/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
@@ -1,4 +1,4 @@
 Significance: patch
-Type: other
+Type: enhancement
 
 AI Assistant: Enable internal testing of the WordPress Agent on connected self-hosted sites.

--- a/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
+++ b/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-AI Assistant: Enable the WordPress Agent in the editor on connected self-hosted sites.

--- a/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
+++ b/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Enable internal testing of the WordPress Agent on connected self-hosted sites.

--- a/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
+++ b/projects/plugins/jetpack/changelog/enable-self-hosted-wordpress-agent-shell
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Assistant: Enable the WordPress Agent in the editor on connected self-hosted sites.

--- a/projects/plugins/jetpack/changelog/refresh-ai-credit-balance
+++ b/projects/plugins/jetpack/changelog/refresh-ai-credit-balance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Allow the free-credit balance to refresh without waiting for the local cache.

--- a/projects/plugins/jetpack/changelog/support-cost-based-ai-credit-status
+++ b/projects/plugins/jetpack/changelog/support-cost-based-ai-credit-status
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: Support cost-based monthly credit status on connected sites.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -314,22 +314,36 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * Whether the current request is coming through the A8C proxy.
+	 *
+	 * This is an internal feature rollout signal, not an authorization check.
+	 *
+	 * @return bool
+	 */
+	private static function is_proxied_request(): bool {
+		return isset( $_SERVER['A8C_PROXIED_REQUEST'] )
+			? (bool) sanitize_text_field( wp_unslash( $_SERVER['A8C_PROXIED_REQUEST'] ) )
+			: defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST;
+	}
+
+	/**
 	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
 	 *
-	 * Defaults to enabled only on WordPress.com platform sites (Simple or WoA)
-	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
-	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
-	 * is a host-level override of that default, respected by init() and every
-	 * sidebar surface that gates on this method. Independently of the filter,
-	 * the sidebar requires at least one of its features (writing assistant or
-	 * SEO enhancer) to be enabled.
+	 * Defaults to enabled for A8C-proxied requests off the WordPress.com platform,
+	 * so Automatticians can test on connected self-hosted sites. WordPress.com
+	 * platform sites (Simple or WoA) keep following Big Sky: the plugin must be
+	 * present and enabled, which defaults on for Simple sites and off on
+	 * WoA/Atomic. The jetpack_ai_sidebar_enabled filter is a host-level override
+	 * of that default, respected by init() and every sidebar surface that gates
+	 * on this method. Independently of the filter, the sidebar requires at least
+	 * one of its features (writing assistant or SEO enhancer) to be enabled.
 	 *
 	 * @return bool
 	 */
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
 		$host = new Host();
 
-		$enabled = false;
+		$enabled = ! $host->is_wpcom_platform() && self::is_proxied_request();
 		if ( $host->is_wpcom_platform() && class_exists( 'Big_Sky' ) ) {
 			$default = $host->is_wpcom_simple() ? '1' : '0';
 			$enabled = (bool) get_option( 'big_sky_enable', $default );
@@ -338,12 +352,13 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to true only on WordPress.com platform sites with Big Sky
-		 * present and enabled. Acts as a host-level override that can force the
-		 * sidebar on (e.g. for local development) or off, and is respected by
-		 * init() and every sidebar surface. The override cannot force the
-		 * sidebar on while the writing-assistant and SEO enhancer features are
-		 * both off — a featureless sidebar never loads.
+		 * Defaults to true for A8C-proxied requests off the WordPress.com platform,
+		 * and on WordPress.com platform sites with Big Sky present and enabled.
+		 * Acts as a host-level override that can force the sidebar on (e.g. for
+		 * local development) or off, and is respected by init() and every sidebar
+		 * surface. The override cannot force the sidebar on while the
+		 * writing-assistant and SEO enhancer features are both off — a featureless
+		 * sidebar never loads.
 		 *
 		 * @param bool $enabled Whether the Jetpack AI sidebar is enabled.
 		 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -251,14 +251,12 @@ class Jetpack_AI_Sidebar {
 	 */
 	private static function get_ai_sidebar_asset_data() {
 		$skip_cache = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
-		$cached     = get_transient( AI_SIDEBAR_ASSET_TRANSIENT );
 
-		if ( 0 === $cached ) {
-			return false;
-		}
-
-		if ( ! $skip_cache && false !== $cached ) {
-			return is_array( $cached ) ? $cached : false;
+		if ( ! $skip_cache ) {
+			$cached = get_transient( AI_SIDEBAR_ASSET_TRANSIENT );
+			if ( false !== $cached ) {
+				return $cached;
+			}
 		}
 
 		$json_path = AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.asset.json';
@@ -276,7 +274,6 @@ class Jetpack_AI_Sidebar {
 			// — for example when the server cannot reach widgets.wp.com. Skip
 			// rather than enqueue a provider whose bundle the browser may also
 			// be unable to load, which would break the Agents Manager merge.
-			set_transient( AI_SIDEBAR_ASSET_TRANSIENT, 0, MINUTE_IN_SECONDS );
 			return false;
 		}
 
@@ -319,21 +316,20 @@ class Jetpack_AI_Sidebar {
 	/**
 	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
 	 *
-	 * Defaults to enabled off the WordPress.com platform, so self-hosted sites
-	 * get the sidebar without opting in. WordPress.com platform sites (Simple or
-	 * WoA) keep following Big Sky instead: the plugin must be present and
-	 * enabled, which defaults on for Simple sites and off on WoA/Atomic. The
-	 * jetpack_ai_sidebar_enabled filter is a host-level override of that default,
-	 * respected by init() and every sidebar surface that gates on this method.
-	 * Independently of the filter, the sidebar requires at least one of its
-	 * features (writing assistant or SEO enhancer) to be enabled.
+	 * Defaults to enabled only on WordPress.com platform sites (Simple or WoA)
+	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
+	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
+	 * is a host-level override of that default, respected by init() and every
+	 * sidebar surface that gates on this method. Independently of the filter,
+	 * the sidebar requires at least one of its features (writing assistant or
+	 * SEO enhancer) to be enabled.
 	 *
 	 * @return bool
 	 */
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
 		$host = new Host();
 
-		$enabled = ! $host->is_wpcom_platform();
+		$enabled = false;
 		if ( $host->is_wpcom_platform() && class_exists( 'Big_Sky' ) ) {
 			$default = $host->is_wpcom_simple() ? '1' : '0';
 			$enabled = (bool) get_option( 'big_sky_enable', $default );
@@ -342,13 +338,12 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to true off the WordPress.com platform, and on WordPress.com
-		 * platform sites only with Big Sky present and enabled. Acts as a
-		 * host-level override that can force the sidebar on (e.g. for local
-		 * development) or off, and is respected by init() and every sidebar
-		 * surface. The override cannot force the sidebar on while the
-		 * writing-assistant and SEO enhancer features are both off — a
-		 * featureless sidebar never loads.
+		 * Defaults to true only on WordPress.com platform sites with Big Sky
+		 * present and enabled. Acts as a host-level override that can force the
+		 * sidebar on (e.g. for local development) or off, and is respected by
+		 * init() and every sidebar surface. The override cannot force the
+		 * sidebar on while the writing-assistant and SEO enhancer features are
+		 * both off — a featureless sidebar never loads.
 		 *
 		 * @param bool $enabled Whether the Jetpack AI sidebar is enabled.
 		 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -251,12 +251,14 @@ class Jetpack_AI_Sidebar {
 	 */
 	private static function get_ai_sidebar_asset_data() {
 		$skip_cache = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		$cached     = get_transient( AI_SIDEBAR_ASSET_TRANSIENT );
 
-		if ( ! $skip_cache ) {
-			$cached = get_transient( AI_SIDEBAR_ASSET_TRANSIENT );
-			if ( false !== $cached ) {
-				return $cached;
-			}
+		if ( 0 === $cached ) {
+			return false;
+		}
+
+		if ( ! $skip_cache && false !== $cached ) {
+			return is_array( $cached ) ? $cached : false;
 		}
 
 		$json_path = AM_ASSET_BASE_PATH . 'jetpack-ai-sidebar.asset.json';
@@ -274,6 +276,7 @@ class Jetpack_AI_Sidebar {
 			// — for example when the server cannot reach widgets.wp.com. Skip
 			// rather than enqueue a provider whose bundle the browser may also
 			// be unable to load, which would break the Agents Manager merge.
+			set_transient( AI_SIDEBAR_ASSET_TRANSIENT, 0, MINUTE_IN_SECONDS );
 			return false;
 		}
 
@@ -316,20 +319,21 @@ class Jetpack_AI_Sidebar {
 	/**
 	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
 	 *
-	 * Defaults to enabled only on WordPress.com platform sites (Simple or WoA)
-	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
-	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
-	 * is a host-level override of that default, respected by init() and every
-	 * sidebar surface that gates on this method. Independently of the filter,
-	 * the sidebar requires at least one of its features (writing assistant or
-	 * SEO enhancer) to be enabled.
+	 * Defaults to enabled off the WordPress.com platform, so self-hosted sites
+	 * get the sidebar without opting in. WordPress.com platform sites (Simple or
+	 * WoA) keep following Big Sky instead: the plugin must be present and
+	 * enabled, which defaults on for Simple sites and off on WoA/Atomic. The
+	 * jetpack_ai_sidebar_enabled filter is a host-level override of that default,
+	 * respected by init() and every sidebar surface that gates on this method.
+	 * Independently of the filter, the sidebar requires at least one of its
+	 * features (writing assistant or SEO enhancer) to be enabled.
 	 *
 	 * @return bool
 	 */
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
 		$host = new Host();
 
-		$enabled = false;
+		$enabled = ! $host->is_wpcom_platform();
 		if ( $host->is_wpcom_platform() && class_exists( 'Big_Sky' ) ) {
 			$default = $host->is_wpcom_simple() ? '1' : '0';
 			$enabled = (bool) get_option( 'big_sky_enable', $default );
@@ -338,12 +342,13 @@ class Jetpack_AI_Sidebar {
 		/**
 		 * Filter to enable or disable the Jetpack AI sidebar feature.
 		 *
-		 * Defaults to true only on WordPress.com platform sites with Big Sky
-		 * present and enabled. Acts as a host-level override that can force the
-		 * sidebar on (e.g. for local development) or off, and is respected by
-		 * init() and every sidebar surface. The override cannot force the
-		 * sidebar on while the writing-assistant and SEO enhancer features are
-		 * both off — a featureless sidebar never loads.
+		 * Defaults to true off the WordPress.com platform, and on WordPress.com
+		 * platform sites only with Big Sky present and enabled. Acts as a
+		 * host-level override that can force the sidebar on (e.g. for local
+		 * development) or off, and is respected by init() and every sidebar
+		 * surface. The override cannot force the sidebar on while the
+		 * writing-assistant and SEO enhancer features are both off — a
+		 * featureless sidebar never loads.
 		 *
 		 * @param bool $enabled Whether the Jetpack AI sidebar is enabled.
 		 */

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
@@ -100,6 +100,46 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An authoritative exhausted free allowance may have a zero credit limit.
+	 */
+	public function test_get_ai_assistance_feature_accepts_zero_credit_allowance() {
+		$response = $this->get_credit_allowance_response(
+			array(
+				'credit-limit'      => 0,
+				'credits-used'      => 0,
+				'credits-remaining' => 0,
+				'is-exhausted'      => true,
+			)
+		);
+		$this->mock_wpcom_response( $response );
+
+		$this->assertSame( $response, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( $response, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * Credit limits cannot be negative.
+	 */
+	public function test_get_ai_assistance_feature_rejects_negative_credit_limit() {
+		$response = $this->get_credit_allowance_response(
+			array(
+				'credit-limit'      => -1,
+				'credits-used'      => 0,
+				'credits-remaining' => 0,
+				'is-exhausted'      => true,
+			)
+		);
+		$this->mock_wpcom_response( $response );
+
+		$result = Jetpack_AI_Helper::get_ai_assistance_feature();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_ai_assistance_feature_response', $result->get_error_code() );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
 	 * Malformed cached data is ignored in favor of a fresh usable response.
 	 */
 	public function test_get_ai_assistance_feature_ignores_malformed_cache() {

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
@@ -49,6 +49,7 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 
 		delete_transient( $this->get_transient_name() );
+		delete_transient( $this->get_refresh_transient_name() );
 		$this->reset_failed_request();
 	}
 
@@ -57,6 +58,7 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		delete_transient( $this->get_transient_name() );
+		delete_transient( $this->get_refresh_transient_name() );
 		$this->remove_wpcom_response_mock();
 		Jetpack_Options::delete_option( array( 'id', 'blog_token', 'master_user', 'user_tokens' ) );
 		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
@@ -79,11 +81,57 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Normal reads also accept the versioned cost-credit contract from cache.
+	 */
+	public function test_get_ai_assistance_feature_uses_cost_credit_cache_by_default() {
+		$cached = $this->get_credit_allowance_response();
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $this->get_credit_allowance_response( array( 'credits-used' => 300, 'credits-remaining' => 700 ) ) );
+
+		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( 0, $this->request_count );
+	}
+
+	/**
+	 * Malformed cached data is ignored in favor of a fresh usable response.
+	 */
+	public function test_get_ai_assistance_feature_ignores_malformed_cache() {
+		$fresh = $this->get_credit_allowance_response();
+		set_transient( $this->get_transient_name(), array( 'has-feature' => true ), MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $fresh );
+
+		$this->assertSame( $fresh, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( $fresh, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
 	 * Forced reads fetch fresh feature data and replace the cache.
 	 */
 	public function test_get_ai_assistance_feature_skip_cache_replaces_cache() {
 		$cached = array( 'requests-count' => 3 );
 		$fresh  = array( 'requests-count' => 4 );
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $fresh );
+
+		$this->assertSame( $fresh, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( $fresh, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * Forced reads replace cached cost-credit data with a fresh paid snapshot.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_replaces_cost_credit_cache() {
+		$cached = $this->get_credit_allowance_response();
+		$fresh  = $this->get_credit_allowance_response(
+			array(
+				'plan-kind'         => 'paid',
+				'credit-limit'      => 10000,
+				'credits-used'      => 350,
+				'credits-remaining' => 9650,
+			)
+		);
 		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
 		$this->mock_wpcom_response( $fresh );
 
@@ -123,6 +171,92 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A malformed successful response is never cached when no usable cache exists.
+	 */
+	public function test_get_ai_assistance_feature_rejects_malformed_response_without_cache() {
+		$this->mock_wpcom_response( array( 'has-feature' => true ) );
+
+		$result = Jetpack_AI_Helper::get_ai_assistance_feature( true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_ai_assistance_feature_response', $result->get_error_code() );
+		$this->assertWPError( get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * An incomplete cost-credit object is not treated as usable status.
+	 */
+	public function test_get_ai_assistance_feature_rejects_incomplete_cost_credit_response() {
+		$response = $this->get_credit_allowance_response();
+		unset( $response['ai-credit-allowance']['resets-at'] );
+		$this->mock_wpcom_response( $response );
+
+		$result = Jetpack_AI_Helper::get_ai_assistance_feature();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_ai_assistance_feature_response', $result->get_error_code() );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * Shadow-only credit data cannot become the active usage contract.
+	 */
+	public function test_get_ai_assistance_feature_rejects_non_authoritative_cost_credit_response() {
+		$response                                        = $this->get_credit_allowance_response();
+		$response['ai-credit-allowance']['authoritative'] = false;
+		$this->mock_wpcom_response( $response );
+
+		$result = Jetpack_AI_Helper::get_ai_assistance_feature();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_ai_assistance_feature_response', $result->get_error_code() );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * A malformed additive allowance is removed from a valid legacy response.
+	 */
+	public function test_get_ai_assistance_feature_strips_malformed_allowance_from_legacy_response() {
+		$response                   = $this->get_credit_allowance_response();
+		$response['requests-count'] = 3;
+		unset( $response['ai-credit-allowance']['resets-at'] );
+		$this->mock_wpcom_response( $response );
+
+		$expected = array( 'requests-count' => 3 );
+		$this->assertSame( $expected, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( $expected, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * A forced refresh within the cooldown returns the usable site cache.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_respects_refresh_cooldown() {
+		$cached = $this->get_credit_allowance_response();
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		set_transient( $this->get_refresh_transient_name(), true, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $this->get_credit_allowance_response( array( 'credits-used' => 300, 'credits-remaining' => 700 ) ) );
+
+		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( 0, $this->request_count );
+	}
+
+	/**
+	 * A forced refresh without usable cache fails closed during the cooldown.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_without_cache_respects_refresh_cooldown() {
+		set_transient( $this->get_refresh_transient_name(), true, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $this->get_credit_allowance_response() );
+
+		$result = Jetpack_AI_Helper::get_ai_assistance_feature( true );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ai_assistance_feature_refresh_rate_limited', $result->get_error_code() );
+		$this->assertSame( 0, $this->request_count );
+	}
+
+	/**
 	 * Forced reads bypass a failure remembered earlier in the request.
 	 */
 	public function test_get_ai_assistance_feature_skip_cache_bypasses_failure_latch() {
@@ -149,6 +283,43 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	 */
 	private function get_transient_name() {
 		return Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID );
+	}
+
+	/**
+	 * Get the feature refresh cooldown transient name.
+	 *
+	 * @return string
+	 */
+	private function get_refresh_transient_name() {
+		return Jetpack_AI_Helper::transient_name_for_ai_assistance_feature_refresh( self::BLOG_ID );
+	}
+
+	/**
+	 * Build a valid versioned cost-credit response.
+	 *
+	 * @param array $overrides Allowance fields to override.
+	 * @return array
+	 */
+	private function get_credit_allowance_response( $overrides = array() ) {
+		return array(
+			'ai-credit-allowance' => array_merge(
+				array(
+					'schema-version'    => 1,
+					'metering-model'    => 'provider-cost-v1',
+					'policy'            => 'jetpack-ai-self-hosted-monthly-v1',
+					'plan-kind'         => 'free',
+					'authoritative'     => true,
+					'credit-limit'      => 1000,
+					'credits-used'      => 250,
+					'credits-remaining' => 750,
+					'period-start'      => '2026-08-01T00:00:00+00:00',
+					'resets-at'         => '2026-09-01T00:00:00+00:00',
+					'rollover'          => false,
+					'is-exhausted'      => false,
+				),
+				$overrides
+			),
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
@@ -86,7 +86,14 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	public function test_get_ai_assistance_feature_uses_cost_credit_cache_by_default() {
 		$cached = $this->get_credit_allowance_response();
 		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
-		$this->mock_wpcom_response( $this->get_credit_allowance_response( array( 'credits-used' => 300, 'credits-remaining' => 700 ) ) );
+		$this->mock_wpcom_response(
+			$this->get_credit_allowance_response(
+				array(
+					'credits-used'      => 300,
+					'credits-remaining' => 700,
+				)
+			)
+		);
 
 		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature() );
 		$this->assertSame( 0, $this->request_count );
@@ -203,7 +210,7 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 	 * Shadow-only credit data cannot become the active usage contract.
 	 */
 	public function test_get_ai_assistance_feature_rejects_non_authoritative_cost_credit_response() {
-		$response                                        = $this->get_credit_allowance_response();
+		$response = $this->get_credit_allowance_response();
 		$response['ai-credit-allowance']['authoritative'] = false;
 		$this->mock_wpcom_response( $response );
 
@@ -236,7 +243,14 @@ class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
 		$cached = $this->get_credit_allowance_response();
 		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
 		set_transient( $this->get_refresh_transient_name(), true, MINUTE_IN_SECONDS );
-		$this->mock_wpcom_response( $this->get_credit_allowance_response( array( 'credits-used' => 300, 'credits-remaining' => 700 ) ) );
+		$this->mock_wpcom_response(
+			$this->get_credit_allowance_response(
+				array(
+					'credits-used'      => 300,
+					'credits-remaining' => 700,
+				)
+			)
+		);
 
 		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
 		$this->assertSame( 0, $this->request_count );

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Jetpack AI Helper unit tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
+
+/**
+ * Class for testing Jetpack_AI_Helper.
+ *
+ * @covers \Jetpack_AI_Helper
+ */
+#[CoversClass( Jetpack_AI_Helper::class )]
+class Jetpack_AI_Helper_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	const BLOG_ID = 1234;
+
+	/**
+	 * Number of mocked WordPress.com requests.
+	 *
+	 * @var int
+	 */
+	private $request_count = 0;
+
+	/**
+	 * Current HTTP mock callback.
+	 *
+	 * @var callable|null
+	 */
+	private $pre_http_request_filter;
+
+	/**
+	 * Set up a connected Jetpack site.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		Jetpack_Options::update_option( 'id', self::BLOG_ID );
+		Jetpack_Options::update_option( 'blog_token', 'blog.secret' );
+		Jetpack_Options::update_option( 'master_user', $user_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'token.secret.' . $user_id ) );
+		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+
+		delete_transient( $this->get_transient_name() );
+		$this->reset_failed_request();
+	}
+
+	/**
+	 * Clean up the mocked connection and cache.
+	 */
+	public function tear_down() {
+		delete_transient( $this->get_transient_name() );
+		$this->remove_wpcom_response_mock();
+		Jetpack_Options::delete_option( array( 'id', 'blog_token', 'master_user', 'user_tokens' ) );
+		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+		wp_set_current_user( 0 );
+		$this->reset_failed_request();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Normal reads use the cached feature response.
+	 */
+	public function test_get_ai_assistance_feature_uses_cache_by_default() {
+		$cached = array( 'requests-count' => 3 );
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( array( 'requests-count' => 4 ) );
+
+		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( 0, $this->request_count );
+	}
+
+	/**
+	 * Forced reads fetch fresh feature data and replace the cache.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_replaces_cache() {
+		$cached = array( 'requests-count' => 3 );
+		$fresh  = array( 'requests-count' => 4 );
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( $fresh );
+
+		$this->assertSame( $fresh, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( $fresh, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * A failed forced refresh leaves a usable cached response intact.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_preserves_cache_on_failure() {
+		$cached = array( 'requests-count' => 3 );
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( array(), 500 );
+
+		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( $cached, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+
+		delete_transient( $this->get_transient_name() );
+		$this->assertWPError( Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( 2, $this->request_count );
+	}
+
+	/**
+	 * A malformed successful response does not replace usable cached data.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_preserves_cache_on_malformed_response() {
+		$cached = array( 'requests-count' => 3 );
+		set_transient( $this->get_transient_name(), $cached, MINUTE_IN_SECONDS );
+		$this->mock_wpcom_response( array( 'has-feature' => true ) );
+
+		$this->assertSame( $cached, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( $cached, get_transient( $this->get_transient_name() ) );
+		$this->assertSame( 1, $this->request_count );
+	}
+
+	/**
+	 * Forced reads bypass a failure remembered earlier in the request.
+	 */
+	public function test_get_ai_assistance_feature_skip_cache_bypasses_failure_latch() {
+		$this->mock_wpcom_response( array(), 500 );
+
+		$failed = Jetpack_AI_Helper::get_ai_assistance_feature();
+		$this->assertWPError( $failed );
+		delete_transient( $this->get_transient_name() );
+
+		$this->remove_wpcom_response_mock();
+		$fresh = array( 'requests-count' => 4 );
+		$this->mock_wpcom_response( $fresh );
+
+		$this->assertSame( $failed, Jetpack_AI_Helper::get_ai_assistance_feature() );
+		$this->assertSame( 1, $this->request_count );
+		$this->assertSame( $fresh, Jetpack_AI_Helper::get_ai_assistance_feature( true ) );
+		$this->assertSame( 2, $this->request_count );
+	}
+
+	/**
+	 * Get the feature cache transient name.
+	 *
+	 * @return string
+	 */
+	private function get_transient_name() {
+		return Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID );
+	}
+
+	/**
+	 * Mock a response from the WordPress.com feature endpoint.
+	 *
+	 * @param mixed $body        Response body.
+	 * @param int   $status_code HTTP status code.
+	 */
+	private function mock_wpcom_response( $body, $status_code = 200 ) {
+		$this->pre_http_request_filter = function ( $preempt, $parsed_args, $url ) use ( $body, $status_code ) {
+			$is_feature_request = false !== strpos( $url, '/sites/' . self::BLOG_ID . '/jetpack-ai/ai-assistant-feature' );
+			if ( 'GET' !== $parsed_args['method'] || ! $is_feature_request ) {
+				return $preempt;
+			}
+
+			++$this->request_count;
+
+			return array(
+				'headers'  => array( 'content-type' => 'application/json' ),
+				'body'     => wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => $status_code,
+					'message' => 200 === $status_code ? 'OK' : 'Server Error',
+				),
+				'cookies'  => array(),
+			);
+		};
+
+		add_filter(
+			'pre_http_request',
+			$this->pre_http_request_filter,
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Remove the current WordPress.com response mock.
+	 */
+	private function remove_wpcom_response_mock() {
+		if ( $this->pre_http_request_filter ) {
+			remove_filter( 'pre_http_request', $this->pre_http_request_filter, 10 );
+			$this->pre_http_request_filter = null;
+		}
+	}
+
+	/**
+	 * Reset the per-request failure latch.
+	 */
+	private function reset_failed_request() {
+		$reflection = new ReflectionClass( Jetpack_AI_Helper::class );
+		$property   = $reflection->getProperty( 'ai_assistant_failed_request' );
+		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
+		// deprecated in 8.5 (a no-op since 8.1), so only call it where it's needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
@@ -200,6 +200,42 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 		$this->assertSame( $credit_response, $response->get_data() );
 	}
 
+	/**
+	 * The local endpoint preserves an authoritative zero-credit response.
+	 */
+	public function test_ai_assistance_feature_route_returns_zero_cost_credit_contract() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		Jetpack_Options::update_option( 'id', self::BLOG_ID );
+
+		$credit_response = array(
+			'ai-credit-allowance' => array(
+				'schema-version'    => 1,
+				'metering-model'    => 'provider-cost-v1',
+				'policy'            => 'jetpack-ai-self-hosted-monthly-v1',
+				'plan-kind'         => 'free',
+				'authoritative'     => true,
+				'credit-limit'      => 0,
+				'credits-used'      => 0,
+				'credits-remaining' => 0,
+				'period-start'      => '2026-08-01T00:00:00+00:00',
+				'resets-at'         => '2026-09-01T00:00:00+00:00',
+				'rollover'          => false,
+				'is-exhausted'      => true,
+			),
+		);
+		set_transient(
+			Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID ),
+			$credit_response,
+			MINUTE_IN_SECONDS
+		);
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::BASIC_ROUTE ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $credit_response, $response->get_data() );
+	}
+
 	public function test_gated_routes_stay_unregistered_when_ai_disabled() {
 		/*
 		 * Force the gate off so the result is independent of the host — on

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
@@ -29,9 +29,17 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 	const BASIC_ROUTE        = '/wpcom/v2/jetpack-ai/ai-assistant-feature';
 	const GATED_ROUTE        = '/wpcom/v2/jetpack-ai/completions';
 	const GATED_IMAGES_ROUTE = '/wpcom/v2/jetpack-ai/images/generations';
+	const BLOG_ID            = 1234;
 
 	const CHAT_SEARCH_ROUTE = '/wpcom/v2/jetpack-search/ai/search';
 	const CHAT_RANK_ROUTE   = '/wpcom/v2/jetpack-search/ai/rank';
+
+	/**
+	 * Current HTTP mock callback.
+	 *
+	 * @var callable|null
+	 */
+	private $pre_http_request_filter;
 
 	/**
 	 * Reset the environment to its original state after the test.
@@ -58,6 +66,14 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 		remove_filter( 'jetpack_ai_enabled', '__return_true' );
 		remove_filter( 'jetpack_ai_chat_enabled', '__return_false' );
 		remove_filter( 'jetpack_ai_chat_enabled', '__return_true' );
+		if ( $this->pre_http_request_filter ) {
+			remove_filter( 'pre_http_request', $this->pre_http_request_filter, 10 );
+			$this->pre_http_request_filter = null;
+		}
+		delete_transient( Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID ) );
+		Jetpack_Options::delete_option( array( 'id', 'blog_token', 'master_user', 'user_tokens' ) );
+		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+		wp_set_current_user( 0 );
 
 		parent::tear_down();
 	}
@@ -92,6 +108,54 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 			$routes,
 			'The ungated jetpack-ai route must register on rest_api_init.'
 		);
+		$this->assertSame( 'boolean', $routes[ self::BASIC_ROUTE ][0]['args']['skip_cache']['type'] );
+		$this->assertFalse( $routes[ self::BASIC_ROUTE ][0]['args']['skip_cache']['default'] );
+	}
+
+	/**
+	 * The REST callback forwards skip_cache to the helper.
+	 */
+	public function test_ai_assistance_feature_route_passes_skip_cache_to_helper() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		Jetpack_Options::update_option( 'id', self::BLOG_ID );
+		Jetpack_Options::update_option( 'blog_token', 'blog.secret' );
+		Jetpack_Options::update_option( 'master_user', $user_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'token.secret.' . $user_id ) );
+		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
+
+		$cached         = array( 'requests-count' => 3 );
+		$fresh          = array( 'requests-count' => 4 );
+		$transient_name = Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID );
+		$request_count  = 0;
+		set_transient( $transient_name, $cached, MINUTE_IN_SECONDS );
+		$this->pre_http_request_filter = static function ( $preempt, $parsed_args, $url ) use ( $fresh, &$request_count ) {
+			$is_feature_request = false !== strpos( $url, '/sites/' . self::BLOG_ID . '/jetpack-ai/ai-assistant-feature' );
+			if ( 'GET' !== $parsed_args['method'] || ! $is_feature_request ) {
+				return $preempt;
+			}
+
+			++$request_count;
+
+			return array(
+				'headers'  => array( 'content-type' => 'application/json' ),
+				'body'     => wp_json_encode( $fresh, JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $this->pre_http_request_filter, 10, 3 );
+
+		$request = new WP_REST_Request( 'GET', self::BASIC_ROUTE );
+		$request->set_param( 'skip_cache', true );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $fresh, $response->get_data() );
+		$this->assertSame( 1, $request_count );
 	}
 
 	public function test_gated_routes_stay_unregistered_when_ai_disabled() {

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
@@ -71,6 +71,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 			$this->pre_http_request_filter = null;
 		}
 		delete_transient( Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID ) );
+		delete_transient( Jetpack_AI_Helper::transient_name_for_ai_assistance_feature_refresh( self::BLOG_ID ) );
 		Jetpack_Options::delete_option( array( 'id', 'blog_token', 'master_user', 'user_tokens' ) );
 		( new Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		wp_set_current_user( 0 );
@@ -156,6 +157,47 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $fresh, $response->get_data() );
 		$this->assertSame( 1, $request_count );
+
+		$coalesced_response = $this->server->dispatch( $request );
+		$this->assertSame( 200, $coalesced_response->get_status() );
+		$this->assertSame( $fresh, $coalesced_response->get_data() );
+		$this->assertSame( 1, $request_count );
+	}
+
+	/**
+	 * The local endpoint passes a versioned cost-credit response through unchanged.
+	 */
+	public function test_ai_assistance_feature_route_returns_cost_credit_contract() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		Jetpack_Options::update_option( 'id', self::BLOG_ID );
+
+		$credit_response = array(
+			'ai-credit-allowance' => array(
+				'schema-version'    => 1,
+				'metering-model'    => 'provider-cost-v1',
+				'policy'            => 'jetpack-ai-self-hosted-monthly-v1',
+				'plan-kind'         => 'free',
+				'authoritative'     => true,
+				'credit-limit'      => 1000,
+				'credits-used'      => 250,
+				'credits-remaining' => 750,
+				'period-start'      => '2026-08-01T00:00:00+00:00',
+				'resets-at'         => '2026-09-01T00:00:00+00:00',
+				'rollover'          => false,
+				'is-exhausted'      => false,
+			),
+		);
+		set_transient(
+			Jetpack_AI_Helper::transient_name_for_ai_assistance_feature( self::BLOG_ID ),
+			$credit_response,
+			MINUTE_IN_SECONDS
+		);
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::BASIC_ROUTE ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $credit_response, $response->get_data() );
 	}
 
 	public function test_gated_routes_stay_unregistered_when_ai_disabled() {

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -389,24 +389,25 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that init() does nothing on a self-hosted site (off the wpcom platform).
+	 * Test that init() wires the sidebar up on a self-hosted site (off the wpcom
+	 * platform) with no override filter in play.
 	 */
-	public function test_init_does_nothing_on_self_hosted() {
+	public function test_init_registers_hooks_on_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		Jetpack_AI_Sidebar::init();
 
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should not be hooked on a self-hosted site.'
+			'register_provider should be hooked on a self-hosted site.'
 		);
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
-			'enable_agents_manager_on_provider_surfaces should not be hooked on a self-hosted site.'
+			'enable_agents_manager_on_provider_surfaces should be hooked on a self-hosted site.'
 		);
-		$this->assertFalse(
+		$this->assertNotFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
-			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
+			'register_toolbar_button_extension should be hooked on a self-hosted site.'
 		);
 	}
 
@@ -464,15 +465,16 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The preview gate is closed off the WordPress.com platform, even with Big Sky present.
+	 * The preview gate is open off the WordPress.com platform by default, without
+	 * Big Sky taking any part in the decision.
 	 */
-	public function test_preview_disabled_on_self_hosted() {
+	public function test_preview_enabled_on_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '1' );
+		update_option( 'big_sky_enable', '0' );
 
-		$this->assertFalse( $this->gate_open() );
+		$this->assertTrue( $this->gate_open() );
 	}
 
 	/**
@@ -517,9 +519,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The jetpack_ai_sidebar_enabled filter overrides the gate in both directions.
 	 */
 	public function test_preview_filter_overrides_gate() {
-		// Gate is closed off-platform; the filter forces it on.
+		// Gate is closed on Atomic with Big Sky present but its setting absent;
+		// the filter forces it on.
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_self_hosted();
+		$this->simulate_wpcom_platform();
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '0' );
+		$this->assertFalse( $this->gate_open() );
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
 		$this->assertTrue( $this->gate_open() );
 
@@ -527,6 +533,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_wpcom_simple();
 		$this->simulate_big_sky_class();
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+		$this->assertFalse( $this->gate_open() );
+
+		// The same override remains the opt-out for the newly enabled self-hosted default.
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		$this->assertFalse( $this->gate_open() );
 	}
@@ -1953,10 +1965,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_sidebar_asset_data_skips_enqueue_when_fetch_fails() {
 		$this->set_block_editor_screen();
+		$request_count = 0;
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
-			function () {
+			function () use ( &$request_count ) {
+				++$request_count;
 				return new WP_Error( 'blocked', 'No HTTP.' );
 			}
 		);
@@ -1967,6 +1981,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
 		$this->assertCount( 0, $providers );
+		$this->assertSame( 1, $request_count, 'A failed manifest fetch should be cached briefly.' );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -1974,9 +1989,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test full flow: init, simulate AM filter, verify provider registered.
+	 * Test full flow on a self-hosted site with no override filter: init() wires
+	 * the provider, the Agents Manager block-editor gate, and the data payload.
 	 */
 	public function test_full_flow_with_default_enabled() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
 		$this->set_block_editor_screen();
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
@@ -1984,7 +2002,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$providers = apply_filters( 'agents_manager_agent_providers', array() );
 
 		$this->assertCount( 1, $providers );
-		$this->assert_jetpack_provider_url( $providers[0] );
+		$this->assertSame( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL, $providers[0] );
+
+		$this->assertTrue(
+			apply_filters( 'agents_manager_enabled_in_block_editor', false ),
+			'The Agents Manager block-editor gate should open on a self-hosted site.'
+		);
+
+		$data = apply_filters(
+			'jetpack_ai_sidebar_agents_manager_data',
+			array( 'sectionName' => 'gutenberg' )
+		);
+
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -389,25 +389,24 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that init() wires the sidebar up on a self-hosted site (off the wpcom
-	 * platform) with no override filter in play.
+	 * Test that init() does nothing on a self-hosted site (off the wpcom platform).
 	 */
-	public function test_init_registers_hooks_on_self_hosted() {
+	public function test_init_does_nothing_on_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		Jetpack_AI_Sidebar::init();
 
-		$this->assertNotFalse(
+		$this->assertFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should be hooked on a self-hosted site.'
+			'register_provider should not be hooked on a self-hosted site.'
 		);
-		$this->assertNotFalse(
+		$this->assertFalse(
 			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
-			'enable_agents_manager_on_provider_surfaces should be hooked on a self-hosted site.'
+			'enable_agents_manager_on_provider_surfaces should not be hooked on a self-hosted site.'
 		);
-		$this->assertNotFalse(
+		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
-			'register_toolbar_button_extension should be hooked on a self-hosted site.'
+			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
 		);
 	}
 
@@ -465,16 +464,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The preview gate is open off the WordPress.com platform by default, without
-	 * Big Sky taking any part in the decision.
+	 * The preview gate is closed off the WordPress.com platform, even with Big Sky present.
 	 */
-	public function test_preview_enabled_on_self_hosted() {
+	public function test_preview_disabled_on_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '0' );
+		update_option( 'big_sky_enable', '1' );
 
-		$this->assertTrue( $this->gate_open() );
+		$this->assertFalse( $this->gate_open() );
 	}
 
 	/**
@@ -519,13 +517,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The jetpack_ai_sidebar_enabled filter overrides the gate in both directions.
 	 */
 	public function test_preview_filter_overrides_gate() {
-		// Gate is closed on Atomic with Big Sky present but its setting absent;
-		// the filter forces it on.
+		// Gate is closed off-platform; the filter forces it on.
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_wpcom_platform();
-		$this->simulate_big_sky_class();
-		update_option( 'big_sky_enable', '0' );
-		$this->assertFalse( $this->gate_open() );
+		$this->simulate_self_hosted();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
 		$this->assertTrue( $this->gate_open() );
 
@@ -533,12 +527,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_wpcom_simple();
 		$this->simulate_big_sky_class();
-		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
-		$this->assertFalse( $this->gate_open() );
-
-		// The same override remains the opt-out for the newly enabled self-hosted default.
-		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_self_hosted();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		$this->assertFalse( $this->gate_open() );
 	}
@@ -1965,12 +1953,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_sidebar_asset_data_skips_enqueue_when_fetch_fails() {
 		$this->set_block_editor_screen();
-		$request_count = 0;
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
-			function () use ( &$request_count ) {
-				++$request_count;
+			function () {
 				return new WP_Error( 'blocked', 'No HTTP.' );
 			}
 		);
@@ -1981,7 +1967,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
 		$this->assertCount( 0, $providers );
-		$this->assertSame( 1, $request_count, 'A failed manifest fetch should be cached briefly.' );
 	}
 
 	// ──────────────────────────────────────────────────
@@ -1989,12 +1974,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test full flow on a self-hosted site with no override filter: init() wires
-	 * the provider, the Agents Manager block-editor gate, and the data payload.
+	 * Test full flow: init, simulate AM filter, verify provider registered.
 	 */
 	public function test_full_flow_with_default_enabled() {
-		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
-		$this->simulate_self_hosted();
 		$this->set_block_editor_screen();
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
@@ -2002,19 +1984,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$providers = apply_filters( 'agents_manager_agent_providers', array() );
 
 		$this->assertCount( 1, $providers );
-		$this->assertSame( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL, $providers[0] );
-
-		$this->assertTrue(
-			apply_filters( 'agents_manager_enabled_in_block_editor', false ),
-			'The Agents Manager block-editor gate should open on a self-hosted site.'
-		);
-
-		$data = apply_filters(
-			'jetpack_ai_sidebar_agents_manager_data',
-			array( 'sectionName' => 'gutenberg' )
-		);
-
-		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
+		$this->assert_jetpack_provider_url( $providers[0] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -394,6 +394,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_init_does_nothing_on_unproxied_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '0';
 		Jetpack_AI_Sidebar::init();
 
 		$this->assertFalse(
@@ -492,6 +493,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_preview_disabled_on_unproxied_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '0';
 		$this->simulate_big_sky_class();
 		update_option( 'big_sky_enable', '1' );
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -389,24 +389,47 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that init() does nothing on a self-hosted site (off the wpcom platform).
+	 * Test that init() does nothing on an unproxied self-hosted site.
 	 */
-	public function test_init_does_nothing_on_self_hosted() {
+	public function test_init_does_nothing_on_unproxied_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		Jetpack_AI_Sidebar::init();
 
 		$this->assertFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should not be hooked on a self-hosted site.'
+			'register_provider should not be hooked on an unproxied self-hosted site.'
 		);
 		$this->assertFalse(
 			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
-			'enable_agents_manager_on_provider_surfaces should not be hooked on a self-hosted site.'
+			'enable_agents_manager_on_provider_surfaces should not be hooked on an unproxied self-hosted site.'
 		);
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
 			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
+		);
+	}
+
+	/**
+	 * Test that init() wires the sidebar up on a proxied self-hosted site.
+	 */
+	public function test_init_registers_hooks_on_proxied_self_hosted() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		Jetpack_AI_Sidebar::init();
+
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should be hooked on a proxied self-hosted site.'
+		);
+		$this->assertNotFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should be hooked on a proxied self-hosted site.'
+		);
+		$this->assertNotFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should be hooked on a proxied self-hosted site.'
 		);
 	}
 
@@ -464,15 +487,28 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The preview gate is closed off the WordPress.com platform, even with Big Sky present.
+	 * The preview gate stays closed on unproxied self-hosted sites, even with Big Sky present.
 	 */
-	public function test_preview_disabled_on_self_hosted() {
+	public function test_preview_disabled_on_unproxied_self_hosted() {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_self_hosted();
 		$this->simulate_big_sky_class();
 		update_option( 'big_sky_enable', '1' );
 
 		$this->assertFalse( $this->gate_open() );
+	}
+
+	/**
+	 * The preview gate opens on proxied self-hosted sites even when Big Sky is disabled.
+	 */
+	public function test_preview_enabled_on_proxied_self_hosted() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$this->simulate_big_sky_class();
+		update_option( 'big_sky_enable', '0' );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$this->assertTrue( $this->gate_open() );
 	}
 
 	/**
@@ -527,6 +563,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		$this->simulate_wpcom_simple();
 		$this->simulate_big_sky_class();
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
+		$this->assertFalse( $this->gate_open() );
+
+		// The filter remains the opt-out for the proxied self-hosted default.
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 		$this->assertFalse( $this->gate_open() );
 	}
@@ -1974,9 +2017,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test full flow: init, simulate AM filter, verify provider registered.
+	 * Test the proxied self-hosted default from init through the Agents Manager payload.
 	 */
 	public function test_full_flow_with_default_enabled() {
+		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
+		$this->simulate_self_hosted();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->set_block_editor_screen();
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
@@ -1985,6 +2031,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $providers );
 		$this->assert_jetpack_provider_url( $providers[0] );
+		$this->assertTrue( apply_filters( 'agents_manager_enabled_in_block_editor', false ) );
+
+		$data = apply_filters(
+			'jetpack_ai_sidebar_agents_manager_data',
+			array( 'sectionName' => 'gutenberg' )
+		);
+
+		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

* Accept an additive, versioned `ai-credit-allowance` status from WordPress.com for connected sites while preserving the legacy request-based response.
* Accept only the authoritative schema-v1 monthly cost-credit contract. Invalid additive data is removed when a usable legacy response is available; otherwise malformed HTTP 200 responses fail closed and are never cached as status.
* Accept an authoritative exhausted allowance with `credit-limit: 0`, while continuing to reject negative limits and inconsistent remaining/exhausted values.
* Preserve the last usable site snapshot when a forced refresh fails or returns malformed data.
* Add a five-second, site-scoped cooldown for forced refreshes so repeated status reads reuse the usable cache instead of repeatedly contacting WordPress.com.
* Cover Free, paid, and zero-credit snapshots; legacy compatibility; shadow-only rejection; malformed responses; cache replacement; and cooldown behavior in helper and REST endpoint tests.

This PR is stacked on #51297. It only changes the connected-site transport path: the `IS_WPCOM` response branch, WordPress.com plan metering, Jetpack AI eligibility, and server-side enforcement are unchanged.

The new contract is deliberately versioned and fail-closed. During rollout, WordPress.com must continue including the legacy `requests-count` fields for unsupported clients, or emit credit-only responses only to compatible Jetpack versions. The cached status is explanatory; server-side admission and enforcement remain authoritative.

## Related product discussion/links

* Depends on #51297.
* Relate to https://github.com/Automattic/wp-calypso/pull/113914

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Run the focused helper and REST endpoint tests:

```sh
jp docker phpunit jetpack -- --filter='(Jetpack_AI_Helper_Test|WPCOM_REST_API_V2_Endpoint_AI_Test)'
```

Run static and coding-standard checks:

```sh
jp phan plugins/jetpack
jp composer phpcs:changed -- projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai.php projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_AI_Helper_Test.php projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
jp pnpm run lint-changed
```

Local verification:

* PHPUnit: 24 tests, 73 assertions.
* Phan: 0 issues.
* PHP syntax, PHPCS, changed-file lint, filename-collision, and changelog checks passed.

For a connected test site whose WordPress.com status endpoint emits the new contract:

1. Request `GET /wp-json/wpcom/v2/jetpack-ai/ai-assistant-feature` and confirm the authoritative `ai-credit-allowance` object is returned unchanged, including an exhausted `0 / 0 / 0` allowance.
2. Request the route twice with `skip_cache=true` within five seconds. Confirm the second response returns the same usable cached status without another upstream request.
3. Confirm a legacy response containing `requests-count` still passes through unchanged when no allowance is present.
