### PR TITLE
wpcomsh: add WORDPRESS_LABS feature slug to WPCOM_Features

### DIFF
--- a/projects/plugins/wpcomsh/changelog/dotprod-175-wordpress-labs-wpcomsh-features
+++ b/projects/plugins/wpcomsh/changelog/dotprod-175-wordpress-labs-wpcomsh-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add WORDPRESS_LABS feature slug to WPCOM_Features, gated by the wordpress-labs blog sticker.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -541,6 +541,7 @@ class WPCOM_Features {
 	public const WOOP                              = 'woop';
 	public const WORDADS                           = 'wordads';
 	public const WORDADS_JETPACK                   = 'wordads-jetpack';
+	public const WORDPRESS_LABS                    = 'wordpress-labs';
 
 	/*
 	 * Private const array of features with sub-array of purchases that include that feature. Sorted alphabetically.
@@ -1763,6 +1764,18 @@ class WPCOM_Features {
 		self::WORDADS_JETPACK                   => array(
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_PREMIUM_AND_HIGHER,
+		),
+
+		/*
+		 * WORDPRESS_LABS - unlocked purely by the `wordpress-labs` blog sticker, independent of any
+		 * purchase.
+		 */
+		self::WORDPRESS_LABS                    => array(
+			array(
+				'required_sticker' => 'wordpress-labs',
+				self::WPCOM_ALL_SITES,
+				self::JETPACK_ALL_SITES,
+			),
 		),
 	);
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* Mirror the WPCOM-side `WPCOM_Features::WORDPRESS_LABS` entry into wpcomsh's copy of `class-wpcom-features.php`, granted purely by the `wordpress-labs` blog sticker, independent of plan — same shape as the existing `flex-cache-site`/`gating-business-q1` sticker-gated entries in this file.
* This file's own docblock requires it to stay verbatim-identical between WPCOM and wpcomsh ("If you make any changes to this class you must MANUALLY update this file in both WPCOM and WPCOMSH"). Without this mirror, `Current_Plan::supports( 'wordpress-labs' )` on Atomic sites resolves through wpcomsh's own local `wpcom_site_has_feature()`/`wpcom_feature_exists()` (not a network call), so it would keep returning `false` on Atomic even after the WPCOM-side PR deploys.
* `Current_Plan::get()['features']['active']` is *not* affected by this gap — it's a pure value synced from the WPCOM-side `/sites/%d` API response — but `supports()` is a much more commonly reached-for entry point across Jetpack, so this closes the gap at the source rather than leaving it as a footgun for future consumers.

## Related product discussion/links
* DOTPROD-175 (Get features added to WordPress Labs)
* DOTPROD-158 (WordPress Labs opt-in entry point) — Automattic/wp-calypso#113597
* This is a draft: the paired WPCOM-side `WPCOM_Features`/`atomic_site_stickers()` change hasn't merged/deployed yet, so `wordpress-labs` isn't a real feature end-to-end until both land.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Add the `wordpress-labs` sticker to an Atomic test site (via WPCOM, once the paired WPCOM-side PR is deployed):
  ```php
  add_blog_sticker( 'wordpress-labs', 'manual test', null, $blog_id );
  ```
* On the Atomic site, force a refresh and confirm the feature is picked up:
  ```bash
  wp eval 'Automattic\Jetpack\Current_Plan::refresh_from_wpcom(); var_dump( Automattic\Jetpack\Current_Plan::supports( "wordpress-labs" ) );'
  ```
  Should return `bool(true)`. Before this PR (wpcomsh copy missing the entry), this returns `false` even with the sticker present and the WPCOM side deployed.
* `composer phpcs:changed -- projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php` passes clean.
* No existing automated test suite covers this file in wpcomsh (it's a manually-synced mirror of the WPCOM copy, which does have coverage under `bin/tests/isolated/suites/Features/ClassWpcomFeaturesTest.php` on the WPCOM side) — verification here is manual/live, as above.
