### PR TITLE
Omnibar: guard /wpcom/v2/admin-bar endpoint against null $wp_admin_bar

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -85,8 +85,6 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		global $wp_admin_bar;
-
 		if ( ! class_exists( 'WP_Screen' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/class-wp-screen.php';
 		}
@@ -106,21 +104,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 		// Simulate a wp-admin context.
 		set_current_screen( 'dashboard' );
 
-		add_filter( 'show_admin_bar', '__return_true', 999 );
-
 		// Core only adds the command palette node when its assets are enqueued,
 		// which normally happens on admin_enqueue_scripts.
 		if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
 			wp_enqueue_command_palette_assets();
 		}
 
-		_wp_admin_bar_init();
-
-		ob_start();
-		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
-		ob_clean();
-
-		$nodes          = $wp_admin_bar->get_nodes() ?? array();
+		$nodes          = $this->get_nodes();
 		$filtered_nodes = $this->filter_nodes( $nodes, self::ALLOWED_TOP_LEVEL_NODES );
 
 		$response = rest_ensure_response( array( 'nodes' => array_values( $filtered_nodes ) ) );
@@ -130,6 +120,26 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Builds the admin bar for the current request and returns its nodes.
+	 *
+	 * @return array Admin bar nodes.
+	 */
+	private function get_nodes() {
+		global $wp_admin_bar;
+
+		add_filter( 'show_admin_bar', '__return_true', 999 );
+		if ( ! _wp_admin_bar_init() || ! $wp_admin_bar instanceof WP_Admin_Bar ) {
+			return array();
+		}
+
+		ob_start();
+		do_action_ref_array( 'admin_bar_menu', array( &$wp_admin_bar ) );
+		ob_end_clean();
+
+		return $wp_admin_bar->get_nodes() ?? array();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-admin-bar-null-guard
+++ b/projects/plugins/jetpack/changelog/fix-admin-bar-null-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin bar: fix a fatal error in the admin bar endpoint global $wp_admin_bar is null.


### PR DESCRIPTION
Fixes p1787917943246709/1787917656.603359-slack-C4N88L95W

## Proposed changes

When calling the `/wpcom/v2/admin-bar` endpoint, there might be certain cases where the global $wp_admin_bar instance is null. In the normal endpoint usage, this shouldn't happen, so I'm guarding it first to stop the fatal, and I'll see how it could be ever null.

## Related product discussion/links


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Patch this PR to your sandbox as instructed.
2. Go to my.wordpress.com.
3. Click a site.
4. Verify the omnibar is shown without any error (no regression).