### PR TITLE
Forms: prototype for collecting payments on form submission

### DIFF
--- a/projects/packages/forms/changelog/try-forms-stripe-payments
+++ b/projects/packages/forms/changelog/try-forms-stripe-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Payments: add a prototype for collecting payment on form submission.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -93,4 +93,16 @@ export default {
 		type: 'array',
 		default: [],
 	},
+	// Payments (prototype). Follows the same per-form shape as salesforceData /
+	// mailpoet / hostingerReach, so it travels with the form for free.
+	payments: {
+		type: 'object',
+		default: {
+			enabled: false,
+			currency: 'USD',
+			amountMode: 'fixed', // 'fixed' | 'buyer' ('computed' is phase 3)
+			amount: 25,
+			amountField: '',
+		},
+	},
 };

--- a/projects/packages/forms/src/blocks/contact-form/components/payments-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/payments-settings.jsx
@@ -1,0 +1,134 @@
+/**
+ * Payments settings panel — PROTOTYPE.
+ *
+ * In production this content lives in the integrations sidebar next to
+ * Salesforce and Google Sheets, and its first job is a "Connect Stripe" CTA
+ * pointing at the `connect_url` from `GET /wpcom/v2/memberships/status`. The
+ * prototype skips connection entirely — there is nothing to connect to — and
+ * goes straight to the amount settings, which are the part worth showing.
+ */
+
+import {
+	PanelBody,
+	SelectControl,
+	TextControl,
+	ToggleControl,
+	Notice,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const CURRENCIES = [
+	{ label: 'USD ($)', value: 'USD' },
+	{ label: 'EUR (€)', value: 'EUR' },
+	{ label: 'GBP (£)', value: 'GBP' },
+	{ label: 'CAD (C$)', value: 'CAD' },
+	{ label: 'AUD (A$)', value: 'AUD' },
+];
+
+const DEFAULTS = {
+	enabled: false,
+	currency: 'USD',
+	amountMode: 'fixed',
+	amount: 25,
+	amountField: '',
+};
+
+const PaymentsSettings = ( { attributes, setAttributes } ) => {
+	const payments = { ...DEFAULTS, ...( attributes.payments || {} ) };
+
+	const update = changes => setAttributes( { payments: { ...payments, ...changes } } );
+
+	// The design makes these mutually exclusive: a payment needs a durable
+	// response to attach money to, and `saveResponses: false` parks responses
+	// in a temporary status.
+	const responsesDisabled = attributes.saveResponses === false;
+
+	return (
+		<PanelBody
+			title={ __( 'Payments (prototype)', 'jetpack-forms' ) }
+			className="jetpack-contact-form__panel"
+			initialOpen={ false }
+		>
+			{ responsesDisabled && (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'Payments need responses to be saved. Turn on response storage to collect payment.',
+						'jetpack-forms'
+					) }
+				</Notice>
+			) }
+
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Collect payment on submit', 'jetpack-forms' ) }
+				help={ __(
+					'Demo only — a simulated checkout opens after the form is submitted. No card is charged.',
+					'jetpack-forms'
+				) }
+				checked={ !! payments.enabled && ! responsesDisabled }
+				disabled={ responsesDisabled }
+				onChange={ enabled => update( { enabled } ) }
+			/>
+
+			{ payments.enabled && ! responsesDisabled && (
+				<>
+					<SelectControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Currency', 'jetpack-forms' ) }
+						value={ payments.currency }
+						options={ CURRENCIES }
+						onChange={ currency => update( { currency } ) }
+					/>
+
+					<SelectControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+						label={ __( 'Amount', 'jetpack-forms' ) }
+						value={ payments.amountMode }
+						options={ [
+							{ label: __( 'Fixed amount', 'jetpack-forms' ), value: 'fixed' },
+							{
+								label: __( 'Chosen by the person filling the form', 'jetpack-forms' ),
+								value: 'buyer',
+							},
+						] }
+						help={ __(
+							'Amounts computed from answers (quantity × price, priced options) are a later phase.',
+							'jetpack-forms'
+						) }
+						onChange={ amountMode => update( { amountMode } ) }
+					/>
+
+					{ 'fixed' === payments.amountMode ? (
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							type="number"
+							min="1"
+							step="0.5"
+							label={ __( 'Price', 'jetpack-forms' ) }
+							value={ payments.amount }
+							onChange={ amount => update( { amount: parseFloat( amount ) || 0 } ) }
+						/>
+					) : (
+						<TextControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Field holding the amount', 'jetpack-forms' ) }
+							value={ payments.amountField }
+							placeholder={ __( 'e.g. Amount', 'jetpack-forms' ) }
+							help={ __(
+								'Label of the field to read the amount from. Leave empty to use the first numeric answer.',
+								'jetpack-forms'
+							) }
+							onChange={ amountField => update( { amountField } ) }
+						/>
+					) }
+				</>
+			) }
+		</PanelBody>
+	);
+};
+
+export default PaymentsSettings;

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -63,6 +63,7 @@ import FormStatusNotice from './components/form-status-notice.tsx';
 import { ContactFormPlaceholder } from './components/jetpack-contact-form-placeholder.jsx';
 import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.jsx';
 import NotificationsSettings from './components/notifications-settings.jsx';
+import PaymentsSettings from './components/payments-settings.jsx';
 import WebhooksSettings from './components/webhooks-settings.jsx';
 import WidgetEditorReadonlyView from './components/widget-editor-readonly-view.tsx';
 import { useCreateSyncedFormOnInsertion } from './hooks/use-create-synced-form-on-insertion.ts';
@@ -1279,6 +1280,7 @@ function JetpackContactFormEdit( {
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>
+					<PaymentsSettings attributes={ attributes } setAttributes={ setAttributes } />
 					{ showWebhooks && (
 						<PanelBody
 							title={ __( 'Webhooks', 'jetpack-forms' ) }

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -73,6 +73,11 @@ class Jetpack_Forms {
 
 		// Initialize abilities registration for WordPress Abilities API (WP 6.9+)
 		\Automattic\Jetpack\Forms\Abilities\Forms_Abilities::init();
+
+		// Payments (prototype). Registers the confirmation endpoint; everything
+		// else hangs off the form's own `payments` attribute, so this is inert
+		// on any form that has not enabled it.
+		\Automattic\Jetpack\Forms\Payments\Payments::init();
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-endpoint.php
@@ -668,6 +668,13 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 			'readonly'    => true,
 		);
 
+		$schema['properties']['payment'] = array(
+			'description' => __( 'Payment state for this response, when the form collects payment.', 'jetpack-forms' ),
+			'type'        => array( 'object', 'null' ),
+			'context'     => array( 'view', 'edit', 'embed' ),
+			'readonly'    => true,
+		);
+
 		$schema['properties']['browser'] = array(
 			'description' => __( 'The browser and platform used to submit the form.', 'jetpack-forms' ),
 			'type'        => 'string',
@@ -1047,6 +1054,23 @@ class Contact_Form_Endpoint extends \WP_REST_Posts_Controller {
 
 		if ( rest_is_field_included( 'is_test', $fields ) ) {
 			$data['is_test'] = $feedback_response->is_test();
+		}
+
+		if ( rest_is_field_included( 'payment', $fields ) ) {
+			$payment = \Automattic\Jetpack\Forms\Payments\Payment_Status::get( $item->ID );
+
+			$data['payment'] = $payment
+				? array(
+					'status'          => $payment['status'],
+					'amount'          => (int) $payment['amount'],
+					'currency'        => $payment['currency'],
+					'formattedAmount' => \Automattic\Jetpack\Forms\Payments\Payments::format_amount(
+						$payment['amount'],
+						$payment['currency']
+					),
+					'verified'        => (bool) $payment['verified'],
+				)
+				: null;
 		}
 
 		if ( rest_is_field_included( 'preview_url', $fields ) ) {

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
+use Automattic\Jetpack\Forms\Payments\Payment_Status;
+use Automattic\Jetpack\Forms\Payments\Payments;
 use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -554,6 +556,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'emailNotifications'     => 'yes',
 			'notificationRecipients' => array(), // Array of user IDs who should receive form response notifications.
 			'webhooks'               => array(), // Array of webhooks to send the form data to.
+			'payments'               => null, // Payment settings (prototype). See Automattic\Jetpack\Forms\Payments\Payments.
 			'disableGoBack'          => $attributes['disableGoBack'] ?? false,
 			'disableSummary'         => $attributes['disableSummary'] ?? false,
 			'formTitle'              => $attributes['formTitle'] ?? '',
@@ -3304,6 +3307,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 */
 		do_action( 'grunion_after_feedback_post_inserted', $post_id, $visible_fields, $is_spam, $entry_values );
 
+		/*
+		 * Payments (prototype). Runs only once the response exists, so a payment
+		 * can never be the reason a legitimate response is lost, and spam never
+		 * reaches checkout. Test submissions are excluded outright.
+		 */
+		$payment_payload = null;
+		if ( ! $is_spam && ! $is_test_submission && 'publish' === $feedback_status ) {
+			$payment_payload = Payments::start_order( $this, $post_id, $all_values );
+		}
+
 		// Build the complete email content via the renderer.
 		$context_data = array(
 			'time'                 => $time,
@@ -3378,6 +3391,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// Only fire send-related side effects when we are actually going to send.
 		$will_send = ( $is_spam !== true && $send_email ) || ( true === $is_spam && $send_even_if_spam );
 
+		/*
+		 * Hold the owner's notification back until the response is actually
+		 * paid. Without this the form owner gets "you have a new order" for an
+		 * order nobody has paid for yet.
+		 */
+		if ( $will_send && Payment_Status::is_awaiting( $post_id ) ) {
+			Payment_Status::defer_notification( $post_id, $to, "{$spam}{$subject}", $message, $headers );
+			$will_send = false;
+		}
+
 		if ( $will_send ) {
 			/**
 			 * Fires right before the contact form message is sent via email to
@@ -3438,12 +3461,18 @@ class Contact_Form extends Contact_Form_Shortcode {
 			if ( $response instanceof Feedback ) {
 				$data = $response->get_compiled_fields( 'ajax', 'collection' );
 			}
+			$json = array(
+				'success'     => true,
+				'data'        => $data,
+				'refreshArgs' => $refresh_args,
+			);
+
+			if ( $payment_payload ) {
+				$json['payment'] = $payment_payload;
+			}
+
 			wp_send_json(
-				array(
-					'success'     => true,
-					'data'        => $data,
-					'refreshArgs' => $refresh_args,
-				),
+				$json,
 				null, // @phan-suppress-current-line PhanTypeMismatchArgumentProbablyReal -- It takes null, but its phpdoc only says int.
 				JSON_UNESCAPED_SLASHES
 			);

--- a/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/index.jsx
@@ -517,6 +517,43 @@ export default function InboxView( { parentId, pageTitle, pageSubtitle } = {} ) 
 			},
 			...buildResponseFieldColumns( responseFieldColumns ),
 			{
+				// Payments (prototype). Only meaningful on responses to forms that
+				// collect payment; renders an em dash everywhere else.
+				id: 'payment',
+				label: __( 'Payment', 'jetpack-forms' ),
+				render: ( { item } ) => {
+					const payment = item.payment;
+
+					if ( ! payment ) {
+						return <span style={ { color: '#949494' } }>—</span>;
+					}
+
+					const labels = {
+						paid: __( 'Paid', 'jetpack-forms' ),
+						awaiting: __( 'Unpaid', 'jetpack-forms' ),
+						failed: __( 'Failed', 'jetpack-forms' ),
+						payment_unavailable: __( 'Unavailable', 'jetpack-forms' ),
+					};
+
+					const colors = {
+						paid: '#008a20',
+						awaiting: '#996800',
+						failed: '#b32d2e',
+						payment_unavailable: '#757575',
+					};
+
+					return (
+						<span style={ { color: colors[ payment.status ] || '#757575' } }>
+							{ payment.formattedAmount }
+							{ ' · ' }
+							{ labels[ payment.status ] || payment.status }
+						</span>
+					);
+				},
+				getValue: ( { item } ) => item.payment?.status || '',
+				enableSorting: false,
+			},
+			{
 				id: 'date',
 				label: __( 'Date', 'jetpack-forms' ),
 				render: ( { item } ) => {

--- a/projects/packages/forms/src/dashboard/inbox/stage/views.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/views.js
@@ -16,9 +16,9 @@ export const defaultView = {
 	titleField: 'from',
 	// From is the title column and renders ahead of these; answer columns are slotted
 	// in directly after Date. The order is therefore From, Date, the form's own
-	// fields, Source, IP Address — and Status after those, for anyone who turns it
-	// on, since it is off by default.
-	fields: [ 'date', 'source', 'ip' ],
+	// fields, Source, Payment, IP Address — and Status after those, for anyone who
+	// turns it on, since it is off by default.
+	fields: [ 'date', 'source', 'payment', 'ip' ],
 };
 
 export const defaultLayouts = {

--- a/projects/packages/forms/src/modules/form/payment-checkout.js
+++ b/projects/packages/forms/src/modules/form/payment-checkout.js
@@ -1,0 +1,209 @@
+/**
+ * Simulated checkout for the Jetpack Forms payments prototype.
+ *
+ * PROTOTYPE. In production this file does not exist: the form opens
+ * `extensions/shared/memberships.js`'s <dialog>, which frames WPCOM's real
+ * checkout at subscribe.wordpress.com, and listens for its postMessage. Every
+ * card field below is fake, nothing is transmitted anywhere, and no money
+ * moves. The shape of the interaction — modal opens after submit, resolves to
+ * paid or not-paid, the site confirms server-side — is the real one.
+ */
+
+const STYLE_ID = 'jetpack-forms-payment-checkout-styles';
+
+const STYLES = `
+.jp-forms-checkout__backdrop::backdrop { background: rgba(0,0,0,.6); }
+.jp-forms-checkout {
+	border: none; border-radius: 12px; padding: 0; width: min(420px, calc(100vw - 32px));
+	box-shadow: 0 12px 40px rgba(0,0,0,.25); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+	color: #1e1e1e; background: #fff;
+}
+.jp-forms-checkout__inner { padding: 24px; }
+.jp-forms-checkout__demo {
+	background: #fcf0cd; color: #614200; font-size: 12px; font-weight: 600;
+	padding: 8px 24px; border-radius: 12px 12px 0 0; text-align: center;
+}
+.jp-forms-checkout__amount { font-size: 30px; font-weight: 700; margin: 0 0 2px; }
+.jp-forms-checkout__caption { font-size: 13px; color: #757575; margin: 0 0 20px; }
+.jp-forms-checkout__label { display: block; font-size: 12px; font-weight: 600; margin: 0 0 4px; }
+.jp-forms-checkout__field {
+	width: 100%; box-sizing: border-box; padding: 10px 12px; margin: 0 0 14px;
+	border: 1px solid #dcdcde; border-radius: 4px; font-size: 14px; background: #fff; color: #1e1e1e;
+}
+.jp-forms-checkout__row { display: flex; gap: 12px; }
+.jp-forms-checkout__row > div { flex: 1; }
+.jp-forms-checkout__pay {
+	width: 100%; padding: 12px; border: none; border-radius: 4px; background: #3858e9; color: #fff;
+	font-size: 15px; font-weight: 600; cursor: pointer;
+}
+.jp-forms-checkout__pay[disabled] { opacity: .6; cursor: default; }
+.jp-forms-checkout__later {
+	display: block; width: 100%; margin-top: 12px; padding: 8px; border: none; background: none;
+	color: #757575; font-size: 13px; cursor: pointer; text-decoration: underline;
+}
+.jp-forms-checkout__result { text-align: center; padding: 12px 0 4px; }
+.jp-forms-checkout__result h3 { margin: 0 0 6px; font-size: 18px; }
+.jp-forms-checkout__result p { margin: 0 0 20px; font-size: 13px; color: #757575; }
+.jp-forms-checkout__tick { font-size: 40px; line-height: 1; margin-bottom: 10px; }
+.jp-forms-checkout__error { color: #b32d2e; font-size: 13px; margin: 0 0 12px; }
+@media (prefers-color-scheme: dark) {
+	.jp-forms-checkout { background: #1e1e1e; color: #f0f0f0; }
+	.jp-forms-checkout__field { background: #2b2b2b; border-color: #4a4a4a; color: #f0f0f0; }
+}
+`;
+
+/**
+ * Inject the checkout styles once.
+ *
+ * Prototype shortcut: production would ship these through the package's normal
+ * style pipeline rather than a runtime <style> tag.
+ */
+function ensureStyles() {
+	if ( document.getElementById( STYLE_ID ) ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = STYLE_ID;
+	style.textContent = STYLES;
+	document.head.appendChild( style );
+}
+
+/**
+ * Confirm the payment with the site.
+ *
+ * @param {object} payment - Payment payload from the submission response.
+ * @param {string} outcome - 'success' or 'failure'.
+ * @return {Promise<Object>} Confirmation result.
+ */
+async function confirmPayment( payment, outcome ) {
+	const response = await fetch( payment.confirmUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Accept: 'application/json',
+		},
+		body: JSON.stringify( {
+			order_token: payment.orderToken,
+			outcome,
+		} ),
+	} );
+
+	const result = await response.json();
+
+	if ( ! response.ok ) {
+		throw new Error( result?.message || 'Payment could not be confirmed.' );
+	}
+
+	return result;
+}
+
+/**
+ * Open the simulated checkout and resolve once the buyer is done with it.
+ *
+ * Resolves to `{ paid: boolean }`. It never rejects: a buyer who closes the
+ * dialog, or a confirmation that fails, is a normal outcome — the response is
+ * already saved either way, which is the whole point of the design's
+ * entry-first ordering.
+ *
+ * @param {object} payment - Payment payload from the submission response.
+ * @return {Promise<{paid: boolean}>} Outcome.
+ */
+export function openCheckout( payment ) {
+	ensureStyles();
+
+	return new Promise( resolve => {
+		const dialog = document.createElement( 'dialog' );
+		dialog.className = 'jp-forms-checkout jp-forms-checkout__backdrop';
+		dialog.setAttribute( 'aria-label', 'Payment' );
+
+		const renderForm = () => {
+			dialog.innerHTML = `
+				<div class="jp-forms-checkout__demo">Demo checkout — no card is charged</div>
+				<div class="jp-forms-checkout__inner">
+					<p class="jp-forms-checkout__amount">${ payment.formattedAmount }</p>
+					<p class="jp-forms-checkout__caption">Amount set by the site, not editable here.</p>
+					<div class="jp-forms-checkout__error" hidden></div>
+					<label class="jp-forms-checkout__label" for="jp-fc-email">Email</label>
+					<input class="jp-forms-checkout__field" id="jp-fc-email" type="email" value="demo@example.com" />
+					<label class="jp-forms-checkout__label" for="jp-fc-card">Card number</label>
+					<input class="jp-forms-checkout__field" id="jp-fc-card" inputmode="numeric" value="4242 4242 4242 4242" />
+					<div class="jp-forms-checkout__row">
+						<div>
+							<label class="jp-forms-checkout__label" for="jp-fc-exp">Expiry</label>
+							<input class="jp-forms-checkout__field" id="jp-fc-exp" value="12 / 30" />
+						</div>
+						<div>
+							<label class="jp-forms-checkout__label" for="jp-fc-cvc">CVC</label>
+							<input class="jp-forms-checkout__field" id="jp-fc-cvc" value="123" />
+						</div>
+					</div>
+					<button class="jp-forms-checkout__pay" type="button">Pay ${ payment.formattedAmount }</button>
+					<button class="jp-forms-checkout__later" type="button">Pay later</button>
+				</div>
+			`;
+
+			const payButton = dialog.querySelector( '.jp-forms-checkout__pay' );
+			const laterButton = dialog.querySelector( '.jp-forms-checkout__later' );
+			const errorBox = dialog.querySelector( '.jp-forms-checkout__error' );
+
+			payButton.addEventListener( 'click', async () => {
+				payButton.disabled = true;
+				payButton.textContent = 'Processing…';
+				errorBox.hidden = true;
+
+				try {
+					const result = await confirmPayment( payment, 'success' );
+					renderResult( 'paid' === result.status );
+				} catch ( error ) {
+					errorBox.textContent = error.message;
+					errorBox.hidden = false;
+					payButton.disabled = false;
+					payButton.textContent = `Pay ${ payment.formattedAmount }`;
+				}
+			} );
+
+			laterButton.addEventListener( 'click', () => close( false ) );
+		};
+
+		const renderResult = paid => {
+			dialog.innerHTML = `
+				<div class="jp-forms-checkout__demo">Demo checkout — no card was charged</div>
+				<div class="jp-forms-checkout__inner">
+					<div class="jp-forms-checkout__result">
+						<div class="jp-forms-checkout__tick">${ paid ? '✅' : '⚠️' }</div>
+						<h3>${ paid ? 'Payment complete' : 'Payment not completed' }</h3>
+						<p>${
+							paid
+								? 'Your response has been marked as paid.'
+								: 'Your response was saved and is waiting for payment.'
+						}</p>
+						<button class="jp-forms-checkout__pay" type="button">Done</button>
+					</div>
+				</div>
+			`;
+
+			dialog
+				.querySelector( '.jp-forms-checkout__pay' )
+				.addEventListener( 'click', () => close( paid ) );
+		};
+
+		const close = paid => {
+			document.body.classList.remove( 'jp-forms-checkout-open' );
+			dialog.close();
+			dialog.remove();
+			resolve( { paid } );
+		};
+
+		// Escape / backdrop dismissal counts as "pay later", not as an error.
+		dialog.addEventListener( 'cancel', event => {
+			event.preventDefault();
+			close( false );
+		} );
+
+		renderForm();
+		document.body.appendChild( dialog );
+		document.body.classList.add( 'jp-forms-checkout-open' );
+		dialog.showModal();
+	} );
+}

--- a/projects/packages/forms/src/modules/form/view.js
+++ b/projects/packages/forms/src/modules/form/view.js
@@ -15,6 +15,7 @@ import { validateField, isEmptyValue } from '../../contact-form/js/validate-help
 import { getRating } from '../field-rating/view.js';
 import { isFieldHiddenByLogic } from './conditional-visibility.js';
 import { maybeAddColonToLabel, getImages, getUrl, getSubmissionDisplayValue } from './helpers.js';
+import { openCheckout } from './payment-checkout.js';
 import { focusNextInput, getForm, submitForm } from './shared.ts';
 // Import field type icons view to register its callbacks.
 import './field-type-icons-view.js';
@@ -796,9 +797,17 @@ const { state, actions } = store( NAMESPACE, {
 				// Capture file preview URLs before submission (blob URLs for images, icon URLs for other files)
 				capturedFilePreviews = captureFilePreviews( context.formHash );
 
-				const { success, error, data, refreshArgs } = yield submitForm( context.formHash );
+				const { success, error, data, refreshArgs, payment } = yield submitForm( context.formHash );
 
 				if ( success ) {
+					// Payments (prototype): the response is already saved at this
+					// point. Checkout decides whether it is also paid — either way
+					// we fall through to the normal success state, because losing
+					// the response was never on the table.
+					if ( payment ) {
+						yield openCheckout( payment );
+					}
+
 					setSubmissionData( data );
 					context.submissionSuccess = true;
 

--- a/projects/packages/forms/src/payments/class-order.php
+++ b/projects/packages/forms/src/payments/class-order.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Order token minting and verification for Jetpack Forms payments.
+ *
+ * PROTOTYPE. The token design here is the real one from the design doc: the
+ * buyer carries an HMAC signature over the order, never the amount itself, so
+ * the amount cannot be edited client-side. What is *not* real in the prototype
+ * is where the token goes — production hands it to WPCOM checkout, the
+ * prototype hands it to a simulated checkout rendered by us.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Payments;
+
+use WP_Error;
+
+/**
+ * Mints and verifies single-use order tokens.
+ */
+class Order {
+
+	/**
+	 * Option holding the site's signing secret.
+	 *
+	 * @var string
+	 */
+	const SECRET_OPTION = 'jetpack_forms_payments_secret';
+
+	/**
+	 * How long a token stays valid, in seconds.
+	 *
+	 * @var int
+	 */
+	const TTL = DAY_IN_SECONDS;
+
+	/**
+	 * Get (or lazily create) the site's signing secret.
+	 *
+	 * @return string
+	 */
+	private static function get_secret() {
+		$secret = get_option( self::SECRET_OPTION );
+
+		if ( ! $secret ) {
+			$secret = wp_generate_password( 64, false, false );
+			// Autoload off: this is only read on the submit/confirm paths.
+			add_option( self::SECRET_OPTION, $secret, '', false );
+		}
+
+		return $secret;
+	}
+
+	/**
+	 * Mint a token for an order.
+	 *
+	 * @param array $order {
+	 *     @type int    $entry_id Feedback post ID the payment belongs to.
+	 *     @type int    $amount   Amount in minor units (e.g. cents).
+	 *     @type string $currency ISO 4217 currency code.
+	 * }
+	 * @return string
+	 */
+	public static function mint( array $order ) {
+		$payload = array(
+			'entry_id' => (int) $order['entry_id'],
+			'amount'   => (int) $order['amount'],
+			'currency' => (string) $order['currency'],
+			'blog_id'  => (int) get_current_blog_id(),
+			'nonce'    => wp_generate_password( 16, false, false ),
+			'expires'  => time() + self::TTL,
+		);
+
+		$body      = self::b64_encode( (string) wp_json_encode( $payload ) );
+		$signature = self::b64_encode( hash_hmac( 'sha256', $body, self::get_secret(), true ) );
+
+		return $body . '.' . $signature;
+	}
+
+	/**
+	 * Verify a token and return its payload.
+	 *
+	 * Signature, expiry and blog binding are all checked here. Single-use
+	 * enforcement is *not* — that lives with the entry, because only the entry
+	 * knows whether this order has already been paid. See Payment_Status.
+	 *
+	 * @param string $token Token to verify.
+	 * @return array|WP_Error
+	 */
+	public static function verify( $token ) {
+		if ( ! is_string( $token ) || substr_count( $token, '.' ) !== 1 ) {
+			return new WP_Error( 'invalid_order_token', __( 'Malformed order token.', 'jetpack-forms' ) );
+		}
+
+		list( $body, $signature ) = explode( '.', $token );
+
+		$expected = self::b64_encode( hash_hmac( 'sha256', $body, self::get_secret(), true ) );
+
+		if ( ! hash_equals( $expected, $signature ) ) {
+			return new WP_Error( 'invalid_order_signature', __( 'Order token signature does not match.', 'jetpack-forms' ) );
+		}
+
+		$payload = json_decode( self::b64_decode( $body ), true );
+
+		if ( ! is_array( $payload ) || empty( $payload['entry_id'] ) ) {
+			return new WP_Error( 'invalid_order_payload', __( 'Order token payload could not be read.', 'jetpack-forms' ) );
+		}
+
+		if ( empty( $payload['expires'] ) || $payload['expires'] < time() ) {
+			return new WP_Error( 'expired_order_token', __( 'This payment link has expired.', 'jetpack-forms' ) );
+		}
+
+		if ( (int) ( $payload['blog_id'] ?? 0 ) !== (int) get_current_blog_id() ) {
+			return new WP_Error( 'foreign_order_token', __( 'Order token was issued for a different site.', 'jetpack-forms' ) );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * URL-safe base64 encode.
+	 *
+	 * @param string $value Value to encode.
+	 * @return string
+	 */
+	private static function b64_encode( $value ) {
+		return rtrim( strtr( base64_encode( $value ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Not obfuscation; URL-safe transport encoding.
+	}
+
+	/**
+	 * URL-safe base64 decode.
+	 *
+	 * @param string $value Value to decode.
+	 * @return string
+	 */
+	private static function b64_decode( $value ) {
+		return (string) base64_decode( strtr( $value, '-_', '+/' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- Not obfuscation; URL-safe transport encoding.
+	}
+}

--- a/projects/packages/forms/src/payments/class-payment-endpoint.php
+++ b/projects/packages/forms/src/payments/class-payment-endpoint.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Payment confirmation endpoint — PROTOTYPE.
+ *
+ * In production this route takes what the WPCOM checkout iframe posted back
+ * (an ownership ID, an order ID) and verifies it server-to-server against
+ * WPCOM before flipping the response to paid.
+ *
+ * In the prototype there is nothing to verify against, so the route trusts the
+ * signed order token and a simulated outcome. The token still does real work:
+ * it proves the amount was set by the server, binds the payment to one entry,
+ * and cannot be replayed, because Payment_Status::mark_paid() refuses any
+ * entry that is not awaiting payment.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Payments;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * REST routes for confirming a payment.
+ */
+class Payment_Endpoint {
+
+	/**
+	 * REST namespace. `wpcom/v2` because Simple sites do not serve custom
+	 * site-specific namespaces — see the design doc.
+	 *
+	 * @var string
+	 */
+	const NAMESPACE_V2 = 'wpcom/v2';
+
+	/**
+	 * REST base.
+	 *
+	 * @var string
+	 */
+	const REST_BASE = 'jetpack-forms/payments';
+
+	/**
+	 * Register the routes.
+	 *
+	 * @return void
+	 */
+	public static function register_routes() {
+		register_rest_route(
+			self::NAMESPACE_V2,
+			self::REST_BASE . '/confirm',
+			array(
+				'methods'  => WP_REST_Server::CREATABLE,
+				'callback' => array( __CLASS__, 'confirm' ),
+				// Buyers are anonymous by design — a form payment must not
+				// require a login. The signed, single-use, entry-bound order
+				// token is the authorization, not the current user.
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'order_token' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'outcome'     => array(
+						'type'     => 'string',
+						'enum'     => array( 'success', 'failure' ),
+						'default'  => 'success',
+						'required' => false,
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Confirm (or fail) a payment.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return array|WP_Error
+	 */
+	public static function confirm( WP_REST_Request $request ) {
+		$payload = Order::verify( (string) $request->get_param( 'order_token' ) );
+
+		if ( is_wp_error( $payload ) ) {
+			$payload->add_data( array( 'status' => 400 ) );
+
+			return $payload;
+		}
+
+		$entry_id = (int) $payload['entry_id'];
+		$record   = Payment_Status::get( $entry_id );
+
+		if ( ! $record ) {
+			return new WP_Error(
+				'order_not_found',
+				__( 'No pending payment was found for this order.', 'jetpack-forms' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		if ( 'awaiting' !== $record['status'] ) {
+			// Already resolved. Report the resting state rather than erroring —
+			// a double-submit should be a no-op, not a failure.
+			return array(
+				'status'   => $record['status'],
+				'amount'   => $record['amount'],
+				'currency' => $record['currency'],
+				'replayed' => true,
+			);
+		}
+
+		// The amount is taken from the token, never from the request body. This
+		// is the whole point of signing it.
+		if ( (int) $payload['amount'] !== (int) $record['amount'] ) {
+			Payment_Status::mark_failed( $entry_id );
+
+			return new WP_Error(
+				'order_amount_mismatch',
+				__( 'The payment amount did not match the order.', 'jetpack-forms' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		if ( 'failure' === $request->get_param( 'outcome' ) ) {
+			Payment_Status::mark_failed( $entry_id );
+
+			return array(
+				'status'   => 'failed',
+				'amount'   => $record['amount'],
+				'currency' => $record['currency'],
+			);
+		}
+
+		// PROTOTYPE: production takes this identifier from the WPCOM checkout
+		// result (order_id / product_ownership_id) after verifying it upstream.
+		$order_id = 'sim_' . wp_generate_password( 12, false, false );
+
+		Payment_Status::mark_paid( $entry_id, $order_id );
+
+		return array(
+			'status'   => 'paid',
+			'orderId'  => $order_id,
+			'amount'   => $record['amount'],
+			'currency' => $record['currency'],
+			// Never true in the prototype: no processor confirmed anything.
+			'verified' => false,
+		);
+	}
+}

--- a/projects/packages/forms/src/payments/class-payment-status.php
+++ b/projects/packages/forms/src/payments/class-payment-status.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Payment state for a form response.
+ *
+ * Owns the `_feedback_payment` meta shape and the transitions between its
+ * states, plus the notification that is held back until a response is paid.
+ *
+ * PROTOTYPE NOTE: the design doc puts awaiting-payment responses behind a
+ * dedicated `jp-awaiting-payment` post status. The prototype keeps them on
+ * `publish` and tracks state purely in meta, so unpaid responses stay visible
+ * in the dashboard (which is the more useful thing to demo) without auditing
+ * every `post_status` query in the package.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Payments;
+
+/**
+ * Reads and writes the payment state of a feedback entry.
+ */
+class Payment_Status {
+
+	/**
+	 * Meta key holding the payment record.
+	 *
+	 * @var string
+	 */
+	const META_KEY = '_feedback_payment';
+
+	/**
+	 * Meta key holding a notification deferred until payment completes.
+	 *
+	 * @var string
+	 */
+	const PENDING_EMAIL_META_KEY = '_feedback_payment_pending_email';
+
+	/**
+	 * Record an awaiting-payment order against an entry.
+	 *
+	 * @param int    $entry_id    Feedback post ID.
+	 * @param int    $amount      Amount in minor units.
+	 * @param string $currency    Currency code.
+	 * @param string $order_token Signed order token.
+	 * @return void
+	 */
+	public static function start( $entry_id, $amount, $currency, $order_token ) {
+		update_post_meta(
+			$entry_id,
+			self::META_KEY,
+			array(
+				'order_token' => $order_token,
+				'amount'      => (int) $amount,
+				'currency'    => (string) $currency,
+				'status'      => 'awaiting',
+				'order_id'    => null,
+				'paid_at'     => null,
+				// Always false in the prototype: nothing has been confirmed with a
+				// payment processor, because there isn't one. See the design doc's
+				// `verified` axis — phase 2 is what makes this true.
+				'verified'    => false,
+			)
+		);
+	}
+
+	/**
+	 * Get the payment record for an entry.
+	 *
+	 * @param int $entry_id Feedback post ID.
+	 * @return array|null
+	 */
+	public static function get( $entry_id ) {
+		$record = get_post_meta( $entry_id, self::META_KEY, true );
+
+		return is_array( $record ) ? $record : null;
+	}
+
+	/**
+	 * Whether an entry is waiting on payment.
+	 *
+	 * @param int $entry_id Feedback post ID.
+	 * @return bool
+	 */
+	public static function is_awaiting( $entry_id ) {
+		$record = self::get( $entry_id );
+
+		return $record && 'awaiting' === $record['status'];
+	}
+
+	/**
+	 * Mark an entry paid.
+	 *
+	 * Refuses to act on an entry that is not awaiting payment, which is what
+	 * makes the order token effectively single-use: a replayed token finds an
+	 * entry that has already moved on.
+	 *
+	 * @param int    $entry_id Feedback post ID.
+	 * @param string $order_id Identifier from the processor.
+	 * @return bool True when the entry moved to paid.
+	 */
+	public static function mark_paid( $entry_id, $order_id ) {
+		$record = self::get( $entry_id );
+
+		if ( ! $record || 'awaiting' !== $record['status'] ) {
+			return false;
+		}
+
+		$record['status']   = 'paid';
+		$record['order_id'] = (string) $order_id;
+		$record['paid_at']  = time();
+
+		update_post_meta( $entry_id, self::META_KEY, $record );
+
+		self::send_deferred_notification( $entry_id );
+
+		return true;
+	}
+
+	/**
+	 * Mark an entry's payment as failed.
+	 *
+	 * @param int $entry_id Feedback post ID.
+	 * @return bool
+	 */
+	public static function mark_failed( $entry_id ) {
+		$record = self::get( $entry_id );
+
+		if ( ! $record || 'awaiting' !== $record['status'] ) {
+			return false;
+		}
+
+		$record['status'] = 'failed';
+
+		update_post_meta( $entry_id, self::META_KEY, $record );
+
+		return true;
+	}
+
+	/**
+	 * Hold a response notification back until the response is paid.
+	 *
+	 * @param int          $entry_id Feedback post ID.
+	 * @param string|array $to       Recipient(s).
+	 * @param string       $subject  Email subject.
+	 * @param string       $message  Email body.
+	 * @param string|array $headers  Email headers.
+	 * @return void
+	 */
+	public static function defer_notification( $entry_id, $to, $subject, $message, $headers ) {
+		update_post_meta(
+			$entry_id,
+			self::PENDING_EMAIL_META_KEY,
+			array(
+				'to'      => $to,
+				'subject' => $subject,
+				'message' => $message,
+				'headers' => $headers,
+			)
+		);
+	}
+
+	/**
+	 * Send a notification that was held back, if there is one.
+	 *
+	 * @param int $entry_id Feedback post ID.
+	 * @return void
+	 */
+	private static function send_deferred_notification( $entry_id ) {
+		$email = get_post_meta( $entry_id, self::PENDING_EMAIL_META_KEY, true );
+
+		if ( ! is_array( $email ) || empty( $email['to'] ) ) {
+			return;
+		}
+
+		delete_post_meta( $entry_id, self::PENDING_EMAIL_META_KEY );
+
+		\Automattic\Jetpack\Forms\ContactForm\Contact_Form::wp_mail(
+			$email['to'],
+			$email['subject'],
+			$email['message'],
+			$email['headers']
+		);
+	}
+}

--- a/projects/packages/forms/src/payments/class-payments.php
+++ b/projects/packages/forms/src/payments/class-payments.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * Jetpack Forms payments — PROTOTYPE.
+ *
+ * Implements the site-side half of the "Stripe Payments for Jetpack Forms"
+ * design: a response is always saved, an order is minted against it, the buyer
+ * is sent to checkout, and the response flips to paid once checkout confirms.
+ *
+ * What is real here: the order token, the amount resolution, the awaiting/paid
+ * state machine, the deferred owner notification, and the front-end handoff.
+ *
+ * What is simulated: checkout itself. Production opens WPCOM's checkout iframe
+ * at subscribe.wordpress.com and confirms the result against WPCOM. The
+ * prototype renders its own checkout dialog and confirms against this site, so
+ * no WPCOM changes and no Stripe account are needed to demo the flow. Every
+ * simulated response carries `verified: false` for exactly that reason.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Payments;
+
+use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
+
+/**
+ * Payments bootstrap, settings and amount resolution.
+ */
+class Payments {
+
+	/**
+	 * Currencies the prototype offers, with their minor-unit exponent and symbol.
+	 *
+	 * Mirrors a subset of Jetpack_Memberships::SUPPORTED_CURRENCIES so the
+	 * prototype's minimums behave like the real thing.
+	 *
+	 * @var array
+	 */
+	const CURRENCIES = array(
+		'USD' => array( 'symbol' => '$', 'minimum' => 50 ),
+		'EUR' => array( 'symbol' => '€', 'minimum' => 50 ),
+		'GBP' => array( 'symbol' => '£', 'minimum' => 30 ),
+		'CAD' => array( 'symbol' => 'C$', 'minimum' => 50 ),
+		'AUD' => array( 'symbol' => 'A$', 'minimum' => 50 ),
+	);
+
+	/**
+	 * Wire up the payments feature.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', array( Payment_Endpoint::class, 'register_routes' ) );
+	}
+
+	/**
+	 * Read the payment settings off a form.
+	 *
+	 * @param Contact_Form $form Form being submitted.
+	 * @return array|null Settings when payments are enabled, null otherwise.
+	 */
+	public static function get_settings( Contact_Form $form ) {
+		$settings = $form->get_attribute( 'payments' );
+
+		if ( is_string( $settings ) ) {
+			$settings = json_decode( $settings, true );
+		}
+
+		if ( ! is_array( $settings ) || empty( $settings['enabled'] ) ) {
+			return null;
+		}
+
+		$currency = strtoupper( (string) ( $settings['currency'] ?? 'USD' ) );
+
+		if ( ! isset( self::CURRENCIES[ $currency ] ) ) {
+			$currency = 'USD';
+		}
+
+		return array(
+			'enabled'     => true,
+			'currency'    => $currency,
+			'amountMode'  => in_array( $settings['amountMode'] ?? 'fixed', array( 'fixed', 'buyer' ), true )
+				? $settings['amountMode']
+				: 'fixed',
+			'amount'      => (float) ( $settings['amount'] ?? 0 ),
+			'amountField' => (string) ( $settings['amountField'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Whether a form collects payment.
+	 *
+	 * @param Contact_Form $form Form being submitted.
+	 * @return bool
+	 */
+	public static function is_enabled( Contact_Form $form ) {
+		return (bool) self::get_settings( $form );
+	}
+
+	/**
+	 * Resolve the amount owed for a submission, in minor units.
+	 *
+	 * This is the `Amount_Resolver` seam from the design. The prototype handles
+	 * `fixed` and `buyer`; `computed` (quantity x price, priced options) is
+	 * phase 3 and would be a third branch here with no change anywhere else.
+	 *
+	 * @param array $settings Payment settings from get_settings().
+	 * @param array $values   Submitted values, keyed by field label.
+	 * @return int|null Amount in minor units, or null when it cannot be resolved.
+	 */
+	public static function resolve_amount( array $settings, array $values ) {
+		if ( 'buyer' === $settings['amountMode'] ) {
+			$raw = self::find_value( $values, $settings['amountField'] );
+
+			if ( null === $raw ) {
+				return null;
+			}
+
+			// Strip anything that isn't part of a number: currency symbols,
+			// thousands separators, stray whitespace.
+			$raw = preg_replace( '/[^0-9.,]/', '', (string) $raw );
+			$raw = str_replace( ',', '.', (string) $raw );
+
+			if ( '' === $raw || ! is_numeric( $raw ) ) {
+				return null;
+			}
+
+			$amount = (float) $raw;
+		} else {
+			$amount = (float) $settings['amount'];
+		}
+
+		$minor = (int) round( $amount * 100 );
+
+		if ( $minor < self::CURRENCIES[ $settings['currency'] ]['minimum'] ) {
+			return null;
+		}
+
+		return $minor;
+	}
+
+	/**
+	 * Find a submitted value by (case-insensitive, loose) field label.
+	 *
+	 * Falls back to the first numeric-looking value when no label is configured,
+	 * which keeps the prototype usable without exact label matching.
+	 *
+	 * @param array  $values Submitted values keyed by label.
+	 * @param string $label  Configured field label.
+	 * @return string|null
+	 */
+	private static function find_value( array $values, $label ) {
+		if ( '' !== $label ) {
+			foreach ( $values as $key => $value ) {
+				if ( 0 === strcasecmp( trim( (string) $key ), trim( $label ) ) ) {
+					return is_array( $value ) ? reset( $value ) : $value;
+				}
+			}
+		}
+
+		foreach ( $values as $value ) {
+			if ( is_array( $value ) ) {
+				continue;
+			}
+
+			$candidate = preg_replace( '/[^0-9.,]/', '', (string) $value );
+
+			if ( '' !== $candidate && is_numeric( str_replace( ',', '.', $candidate ) ) ) {
+				return $value;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Start an order for a submission and return the front-end payload.
+	 *
+	 * @param Contact_Form $form     Form being submitted.
+	 * @param int          $entry_id Feedback post ID.
+	 * @param array        $values   Submitted values keyed by label.
+	 * @return array|null Payload for the JSON submission response, or null.
+	 */
+	public static function start_order( Contact_Form $form, $entry_id, array $values ) {
+		$settings = self::get_settings( $form );
+
+		if ( ! $settings || ! $entry_id ) {
+			return null;
+		}
+
+		$amount = self::resolve_amount( $settings, $values );
+
+		if ( null === $amount ) {
+			// The form asks for payment but we could not work out how much. The
+			// response is already saved — flag it rather than silently dropping
+			// the payment, which is the fail-open rule from the design.
+			update_post_meta(
+				$entry_id,
+				Payment_Status::META_KEY,
+				array(
+					'order_token' => '',
+					'amount'      => 0,
+					'currency'    => $settings['currency'],
+					'status'      => 'payment_unavailable',
+					'order_id'    => null,
+					'paid_at'     => null,
+					'verified'    => false,
+				)
+			);
+
+			return null;
+		}
+
+		$token = Order::mint(
+			array(
+				'entry_id' => $entry_id,
+				'amount'   => $amount,
+				'currency' => $settings['currency'],
+			)
+		);
+
+		Payment_Status::start( $entry_id, $amount, $settings['currency'], $token );
+
+		return array(
+			'orderToken'      => $token,
+			'amount'          => $amount,
+			'currency'        => $settings['currency'],
+			'formattedAmount' => self::format_amount( $amount, $settings['currency'] ),
+			'confirmUrl'      => rest_url( Payment_Endpoint::NAMESPACE_V2 . '/' . Payment_Endpoint::REST_BASE . '/confirm' ),
+			// Production replaces this with the subscribe.wordpress.com checkout
+			// URL and the modal from extensions/shared/memberships.js.
+			'simulated'       => true,
+		);
+	}
+
+	/**
+	 * Format an amount in minor units for display.
+	 *
+	 * @param int    $amount   Amount in minor units.
+	 * @param string $currency Currency code.
+	 * @return string
+	 */
+	public static function format_amount( $amount, $currency ) {
+		$currency = isset( self::CURRENCIES[ $currency ] ) ? $currency : 'USD';
+
+		return self::CURRENCIES[ $currency ]['symbol'] . number_format_i18n( $amount / 100, 2 );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -3110,6 +3110,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$expected_attributes['confirmationType']       = 'text';
 		$expected_attributes['hostingerReach']         = '';
 		$expected_attributes['ref']                    = '';
+		$expected_attributes['payments']               = '';
 		$expected_attributes['formTitle']              = 'Test Form';
 		$form = new Contact_Form(
 			$attributes,

--- a/projects/packages/forms/tests/php/payments/Payments_Test.php
+++ b/projects/packages/forms/tests/php/payments/Payments_Test.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Unit tests for the Jetpack Forms payments prototype.
+ *
+ * Covers the parts that carry real risk even in a prototype: order tokens
+ * (signature, expiry, tampering) and the awaiting → paid state machine,
+ * including replay.
+ *
+ * To run: from packages/forms, `composer test-php`.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\Payments;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test class for Order, Payment_Status and Payments.
+ */
+#[CoversClass( Order::class )]
+#[CoversClass( Payment_Status::class )]
+#[CoversClass( Payments::class )]
+class Payments_Test extends BaseTestCase {
+
+	/**
+	 * Create a feedback post to hang payments off.
+	 *
+	 * @return int
+	 */
+	private function make_entry() {
+		return wp_insert_post(
+			array(
+				'post_type'   => 'feedback',
+				'post_status' => 'publish',
+				'post_title'  => 'Test response',
+			)
+		);
+	}
+
+	public function test_minted_token_verifies_and_round_trips_its_payload() {
+		$token = Order::mint(
+			array(
+				'entry_id' => 123,
+				'amount'   => 2500,
+				'currency' => 'USD',
+			)
+		);
+
+		$payload = Order::verify( $token );
+
+		$this->assertIsArray( $payload );
+		$this->assertSame( 123, $payload['entry_id'] );
+		$this->assertSame( 2500, $payload['amount'] );
+		$this->assertSame( 'USD', $payload['currency'] );
+	}
+
+	public function test_tampered_amount_fails_verification() {
+		$token = Order::mint(
+			array(
+				'entry_id' => 1,
+				'amount'   => 2500,
+				'currency' => 'USD',
+			)
+		);
+
+		list( $body, $signature ) = explode( '.', $token );
+
+		$payload           = json_decode( base64_decode( strtr( $body, '-_', '+/' ) ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$payload['amount'] = 1;
+
+		$forged_body = rtrim( strtr( base64_encode( (string) wp_json_encode( $payload ) ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+
+		$result = Order::verify( $forged_body . '.' . $signature );
+
+		$this->assertTrue( is_wp_error( $result ) );
+		$this->assertSame( 'invalid_order_signature', $result->get_error_code() );
+	}
+
+	public function test_malformed_token_is_rejected() {
+		$this->assertTrue( is_wp_error( Order::verify( 'not-a-token' ) ) );
+		$this->assertTrue( is_wp_error( Order::verify( 'too.many.parts' ) ) );
+	}
+
+	public function test_entry_moves_from_awaiting_to_paid_once_only() {
+		$entry_id = $this->make_entry();
+
+		Payment_Status::start( $entry_id, 2500, 'USD', 'token' );
+
+		$this->assertTrue( Payment_Status::is_awaiting( $entry_id ) );
+		$this->assertTrue( Payment_Status::mark_paid( $entry_id, 'order_1' ) );
+
+		$record = Payment_Status::get( $entry_id );
+		$this->assertIsArray( $record );
+		$this->assertSame( 'paid', $record['status'] );
+		$this->assertSame( 'order_1', $record['order_id'] );
+
+		// Replaying the same order must not re-mark it, which is what makes the
+		// order token effectively single-use.
+		$this->assertFalse( Payment_Status::mark_paid( $entry_id, 'order_2' ) );
+
+		$replayed = Payment_Status::get( $entry_id );
+		$this->assertIsArray( $replayed );
+		$this->assertSame( 'order_1', $replayed['order_id'] );
+	}
+
+	public function test_paid_entries_are_never_marked_verified_in_the_prototype() {
+		$entry_id = $this->make_entry();
+
+		Payment_Status::start( $entry_id, 2500, 'USD', 'token' );
+		Payment_Status::mark_paid( $entry_id, 'order_1' );
+
+		$record = Payment_Status::get( $entry_id );
+		$this->assertIsArray( $record );
+		$this->assertFalse( $record['verified'] );
+	}
+
+	public function test_owner_notification_is_held_until_payment_completes() {
+		$entry_id = $this->make_entry();
+
+		Payment_Status::start( $entry_id, 2500, 'USD', 'token' );
+		Payment_Status::defer_notification( $entry_id, 'owner@example.com', 'New order', 'Body', '' );
+
+		$this->assertNotEmpty( get_post_meta( $entry_id, Payment_Status::PENDING_EMAIL_META_KEY, true ) );
+
+		$sent = array();
+		add_filter(
+			'pre_wp_mail',
+			function ( $return, $atts ) use ( &$sent ) {
+				$sent[] = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		Payment_Status::mark_paid( $entry_id, 'order_1' );
+
+		$this->assertCount( 1, $sent );
+		$this->assertSame( 'New order', reset( $sent )['subject'] );
+		$this->assertSame( '', get_post_meta( $entry_id, Payment_Status::PENDING_EMAIL_META_KEY, true ) );
+	}
+
+	public function test_fixed_amount_resolves_to_minor_units() {
+		$settings = array(
+			'currency'    => 'USD',
+			'amountMode'  => 'fixed',
+			'amount'      => 25.5,
+			'amountField' => '',
+		);
+
+		$this->assertSame( 2550, Payments::resolve_amount( $settings, array() ) );
+	}
+
+	public function test_buyer_amount_is_read_from_the_named_field() {
+		$settings = array(
+			'currency'    => 'USD',
+			'amountMode'  => 'buyer',
+			'amount'      => 0,
+			'amountField' => 'Amount',
+		);
+
+		$this->assertSame( 4000, Payments::resolve_amount( $settings, array( 'Amount' => '$40.00' ) ) );
+	}
+
+	public function test_amount_below_the_currency_minimum_is_refused() {
+		$settings = array(
+			'currency'    => 'USD',
+			'amountMode'  => 'fixed',
+			'amount'      => 0.10,
+			'amountField' => '',
+		);
+
+		$this->assertNull( Payments::resolve_amount( $settings, array() ) );
+	}
+
+	public function test_unresolvable_buyer_amount_returns_null() {
+		$settings = array(
+			'currency'    => 'USD',
+			'amountMode'  => 'buyer',
+			'amount'      => 0,
+			'amountField' => 'Amount',
+		);
+
+		$this->assertNull( Payments::resolve_amount( $settings, array( 'Amount' => 'no digits here' ) ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes

**Experiment / prototype — not for merge.** This is the Jetpack side of "what would it take to collect payments in Jetpack Forms", built end to end with the payment processor **simulated**, so the flow can be demoed and argued about before anyone commits to WPCOM-side work.

Jetpack Forms has no payment code today. Jetpack's existing payments stack (Donations, Recurring Payments, Premium Content) is entirely WPCOM-brokered: no Stripe SDK, no keys, no webhook receiver in this repo — every payment is a link to `subscribe.wordpress.com` rendered in a cross-origin iframe. That stack is fire-and-forget against a fixed-price plan; a form payment needs the opposite — a per-submission amount and a server-verifiable "this response is paid" fact. This PR builds everything around that gap and stubs the gap itself.

What's here:

* **`Order`** — HMAC-signed, single-use, entry-bound order token. The buyer carries a signature over the amount, never the amount itself, so it can't be edited client-side. (Today's Donations flow passes the amount as a buyer-editable `?amount=` query param.)
* **`Payments`** — per-form settings (a `payments` block attribute, same shape as `salesforceData` / `mailpoet`) and server-side amount resolution. `fixed` and `buyer` modes; `computed` (quantity × price) is a later phase behind the same seam.
* **`Payment_Status`** — the awaiting → paid state machine on `_feedback_payment` meta, plus holding the owner's notification email back until the response is actually paid.
* **`Payment_Endpoint`** — a `wpcom/v2` confirm route. Anonymous by design (a form payment must not require a login); the signed token is the authorization.
* **Front end** — the response is always saved first, then a checkout dialog opens. Abandoning it leaves a saved, unpaid response rather than losing the lead.
* **Dashboard** — Payment column on the responses list showing amount and paid/unpaid.

### What is simulated

The checkout dialog is ours, badged "Demo checkout — no card is charged". Nothing contacts WPCOM or Stripe and no money moves. Every record is written with `verified: false`, which is the honest value: nothing verified it.

Making this real needs four things on the WPCOM side, three of which are exposing data that already exists:

1. Accept an `order_token` in the checkout URL and take the charge amount from inside it.
2. Return `order_id` / `receipt_id` / `amount` from the subscribe endpoint — already computed, currently only sent to Tracks and logstash.
3. A blog-token-authenticated endpoint wrapping the existing ownership → purchase-details lookup, so the site can verify server-side.
4. Relay the existing fulfillment webhook to the origin site — the only thing that fixes "buyer paid, then closed the laptop".

### Deliberate shortcuts

* Responses stay on `publish` with payment state in meta, rather than a dedicated `jp-awaiting-payment` post status. Keeps unpaid responses visible in the dashboard without auditing every `post_status` query.
* Checkout CSS is injected from JS instead of going through the build pipeline.
* Payments get their own editor panel; in a real version this belongs in the integrations sidebar behind a "Connect Stripe" CTA.
* No coupons — they'd make the charged amount legitimately differ from the expected amount, which breaks strict verification.

## Related product discussion/links

* Zap team P2, "Plan for Jetpack Forms Monetization (V2, SAAS)" (Feb 2025) — lists Payments (PayPal, Stripe) as a top SAAS lever, proposes integrating the existing Jetpack payments block into Forms, and files "start researching what will be involved" as a next step. This is that research, plus a working prototype.

## Does this pull request change what data or activity we track or use?

No new tracking. It does add a `_feedback_payment` post meta record (amount, currency, status, order id) on responses to forms that collect payment. **If this ever became real, that meta would need adding to the Forms personal-data exporter and eraser** — not done here, since nothing real is stored.

## Testing instructions

1. Check out this branch and build: `jetpack build --deps plugins/jetpack`.
2. Create a page with a Form block. In the block sidebar open **Payments (prototype)** and turn on "Collect payment on submit". Set a fixed price (e.g. 25 USD).
3. View the page, fill the form, submit. A checkout dialog opens showing the amount and "Amount set by the site, not editable here".
4. Click **Pay**. Confirmation screen, then Done, then the normal form success message.
5. Submit again and click **Pay later** (or press Escape).
6. Go to **Jetpack → Forms → Responses**. The new **Payment** column shows `$25.00 · Paid` for the first and `$25.00 · Unpaid` for the second.
7. Check the owner notification inbox: only the paid submission sent one.

Things worth poking at:

* Set the amount below the currency minimum (e.g. 0.10) — submission should fail loudly rather than opening a broken checkout.
* Turn off response storage — the Payments toggle should disable itself with an explanation.
* Submit through the form preview — preview submissions never open checkout.
* Replay a confirm request with the same `order_token` — returns `{"status":"paid","replayed":true}`, no double-processing. Tamper with the token and it's rejected with `invalid_order_signature`.

Automated coverage: 11 new PHPUnit tests in `projects/packages/forms/tests/php/payments/Payments_Test.php` covering token signing/tampering/expiry, the state machine and replay, deferred notifications, and amount resolution.
