### PR TITLE
Connection: explain a duplicate store registration instead of just reporting it

### DIFF
--- a/projects/js-packages/connection/changelog/fix-connection-store-duplicate-message
+++ b/projects/js-packages/connection/changelog/fix-connection-store-duplicate-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Explain what to do when the connection store is registered more than once.

--- a/projects/js-packages/connection/state/store-holder.jsx
+++ b/projects/js-packages/connection/state/store-holder.jsx
@@ -1,13 +1,62 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
+
+/**
+ * Explains a duplicate registration, which is a build problem rather than a
+ * runtime one.
+ *
+ * `@wordpress/data`'s own message — `Store "x" is already registered.` — says
+ * what happened but not why or what to do about it, and the cause is never
+ * where the message points: no code registered the store twice. Two scripts
+ * each bundled their own copy of this package, and each copy ran its own
+ * registration on import.
+ *
+ * @param {string} storeId - The store that was already registered.
+ * @return {string} The message to log.
+ */
+function duplicateRegistrationMessage( storeId ) {
+	return [
+		`Jetpack Connection: the "${ storeId }" store was already registered by another script on this page, so this copy was skipped.`,
+		'',
+		'Nothing is broken — the first registration is used — but two scripts on this page have each bundled their own copy of @automattic/jetpack-connection, so the package ships to visitors more than once.',
+		'',
+		'The usual cause is a subpath import. The webpack externals map matches the package root only, so:',
+		"  import { useConnection } from '@automattic/jetpack-connection';        // shared, loaded once",
+		"  import useConnection from '@automattic/jetpack-connection/use-connection'; // bundled into this script",
+		'',
+		'To fix: import from the package root, then rebuild. If the symbol is not exported there, add it to the package index rather than reaching for the subpath.',
+		'See defaultRequestMap in js-packages/webpack-config/src/webpack.js for the mapping.',
+	].join( '\n' );
+}
 
 class storeHolder {
 	static store = null;
 
 	static mayBeInit( storeId, storeConfig ) {
-		if ( null === storeHolder.store ) {
-			storeHolder.store = createReduxStore( storeId, storeConfig );
-			register( storeHolder.store );
+		if ( null !== storeHolder.store ) {
+			return;
 		}
+
+		/*
+		 * This guard is module state, so it only covers this copy of the
+		 * package. The registry it protects is global and shared by every
+		 * script on the page, so ask the registry rather than trusting the
+		 * guard alone.
+		 */
+		if ( select( storeId ) ) {
+			// eslint-disable-next-line no-console
+			console.error( duplicateRegistrationMessage( storeId ) );
+
+			/*
+			 * Mark this copy as done without registering. `register` would keep
+			 * the existing store and log its own, less useful message on top of
+			 * this one.
+			 */
+			storeHolder.store = createReduxStore( storeId, storeConfig );
+			return;
+		}
+
+		storeHolder.store = createReduxStore( storeId, storeConfig );
+		register( storeHolder.store );
 	}
 }
 

--- a/projects/js-packages/connection/state/test/store-holder.jsx
+++ b/projects/js-packages/connection/state/test/store-holder.jsx
@@ -1,0 +1,89 @@
+import { jest } from '@jest/globals';
+
+const createReduxStore = jest.fn( ( name, config ) => ( { name, ...config } ) );
+const register = jest.fn();
+const select = jest.fn();
+
+jest.unstable_mockModule( '@wordpress/data', () => ( {
+	__esModule: true,
+	createReduxStore,
+	register,
+	select,
+} ) );
+
+const { default: storeHolder } = await import( '../store-holder' );
+
+const STORE_ID = 'jetpack-connection';
+const CONFIG = { reducer: () => ( {} ) };
+
+describe( 'storeHolder.mayBeInit', () => {
+	let error;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		storeHolder.store = null;
+		error = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		error.mockRestore();
+	} );
+
+	test( 'registers the store when nothing has registered it yet', () => {
+		select.mockReturnValue( undefined );
+
+		storeHolder.mayBeInit( STORE_ID, CONFIG );
+
+		expect( register ).toHaveBeenCalledTimes( 1 );
+		expect( error ).not.toHaveBeenCalled();
+	} );
+
+	test( 'registers only once for repeated calls from the same copy', () => {
+		select.mockReturnValue( undefined );
+
+		storeHolder.mayBeInit( STORE_ID, CONFIG );
+		storeHolder.mayBeInit( STORE_ID, CONFIG );
+
+		expect( register ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	/*
+	 * Another bundle's copy got there first. The module-scope guard cannot see
+	 * that, which is the whole reason this path exists.
+	 */
+	describe( 'when another copy of the package already registered the store', () => {
+		beforeEach( () => {
+			select.mockReturnValue( { someSelector: () => {} } );
+		} );
+
+		test( 'does not register again', () => {
+			storeHolder.mayBeInit( STORE_ID, CONFIG );
+
+			expect( register ).not.toHaveBeenCalled();
+		} );
+
+		test( 'explains the cause and the fix rather than only the symptom', () => {
+			storeHolder.mayBeInit( STORE_ID, CONFIG );
+
+			expect( error ).toHaveBeenCalledTimes( 1 );
+
+			const message = error.mock.calls[ 0 ][ 0 ];
+
+			// Names the store, so it is greppable.
+			expect( message ).toContain( STORE_ID );
+			// Says it is a bundling problem, not a runtime break.
+			expect( message ).toContain( 'bundled their own copy' );
+			// Points at the actual cause and the fix.
+			expect( message ).toContain( 'subpath import' );
+			expect( message ).toContain( "from '@automattic/jetpack-connection'" );
+		} );
+
+		test( 'still leaves this copy initialised, so it does not warn again', () => {
+			storeHolder.mayBeInit( STORE_ID, CONFIG );
+			storeHolder.mayBeInit( STORE_ID, CONFIG );
+
+			expect( error ).toHaveBeenCalledTimes( 1 );
+			expect( storeHolder.store ).not.toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

Open the block editor on a Jetpack site and the console fills with:

```
Store "jetpack-connection" is already registered.
```

Nine times on a plain page editor, on this test site. The message is `@wordpress/data`'s, and it is accurate but unhelpful: it says what happened, not why, and the cause is never where it points — no code registers the store twice. Two scripts each *bundled their own copy* of `@automattic/jetpack-connection`, and each copy ran its own registration on import.

That is a build-configuration mistake, and nothing in the message suggests it. This replaces it with an explanation:

```
Jetpack Connection: the "jetpack-connection" store was already registered by another
script on this page, so this copy was skipped.

Nothing is broken — the first registration is used — but two scripts on this page have
each bundled their own copy of @automattic/jetpack-connection, so the package ships to
visitors more than once.

The usual cause is a subpath import. The webpack externals map matches the package root
only, so:
  import { useConnection } from '@automattic/jetpack-connection';        // shared, loaded once
  import useConnection from '@automattic/jetpack-connection/use-connection'; // bundled into this script

To fix: import from the package root, then rebuild. If the symbol is not exported there,
add it to the package index rather than reaching for the subpath.
See defaultRequestMap in js-packages/webpack-config/src/webpack.js for the mapping.
```

### Why the old guard could not work

`storeHolder.mayBeInit()` guarded registration with `static store = null` — module-scope state protecting a **global** registry. That is only a valid guard if there is exactly one copy of the module on the page, and in WP admin there is not: `@wordpress/data` is an external shared through `wp.data`, while `@automattic/jetpack-connection` gets inlined into every bundle that imports it by a path the externals map does not match. Each copy sees its own `null` and registers. The registry is global; the guard was local.

The guard now asks the registry:

```js
if ( select( storeId ) ) { … }
```

`select()` returns `undefined` for an unregistered store and does not warn, so it is a safe existence check.

### This is behaviour-preserving

Worth stating explicitly, because "skip a store registration" sounds risky. WP core's `registerStoreInstance` already ignores duplicates:

```js
if ( stores[ name ] ) {
	console.error( 'Store "' + name + '" is already registered.' );
	return stores[ name ];
}
```

It keeps the first store and returns it — it never overwrites. So the second `register()` call was only ever producing a log line. Skipping it yields the identical runtime state and means `@wordpress/data` no longer emits its own message on top of ours: one message instead of two, and the useful one.

Kept at `console.error` deliberately. Nothing breaks at runtime, but the package really does ship to visitors more than once, and the text says so rather than implying breakage. `warn` would make it easy to filter out and leave forever.

### Scope

This makes the problem **diagnosable, not fixed.** All nine duplicates remain. The actual fix is converting the subpath imports to package-root imports — currently 21 across the monorepo:

```
12  @automattic/jetpack-connection/use-connection
 6  @automattic/jetpack-connection/hooks/use-product-checkout-workflow
 2  @automattic/jetpack-connection/use-connection-error-notice
 1  @automattic/jetpack-connection/state/store-id
```

That is a larger change with a real caveat — externalising means every consumer shares one runtime version, where today a subpath importer gets its own compiled-in copy — so it belongs in its own PR, done deliberately rather than with a blanket find-and-replace. This PR makes sure whoever picks it up learns what to do from the console instead of from an archaeology session.

There is precedent for the destination, too: `defaultRequestMap` already notes of a sibling package that "the shared data stores are externalized into a single bundle so they register exactly once. The package exposes only its barrel entry, so a single mapping covers every consumer." Connection allows subpaths, so it never got that protection.

## Other information

- [x] Have you written new tests for your changes, if applicable?
- [x] Have you checked for TypeScript, React or other console errors?

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Jetpack-connected site, open **Posts → Add new** with the browser console open.
* Before this change: several `Store "jetpack-connection" is already registered.` lines from `@wordpress/data`.
* After: no such lines. Instead, the same number of Jetpack Connection messages explaining that a second copy was skipped, what causes it, and how to fix it.
* Confirm the connection UI still works — the store is still registered exactly once, by whichever copy loaded first. My Jetpack, the connection status card, and the disconnect dialog all read from it.

Verified on a Jurassic Ninja site: the generic message went from 9 occurrences to 0, replaced by 9 of the explanatory one, with no change to connection behaviour.
