### PR TITLE
Forms: tidy up how a response lists its uploaded files

### DIFF
--- a/projects/packages/forms/changelog/tweak-upload-design
+++ b/projects/packages/forms/changelog/tweak-upload-design
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Inbox: add spacing between the files listed on a response, so a multi-file upload no longer reads as one block.
+Inbox: space out the files listed on a response and line their download buttons up on one edge.

--- a/projects/packages/forms/changelog/tweak-upload-design
+++ b/projects/packages/forms/changelog/tweak-upload-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Inbox: add spacing between the files listed on a response, so a multi-file upload no longer reads as one block.

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
@@ -14,6 +14,10 @@
 	gap: 12px;
 }
 
+.jp-forms__inbox-response-file__item-actions {
+	flex-shrink: 0;
+}
+
 .jp-forms__inbox-response-file__icon {
 	width: 32px;
 	min-width: 32px;
@@ -86,4 +90,18 @@
 .jp-forms__inbox-response-file__info {
 	display: flex;
 	gap: 12px;
+
+	// Lets a long name wrap instead of pushing the download button past the edge.
+	min-width: 0;
+}
+
+.jp-forms__inbox-response-file__name {
+
+	/*
+	 * A file name arrives as one unbroken word as often as not, and a flex item
+	 * refuses to shrink below that word's width unless told to. Without both of
+	 * these the name runs under the download button rather than wrapping.
+	 */
+	min-width: 0;
+	overflow-wrap: anywhere;
 }

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-file/style.scss
@@ -2,6 +2,9 @@
 @use "@wordpress/base-styles/colors";
 
 .jp-forms__inbox-response-field-file {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
 	margin-top: 4px;
 }
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -21,6 +21,16 @@
 			line-height: var(--wpds-typography-line-height-sm);
 		}
 
+		/*
+		 * Every other field is as wide as its answer, but a file field pins a
+		 * download button opposite each name. Left to shrink-to-fit, those
+		 * buttons land wherever the longest name in that response ends, so the
+		 * column moves between responses. Full width holds one edge.
+		 */
+		.jp-forms__field-preview.is-field-type-file .jp-forms__field-preview-content {
+			flex-grow: 1;
+		}
+
 		// Value needed for positioning with the icon in case label is missing.
 		.jp-forms__field-preview-label,
 		.jp-forms__field-preview-value {

--- a/projects/plugins/jetpack/changelog/tweak-upload-design
+++ b/projects/plugins/jetpack/changelog/tweak-upload-design
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: add spacing between the files listed on a response, so a multi-file upload no longer reads as one block.
+Forms: space out the files listed on a response and line their download buttons up on one edge.

--- a/projects/plugins/jetpack/changelog/tweak-upload-design
+++ b/projects/plugins/jetpack/changelog/tweak-upload-design
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: add spacing between the files listed on a response, so a multi-file upload no longer reads as one block.


### PR DESCRIPTION
## Proposed changes

Two small fixes to how a form response lists its uploaded files, following the multi-file upload work in #51549 and #51551.

* **Spacing.** The file rows stacked with no vertical gap, so the icons touched and several files read as one block. `.jp-forms__inbox-response-field-file` is now a flex column with a `12px` gap, matching the gap already used inside each row.
* **Download button alignment.** The file field's column shrank to fit its content, so the download buttons landed wherever the longest file name in that response ended -- one response put them a third of the way across the line, the next almost at the edge. That column now takes the full width, so the buttons hold the same edge in every response. A long file name wraps instead of running under the button, which needs both `min-width: 0` and `overflow-wrap: anywhere` on the name, since a flex item will not otherwise shrink below the width of an unbroken word.

### Before / after

Live Jurassic Ninja site with a Complete plan, four files submitted through the front end, captured in the Forms inbox at 1440x900.

Files with similar names:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/tweak-upload-design/before-response-files.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/tweak-upload-design/after-response-files.png) |

Files with very different name lengths -- note how the button column sits in a different place from the response above, before the change:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/tweak-upload-design/before-mixed-names.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/tweak-upload-design/after-mixed-names.png) |

A 110-character unbroken name at a 700px viewport wraps and leaves the button alone (name injected into the DOM to force the case, so this one is a stress test rather than a real upload):

![long name](https://github.com/Automattic/jetpack/raw/screenshots/tweak-upload-design/after-long-name-wrap.png)

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a page with a Form block and add a File Upload field. Set **Maximum files** to 4 in the field's sidebar. The field needs a Jetpack Complete plan on a connected site.
* Publish the page, then submit the form from the front end with four files attached. Give the files names of noticeably different lengths.
* Go to **Jetpack > Forms > Responses** and open the response (if Akismet flags it, mark it as not spam first).
* The files under **Upload a file** should be separated by a clear gap, and every download button should sit against the right edge of the response line.
* Submit a second response whose files all have short names and open it. The download buttons should sit on the same edge as they did in the first response.
* Narrow the window. Long names should wrap rather than sliding under the button, and nothing should scroll sideways.
* A response with a single file should look unchanged.
