### PR TITLE
Forms: keep flagged conditional logic out of the Jetpack changelog, and restore the dropped 7.25.0 line

### DIFF
--- a/projects/packages/forms/CHANGELOG.md
+++ b/projects/packages/forms/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.25.0] - 2026-08-20
 ### Added
 - Add a Print action to form responses, which opens the response on its own page and prints just the response. [#51368]
+- Add conditional logic to form fields, so any field can be shown or hidden based on another field's answer. Disabled by default while in testing; enable it with the forms-conditional-logic feature flag. [#50938]
 - Contact Form: Add background image support to the Form and Step blocks. [#50975]
 - Feedback author avatars: Pick a stable Color Studio background color per email for initials identity avatars via `bg_color`. [#50578]
 

--- a/projects/packages/forms/changelog/fix-forms-changelog-restore-conditional-logic
+++ b/projects/packages/forms/changelog/fix-forms-changelog-restore-conditional-logic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Restore the conditional logic entry to the 7.25.0 CHANGELOG section; it was dropped when that release was cut. Documentation only, no code change.
+
+

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-duplicate-field-ids
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-duplicate-field-ids
@@ -1,4 +1,5 @@
 Significance: patch
-Type: bugfix
+Type: other
+Comment: Conditional logic is behind the forms-conditional-logic feature flag, off by default, so this fix is not reachable by Jetpack users yet.
 
-Forms: Explain when fields share a Name/ID rather than offering them as conditional logic conditions that cannot be told apart.
+

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-feedback
@@ -1,4 +1,5 @@
 Significance: patch
-Type: bugfix
+Type: other
+Comment: Conditional logic is behind the forms-conditional-logic feature flag, off by default, so this fix is not reachable by Jetpack users yet.
 
-Forms: Name a checkbox by its own label when building conditional logic, keep a value typed before the field was chosen, and show an unticked checkbox as "No" rather than a blank.
+

--- a/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-modal-sidebar-closed
+++ b/projects/plugins/jetpack/changelog/fix-forms-conditional-logic-modal-sidebar-closed
@@ -1,4 +1,5 @@
 Significance: patch
-Type: bugfix
+Type: other
+Comment: Conditional logic is behind the forms-conditional-logic feature flag, off by default, so this fix is not reachable by Jetpack users yet.
 
-Forms: Fix the conditional logic rules dialog not opening from the block toolbar while the settings sidebar is closed.
+


### PR DESCRIPTION
## Proposed changes

Two related changelog corrections around Forms conditional logic. Both are documentation only — no code changes, so there is nothing to build or run.

**Keep the flagged feature quiet in the Jetpack plugin changelog.**

Conditional logic ships behind the `forms-conditional-logic` feature flag, registered with `'default' => false` in `projects/packages/forms/src/class-jetpack-forms.php`. A site owner can't reach any of it. The feature PR (50938) recognized that and filed a silent `Type: other` entry for `plugins/jetpack`, so the plugin changelog says nothing about the feature.

The three follow-up fixes since then didn't follow suit — they landed as user-facing `Type: bugfix` entries. Left alone, the next Jetpack release would ship three lines describing a rules dialog, a conditions dropdown, and duplicate Name/ID handling for a feature its changelog has never mentioned and no user can open.

This makes those three silent, matching what 50938 chose. The `packages/forms` entries are untouched and still announce normally, so the package CHANGELOG keeps documenting the work.

**Restore the line dropped from the packages/forms 7.25.0 section.**

The 16.2-a.1 release (`3f6d67ce26`) consumed `try-conditional-form-fields` out of `packages/forms/changelog/` but never wrote it into `CHANGELOG.md`. The release that actually shipped conditional logic documents it nowhere — and the lost sentence is the one that explained the flag. Restored verbatim, PR reference included.

**One thing to check before merging.** That release pass consumed 21 forms entries and wrote 19 lines' worth. The two it skipped were the only two describing something invisible to users: this one, and the email open Tracks `blog_id` fix from PR 51193. Five neighboring releases dropped nothing at all (16.2-a.3 wrote 8 of 8), and the same pass demonstrably reworded other entries by hand. That pattern reads as a deliberate editorial call, not a tooling fault. If it was one, this commit reverses it — happy to drop the second commit if the release side prefers it stay out. The 51193 entry is deliberately left alone here.

## Related product discussion/links

* Follows up on PR 50938, PR 51417, PR 51617, and PR 51193.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is no runtime behavior to test. To verify the changelog files themselves:

* Check out this branch.
* Run `jetpack changelog validate plugins/jetpack` and `jetpack changelog validate packages/forms`. Both should pass.
* Confirm the three `projects/plugins/jetpack/changelog/fix-forms-conditional-logic-*` files are `Type: other` with an empty entry and a Comment. `other` is defined in the plugin's `composer.json` as not copied to `readme.txt`, so these stay out of the user-facing changelog.
* Confirm the matching `projects/packages/forms/changelog/fix-forms-conditional-logic-*` files are unchanged and still `Type: fixed`.
* Confirm the 7.25.0 Added section of `projects/packages/forms/CHANGELOG.md` now lists the conditional logic entry, alphabetically between the Print action and Contact Form lines.
