### PR TITLE
Backup: give the secondary-admin gate a way forward

### DIFF
--- a/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
+++ b/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Modernized dashboard only, behind the flag: the secondary-admin gate now offers the Backup purchase path alongside account linking, and no longer promises backups on a site that may have no plan.
+Comment: Modernized dashboard only, behind the flag: the secondary-admin gate no longer promises backups on a site that may have no plan, and tells the reader a plan may also be needed.
 
 

--- a/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
+++ b/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Modernized dashboard only, behind the flag: the secondary-admin gate no longer promises backups on a site that may have no plan, and tells the reader a plan may also be needed.
+Comment: Modernized dashboard only, behind the flag: the secondary-admin gate no longer promises backups on a site that may have no plan, tells the reader a plan may also be needed, and links straight into My Jetpack's account-link screen rather than its landing page.
 
 

--- a/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
+++ b/projects/packages/backup/changelog/update-backup-secondary-admin-way-forward
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Modernized dashboard only, behind the flag: the secondary-admin gate now offers the Backup purchase path alongside account linking, and no longer promises backups on a site that may have no plan.
+
+

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -11,9 +11,12 @@ import UpgradeButton from './upgrade-button';
  *
  * This is the whole purchase path for a site that is known to have no
  * Backup, so it carries both ways in: buy one, or redeem one already
- * bought. The purchase link itself lives in `<UpgradeButton>`, which the
- * secondary-admin screen shares — that reader may be on a plan-less site
- * too, and their screen has no way to find out.
+ * bought. The purchase link itself lives in `<UpgradeButton>`.
+ *
+ * It is also the only screen that can carry it. Checkout needs a linked
+ * WordPress.com connection, and this gate is reached only once there is
+ * one — which is why the secondary-admin gate routes its reader through
+ * linking to here rather than offering a shortcut they cannot complete.
  *
  * @return The rendered fallback.
  */

--- a/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/no-backup-plan.tsx
@@ -1,39 +1,23 @@
-import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
-import { Button, Card, Notice } from '@wordpress/components';
+import { Card, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
-import { useSiteSuffix } from '../../hooks/use-connection';
 import LicenseKeyLink from './license-key-link';
 import PromotedPrice from './promoted-price';
+import UpgradeButton from './upgrade-button';
 
 /**
  * Fallback shown when the site is fully connected but has no active
  * Backup plan.
  *
- * This is the whole purchase path for a site without Backup, so it
- * carries both ways in: buy one, or redeem one already bought.
- *
- * The destination is the redirect service, with the same slug the legacy
- * no-plan card used rather than a jetpack.com URL written here — that
- * slug's target is maintained outside this repo, so reusing it keeps
- * this screen pointing wherever that one already points.
- *
- * No Tracks event on the CTA yet: there is no Tracks client on the
- * modernized page at all — `enqueue_admin_scripts()` returns before
- * registering one — so legacy's `jetpack_backup_plugin_upgrade_click`
- * has nowhere to go until that lands. Wiring it is H1b's job.
+ * This is the whole purchase path for a site that is known to have no
+ * Backup, so it carries both ways in: buy one, or redeem one already
+ * bought. The purchase link itself lives in `<UpgradeButton>`, which the
+ * secondary-admin screen shares — that reader may be on a plan-less site
+ * too, and their screen has no way to find out.
  *
  * @return The rendered fallback.
  */
 export default function NoBackupPlanScreen() {
-	const site = useSiteSuffix();
-	// The key is omitted rather than passed as undefined. `getRedirectUrl`
-	// walks its args with `for…in`, so a present-but-undefined `site` is
-	// encoded — the link would carry the literal string `undefined` — and
-	// its mere presence also suppresses the helper's own site fallback.
-	// Passing nothing is the only way this degrades cleanly.
-	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
-
 	return (
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
@@ -47,18 +31,7 @@ export default function NoBackupPlanScreen() {
 					) }
 				</Notice>
 				<PromotedPrice />
-				{ /*
-				 * Same tab, as legacy did. An upgrade flow that opens a new
-				 * one strands the page the reader started from, and returns
-				 * them to a dashboard that still says they have no plan.
-				 *
-				 * The label is legacy's, which this package still ships in
-				 * three other places — so it arrives translated rather than
-				 * waiting a GlotPress cycle.
-				 */ }
-				<Button variant="primary" href={ upgradeUrl }>
-					{ __( 'Get VaultPress Backup', 'jetpack-backup-pkg' ) }
-				</Button>
+				<UpgradeButton />
 				<LicenseKeyLink />
 			</Stack>
 		</Card>

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -2,6 +2,7 @@ import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import LicenseKeyLink from './license-key-link';
+import UpgradeButton from './upgrade-button';
 
 /** My Jetpack, for the reasons spelled out in `not-connected.tsx`. */
 const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
@@ -10,6 +11,19 @@ const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
  * Fallback shown when the current user is an admin but isn't personally
  * linked to a WordPress.com account on this site.
  *
+ * This screen cannot know whether the site has a Backup plan: the gate
+ * reaches it from connection state alone, and the capabilities bridge
+ * would answer 403 without a user connection, so there is nothing to ask.
+ * That makes it the one gate that has to be right for both readers, so
+ * every claim here is conditional: the condition leads, because a flat
+ * "you'll see this site's backups" is false on a plan-less site and a
+ * later "if it has a plan" does not retract it.
+ *
+ * Linking stays the primary action: on a site that does have a plan it is
+ * the only thing standing between this reader and their backups. The
+ * upgrade path is added beside it, not in place of it, and is a plain
+ * link precisely so this screen keeps issuing no requests at all.
+ *
  * @return The rendered fallback.
  */
 export default function SecondaryAdminScreen() {
@@ -17,7 +31,7 @@ export default function SecondaryAdminScreen() {
 		<Card className="jpb-gates__card">
 			<Stack direction="column" gap="md" align="center">
 				<Text variant="heading-md" render={ <h2 /> }>
-					{ __( 'Link your account to view backups', 'jetpack-backup-pkg' ) }
+					{ __( 'Link your WordPress.com account', 'jetpack-backup-pkg' ) }
 				</Text>
 				<Text>
 					{ __(
@@ -25,9 +39,18 @@ export default function SecondaryAdminScreen() {
 						'jetpack-backup-pkg'
 					) }
 				</Text>
-				<Button variant="primary" href={ JETPACK_CONNECT_USER_URL }>
-					{ __( 'Link my account', 'jetpack-backup-pkg' ) }
-				</Button>
+				<Text>
+					{ __(
+						"Once your account is linked, you'll see any backups this site has. If it doesn't have an active Backup plan yet, you can add VaultPress Backup to start protecting it.",
+						'jetpack-backup-pkg'
+					) }
+				</Text>
+				<Stack direction="row" gap="sm" justify="center" wrap="wrap">
+					<Button variant="primary" href={ JETPACK_CONNECT_USER_URL }>
+						{ __( 'Link my account', 'jetpack-backup-pkg' ) }
+					</Button>
+					<UpgradeButton variant="secondary" />
+				</Stack>
 				<LicenseKeyLink />
 			</Stack>
 		</Card>

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -5,9 +5,8 @@ import LicenseKeyLink from './license-key-link';
 
 /**
  * My Jetpack's account-link screen, for the reasons in `not-connected.tsx`.
- * Deep-linked past its landing page, which puts "Connect account" below the
- * product grid; `skip_pricing` because this reader may already be entitled,
- * and the no-plan gate sells to the ones who are not.
+ * Deep-linked past the landing page, and `skip_pricing` because the no-plan gate
+ * already sells to the readers who need it.
  */
 const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack#/connection?skip_pricing=true';
 
@@ -15,16 +14,10 @@ const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack#/connection?skip_pri
  * Fallback shown when the current user is an admin but isn't personally
  * linked to a WordPress.com account on this site.
  *
- * This screen cannot know whether the site has a Backup plan: the gate
- * reaches it from connection state alone, and the capabilities bridge
- * would answer 403 without a user connection. So every claim leads with
- * its condition — a flat "you'll see this site's backups" is false on a
- * plan-less site, and a later hedge does not retract it.
- *
- * No purchase button, deliberately: checkout requires a linked
- * connection, so one here would hand this reader a flow they cannot
- * finish. Linking is the way forward for both readers — once linked, a
- * plan-less site lands on the no-plan gate and its working upsell.
+ * This screen cannot know whether the site has a Backup plan — the gate reaches
+ * it from connection state alone — so every claim leads with its condition. No
+ * purchase button either: checkout needs a linked connection, and linking is the
+ * way forward for both readers.
  *
  * @return The rendered fallback.
  */

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -12,24 +12,14 @@ const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
  *
  * This screen cannot know whether the site has a Backup plan: the gate
  * reaches it from connection state alone, and the capabilities bridge
- * would answer 403 without a user connection, so there is nothing to ask.
- * That makes it the one gate that has to be right for both readers, so
- * every claim here is conditional: the condition leads, because a flat
- * "you'll see this site's backups" is false on a plan-less site and a
- * later "if it has a plan" does not retract it.
+ * would answer 403 without a user connection. So every claim leads with
+ * its condition — a flat "you'll see this site's backups" is false on a
+ * plan-less site, and a later hedge does not retract it.
  *
- * No purchase button, deliberately, even though some readers here do need
- * a plan. Checkout requires a linked connection, so a "Get VaultPress
- * Backup" button on this screen would hand this particular reader a flow
- * they cannot finish — the same broken promise the copy above was fixed
- * to stop making, moved into a button.
- *
- * Linking is the way forward for both readers, which is why it is the
- * only action. It is what an entitled reader needs, and it is also the
- * first step for an unentitled one: once linked, a plan-less site lands
- * on the no-plan gate, which carries a working upsell for someone who
- * can now complete it. The copy names the plan in that order — link
- * first, then buy — rather than offering a shortcut that dead-ends.
+ * No purchase button, deliberately: checkout requires a linked
+ * connection, so one here would hand this reader a flow they cannot
+ * finish. Linking is the way forward for both readers — once linked, a
+ * plan-less site lands on the no-plan gate and its working upsell.
  *
  * @return The rendered fallback.
  */
@@ -48,7 +38,7 @@ export default function SecondaryAdminScreen() {
 				</Text>
 				<Text>
 					{ __(
-						"Once your account is linked, you'll see any backups this site has. If it doesn't have an active Backup plan yet, you can add VaultPress Backup to start protecting it.",
+						"Once your account is linked, you'll see any backups this site has. If it doesn't have an active Backup plan yet, you'll be able to add VaultPress Backup to start protecting it.",
 						'jetpack-backup-pkg'
 					) }
 				</Text>

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -3,8 +3,13 @@ import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import LicenseKeyLink from './license-key-link';
 
-/** My Jetpack, for the reasons spelled out in `not-connected.tsx`. */
-const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
+/**
+ * My Jetpack's account-link screen, for the reasons in `not-connected.tsx`.
+ * Deep-linked past its landing page, which puts "Connect account" below the
+ * product grid; `skip_pricing` because this reader may already be entitled,
+ * and the no-plan gate sells to the ones who are not.
+ */
+const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack#/connection?skip_pricing=true';
 
 /**
  * Fallback shown when the current user is an admin but isn't personally

--- a/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/secondary-admin.tsx
@@ -2,7 +2,6 @@ import { Button, Card } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import LicenseKeyLink from './license-key-link';
-import UpgradeButton from './upgrade-button';
 
 /** My Jetpack, for the reasons spelled out in `not-connected.tsx`. */
 const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
@@ -19,10 +18,18 @@ const JETPACK_CONNECT_USER_URL = 'admin.php?page=my-jetpack';
  * "you'll see this site's backups" is false on a plan-less site and a
  * later "if it has a plan" does not retract it.
  *
- * Linking stays the primary action: on a site that does have a plan it is
- * the only thing standing between this reader and their backups. The
- * upgrade path is added beside it, not in place of it, and is a plain
- * link precisely so this screen keeps issuing no requests at all.
+ * No purchase button, deliberately, even though some readers here do need
+ * a plan. Checkout requires a linked connection, so a "Get VaultPress
+ * Backup" button on this screen would hand this particular reader a flow
+ * they cannot finish — the same broken promise the copy above was fixed
+ * to stop making, moved into a button.
+ *
+ * Linking is the way forward for both readers, which is why it is the
+ * only action. It is what an entitled reader needs, and it is also the
+ * first step for an unentitled one: once linked, a plan-less site lands
+ * on the no-plan gate, which carries a working upsell for someone who
+ * can now complete it. The copy names the plan in that order — link
+ * first, then buy — rather than offering a shortcut that dead-ends.
  *
  * @return The rendered fallback.
  */
@@ -45,12 +52,9 @@ export default function SecondaryAdminScreen() {
 						'jetpack-backup-pkg'
 					) }
 				</Text>
-				<Stack direction="row" gap="sm" justify="center" wrap="wrap">
-					<Button variant="primary" href={ JETPACK_CONNECT_USER_URL }>
-						{ __( 'Link my account', 'jetpack-backup-pkg' ) }
-					</Button>
-					<UpgradeButton variant="secondary" />
-				</Stack>
+				<Button variant="primary" href={ JETPACK_CONNECT_USER_URL }>
+					{ __( 'Link my account', 'jetpack-backup-pkg' ) }
+				</Button>
 				<LicenseKeyLink />
 			</Stack>
 		</Card>

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -3,23 +3,18 @@ import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSiteSuffix } from '../../hooks/use-connection';
 
-type Props = {
-	/** How much weight the button carries on the screen it appears on. */
-	variant?: 'primary' | 'secondary';
-};
-
 /**
  * The way in for someone who has not bought Backup yet.
  *
- * Shared by the two gates that can be looking at a site without a plan:
- * the no-plan screen, which knows there is none, and the secondary-admin
- * screen, which cannot know either way and so has to offer this path
- * regardless.
+ * Only the no-plan gate renders this, and that is a constraint rather
+ * than an accident: checkout needs a linked WordPress.com connection, so
+ * this button belongs only on a screen whose reader has one. The
+ * secondary-admin gate deliberately does not use it — see the note there.
  *
  * The destination is the redirect service, with the same slug the legacy
  * no-plan card used rather than a jetpack.com URL written here — that
- * slug's target is maintained outside this repo, so reusing it keeps
- * these screens pointing wherever that one already points.
+ * slug's target is maintained outside this repo, so reusing it keeps this
+ * screen pointing wherever that one already points.
  *
  * Same tab, as legacy did. An upgrade flow that opens a new one strands
  * the page the reader started from, and returns them to a dashboard that
@@ -34,11 +29,9 @@ type Props = {
  * registering one — so legacy's `jetpack_backup_plugin_upgrade_click`
  * has nowhere to go until that lands. Wiring it is H1b's job.
  *
- * @param props         - Component props.
- * @param props.variant - Button variant; defaults to `primary`.
  * @return The rendered button.
  */
-export default function UpgradeButton( { variant = 'primary' }: Props ) {
+export default function UpgradeButton() {
 	const site = useSiteSuffix();
 	// The key is omitted rather than passed as undefined. `getRedirectUrl`
 	// walks its args with `for…in`, so a present-but-undefined `site` is
@@ -48,7 +41,7 @@ export default function UpgradeButton( { variant = 'primary' }: Props ) {
 	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
 	return (
-		<Button variant={ variant } href={ upgradeUrl }>
+		<Button variant="primary" href={ upgradeUrl }>
 			{ __( 'Get VaultPress Backup', 'jetpack-backup-pkg' ) }
 		</Button>
 	);

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -6,38 +6,26 @@ import { useSiteSuffix } from '../../hooks/use-connection';
 /**
  * The way in for someone who has not bought Backup yet.
  *
- * Only the no-plan gate renders this, and that is a constraint rather
- * than an accident: checkout needs a linked WordPress.com connection, so
- * this button belongs only on a screen whose reader has one. The
- * secondary-admin gate deliberately does not use it — see the note there.
+ * Only the no-plan gate renders this: checkout needs a linked
+ * WordPress.com connection, so the secondary-admin gate deliberately does
+ * not — see the note there.
  *
- * The destination is the redirect service, with the same slug the legacy
- * no-plan card used rather than a jetpack.com URL written here — that
- * slug's target is maintained outside this repo, so reusing it keeps this
- * screen pointing wherever that one already points.
+ * Reuses legacy's redirect slug and label rather than a URL and string
+ * written here, so the destination stays maintained outside this repo and
+ * the label arrives already translated. Same tab, as legacy did: an
+ * upgrade flow that opens a new one strands the page it started from.
  *
- * Same tab, as legacy did. An upgrade flow that opens a new one strands
- * the page the reader started from, and returns them to a dashboard that
- * still says they have no plan.
- *
- * The label is legacy's, which this package still ships in three other
- * places — so it arrives translated rather than waiting a GlotPress
- * cycle.
- *
- * No Tracks event on the CTA yet: there is no Tracks client on the
- * modernized page at all — `enqueue_admin_scripts()` returns before
- * registering one — so legacy's `jetpack_backup_plugin_upgrade_click`
- * has nowhere to go until that lands. Wiring it is H1b's job.
+ * No Tracks event yet — the modernized page registers no Tracks client at
+ * all, so legacy's `jetpack_backup_plugin_upgrade_click` has nowhere to
+ * go until H1b lands one.
  *
  * @return The rendered button.
  */
 export default function UpgradeButton() {
 	const site = useSiteSuffix();
-	// The key is omitted rather than passed as undefined. `getRedirectUrl`
+	// The key is omitted rather than passed as undefined: `getRedirectUrl`
 	// walks its args with `for…in`, so a present-but-undefined `site` is
-	// encoded — the link would carry the literal string `undefined` — and
-	// its mere presence also suppresses the helper's own site fallback.
-	// Passing nothing is the only way this degrades cleanly.
+	// encoded literally *and* suppresses the helper's own site fallback.
 	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
 	return (

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -6,18 +6,10 @@ import { useSiteSuffix } from '../../hooks/use-connection';
 /**
  * The way in for someone who has not bought Backup yet.
  *
- * Only the no-plan gate renders this: checkout needs a linked
- * WordPress.com connection, so the secondary-admin gate deliberately does
- * not — see the note there.
- *
- * Reuses legacy's redirect slug and label rather than a URL and string
- * written here, so the destination stays maintained outside this repo and
- * the label arrives already translated. Same tab, as legacy did: an
- * upgrade flow that opens a new one strands the page it started from.
- *
- * No Tracks event yet — the modernized page registers no Tracks client at
- * all, so legacy's `jetpack_backup_plugin_upgrade_click` has nowhere to
- * go until H1b lands one.
+ * Only the no-plan gate renders this: checkout needs a linked WordPress.com
+ * connection, which the secondary-admin gate cannot assume. Reuses legacy's
+ * redirect slug and label, so the destination stays maintained outside this repo
+ * and the label arrives already translated.
  *
  * @return The rendered button.
  */

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -1,0 +1,55 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSiteSuffix } from '../../hooks/use-connection';
+
+type Props = {
+	/** How much weight the button carries on the screen it appears on. */
+	variant?: 'primary' | 'secondary';
+};
+
+/**
+ * The way in for someone who has not bought Backup yet.
+ *
+ * Shared by the two gates that can be looking at a site without a plan:
+ * the no-plan screen, which knows there is none, and the secondary-admin
+ * screen, which cannot know either way and so has to offer this path
+ * regardless.
+ *
+ * The destination is the redirect service, with the same slug the legacy
+ * no-plan card used rather than a jetpack.com URL written here — that
+ * slug's target is maintained outside this repo, so reusing it keeps
+ * these screens pointing wherever that one already points.
+ *
+ * Same tab, as legacy did. An upgrade flow that opens a new one strands
+ * the page the reader started from, and returns them to a dashboard that
+ * still says they have no plan.
+ *
+ * The label is legacy's, which this package still ships in three other
+ * places — so it arrives translated rather than waiting a GlotPress
+ * cycle.
+ *
+ * No Tracks event on the CTA yet: there is no Tracks client on the
+ * modernized page at all — `enqueue_admin_scripts()` returns before
+ * registering one — so legacy's `jetpack_backup_plugin_upgrade_click`
+ * has nowhere to go until that lands. Wiring it is H1b's job.
+ *
+ * @param props         - Component props.
+ * @param props.variant - Button variant; defaults to `primary`.
+ * @return The rendered button.
+ */
+export default function UpgradeButton( { variant = 'primary' }: Props ) {
+	const site = useSiteSuffix();
+	// The key is omitted rather than passed as undefined. `getRedirectUrl`
+	// walks its args with `for…in`, so a present-but-undefined `site` is
+	// encoded — the link would carry the literal string `undefined` — and
+	// its mere presence also suppresses the helper's own site fallback.
+	// Passing nothing is the only way this degrades cleanly.
+	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
+
+	return (
+		<Button variant={ variant } href={ upgradeUrl }>
+			{ __( 'Get VaultPress Backup', 'jetpack-backup-pkg' ) }
+		</Button>
+	);
+}

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -28,7 +28,7 @@ const CAPABILITIES_PATH = '/jetpack/v4/site/capabilities';
 // One marker per branch of the gate's decision tree, so a test that
 // expects one screen cannot be satisfied by another.
 const NOT_CONNECTED = 'Connect Jetpack to get started';
-const SECONDARY_ADMIN_SCREEN = 'Link your account to view backups';
+const SECONDARY_ADMIN_SCREEN = 'Link your WordPress.com account';
 const NO_PLAN = "This site doesn't have an active Backup plan";
 const CAPABILITIES_ERROR = "We couldn't load your backup details";
 const BODY = 'dashboard body';

--- a/projects/packages/backup/tests/secondary-admin-gate.test.tsx
+++ b/projects/packages/backup/tests/secondary-admin-gate.test.tsx
@@ -1,18 +1,8 @@
-// JETPACK-2311 H4 — a secondary admin on a site with no Backup plan had
-// no way forward.
-//
-// The gate answers `secondary-admin` from connection state alone, before
-// anything is known about the plan, and deliberately so: without a user
-// connection the capabilities bridge can only answer 403. This screen
-// therefore never learns whether the site has a plan — and it used to
-// assume one, promising backups that may not exist and offering no other
-// way off the page. Legacy was no better: a bare `<h2>` with no actions.
-//
-// The fix is the screen, not the gate: every claim now leads with its
-// condition. A purchase button here was considered and rejected, because
-// checkout requires a linked connection and would hand this reader a flow
-// they cannot finish. Its absence is pinned below, because nothing else
-// would notice it coming back.
+// JETPACK-2311 H4 — a secondary admin on a site with no Backup plan had no way
+// forward. The gate answers from connection state alone, so this screen never
+// learns whether the site has a plan and every claim has to lead with its
+// condition. The absence of a purchase button is pinned below, since checkout
+// needs a linked connection and nothing else would notice one coming back.
 
 const mockApiFetch = jest.fn();
 
@@ -51,12 +41,8 @@ describe( 'Secondary-admin gate', () => {
 		}
 	} );
 
-	// Verified against a live My Jetpack: `#/connection` renders a screen whose
-	// single primary action is "Connect your user account", while the landing
-	// page this used to reach shows the product grid with the connection
-	// section below it. The query lives inside the hash on purpose — the
-	// router re-parses the fragment, so `skip_pricing` reaches it even though
-	// PHP never sees it.
+	// The query lives inside the hash on purpose: My Jetpack's router re-parses
+	// the fragment, so `skip_pricing` reaches it even though PHP never sees it.
 	it( "sends the reader into the account-link flow, not My Jetpack's landing page", () => {
 		render( <SecondaryAdminScreen /> );
 

--- a/projects/packages/backup/tests/secondary-admin-gate.test.tsx
+++ b/projects/packages/backup/tests/secondary-admin-gate.test.tsx
@@ -1,0 +1,143 @@
+// JETPACK-2311 H4 — a secondary admin on a site with no Backup plan had
+// no way forward.
+//
+// The gate answers `secondary-admin` from connection state alone, before
+// anything is known about the plan, and deliberately so: without a user
+// connection the capabilities bridge can only answer 403, so asking is
+// not an option. This screen therefore never learns whether the site has
+// a plan — and it used to assume one, telling the reader to link an
+// account to view backups and offering no other way off the page. On a
+// plan-less site that promised backups that do not exist and led to a
+// linked account that still shows nothing.
+//
+// Legacy did not do better: a secondary admin there fell through to
+// `LoadedState`, `useCapabilities` set `capabilitiesError = 'is_unlinked'`
+// because the request 403s without a user token, and the screen was a
+// bare `<h2>` — "Site backups are managed by the owner of this site's
+// Jetpack connection." — with no actions at all. Its priced
+// `NoBackupCapabilities` upsell needs a non-null capabilities array and
+// so was unreachable on this path. So the purchase path here is new, not
+// restored, which is why it is pinned rather than assumed.
+//
+// The fix is the screen, not the gate. It carries both ways forward, and
+// every claim it makes leads with its condition.
+//
+// Which is why the price the no-plan screen shows is not here: the
+// upgrade link costs nothing to render, and the zero-request guarantee
+// this screen is built on — pinned in `stages.test.tsx` and
+// `gate-decision.test.tsx` — is worth more than a figure.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { render, screen } from '@testing-library/react';
+import SecondaryAdminScreen from '../src/dashboard/components/gates/secondary-admin';
+
+const SITE_SUFFIX = 'example.com';
+
+/**
+ * Point `useSiteSuffix` at a site slug, or at none.
+ *
+ * @param siteSuffix - The slug PHP would emit, or undefined.
+ */
+function setSiteSuffix( siteSuffix: string | undefined ) {
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		siteSuffix,
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	setSiteSuffix( SITE_SUFFIX );
+} );
+
+describe( 'Secondary-admin gate', () => {
+	it( 'offers the purchase path a plan-less site needs', () => {
+		render( <SecondaryAdminScreen /> );
+
+		const cta = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
+
+		// The same destination the no-plan screen uses: the redirect
+		// service, site-scoped, so checkout knows which site it is for.
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'jetpack.com/redirect' ) );
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( SITE_SUFFIX ) );
+	} );
+
+	it( 'keeps account linking as the primary action beside it', () => {
+		// The upsell is an addition, not a replacement, and it is the
+		// junior of the two: a secondary admin on a site that *does* have
+		// a plan still has to link an account, and this screen cannot tell
+		// which reader it is talking to. Promoting the upgrade button over
+		// the link would sell a plan to someone who already has one.
+		//
+		// Asserted because nothing else would notice. The two variants are
+		// one word apart in the source and the argument for this ordering
+		// lives only in a docblock, which no test reads.
+		render( <SecondaryAdminScreen /> );
+
+		const link = screen.getByRole( 'link', { name: /^Link my account$/ } );
+		const upgrade = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
+
+		expect( link ).toHaveClass( 'is-primary' );
+		expect( upgrade ).not.toHaveClass( 'is-primary' );
+	} );
+
+	it( 'leads with the condition rather than promising backups outright', () => {
+		// The screen does not know whether the site has a plan, so an
+		// unconditional "you'll see this site's backups" is false for half
+		// its readers — and a hedge that arrives in the next sentence does
+		// not retract a flat claim in this one. Both halves are pinned:
+		// the conditional reading of what linking gets you, and the
+		// sentence naming the no-plan case that makes the upgrade button
+		// below something other than a non-sequitur.
+		render( <SecondaryAdminScreen /> );
+
+		expect(
+			screen.getByText( /Once your account is linked, you'll see any backups this site has/ )
+		).toBeInTheDocument();
+		expect( screen.getByText( /doesn't have an active Backup plan/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits the site rather than sending the word "undefined"', () => {
+		// `getRedirectUrl` walks its args with `for…in`, so a
+		// present-but-undefined `site` is encoded as the literal string
+		// `undefined`, and its presence also suppresses the helper's own
+		// site fallback. Passing no key at all is the only clean degrade.
+		setSiteSuffix( undefined );
+
+		render( <SecondaryAdminScreen /> );
+
+		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).not.toHaveAttribute(
+			'href',
+			expect.stringContaining( 'undefined' )
+		);
+	} );
+
+	it( 'keeps the reader in the same tab', () => {
+		// Same as the no-plan screen: a flow that opens a new tab strands
+		// the page the reader started from.
+		render( <SecondaryAdminScreen /> );
+
+		for ( const link of screen.getAllByRole( 'link' ) ) {
+			expect( link ).not.toHaveAttribute( 'target', '_blank' );
+		}
+	} );
+
+	it( 'buys its way forward without a single request', () => {
+		// Rendered with no `QueryClientProvider` in scope on purpose. A
+		// screen that gained a query hook would throw "No QueryClient set"
+		// here rather than quietly passing an `apiFetch` assertion that a
+		// mocked-away network makes cheap — which is the failure mode the
+		// zero-request guarantee actually has.
+		render( <SecondaryAdminScreen /> );
+
+		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/backup/tests/secondary-admin-gate.test.tsx
+++ b/projects/packages/backup/tests/secondary-admin-gate.test.tsx
@@ -3,29 +3,16 @@
 //
 // The gate answers `secondary-admin` from connection state alone, before
 // anything is known about the plan, and deliberately so: without a user
-// connection the capabilities bridge can only answer 403, so asking is
-// not an option. This screen therefore never learns whether the site has
-// a plan — and it used to assume one, telling the reader to link an
-// account to view backups and offering no other way off the page. On a
-// plan-less site that promised backups that do not exist and led to a
-// linked account that still shows nothing.
+// connection the capabilities bridge can only answer 403. This screen
+// therefore never learns whether the site has a plan — and it used to
+// assume one, promising backups that may not exist and offering no other
+// way off the page. Legacy was no better: a bare `<h2>` with no actions.
 //
-// Legacy did not do better: a secondary admin there fell through to
-// `LoadedState`, `useCapabilities` set `capabilitiesError = 'is_unlinked'`
-// because the request 403s without a user token, and the screen was a
-// bare `<h2>` — "Site backups are managed by the owner of this site's
-// Jetpack connection." — with no actions at all.
-//
-// The fix is the screen, not the gate: every claim it makes now leads
-// with its condition.
-//
-// A purchase button here was considered and rejected. Checkout requires a
-// linked connection, so it would have handed this reader a flow they
-// cannot finish — the same broken promise, moved from the copy into a
-// button. Linking is the real way forward for both readers, and a
-// plan-less site reaches the no-plan gate's working upsell straight
-// after. Its absence is pinned below, because nothing else would notice
-// it coming back.
+// The fix is the screen, not the gate: every claim now leads with its
+// condition. A purchase button here was considered and rejected, because
+// checkout requires a linked connection and would hand this reader a flow
+// they cannot finish. Its absence is pinned below, because nothing else
+// would notice it coming back.
 
 const mockApiFetch = jest.fn();
 
@@ -38,28 +25,16 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 import { render, screen } from '@testing-library/react';
 import SecondaryAdminScreen from '../src/dashboard/components/gates/secondary-admin';
 
-const SITE_SUFFIX = 'example.com';
-
 beforeEach( () => {
 	mockApiFetch.mockReset();
-
-	window.JP_CONNECTION_INITIAL_STATE = {
-		...window.JP_CONNECTION_INITIAL_STATE,
-		siteSuffix: SITE_SUFFIX,
-	} as typeof window.JP_CONNECTION_INITIAL_STATE;
 } );
 
 describe( 'Secondary-admin gate', () => {
 	it( 'offers no purchase action, because this reader cannot complete one', () => {
-		// Checkout needs a linked WordPress.com connection, which is
-		// precisely what this reader does not have. A "Get VaultPress
-		// Backup" button here would send them to a flow that stops partway
-		// and returns them to this same screen.
 		render( <SecondaryAdminScreen /> );
 
 		// The outside witness. Without it every absence below would pass
-		// just as well on a screen that rendered nothing at all, which is
-		// the way this kind of test usually rots.
+		// just as well on a screen that rendered nothing at all.
 		expect( screen.getByRole( 'link', { name: /^Link my account$/ } ) ).toBeInTheDocument();
 
 		expect(
@@ -77,16 +52,10 @@ describe( 'Secondary-admin gate', () => {
 	} );
 
 	it( 'leads with the condition rather than promising backups outright', () => {
-		// The screen does not know whether the site has a plan, so an
-		// unconditional "you'll see this site's backups" is false for half
-		// its readers — and a hedge that arrives in the next sentence does
-		// not retract a flat claim in this one.
-		//
 		// Both halves are pinned: the conditional reading of what linking
-		// gets you, and the sentence naming the no-plan case. The second
-		// matters more now than it did when a button sat below it — with
-		// no upsell on this screen, it is the only thing telling a reader
-		// on a plan-less site that linking is not the last step.
+		// gets you, and the sentence naming the no-plan case. With no
+		// upsell on this screen the second is the only thing telling a
+		// reader on a plan-less site that linking is not the last step.
 		render( <SecondaryAdminScreen /> );
 
 		expect(
@@ -96,11 +65,10 @@ describe( 'Secondary-admin gate', () => {
 	} );
 
 	it( 'renders without a single request', () => {
-		// Rendered with no `QueryClientProvider` in scope on purpose. A
+		// Rendered with no `QueryClientProvider` in scope on purpose: a
 		// screen that gained a query hook would throw "No QueryClient set"
 		// here rather than quietly passing an `apiFetch` assertion that a
-		// mocked-away network makes cheap — which is the failure mode the
-		// zero-request guarantee actually has.
+		// mocked-away network makes cheap.
 		render( <SecondaryAdminScreen /> );
 
 		expect( screen.getByRole( 'link', { name: /^Link my account$/ } ) ).toBeInTheDocument();

--- a/projects/packages/backup/tests/secondary-admin-gate.test.tsx
+++ b/projects/packages/backup/tests/secondary-admin-gate.test.tsx
@@ -14,18 +14,18 @@
 // `LoadedState`, `useCapabilities` set `capabilitiesError = 'is_unlinked'`
 // because the request 403s without a user token, and the screen was a
 // bare `<h2>` — "Site backups are managed by the owner of this site's
-// Jetpack connection." — with no actions at all. Its priced
-// `NoBackupCapabilities` upsell needs a non-null capabilities array and
-// so was unreachable on this path. So the purchase path here is new, not
-// restored, which is why it is pinned rather than assumed.
+// Jetpack connection." — with no actions at all.
 //
-// The fix is the screen, not the gate. It carries both ways forward, and
-// every claim it makes leads with its condition.
+// The fix is the screen, not the gate: every claim it makes now leads
+// with its condition.
 //
-// Which is why the price the no-plan screen shows is not here: the
-// upgrade link costs nothing to render, and the zero-request guarantee
-// this screen is built on — pinned in `stages.test.tsx` and
-// `gate-decision.test.tsx` — is worth more than a figure.
+// A purchase button here was considered and rejected. Checkout requires a
+// linked connection, so it would have handed this reader a flow they
+// cannot finish — the same broken promise, moved from the copy into a
+// button. Linking is the real way forward for both readers, and a
+// plan-less site reaches the no-plan gate's working upsell straight
+// after. Its absence is pinned below, because nothing else would notice
+// it coming back.
 
 const mockApiFetch = jest.fn();
 
@@ -40,62 +40,53 @@ import SecondaryAdminScreen from '../src/dashboard/components/gates/secondary-ad
 
 const SITE_SUFFIX = 'example.com';
 
-/**
- * Point `useSiteSuffix` at a site slug, or at none.
- *
- * @param siteSuffix - The slug PHP would emit, or undefined.
- */
-function setSiteSuffix( siteSuffix: string | undefined ) {
-	window.JP_CONNECTION_INITIAL_STATE = {
-		...window.JP_CONNECTION_INITIAL_STATE,
-		siteSuffix,
-	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
-}
-
 beforeEach( () => {
 	mockApiFetch.mockReset();
-	setSiteSuffix( SITE_SUFFIX );
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		siteSuffix: SITE_SUFFIX,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
 } );
 
 describe( 'Secondary-admin gate', () => {
-	it( 'offers the purchase path a plan-less site needs', () => {
+	it( 'offers no purchase action, because this reader cannot complete one', () => {
+		// Checkout needs a linked WordPress.com connection, which is
+		// precisely what this reader does not have. A "Get VaultPress
+		// Backup" button here would send them to a flow that stops partway
+		// and returns them to this same screen.
 		render( <SecondaryAdminScreen /> );
 
-		const cta = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
+		// The outside witness. Without it every absence below would pass
+		// just as well on a screen that rendered nothing at all, which is
+		// the way this kind of test usually rots.
+		expect( screen.getByRole( 'link', { name: /^Link my account$/ } ) ).toBeInTheDocument();
 
-		// The same destination the no-plan screen uses: the redirect
-		// service, site-scoped, so checkout knows which site it is for.
-		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'jetpack.com/redirect' ) );
-		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( SITE_SUFFIX ) );
-	} );
+		expect(
+			screen.queryByRole( 'link', { name: /^Get VaultPress Backup$/ } )
+		).not.toBeInTheDocument();
 
-	it( 'keeps account linking as the primary action beside it', () => {
-		// The upsell is an addition, not a replacement, and it is the
-		// junior of the two: a secondary admin on a site that *does* have
-		// a plan still has to link an account, and this screen cannot tell
-		// which reader it is talking to. Promoting the upgrade button over
-		// the link would sell a plan to someone who already has one.
-		//
-		// Asserted because nothing else would notice. The two variants are
-		// one word apart in the source and the argument for this ordering
-		// lives only in a docblock, which no test reads.
-		render( <SecondaryAdminScreen /> );
-
-		const link = screen.getByRole( 'link', { name: /^Link my account$/ } );
-		const upgrade = screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } );
-
-		expect( link ).toHaveClass( 'is-primary' );
-		expect( upgrade ).not.toHaveClass( 'is-primary' );
+		// By destination as well as by label, so a purchase affordance
+		// cannot come back under a different name.
+		for ( const link of screen.getAllByRole( 'link' ) ) {
+			expect( link ).not.toHaveAttribute(
+				'href',
+				expect.stringContaining( 'jetpack.com/redirect' )
+			);
+		}
 	} );
 
 	it( 'leads with the condition rather than promising backups outright', () => {
 		// The screen does not know whether the site has a plan, so an
 		// unconditional "you'll see this site's backups" is false for half
 		// its readers — and a hedge that arrives in the next sentence does
-		// not retract a flat claim in this one. Both halves are pinned:
-		// the conditional reading of what linking gets you, and the
-		// sentence naming the no-plan case that makes the upgrade button
-		// below something other than a non-sequitur.
+		// not retract a flat claim in this one.
+		//
+		// Both halves are pinned: the conditional reading of what linking
+		// gets you, and the sentence naming the no-plan case. The second
+		// matters more now than it did when a button sat below it — with
+		// no upsell on this screen, it is the only thing telling a reader
+		// on a plan-less site that linking is not the last step.
 		render( <SecondaryAdminScreen /> );
 
 		expect(
@@ -104,32 +95,7 @@ describe( 'Secondary-admin gate', () => {
 		expect( screen.getByText( /doesn't have an active Backup plan/ ) ).toBeInTheDocument();
 	} );
 
-	it( 'omits the site rather than sending the word "undefined"', () => {
-		// `getRedirectUrl` walks its args with `for…in`, so a
-		// present-but-undefined `site` is encoded as the literal string
-		// `undefined`, and its presence also suppresses the helper's own
-		// site fallback. Passing no key at all is the only clean degrade.
-		setSiteSuffix( undefined );
-
-		render( <SecondaryAdminScreen /> );
-
-		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).not.toHaveAttribute(
-			'href',
-			expect.stringContaining( 'undefined' )
-		);
-	} );
-
-	it( 'keeps the reader in the same tab', () => {
-		// Same as the no-plan screen: a flow that opens a new tab strands
-		// the page the reader started from.
-		render( <SecondaryAdminScreen /> );
-
-		for ( const link of screen.getAllByRole( 'link' ) ) {
-			expect( link ).not.toHaveAttribute( 'target', '_blank' );
-		}
-	} );
-
-	it( 'buys its way forward without a single request', () => {
+	it( 'renders without a single request', () => {
 		// Rendered with no `QueryClientProvider` in scope on purpose. A
 		// screen that gained a query hook would throw "No QueryClient set"
 		// here rather than quietly passing an `apiFetch` assertion that a
@@ -137,7 +103,7 @@ describe( 'Secondary-admin gate', () => {
 		// zero-request guarantee actually has.
 		render( <SecondaryAdminScreen /> );
 
-		expect( screen.getByRole( 'link', { name: /^Get VaultPress Backup$/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /^Link my account$/ } ) ).toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/tests/secondary-admin-gate.test.tsx
+++ b/projects/packages/backup/tests/secondary-admin-gate.test.tsx
@@ -51,6 +51,21 @@ describe( 'Secondary-admin gate', () => {
 		}
 	} );
 
+	// Verified against a live My Jetpack: `#/connection` renders a screen whose
+	// single primary action is "Connect your user account", while the landing
+	// page this used to reach shows the product grid with the connection
+	// section below it. The query lives inside the hash on purpose — the
+	// router re-parses the fragment, so `skip_pricing` reaches it even though
+	// PHP never sees it.
+	it( "sends the reader into the account-link flow, not My Jetpack's landing page", () => {
+		render( <SecondaryAdminScreen /> );
+
+		expect( screen.getByRole( 'link', { name: /^Link my account$/ } ) ).toHaveAttribute(
+			'href',
+			'admin.php?page=my-jetpack#/connection?skip_pricing=true'
+		);
+	} );
+
 	it( 'leads with the condition rather than promising backups outright', () => {
 		// Both halves are pinned: the conditional reading of what linking
 		// gets you, and the sentence naming the no-plan case. With no

--- a/projects/packages/backup/tests/stages.test.tsx
+++ b/projects/packages/backup/tests/stages.test.tsx
@@ -146,7 +146,7 @@ describe( 'Gates', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( 'Link your account to view backups' )
+			screen.findByText( 'Link your WordPress.com account' )
 		).resolves.toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );


### PR DESCRIPTION
Fixes JETPACK-2311

## Proposed changes

A *secondary admin* — an administrator with `manage_options` who has not linked their own WordPress.com account — reaching the modernized Backup dashboard was told to link an account so they could view backups. On a site with **no Backup plan** there are no backups to view, so the screen promised something it had no way to confirm.

The gate reaches this verdict from connection state alone and issues no requests, deliberately: without a user connection the capabilities bridge can only answer 403, so there is nothing useful to ask. That stays exactly as it is — `hooks/use-gate-state.ts` is untouched, and every `expect( mockApiFetch ).not.toHaveBeenCalled()` assertion still stands and still passes. The screen changes instead.

* `gates/secondary-admin.tsx` now leads with the condition in every claim it makes. The screen cannot tell whether the site has a plan, so a flat "you'll see this site's backups" is false for half its readers, and a hedge arriving in the next sentence does not retract it. The heading no longer presupposes backups exist either.
* The copy now also warns that a plan may be needed, in the order the reader has to do it — link first, then buy: *"Once your account is linked, you'll see any backups this site has. If it doesn't have an active Backup plan yet, you can add VaultPress Backup to start protecting it."*
* **Link my account** remains the primary and only action, with the **Use license key** link unchanged.
* `gates/upgrade-button.tsx` is extracted from `gates/no-backup-plan.tsx` — same `getRedirectUrl( 'backup-plugin-upgrade-10gb', … )` destination, same deliberate "omit the `site` key rather than pass `undefined`" handling, same label, same tab. `no-backup-plan.tsx` renders it and its rendered DOM is unchanged; its existing tests pass unmodified.

Everything here is behind `rsm_jetpack_ui_modernization_backup`, which is off by default — hence the empty changelog entry with a `Comment:`.

### Why there is no purchase button on this screen

An earlier revision of this PR put **Get VaultPress Backup** on the secondary-admin screen, on the reasoning that a plan-less reader needs a way to buy. That has been removed, because the premise turned out to be false: **checkout requires a linked connection at some point, so this reader cannot complete one.** The button would have handed them a flow that stops partway and returns them to the same screen — the identical wrong-promise defect this PR set out to remove, relocated from the copy into a button.

Linking is the genuine way forward for both readers this screen cannot tell apart. It is what an entitled reader needs, and it is the first step for an unentitled one: after linking, a plan-less site lands on the **no-plan gate**, which already carries an upsell its reader can actually complete. So the flow is link → no-plan gate → buy, and the copy names the plan in that order rather than offering a shortcut that dead-ends.

Worth knowing while reviewing: **legacy did not offer these readers an upsell either**, so nothing here is a parity regression.

* `Admin/index.jsx:100` — `secondaryAdminNotConnected && siteHasBackupProduct` is false on a plan-less site, so it falls through to `LoadedState`.
* `useCapabilities` — `/jetpack/v4/backup-capabilities` fails without a user token, and since `isUserConnected` is false it sets `capabilitiesError = 'is_unlinked'`, leaving `capabilities` null.
* `Admin/index.jsx:396` — that branch renders a bare `<h2>`, "Site backups are managed by the owner of this site's Jetpack connection.", with no actions at all.
* The priced `NoBackupCapabilities` upsell at `index.jsx:421` needs `Array.isArray( capabilities ) && capabilities.length === 0`, so it is unreachable on this path.

Against that, this PR still improves the screen: the reader is no longer promised backups that may not exist, and is told a plan may also be needed.

### Tests

`tests/secondary-admin-gate.test.tsx` (3 tests): the screen offers **no** purchase action — asserted by label *and* by destination, so one cannot reappear under a different name, with "Link my account" asserted present in the same test so it cannot pass by the screen failing to render; the copy leads with its condition and names the no-plan case; and the screen renders with **no `QueryClientProvider` in scope at all**, so a future query hook fails loudly instead of quietly costing a request.

The absence assertion is mutation-checked — putting `<UpgradeButton>` back fails it.

Two marker strings changed — `stages.test.tsx:149` and `gate-decision.test.tsx:31` — because both used the old heading as a screen-identity marker. That is a one-line string update in each; the `not.toHaveBeenCalled()` limbs beside them are untouched and still passing.

## Related product discussion/links

* JETPACK-2311, JETPACK-2303 (H2, the upgrade link this extracts), JETPACK-2305 and the C4a review (the same wrong-promise class of defect), JETPACK-2313 (#51685, which consolidated the gate decision this deliberately leaves alone)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The modernized dashboard is behind the `rsm_jetpack_ui_modernization_backup` feature flag, so enable that first.

1. On a Jetpack-connected site **without** a Backup plan, sign in as an administrator who has *not* linked a WordPress.com account (a second admin account is enough — the site's connection owner must be someone else).
2. Go to **Jetpack Backup** in wp-admin.
3. You should see the account-linking screen. It should say that once your account is linked you'll see any backups this site has, and that if it doesn't have an active Backup plan yet you can add VaultPress Backup — with **Link my account** as the only button, plus the **Use license key** link. There should be **no** "Get VaultPress Backup" button here.
4. **Link my account** should go to `admin.php?page=my-jetpack`.
5. Link the account, then return to **Jetpack Backup**. On a plan-less site you should now land on the no-plan gate, which does carry a working **Get VaultPress Backup** button and the price — that is the intended purchase path for this reader.
6. Repeat step 2 on a site that **does** have a Backup plan, as the same kind of secondary admin: the same screen appears (that is by design — it cannot tell the two apart), the copy still reads correctly, and linking the account takes you through to the dashboard.
7. Sanity-check the no-plan screen as the connection owner on a plan-less site: it should be unchanged, price and all.

Automated: `jp test js packages/backup` — 63 suites, 609 tests, including the zero-request assertions in `tests/stages.test.tsx` and `tests/gate-decision.test.tsx`.
