### PR TITLE
JITM: fall back to the jetpack/v4 route when wpcom/v3 is missing

### DIFF
--- a/projects/packages/jitm/changelog/fix-jitm-endpoint-fallback
+++ b/projects/packages/jitm/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load messages from the jetpack/v4 route when wpcom/v3 is unavailable, fixing missing messages and a console error on sites without the Jetpack plugin.

--- a/projects/packages/jitm/src/js/jetpack-jitm.js
+++ b/projects/packages/jitm/src/js/jetpack-jitm.js
@@ -8,6 +8,41 @@ domReady( function() {
     // Site ID will be automatically added to the request.
     const JITM_ENDPOINT_URL = `/wpcom/v3/jitm`;
 
+    /*
+     * The wpcom/v3 route above is served by WordPress.com on Simple sites and by the
+     * Jetpack plugin on connected self-hosted sites. Standalone Jetpack plugins ship
+     * this script but not that route, so fall back to the one this package registers
+     * for itself in Rest_Api_Endpoints.
+     */
+    const JITM_FALLBACK_ENDPOINT_URL = `/jetpack/v4/jitm`;
+
+    // The route that answered last, reused for dismissals and later fetches.
+    let jitmEndpointUrl = JITM_ENDPOINT_URL;
+
+    const isMissingRoute = function(error) {
+        return !!error && ('rest_no_route' === error.code || 404 === error?.data?.status);
+    };
+
+    const fetchJitms = function(queryArgs) {
+        const request = function(path) {
+            return apiFetch({
+                path: addQueryArgs(path, queryArgs),
+                method: 'GET',
+            });
+        };
+
+        return request(jitmEndpointUrl).catch(function(error) {
+            if (jitmEndpointUrl !== JITM_ENDPOINT_URL || !isMissingRoute(error)) {
+                throw error;
+            }
+
+            // Remember the working route so subsequent fetches skip the 404.
+            jitmEndpointUrl = JITM_FALLBACK_ENDPOINT_URL;
+
+            return request(jitmEndpointUrl);
+        });
+    };
+
     const templates = {
         default: function(envelope) {
             const EXTERNAL_LINK_ICON = `
@@ -172,12 +207,15 @@ domReady( function() {
                 templateEl.style.display = 'none';
 
                 apiFetch({
-                    path: JITM_ENDPOINT_URL,
+                    path: jitmEndpointUrl,
                     method: 'POST',
                     data: {
                         id: response.id,
                         feature_class: response.feature_class,
                     },
+                }).catch(function() {
+                    // The banner is already hidden locally, so a failed dismissal
+                    // is not worth surfacing to the user.
                 });
             });
         }
@@ -333,19 +371,21 @@ domReady( function() {
 
             const full_jp_logo_exists = document.querySelector('.jetpack-logo__masthead') ? true : false;
 
-            apiFetch({
-                path: addQueryArgs(JITM_ENDPOINT_URL, {
-                    message_path,
-                    query,
-                    full_jp_logo_exists,
-                }),
-                method: 'GET',
-            }).then(function(messages) {
-                const message = messages?.[0];
-                if (message?.content) {
-                    setJITMContent(el, message, redirect);
-                }
-            });
+            fetchJitms({
+                message_path,
+                query,
+                full_jp_logo_exists,
+            })
+                .then(function(messages) {
+                    const message = messages?.[0];
+                    if (message?.content) {
+                        setJITMContent(el, message, redirect);
+                    }
+                })
+                .catch(function() {
+                    // JITMs are non-essential. Swallow the failure rather than
+                    // leaving an unhandled rejection in the console.
+                });
         });
     };
 

--- a/projects/plugins/backup/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/backup/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/boost/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/boost/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/protect/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/protect/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/search/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/search/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/social/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/social/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/stats/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/stats/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.

--- a/projects/plugins/videopress/changelog/fix-jitm-endpoint-fallback
+++ b/projects/plugins/videopress/changelog/fix-jitm-endpoint-fallback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+JITM: Fix missing messages and a console error on sites without the Jetpack plugin active.


### PR DESCRIPTION
## Proposed changes

* The JITM script requests `/wpcom/v3/jitm`, but that route is registered only by the Jetpack plugin (`projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v3-endpoint-jitm.php`), and by WordPress.com itself on Simple sites. The `jitm` package enqueues the script (`class-jitm.php`) but registers a different route for itself, `jetpack/v4/jitm` (`class-rest-api-endpoints.php`). So on a site running only standalone Jetpack plugins, the request 404s, no messages ever render, and because the `apiFetch` GET had no `.catch()`, the rejection lands in the console as `Uncaught (in promise) Object`.
* Fall back to `/jetpack/v4/jitm` when the primary route returns `rest_no_route`/404, and remember which route answered so later fetches and dismissals skip the failed request. That matters on My Jetpack in particular, where `reFetch()` runs again on every `hashchange`.
* Catch failures on both the fetch and the dismissal, so an endpoint that is missing or simply unreachable never leaves an unhandled rejection behind.

Not a regression: the script has pointed at `wpcom/v3` since the Simple-site work in PR 41252.

Two things worth a reviewer's eye:

* The two endpoints shape the `query` argument differently before handing it to `get_messages()`. The package endpoint does `parse_str()` and passes a real associative array; the `wpcom/v3` one passes `array( 'query' => $query_string )`, which `build_query()` then re-encodes as `query=page%3D...`. The package's version looks more correct, and it only affects sites that currently receive nothing at all, so this should not regress anything. Flagging it because the fallback makes that path live.
* Changelog entries went to the standalone plugins where the fallback is actually reachable. I left out `plugins/jetpack` (its own endpoint already answers, so nothing changes for those users), `wpcomsh` and `mu-wpcom-plugin` (WoA/Simple, where WordPress.com or the Jetpack plugin serves `wpcom/v3`), and `starter-plugin`. Happy to add any of them if you'd rather be generous.

## Related product discussion/links

* Found while debugging a console error on a self-hosted site running standalone Boost + VideoPress with no Jetpack plugin.

## Does this pull request change what data or activity we track or use?

No. Same requests, same parameters, only a different route when the first one is absent.

## Testing instructions

On a site **without** the Jetpack plugin active (any standalone plugin will do: Boost, Social, Protect, Search, VideoPress, Backup, or Stats):

* Confirm the bug first: visit `/wp-json/` and note that `wpcom/v3` is absent while `jetpack/v4` is present. `curl "https://<site>/wp-json/wpcom/v3/jitm?message_path=wp:jetpack_page_my-jetpack_overview:admin_notices"` returns 404; the same path under `jetpack/v4` returns 200.
* On `trunk`, open any Jetpack admin screen (`wp-admin/admin.php?page=my-jetpack`) with the browser console open. You should see a 404 for `/wp-json/wpcom/v3/jitm?...` and an `Uncaught (in promise) Object` beneath it.
* Build this branch (`jetpack build packages/jitm`) and reload. The console should be clean: one 404 for `wpcom/v3` on the first fetch, then a successful `jetpack/v4/jitm` request, and no unhandled rejection.
* Navigate around My Jetpack (`#/overview` to `#/add-...` and back) to fire `hashchange`. Only the very first fetch should hit `wpcom/v3`; every later one should go straight to `jetpack/v4`.
* If a JITM renders, dismiss it and confirm the `POST` goes to `jetpack/v4/jitm` and that the message stays dismissed after a reload.

On a site **with** the Jetpack plugin active, confirm nothing changed: the fetch should hit `wpcom/v3/jitm` and succeed, with no request to `jetpack/v4` at all.
