### PR TITLE
Backup: name every progress bar on the modernized dashboard

### DIFF
--- a/projects/packages/backup/changelog/update-backup-progress-bar-names
+++ b/projects/packages/backup/changelog/update-backup-progress-bar-names
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Modernized dashboard only, behind the flag: name the restore and download progress bars so they no longer announce as a generic "Loading".
+Comment: Modernized dashboard only, behind the flag: name all six of the Overview, Restore and Download progress bars so they no longer announce as a generic "Loading".
 
 

--- a/projects/packages/backup/changelog/update-backup-progress-bar-names
+++ b/projects/packages/backup/changelog/update-backup-progress-bar-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Modernized dashboard only, behind the flag: name the restore and download progress bars so they no longer announce as a generic "Loading".
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -39,7 +39,16 @@ export default function BackupStatusBanner( { progress }: Props ) {
 			<Text variant="body-sm" aria-live="polite">
 				{ __( 'Your backup will be ready soon', 'jetpack-backup-pkg' ) }
 			</Text>
-			<ProgressBar className="jpb-backup-status-banner__bar" value={ progress } />
+			{ /*
+			 * Named: `ProgressBar` defaults to a generic `aria-label="Loading …"`,
+			 * and neither the line above nor the percentage beside it is
+			 * associated with the bar.
+			 */ }
+			<ProgressBar
+				className="jpb-backup-status-banner__bar"
+				value={ progress }
+				aria-label={ __( 'Backing up your site', 'jetpack-backup-pkg' ) }
+			/>
 			<Text variant="body-sm" className="jpb-text-muted">
 				{ sprintf(
 					/* translators: %d: how much of the running backup is complete, as a percentage. */

--- a/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/banner.tsx
@@ -40,9 +40,8 @@ export default function BackupStatusBanner( { progress }: Props ) {
 				{ __( 'Your backup will be ready soon', 'jetpack-backup-pkg' ) }
 			</Text>
 			{ /*
-			 * Named: `ProgressBar` defaults to a generic `aria-label="Loading …"`,
-			 * and neither the line above nor the percentage beside it is
-			 * associated with the bar.
+			 * Named because neither the line above nor the percentage beside it
+			 * is associated with the bar — see `tests/progress-bar-names.test.tsx`.
 			 */ }
 			<ProgressBar
 				className="jpb-backup-status-banner__bar"

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -141,13 +141,10 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 				<div className="jpb-backup-status__progress">
 					{ /*
 					 * Omitting `value` is what puts ProgressBar into its animated
-					 * indeterminate mode.
-					 *
-					 * One name serves both modes: they are the same situation to
-					 * the reader, whose first backup has not arrived either way.
-					 * Named at all because `ProgressBar` otherwise announces itself
-					 * as a generic "Loading …", and the title above is not
-					 * associated with the bar.
+					 * indeterminate mode. One name serves both: they are the same
+					 * situation to the reader, whose first backup has not arrived
+					 * either way. The title above is not associated with the bar —
+					 * see `tests/progress-bar-names.test.tsx`.
 					 */ }
 					<ProgressBar
 						className="jpb-backup-status__bar"

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -140,11 +140,9 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 			{ showProgress && (
 				<div className="jpb-backup-status__progress">
 					{ /*
-					 * Omitting `value` is what puts ProgressBar into its animated
-					 * indeterminate mode. One name serves both: they are the same
-					 * situation to the reader, whose first backup has not arrived
-					 * either way. The title above is not associated with the bar —
-					 * see `tests/progress-bar-names.test.tsx`.
+					 * Omitting `value` puts ProgressBar into indeterminate mode. One name
+					 * serves both states, and the title above is not associated with the
+					 * bar — see `tests/progress-bar-names.test.tsx`.
 					 */ }
 					<ProgressBar
 						className="jpb-backup-status__bar"

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -139,11 +139,20 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 			</EmptyState.Title>
 			{ showProgress && (
 				<div className="jpb-backup-status__progress">
-					{ /* Omitting `value` is what puts ProgressBar into its
-					     animated indeterminate mode. */ }
+					{ /*
+					 * Omitting `value` is what puts ProgressBar into its animated
+					 * indeterminate mode.
+					 *
+					 * One name serves both modes: they are the same situation to
+					 * the reader, whose first backup has not arrived either way.
+					 * Named at all because `ProgressBar` otherwise announces itself
+					 * as a generic "Loading …", and the title above is not
+					 * associated with the bar.
+					 */ }
 					<ProgressBar
 						className="jpb-backup-status__bar"
 						value={ isDeterminate ? progress : undefined }
+						aria-label={ __( 'Preparing your first cloud backup', 'jetpack-backup-pkg' ) }
 					/>
 					{ isDeterminate && (
 						<Text variant="body-sm" className="jpb-text-muted">

--- a/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/meter.tsx
@@ -66,11 +66,9 @@ export default function StorageMeter( { storageUsed, storageLimit, usageLevel }:
 	return (
 		<div className="jpb-storage-meter">
 			{ /*
-			 * `<ProgressBar>` hardcodes `aria-label="Loading …"` but
-			 * spreads the caller's props after it, so this replaces it.
-			 * Without the override a screen reader announces the storage
-			 * meter as a loading indicator — which is what the legacy
-			 * dashboard's bar does today.
+			 * Named because nothing else on the card is associated with the
+			 * bar; the legacy dashboard's meter still announces itself as a
+			 * loading indicator. See `tests/progress-bar-names.test.tsx`.
 			 */ }
 			<ProgressBar
 				className={ classNames.join( ' ' ) }

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -126,7 +126,10 @@ export default function DownloadScreen() {
 					{ state.phase === 'progress' && (
 						<Stack direction="column" gap="sm">
 							<Text>{ __( 'Preparing download…', 'jetpack-backup-pkg' ) }</Text>
-							<ProgressBar value={ state.percent } />
+							<ProgressBar
+								value={ state.percent }
+								aria-label={ __( 'Preparing your download', 'jetpack-backup-pkg' ) }
+							/>
 						</Stack>
 					) }
 					{ state.phase === 'success' && (

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -188,9 +188,9 @@ export default function RestoreScreen() {
 					 * determinate bar pinned at 0%, which reads as a stall during the
 					 * opening seconds of every restore.
 					 *
-					 * Named, like every other bar here: `ProgressBar` defaults to a
-					 * generic `aria-label="Loading …"`, and the `<Text>` beside it is not
-					 * associated with the bar.
+					 * Named, like every other bar on this screen: `ProgressBar` defaults
+					 * to a generic `aria-label="Loading …"`, and the `<Text>` beside it is
+					 * not associated with the bar.
 					 */ }
 					{ state.phase === 'queued' && (
 						<Stack direction="column" gap="sm">

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -187,19 +187,28 @@ export default function RestoreScreen() {
 					 * without naming an id we can poll. Indeterminate rather than a
 					 * determinate bar pinned at 0%, which reads as a stall during the
 					 * opening seconds of every restore.
+					 *
+					 * Named, like every other bar here: `ProgressBar` defaults to a
+					 * generic `aria-label="Loading …"`, and the `<Text>` beside it is not
+					 * associated with the bar.
 					 */ }
 					{ state.phase === 'queued' && (
 						<Stack direction="column" gap="sm">
 							<Text>
 								{ __( 'Your restore is queued and will begin shortly…', 'jetpack-backup-pkg' ) }
 							</Text>
-							<ProgressBar />
+							<ProgressBar
+								aria-label={ __( 'Waiting for your restore to begin', 'jetpack-backup-pkg' ) }
+							/>
 						</Stack>
 					) }
 					{ state.phase === 'progress' && (
 						<Stack direction="column" gap="sm">
 							<Text>{ __( 'Restoring…', 'jetpack-backup-pkg' ) }</Text>
-							<ProgressBar value={ state.percent } />
+							<ProgressBar
+								value={ state.percent }
+								aria-label={ __( 'Restoring your site', 'jetpack-backup-pkg' ) }
+							/>
 						</Stack>
 					) }
 					{ state.phase === 'success' && (
@@ -254,7 +263,9 @@ export default function RestoreScreen() {
 									{ state.detail }
 								</Text>
 							) }
-							<ProgressBar />
+							<ProgressBar
+								aria-label={ __( 'Checking whether your restore started', 'jetpack-backup-pkg' ) }
+							/>
 						</Stack>
 					) }
 					{ /*

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -22,6 +22,10 @@ const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
  * shared item checklist, and a Confirm button. Submit drives a real
  * state machine over the `/jetpack/v4/rewind/to/$rewindId` bridge.
  *
+ * Every `ProgressBar` below is given an `aria-label`, for the reason
+ * recorded in `tests/progress-bar-names.test.tsx`; the `<Text>` beside
+ * each one never reaches the bar's accessible name.
+ *
  * @return The rendered Restore screen.
  */
 export default function RestoreScreen() {
@@ -187,10 +191,6 @@ export default function RestoreScreen() {
 					 * without naming an id we can poll. Indeterminate rather than a
 					 * determinate bar pinned at 0%, which reads as a stall during the
 					 * opening seconds of every restore.
-					 *
-					 * Named, like every other bar on this screen: `ProgressBar` defaults
-					 * to a generic `aria-label="Loading …"`, and the `<Text>` beside it is
-					 * not associated with the bar.
 					 */ }
 					{ state.phase === 'queued' && (
 						<Stack direction="column" gap="sm">

--- a/projects/packages/backup/tests/progress-bar-names.test.tsx
+++ b/projects/packages/backup/tests/progress-bar-names.test.tsx
@@ -1,30 +1,13 @@
-// A progress bar has to say what it is measuring.
+// Each of the six progress bars has to say what it is measuring.
 //
-// This header is the one place the mechanism below is written down; the
-// bars themselves carry only what is specific to their own screen and
-// point here.
+// The trap: `ProgressBar` supplies a generic "Loading …" `aria-label` and
+// spreads caller props after it, so a bare `<ProgressBar />` is labelled — just
+// not usefully — and any test that finds *a* progressbar passes against it. The
+// `<Text>` beside each bar never reaches the accessible name.
 //
-// `@wordpress/components`' `ProgressBar` supplies an `aria-label` of its
-// own — a generic "Loading …" — and spreads the caller's props after it.
-// So a bare `<ProgressBar />` is not unlabelled, which is the trap: it
-// is labelled with a name that identifies neither the operation nor the
-// phase, and any test that merely finds *a* progressbar passes against
-// it. The `<Text>` beside each bar ("Restoring…", "Preparing download…")
-// is not associated with it and never reaches the accessible name.
-//
-// Six bars across the Overview, Restore and Download screens, each
-// measuring something different. These tests pin the name each one
-// exposes.
-//
-// Caveat worth knowing, and the same one `storage-meter.test.tsx` records
-// for the storage meter: these routes externalize `@wordpress/components`
-// to the `wp-components` handle, so the `<ProgressBar>` that runs in
-// wp-admin is WordPress core's, not the version pinned here and resolved
-// by jest. The override holds because the implementation spreads caller
-// props *after* its own hardcoded `aria-label` — prop-spread ordering,
-// which is not a documented contract. If core ever reverses it, all six
-// bars silently go back to announcing themselves as loading indicators
-// and these tests will not notice.
+// These routes externalize `@wordpress/components`, so wp-admin runs core's
+// copy, not the one jest resolves. The override rests on that prop-spread
+// ordering, which is not a documented contract.
 
 const mockApiFetch = jest.fn();
 

--- a/projects/packages/backup/tests/progress-bar-names.test.tsx
+++ b/projects/packages/backup/tests/progress-bar-names.test.tsx
@@ -1,0 +1,192 @@
+// A progress bar has to say what it is measuring.
+//
+// `@wordpress/components`' `ProgressBar` supplies an `aria-label` of its
+// own — a generic "Loading …" — and spreads the caller's props after it.
+// So a bare `<ProgressBar />` is not unlabelled, which is the trap: it
+// is labelled with a name that identifies neither the operation nor the
+// phase, and any test that merely finds *a* progressbar passes against
+// it. The `<Text>` beside each bar ("Restoring…", "Preparing download…")
+// is not associated with it and never reaches the accessible name.
+//
+// Four bars across the two screens, four phases, four different answers.
+// These tests pin the name each phase exposes.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( { rewindId: '1786663613.9425' } ),
+	Link: ( { children, to, ...rest }: { children: React.ReactNode; to: string } ) => (
+		<a href={ to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as DownloadStage } from '../routes/download/stage';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const REWIND_ID = '1786663613.9425';
+const RESTORE_ID = 912682;
+const DOWNLOAD_ID = 5150;
+
+const SETTLE = { timeout: 10000 };
+
+/**
+ * A restore-status payload in the shape the bridge projects.
+ *
+ * @param over - Fields to override.
+ * @return The payload.
+ */
+function restoreStatus( over: Record< string, unknown > = {} ) {
+	return {
+		id: RESTORE_ID,
+		status: 'running',
+		progress: 42,
+		rewind_id: REWIND_ID,
+		error_code: '',
+		message: '',
+		...over,
+	};
+}
+
+/**
+ * Route every request by path, leaving the caller only the two answers
+ * that vary between these cases.
+ *
+ * @param options          - Overrides.
+ * @param options.initiate - What the initiate POST does.
+ * @param options.status   - What a status poll does.
+ */
+function arrange( {
+	initiate = () => Promise.resolve< unknown >( { id: RESTORE_ID, rewind_id: REWIND_ID } ),
+	status = () => Promise.resolve< unknown >( restoreStatus() ),
+}: {
+	initiate?: () => Promise< unknown >;
+	status?: () => Promise< unknown >;
+} = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( options?.method === 'POST' ) {
+			return initiate();
+		}
+		if ( path.includes( '/status' ) ) {
+			return status();
+		}
+		// The restores collection, read before every restore and again
+		// while one is still missing its id. Empty: nothing is running.
+		return Promise.resolve( [] );
+	} );
+}
+
+/**
+ * Submit the default six-of-six checklist on whichever screen is
+ * rendered.
+ *
+ * @param name - The submit button's accessible name.
+ */
+async function submit( name: RegExp ) {
+	await userEvent.click( await screen.findByRole( 'button', { name }, SETTLE ) );
+}
+
+/**
+ * The progress bar carrying the given accessible name.
+ *
+ * `findByRole` and not a text query: the name is what a screen reader is
+ * handed, and it lives in an attribute no text query can see.
+ *
+ * @param name - The expected accessible name.
+ * @return The progress bar.
+ */
+async function progressBarNamed( name: string ) {
+	return screen.findByRole( 'progressbar', { name }, SETTLE );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the Restore screen', () => {
+	// Accepted, nothing to report yet. Indeterminate, so the name is the
+	// only thing carrying meaning — there is not even a percentage.
+	it( 'names the wait while the restore is queued', async () => {
+		arrange( { status: () => Promise.resolve( restoreStatus( { status: 'queued' } ) ) } );
+		render( <RestoreStage /> );
+
+		await submit( /Confirm restore/ );
+
+		const bar = await progressBarNamed( 'Waiting for your restore to begin' );
+		expect( bar ).toBeInTheDocument();
+	} );
+
+	it( 'names the restore itself once it is running', async () => {
+		arrange( { status: () => Promise.resolve( restoreStatus( { status: 'running' } ) ) } );
+		render( <RestoreStage /> );
+
+		await submit( /Confirm restore/ );
+
+		const bar = await progressBarNamed( 'Restoring your site' );
+		expect( bar ).toBeInTheDocument();
+	} );
+
+	// A submission whose answer never arrived: the recovery poll is
+	// looking for the restore, and the bar is measuring that search
+	// rather than the restore, so it must not claim one is under way.
+	it( 'names the search when the submission went unanswered', async () => {
+		arrange( { initiate: () => Promise.reject( new Error( 'Gateway timeout.' ) ) } );
+		render( <RestoreStage /> );
+
+		await submit( /Confirm restore/ );
+
+		const bar = await progressBarNamed( 'Checking whether your restore started' );
+		expect( bar ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'the Download screen', () => {
+	// "Preparing", not "downloading": the bar measures WordPress.com
+	// building the archive, which finishes before any file is fetched.
+	it( 'names the archive being prepared', async () => {
+		arrange( {
+			initiate: () => Promise.resolve( { id: DOWNLOAD_ID } ),
+			status: () =>
+				Promise.resolve( {
+					id: DOWNLOAD_ID,
+					status: 'running',
+					progress: 63,
+					url: '',
+					valid_until: '',
+					error: '',
+				} ),
+		} );
+		render( <DownloadStage /> );
+
+		await submit( /Generate download/ );
+
+		const bar = await progressBarNamed( 'Preparing your download' );
+		expect( bar ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/progress-bar-names.test.tsx
+++ b/projects/packages/backup/tests/progress-bar-names.test.tsx
@@ -1,5 +1,9 @@
 // A progress bar has to say what it is measuring.
 //
+// This header is the one place the mechanism below is written down; the
+// bars themselves carry only what is specific to their own screen and
+// point here.
+//
 // `@wordpress/components`' `ProgressBar` supplies an `aria-label` of its
 // own — a generic "Loading …" — and spreads the caller's props after it.
 // So a bare `<ProgressBar />` is not unlabelled, which is the trap: it

--- a/projects/packages/backup/tests/progress-bar-names.test.tsx
+++ b/projects/packages/backup/tests/progress-bar-names.test.tsx
@@ -8,8 +8,19 @@
 // it. The `<Text>` beside each bar ("Restoring…", "Preparing download…")
 // is not associated with it and never reaches the accessible name.
 //
-// Four bars across the two screens, four phases, four different answers.
-// These tests pin the name each phase exposes.
+// Six bars across the Overview, Restore and Download screens, each
+// measuring something different. These tests pin the name each one
+// exposes.
+//
+// Caveat worth knowing, and the same one `storage-meter.test.tsx` records
+// for the storage meter: these routes externalize `@wordpress/components`
+// to the `wp-components` handle, so the `<ProgressBar>` that runs in
+// wp-admin is WordPress core's, not the version pinned here and resolved
+// by jest. The override holds because the implementation spreads caller
+// props *after* its own hardcoded `aria-label` — prop-spread ordering,
+// which is not a documented contract. If core ever reverses it, all six
+// bars silently go back to announcing themselves as loading indicators
+// and these tests will not notice.
 
 const mockApiFetch = jest.fn();
 
@@ -34,10 +45,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as DownloadStage } from '../routes/download/stage';
 import { stage as RestoreStage } from '../routes/restore/stage';
+import BackupStatusPanel from '../src/dashboard/components/backup-status';
+import BackupStatusBanner from '../src/dashboard/components/backup-status/banner';
 import { queryClient } from '../src/dashboard/data/query-client';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
+// Must match the literal in the `@wordpress/route` factory above, which
+// jest hoists above every declaration and so cannot reference this.
 const REWIND_ID = '1786663613.9425';
 const RESTORE_ID = 912682;
 const DOWNLOAD_ID = 5150;
@@ -127,6 +142,36 @@ beforeEach( () => {
 		...window.JP_CONNECTION_INITIAL_STATE,
 		connectionStatus: CONNECTED,
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the Overview screen', () => {
+	// The banner sits above a usable activity list while a routine backup
+	// runs, so what is progressing is the backup — not the page, which has
+	// already loaded, and not the list beside it.
+	it( 'names the running backup in the banner', async () => {
+		render( <BackupStatusBanner progress={ 37 } /> );
+
+		const bar = await progressBarNamed( 'Backing up your site' );
+		expect( bar ).toBeInTheDocument();
+	} );
+
+	// One name covers both of the panel's modes. `in-progress` reports a
+	// real percentage and `no-backups` runs indeterminate, but they are the
+	// same situation to the reader — the first backup has not arrived yet —
+	// and the panel's own title says exactly that.
+	it( 'names the first backup while it is running', async () => {
+		render( <BackupStatusPanel state="in-progress" progress={ 19 } /> );
+
+		const bar = await progressBarNamed( 'Preparing your first cloud backup' );
+		expect( bar ).toBeInTheDocument();
+	} );
+
+	it( 'names the first backup before there is a percentage to report', async () => {
+		render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );
+
+		const bar = await progressBarNamed( 'Preparing your first cloud backup' );
+		expect( bar ).toBeInTheDocument();
+	} );
 } );
 
 describe( 'the Restore screen', () => {


### PR DESCRIPTION
Fixes JETPACK-2315

This is item 3 of JETPACK-2315, and the last one — items 1 and 2 (the dead `isComplete` field and the orphaned `&__actions` CSS rule) landed in #51683. **This PR completes the issue.**

## Proposed changes

* Give every `ProgressBar` on the modernized dashboard a translated `aria-label` naming what is actually progressing.

`@wordpress/components`' `ProgressBar` supplies an `aria-label` of its own — a generic `"Loading …"` — and spreads the caller's props *after* it. So a bare `<ProgressBar />` is not unlabelled, which is the part that hid this: it is labelled with a name that identifies neither the operation nor the phase. The adjacent copy ("Restoring…", "Preparing download…", "Your backup will be ready soon") is not associated with the bar, so it never reaches the accessible name either. Every bar announced as "Loading", and the override is one prop each.

| Call site | Situation | What the reader sees | New accessible name |
| --- | --- | --- | --- |
| `backup-status/banner.tsx` | routine backup running, restore points already listed | "Your backup will be ready soon" + a percentage | Backing up your site |
| `backup-status/index.tsx` | first-run panel, `in-progress` and `no-backups` | "Your first cloud backup will be ready soon" | Preparing your first cloud backup |
| `screens/restore.tsx` | `queued`, indeterminate | "Your restore is queued and will begin shortly…" | Waiting for your restore to begin |
| `screens/restore.tsx` | `progress` | "Restoring…" | Restoring your site |
| `screens/restore.tsx` | `unconfirmed`, indeterminate | "We didn't hear back from WordPress.com. Checking whether your restore started…" | Checking whether your restore started |
| `screens/download.tsx` | `progress` | "Preparing download…" | Preparing your download |

**The issue enumerated only the four Restore and Download sites**, and the first draft of this PR stopped there. The two Overview bars were added on review: JETPACK-2299 was re-scoped on 26 Aug to the file browser and preview pane and is Done, so nothing else was tracking them, and closing 2315 with them bare would have reported the dashboard's bars as finished when they weren't. Concretely: a site whose first cloud backup is running rendered `<BackupStatusBanner>` and a screen reader heard "Loading …, 37%", with no indication that a backup was what was running.

Three of the six are deliberately not named after the operation the screen is about:

* The `unconfirmed` bar measures the *recovery search* — nothing is confirmed to be running — so it must not claim a restore is under way.
* The download bar says "preparing" rather than "downloading" because it tracks WordPress.com building the archive, which finishes before any file is fetched.
* The first-run panel's single bar carries one name across both of its modes. `in-progress` reports a real percentage and `no-backups` runs indeterminate, but they are the same situation to the reader, and the panel's own title already says so. A ternary between two `__()` calls was avoided on purpose: this file's own `BackupTroubleBanner` records why that is a msgid-extraction hazard.

Behind `rsm_jetpack_ui_modernization_backup`, default off, so there is no user-visible change with the flag as shipped. Hence the empty changelog entry with a `Comment:`.

### One thing left deliberately alone

"Waiting for your restore to begin" is momentarily over-confident, and this PR inherits rather than introduces it. `deriveState`'s `default:` branch also covers an *adopted* restore that is already running but has not yet returned its first status reading, so for a few seconds the bar says "waiting" about something already under way. The `<Text>` directly above it says the same thing in the same situation, so fixing it means rewording shipped copy rather than adding a prop — out of scope here, but flagged so someone can decide.

## Related product discussion/links

* [JETPACK-2315](https://linear.app/a8c/issue/JETPACK-2315) — items 1 and 2 landed in #51683
* [JETPACK-2299](https://linear.app/a8c/issue/JETPACK-2299) — the rest of the a11y cluster, re-scoped and Done. Neither issue gates the flag flip.
* Touches `backup-status/index.tsx`, which #51739 also edits (a separate hunk ~20 lines below).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Automated.** `jp test js packages/backup`. The new `tests/progress-bar-names.test.tsx` reaches all six bars — the Overview two by rendering their components, the other four by driving the real hooks into each phase — and asserts each accessible name with `findByRole( 'progressbar', { name: … } )`. All six fail against `trunk` with `Unable to find role="progressbar" and name "…"`: the bar is rendered, under the wrong name, which is exactly the bug.

The file also records the caveat `storage-meter.test.tsx` already carries for this same override. Jest resolves the pinned `@wordpress/components`, while the routes externalize to core's `wp-components` handle, and the override rests on prop-spread ordering rather than a documented contract. It holds in core today, but if a future release reverses it all six bars revert silently and these tests will not notice.

**Manual**, with `rsm_jetpack_ui_modernization_backup` enabled on a site with an active Backup plan. Inspect each bar in DevTools' Accessibility pane, or listen with a screen reader:

* **Jetpack → Backup** on a site whose backups are still running: the Overview bar is named "Backing up your site" (banner, when restore points already exist) or "Preparing your first cloud backup" (first-run panel) — not "Loading …".
* Pick a backup and choose **Download**. Leave at least one category ticked, press **Generate download**, and check the bar while the archive builds: "Preparing your download".
* Go back, pick a backup, choose **Restore**, and press **Confirm restore**. The bar is named "Waiting for your restore to begin" while the restore is queued, and "Restoring your site" once WordPress.com reports it running.
* The sixth name, "Checking whether your restore started", belongs to the `unconfirmed` phase — reachable by making the initiate POST fail ambiguously (block `/jetpack/v4/rewind/to/…` so it returns a 504), or by reading the jest case that covers it.
