### PR TITLE
Backup: link out to Calypso only where wp-admin cannot do the job

### DIFF
--- a/projects/packages/backup/changelog/update-backup-calypso-link-policy
+++ b/projects/packages/backup/changelog/update-backup-calypso-link-policy
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Modernized dashboard only, behind the flag: drop the first-run panel's Calypso link and bring back the schedule Modify link. No behaviour change.
+
+

--- a/projects/packages/backup/changelog/update-backup-calypso-link-policy
+++ b/projects/packages/backup/changelog/update-backup-calypso-link-policy
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Modernized dashboard only, behind the flag: drop the first-run panel's Calypso link and bring back the schedule Modify link. No behaviour change.
+Comment: Backup: drop the modernized dashboard's link to backup management on Jetpack.com, which pointed at the Calypso screen this dashboard replaces, and bring legacy's schedule "Modify" link and its Tracks event to the next-backup line — cloud.jetpack.com/settings is the only place a backup's time can be changed. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -73,7 +73,11 @@ export function ContactSupportLine() {
 			a: (
 				<Link
 					openInNewTab
-					href={ getRedirectUrl( 'jetpack-contact-support', { site: siteSuffix } ) }
+					// Omitted rather than passed as undefined — see `useSiteSuffix`.
+					href={ getRedirectUrl(
+						'jetpack-contact-support',
+						siteSuffix ? { site: siteSuffix } : {}
+					) }
 				/>
 			),
 		}

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -98,10 +98,8 @@ export function ContactSupportLine() {
  * states renders as DataViews' bare "No results" — leaving a site whose
  * backups are failing indistinguishable from a healthy new one.
  *
- * Legacy's closing sentence, offering "backup management on Jetpack.com"
- * (`js/components/Backups.jsx:374`), is deliberately gone: it points at
- * `cloud.jetpack.com/backup`, which is the screen this dashboard replaces
- * (JETPACK-2329).
+ * Legacy's closing "backup management on Jetpack.com" is deliberately gone: it
+ * points at the screen this dashboard replaces (JETPACK-2329).
  *
  * @param props          - Component props.
  * @param props.state    - Derived backup state.

--- a/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-status/index.tsx
@@ -94,14 +94,17 @@ export function ContactSupportLine() {
  * states renders as DataViews' bare "No results" — leaving a site whose
  * backups are failing indistinguishable from a healthy new one.
  *
+ * Legacy's closing sentence, offering "backup management on Jetpack.com"
+ * (`js/components/Backups.jsx:374`), is deliberately gone: it points at
+ * `cloud.jetpack.com/backup`, which is the screen this dashboard replaces
+ * (JETPACK-2329).
+ *
  * @param props          - Component props.
  * @param props.state    - Derived backup state.
  * @param props.progress - Completion of the running backup, 0–100.
  * @return The rendered panel.
  */
 export default function BackupStatusPanel( { state, progress }: Props ) {
-	const siteSuffix = useSiteSuffix();
-
 	if ( state === 'no-good-backups' ) {
 		return (
 			<EmptyState.Root className="jpb-backup-status">
@@ -160,22 +163,6 @@ export default function BackupStatusPanel( { state, progress }: Props ) {
 				{ __(
 					'The first backup usually takes a few minutes, so it will become available soon.',
 					'jetpack-backup-pkg'
-				) }
-			</EmptyState.Description>
-			<EmptyState.Description>
-				{ createInterpolateElement(
-					__(
-						'In the meanwhile, you can start getting familiar with your <a>backup management on Jetpack.com</a>.',
-						'jetpack-backup-pkg'
-					),
-					{
-						a: (
-							<Link
-								openInNewTab
-								href={ getRedirectUrl( 'jetpack-backup', { site: siteSuffix } ) }
-							/>
-						),
-					}
 				) }
 			</EmptyState.Description>
 		</EmptyState.Root>

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -1,6 +1,10 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Skeleton, Text } from '@wordpress/ui';
+import { Link, Skeleton, Text } from '@wordpress/ui';
+import { useAnalytics } from '../../hooks/use-analytics';
 import { useNextBackupSchedule } from '../../hooks/use-backup-schedule';
+import { useSiteSuffix } from '../../hooks/use-connection';
 import { useSiteSize } from '../../hooks/use-site-size';
 import './style.scss';
 
@@ -17,8 +21,10 @@ import './style.scss';
  * the rest in source order, so dropping the `$` swaps date and time under any
  * translation that reorders them.
  *
- * Legacy's "Modify" link is deliberately absent: it points at Calypso, and whether this
- * dashboard links out there at all is open (JETPACK-2329). Its Tracks event goes with it.
+ * Legacy's "Modify" link comes with it, and so does its Tracks event. This is the one
+ * Calypso destination the modernized dashboard keeps (JETPACK-2329):
+ * `cloud.jetpack.com/settings` is the only place a backup's time can be changed, and
+ * there is no schedule-editing UI here to send the reader to instead.
  *
  * On a half-hour timezone this deliberately disagrees with legacy, which throws the
  * minutes away and reports a window the site does not have.
@@ -26,10 +32,16 @@ import './style.scss';
  * @return The rendered line, a placeholder, or nothing.
  */
 export default function NextScheduledBackup() {
+	const { tracks } = useAnalytics();
+	const site = useSiteSuffix();
 	const schedule = useNextBackupSchedule();
 	// The same `/site/backup/size` query the storage section and "Back up now" already
 	// read, shared through `useSiteSizeQuery` rather than issued again.
 	const { backupsStopped, isLoading: stoppedIsLoading } = useSiteSize();
+
+	const onModifyClick = useCallback( () => {
+		tracks.recordEvent( 'jetpack_backup_schedule_modify_click' );
+	}, [ tracks ] );
 
 	// Both reads, or the line appears and then retracts: a site whose backups have
 	// stopped would promise a run for as long as `/size` takes to say otherwise.
@@ -45,16 +57,32 @@ export default function NextScheduledBackup() {
 		return null;
 	}
 
+	// The key is omitted rather than passed as undefined. `getRedirectUrl` walks its args
+	// with `for…in`, so a present-but-undefined `site` is encoded — the link would carry
+	// the literal string `undefined` — and its mere presence also suppresses the helper's
+	// own site fallback. See `gates/no-backup-plan.tsx`.
+	const modifyUrl = getRedirectUrl( 'backup-plugin-schedule-time-setting', site ? { site } : {} );
+
 	return (
-		// Left as `Text`'s default `<span>`: a `<p>` would come into reach of
-		// `@wordpress/ui`'s unlayered global-CSS defense — see `style.scss`.
-		<Text variant="body-sm" className="jpb-text-muted jpb-next-scheduled-backup">
-			{ sprintf(
-				/* translators: %1$s is the formatted date (e.g. "Oct 22"); %2$s is a time range (e.g. "10:00-10:59 AM"). */
-				__( 'Next full backup: %1$s, %2$s.', 'jetpack-backup-pkg' ),
-				schedule.nextBackupDate,
-				schedule.timeRange
-			) }
+		// The row is the `Text`, rendered as a `<div>`, so the sentence and the link are
+		// sized together the way legacy sizes its row — a link left to inherit wp-admin's
+		// 13px would sit a step larger than the caption beside it. A `<div>` rather than a
+		// `<p>` because `@wordpress/ui`'s global-CSS defense is unlayered and matches `p`
+		// at (0,1,1), which would drop the class-selector margin below silently.
+		<Text variant="body-sm" className="jpb-next-scheduled-backup" render={ <div /> }>
+			{ /* Only the sentence is de-emphasized; a muted link would read as a
+			     disabled one. */ }
+			<span className="jpb-text-muted">
+				{ sprintf(
+					/* translators: %1$s is the formatted date (e.g. "Oct 22"); %2$s is a time range (e.g. "10:00-10:59 AM"). */
+					__( 'Next full backup: %1$s, %2$s.', 'jetpack-backup-pkg' ),
+					schedule.nextBackupDate,
+					schedule.timeRange
+				) }
+			</span>{ ' ' }
+			<Link openInNewTab href={ modifyUrl } onClick={ onModifyClick }>
+				{ __( 'Modify', 'jetpack-backup-pkg' ) }
+			</Link>
 		</Text>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/index.tsx
@@ -64,11 +64,9 @@ export default function NextScheduledBackup() {
 	const modifyUrl = getRedirectUrl( 'backup-plugin-schedule-time-setting', site ? { site } : {} );
 
 	return (
-		// The row is the `Text`, rendered as a `<div>`, so the sentence and the link are
-		// sized together the way legacy sizes its row — a link left to inherit wp-admin's
-		// 13px would sit a step larger than the caption beside it. A `<div>` rather than a
-		// `<p>` because `@wordpress/ui`'s global-CSS defense is unlayered and matches `p`
-		// at (0,1,1), which would drop the class-selector margin below silently.
+		// The `Text` is the row, so sentence and link are sized together rather than the
+		// link inheriting wp-admin's 13px. A `<div>` not a `<p>`: `@wordpress/ui`'s
+		// unlayered global-CSS defense matches `p` at (0,1,1) and drops the margin below.
 		<Text variant="body-sm" className="jpb-next-scheduled-backup" render={ <div /> }>
 			{ /* Only the sentence is de-emphasized; a muted link would read as a
 			     disabled one. */ }

--- a/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
+++ b/projects/packages/backup/src/dashboard/components/next-scheduled-backup/style.scss
@@ -1,14 +1,10 @@
 // A sibling of `.jpb-overview` rather than a child: that element is a
 // two-column grid at >= 961px, so a third child would be auto-placed.
 .jpb-next-scheduled-backup {
-	// `Text` renders a `<span>`, and vertical margins do not apply to an
-	// inline box. `margin-block-end` still computes to 16px, so reading the
-	// computed style alone would say this was working.
-	display: block;
-
-	// And why the element stays a `<span>`: `@wordpress/ui`'s global-CSS
-	// defense is unlayered and matches `p` at (0,1,1), outranking a plain
-	// class selector and dropping this margin silently. 16px rather than
+	// Why the row is rendered as a `<div>` rather than left as `Text`'s
+	// default `<span>`: vertical margins do not apply to an inline box, and
+	// `margin-block-end` still computes to 16px on one — so reading the
+	// computed style alone would say this was working. 16px rather than
 	// legacy's 24px because the storage section below carries its own.
 	margin-block-end: 16px;
 

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -26,7 +26,8 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 const SITE = 'example.wordpress.com';
 
 /**
- * Replace the site slug the connection global reports, for one test.
+ * Override the site slug the connection global reports, for one test.
+ * The `beforeEach` restores `SITE` before the next one.
  *
  * @param siteSuffix - The slug, or undefined for a global that carries none.
  */
@@ -106,9 +107,13 @@ function entry( overrides: Record< string, unknown > = {} ) {
 beforeEach( () => {
 	mockApiFetch.mockReset();
 	mockEndpoints();
+	// `siteSuffix` is pinned here, not just where a test needs it: the
+	// spread carries the previous test's value forward, so the one test
+	// that clears it would otherwise leak `undefined` into every test below.
 	window.JP_CONNECTION_INITIAL_STATE = {
 		...window.JP_CONNECTION_INITIAL_STATE,
 		connectionStatus: CONNECTED,
+		siteSuffix: SITE,
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
 } );
 

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -231,10 +231,8 @@ describe( 'BackupStatusPanel', () => {
 		);
 	} );
 
-	// JETPACK-2329. The panel used to close on "…get familiar with your backup
-	// management on Jetpack.com", pointing at `cloud.jetpack.com/backup` — the
-	// Backup home this dashboard replaces. Legacy still ships that sentence
-	// (`js/components/Backups.jsx:374`), so this is what stops it coming back as
+	// JETPACK-2329. Legacy still closes on "…backup management on Jetpack.com",
+	// pointing at the screen this dashboard replaces; this stops it returning as
 	// missing parity.
 	it( 'sends a waiting site nowhere, having nothing to offer that this page does not', () => {
 		const { rerender } = render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -186,6 +186,29 @@ describe( 'BackupStatusPanel', () => {
 		expect( screen.getByText( "We're having trouble backing up your site" ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toBeInTheDocument();
 	} );
+
+	// JETPACK-2329. The panel used to close on "…get familiar with your backup
+	// management on Jetpack.com", pointing at `cloud.jetpack.com/backup` — the
+	// Backup home this dashboard replaces. Legacy still ships that sentence
+	// (`js/components/Backups.jsx:374`), so this is what stops it coming back as
+	// missing parity.
+	it( 'sends a waiting site nowhere, having nothing to offer that this page does not', () => {
+		const { rerender } = render( <BackupStatusPanel state="no-backups" progress={ 0 } /> );
+
+		// Every state that shares this branch, and each one witnessed by its own
+		// copy: the absence has to be a link that is gone, not a panel that
+		// never rendered. The support link two tests up is the other half — it
+		// proves this file's link query finds one when there is one to find.
+		for ( const state of [ 'no-backups', 'in-progress', 'will-retry' ] as const ) {
+			rerender( <BackupStatusPanel state={ state } progress={ 0 } /> );
+			expect(
+				screen.getByText(
+					'The first backup usually takes a few minutes, so it will become available soon.'
+				)
+			).toBeInTheDocument();
+			expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		}
+	} );
 } );
 
 describe( 'BackupStatusBanner', () => {

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -23,6 +23,19 @@ import { keys } from '../src/dashboard/data/query-client';
 import type { ReactNode } from 'react';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SITE = 'example.wordpress.com';
+
+/**
+ * Replace the site slug the connection global reports, for one test.
+ *
+ * @param siteSuffix - The slug, or undefined for a global that carries none.
+ */
+function setSiteSuffix( siteSuffix: string | undefined ) {
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		siteSuffix,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+}
 
 /**
  * Render inside an isolated QueryClient.
@@ -185,6 +198,32 @@ describe( 'BackupStatusPanel', () => {
 
 		expect( screen.getByText( "We're having trouble backing up your site" ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toBeInTheDocument();
+	} );
+
+	it( 'tells support which site is asking', () => {
+		setSiteSuffix( SITE );
+
+		render( <BackupStatusPanel state="no-good-backups" progress={ 0 } /> );
+
+		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toHaveAttribute(
+			'href',
+			`https://jetpack.com/redirect/?source=jetpack-contact-support&site=${ SITE }`
+		);
+	} );
+
+	it( 'omits the site entirely when the connection global carries no slug', () => {
+		// `getRedirectUrl` walks its args with `for…in`, so a present-but-undefined
+		// `site` is encoded as the literal string `undefined` *and* suppresses the
+		// helper's own site fallback — dropping the site in the one state where
+		// support most needs to know which one is asking.
+		setSiteSuffix( undefined );
+
+		render( <BackupStatusPanel state="no-good-backups" progress={ 0 } /> );
+
+		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toHaveAttribute(
+			'href',
+			'https://jetpack.com/redirect/?source=jetpack-contact-support'
+		);
 	} );
 
 	// JETPACK-2329. The panel used to close on "…get familiar with your backup

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -299,9 +299,7 @@ function scheduleLine(): Promise< HTMLElement > {
 /**
  * The "Modify" link that follows the sentence, once it has arrived.
  *
- * Matched on a fragment of its name: `Link` appends an "(opens in a new tab)"
- * indicator to anything with `openInNewTab`, so the accessible name is never
- * just the label.
+ * Matched on a name fragment: `Link` appends "(opens in a new tab)".
  *
  * @return The anchor.
  */
@@ -312,10 +310,8 @@ function modifyLink(): Promise< HTMLElement > {
 /**
  * The row holding the sentence and the link.
  *
- * A layout container with no role and no accessible name, so its class is the
- * only handle — the same escape hatch the storage suites use. It is what the
- * Overview places, so the placement assertions are about this and not about the
- * sentence nested inside it.
+ * No role and no accessible name, so its class is the only handle — the same
+ * escape hatch the storage suites use.
  *
  * @return The row, or null before it has rendered.
  */

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -36,6 +36,7 @@ import { useNextBackupSchedule } from '../src/dashboard/hooks/use-backup-schedul
 import type { ReactNode } from 'react';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SITE = 'example.wordpress.com';
 
 // The route stages render behind several sequential requests and have
 // taken well over Testing Library's 1s default on a loaded runner.
@@ -296,6 +297,33 @@ function scheduleLine(): Promise< HTMLElement > {
 }
 
 /**
+ * The "Modify" link that follows the sentence, once it has arrived.
+ *
+ * Matched on a fragment of its name: `Link` appends an "(opens in a new tab)"
+ * indicator to anything with `openInNewTab`, so the accessible name is never
+ * just the label.
+ *
+ * @return The anchor.
+ */
+function modifyLink(): Promise< HTMLElement > {
+	return screen.findByRole( 'link', { name: /Modify/ } );
+}
+
+/**
+ * The row holding the sentence and the link.
+ *
+ * A layout container with no role and no accessible name, so its class is the
+ * only handle — the same escape hatch the storage suites use. It is what the
+ * Overview places, so the placement assertions are about this and not about the
+ * sentence nested inside it.
+ *
+ * @return The row, or null before it has rendered.
+ */
+function scheduleRow(): HTMLElement | null {
+	return document.querySelector( '.jpb-next-scheduled-backup' );
+}
+
+/**
  * The Overview's two-pane grid.
  *
  * A layout container with no role and no accessible name, so its class is
@@ -313,20 +341,20 @@ function overviewGrid(): HTMLElement | null {
  * The direct node access lives here rather than in the test body: neither "is a sibling
  * of" nor "comes before" has a Testing Library query.
  *
- * @param line - The rendered schedule line.
+ * @param row - The rendered schedule row.
  * @return Whether it is a sibling of the grid, and whether it precedes it.
  */
-function placementRelativeToGrid( line: HTMLElement ) {
+function placementRelativeToGrid( row: HTMLElement ) {
 	/* eslint-disable testing-library/no-node-access -- the question *is* about node relationships; see above. */
 	const grid = overviewGrid();
 	const gridParent = grid?.parentElement ?? null;
 
 	return {
-		isSibling: gridParent !== null && line.parentElement === gridParent,
+		isSibling: gridParent !== null && row.parentElement === gridParent,
 		comesFirst: Boolean(
 			grid &&
 				// eslint-disable-next-line no-bitwise -- compareDocumentPosition returns a bitmask.
-				line.compareDocumentPosition( grid ) & Node.DOCUMENT_POSITION_FOLLOWING
+				row.compareDocumentPosition( grid ) & Node.DOCUMENT_POSITION_FOLLOWING
 		),
 	};
 	/* eslint-enable testing-library/no-node-access */
@@ -355,6 +383,7 @@ beforeEach( () => {
 	window.JP_CONNECTION_INITIAL_STATE = {
 		...window.JP_CONNECTION_INITIAL_STATE,
 		connectionStatus: CONNECTED,
+		siteSuffix: SITE,
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
 } );
 
@@ -654,6 +683,60 @@ describe( 'the line, translated', () => {
 	} );
 } );
 
+describe( 'the Modify link', () => {
+	// JETPACK-2329. The one Calypso destination this dashboard is allowed to send
+	// anyone to, because `cloud.jetpack.com/settings` is the only place a backup's
+	// time can be changed and there is no schedule-editing UI here. Dropping it
+	// would take a capability legacy readers have away from them.
+	it( 'points at the schedule settings, scoped to this site and opened away from here', async () => {
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		const link = await modifyLink();
+		expect( link ).toHaveAttribute(
+			'href',
+			`https://jetpack.com/redirect/?source=backup-plugin-schedule-time-setting&site=${ SITE }`
+		);
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'omits the site entirely when the connection global carries no slug', async () => {
+		// Not cosmetic: `getRedirectUrl` walks its args with `for…in`, so passing
+		// the key as undefined encodes the literal string `undefined` *and*
+		// suppresses the helper's own site fallback.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: 10 } } );
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix: undefined,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		renderWithClient( <NextScheduledBackup /> );
+
+		await expect( modifyLink() ).resolves.toHaveAttribute(
+			'href',
+			'https://jetpack.com/redirect/?source=backup-plugin-schedule-time-setting'
+		);
+	} );
+
+	it( 'goes with the line when there is no schedule to modify', async () => {
+		// The link lives inside the same return as the sentence, so it can only
+		// survive a change that pulls it out of there. The sentence arriving under
+		// a probe elsewhere in this file is the witness that the data was readable.
+		freezeClock( '2026-10-22T05:00:00Z' );
+		mockEndpoints( { schedule: { ok: true, scheduled_hour: null } } );
+
+		const client = newQueryClient();
+		renderWithClient( <NextScheduledBackup />, client );
+
+		await readsSettled( client );
+		expect( placeholder() ).toBeNull();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );
+
 describe( 'on the Overview', () => {
 	it( 'renders above the activity list', async () => {
 		freezeClock( '2026-10-22T05:00:00Z' );
@@ -667,8 +750,17 @@ describe( 'on the Overview', () => {
 		// Placement, not just presence: `.jpb-overview` is a two-column grid above
 		// 960px, so a child would be auto-placed into a cell and a following sibling
 		// would sit below the fold. Asserting the text alone let both through.
+		const row = scheduleRow();
 		expect( overviewGrid() ).not.toBeNull();
-		expect( placementRelativeToGrid( line ) ).toEqual( { isSibling: true, comesFirst: true } );
+		expect( row ).not.toBeNull();
+		// A block box, or the 16px separating this from the storage section below
+		// computes and then does nothing — vertical margins do not apply to the
+		// inline box `Text` renders by default.
+		expect( row?.tagName ).toBe( 'DIV' );
+		expect( placementRelativeToGrid( row as HTMLElement ) ).toEqual( {
+			isSibling: true,
+			comesFirst: true,
+		} );
 	} );
 
 	it( 'still reports the schedule while a backup is running', async () => {

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -80,9 +80,7 @@ function mockEndpointsForButton() {
 /**
  * Answer the two routes `<NextScheduledBackup>` reads before it renders.
  *
- * It renders nothing without a readable hour, and nothing while WordPress.com
- * says backups have stopped — so a bare mock leaves no link to click and the
- * test would pass by finding neither the link nor the event.
+ * Without both, there is no link to click and the test passes vacuously.
  */
 function mockEndpointsForSchedule() {
 	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
@@ -304,8 +302,7 @@ describe( 'Modify schedule', () => {
 	/**
 	 * The "Modify" link, once the two reads behind the line have landed.
 	 *
-	 * Matched on a fragment of its name: `Link` appends an "(opens in a new tab)"
-	 * indicator to anything with `openInNewTab`.
+	 * Matched on a name fragment: `Link` appends "(opens in a new tab)".
 	 *
 	 * @return The anchor.
 	 */
@@ -313,11 +310,8 @@ describe( 'Modify schedule', () => {
 		return screen.findByRole( 'link', { name: /Modify/ } );
 	}
 
-	// JETPACK-2329. Legacy records this on the "Modify" link beside the
-	// next-backup line (`js/components/next-scheduled-backup.tsx:29-31`). The link
-	// and the event were held back together when that line was ported, so they
-	// come back together — otherwise the only measurement of readers leaving for
-	// `cloud.jetpack.com/settings` is silently missing.
+	// JETPACK-2329. Legacy records this on the same link, and it is the only
+	// measurement of readers leaving for `cloud.jetpack.com/settings`.
 	it( 'records the reader leaving for the schedule settings', async () => {
 		await renderScheduleLine();
 

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -77,6 +77,26 @@ function mockEndpointsForButton() {
 	} );
 }
 
+/**
+ * Answer the two routes `<NextScheduledBackup>` reads before it renders.
+ *
+ * It renders nothing without a readable hour, and nothing while WordPress.com
+ * says backups have stopped — so a bare mock leaves no link to click and the
+ * test would pass by finding neither the link nor the event.
+ */
+function mockEndpointsForSchedule() {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/backup/schedule' ) ) {
+			return Promise.resolve( { ok: true, scheduled_hour: 10 } );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
 const ORIGINAL_STATE = window.JP_CONNECTION_INITIAL_STATE;
@@ -258,6 +278,60 @@ describe( 'Back up now', () => {
 		await expect(
 			screen.findByRole( 'button', { name: /back up now/i } )
 		).resolves.toBeInTheDocument();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'Modify schedule', () => {
+	/**
+	 * Render the next-backup line inside the dashboard's query client.
+	 *
+	 * @return The Testing Library render result.
+	 */
+	async function renderScheduleLine() {
+		mockEndpointsForSchedule();
+		const NextScheduledBackup = (
+			await import( '../src/dashboard/components/next-scheduled-backup' )
+		).default;
+
+		return render(
+			<QueryClientProvider>
+				<NextScheduledBackup />
+			</QueryClientProvider>
+		);
+	}
+
+	/**
+	 * The "Modify" link, once the two reads behind the line have landed.
+	 *
+	 * Matched on a fragment of its name: `Link` appends an "(opens in a new tab)"
+	 * indicator to anything with `openInNewTab`.
+	 *
+	 * @return The anchor.
+	 */
+	function modifyLink(): Promise< HTMLElement > {
+		return screen.findByRole( 'link', { name: /Modify/ } );
+	}
+
+	// JETPACK-2329. Legacy records this on the "Modify" link beside the
+	// next-backup line (`js/components/next-scheduled-backup.tsx:29-31`). The link
+	// and the event were held back together when that line was ported, so they
+	// come back together — otherwise the only measurement of readers leaving for
+	// `cloud.jetpack.com/settings` is silently missing.
+	it( 'records the reader leaving for the schedule settings', async () => {
+		await renderScheduleLine();
+
+		await userEvent.click( await modifyLink() );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_schedule_modify_click' );
+	} );
+
+	it( 'records nothing until the reader actually clicks', async () => {
+		await renderScheduleLine();
+
+		// Settled on the link being there to click, so this is a click that did
+		// not happen rather than a component that never rendered.
+		await expect( modifyLink() ).resolves.toBeInTheDocument();
 		expect( mockRecordEvent ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -324,6 +324,9 @@ describe( 'Modify schedule', () => {
 		await userEvent.click( await modifyLink() );
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_schedule_modify_click' );
+		// Once, not merely at least once: a row that later grew a second click
+		// target would double-count every Modify click in Tracks, silently.
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'records nothing until the reader actually clicks', async () => {


### PR DESCRIPTION
Fixes JETPACK-2329

## Proposed changes

The modernized Backup dashboard now follows one rule for linking out: **it links to Calypso only where the destination offers something the dashboard genuinely cannot do.** Never to a screen the dashboard already is. That rule is testable by a reviewer who has never seen the link before — "does wp-admin have this capability? then no link" — which is the point of stating it that way.

Applying it moves two links in opposite directions.

* **Removed** the first-run panel's link to `cloud.jetpack.com/backup` (`backup-status/index.tsx`). That is the Backup home this dashboard replaces, so it fails the rule. The link was interpolated *inside* a sentence with `createInterpolateElement` — "In the meanwhile, you can start getting familiar with your `<a>`backup management on Jetpack.com`</a>`." — so the whole `EmptyState.Description` goes rather than just the anchor. Leaving an `<a>` in the msgid with nothing to interpolate would throw. The preceding sentence, "The first backup usually takes a few minutes…", already carries the panel's message on its own.
* **Added** the schedule "Modify" link to the next-backup line (`next-scheduled-backup/index.tsx`), ported from legacy. `cloud.jetpack.com/settings` is the only place a site owner can change their backup time, and this dashboard has no schedule-editing UI — so leaving it out would take a capability legacy readers have today away from them. Legacy's Tracks event, `jetpack_backup_schedule_modify_click`, comes back with it.
* **Kept** the storage section's retention link (`storage-space/usage-details.tsx`), which resolves to the same `cloud.jetpack.com/settings` and passes the same rule. It is untouched here; it is noted because it landed after the issue was written and a sweep that thought the first-run link was the only live one would have deleted it.

One fix caught on the way past, in the same file:

* The "Get in touch with us" support link passed `{ site: siteSuffix }` unguarded. `useSiteSuffix()` returns `string | undefined`, so on a global carrying no slug that emitted `…&site=undefined` **and** suppressed the `jetpack_redirects` fallback — losing the site entirely in the one state where support most needs to know which site is asking. Pre-existing, but this PR left it the only unguarded `site` argument in `src/dashboard/`, three lines below an import it deliberately keeps.

Notes on the port:

* The site suffix is read the way the rest of `src/dashboard/` reads it, via `useSiteSuffix()`, rather than legacy's Redux `domain` prop. The `site` key is **omitted** rather than passed as `undefined` — `getRedirectUrl` walks its args with `for…in`, so a present-but-undefined key is encoded as the literal string `undefined` *and* suppresses the helper's own site fallback. Same pattern as `gates/no-backup-plan.tsx`.
* The row is now the `Text`, rendered as a `<div>`, so the sentence and the link are sized together the way legacy sizes its row — a link left to inherit wp-admin's 13px would sit a step larger than the caption beside it. Only the sentence is muted; a muted link reads as a disabled one. `style.scss` loses its `display: block` workaround as a result.
* The docblock in `next-scheduled-backup/index.tsx` said the link was "deliberately absent" pending this issue. That question is now answered, and the docblock says which way and why.

Legacy's own two Calypso CTAs in `js/components/Backups.jsx` (`jetpack-backup` and `backup-plugin-activity-log`) are **deliberately not ported**, and no code here changes for them. `cloud.jetpack.com/activity-log` in particular is precisely what the modernized Overview already is — porting it would ship a button that sends the reader to Calypso to look at the list already on their screen. `src/js/` is untouched.

After this, every Calypso link in `src/dashboard/` points at `cloud.jetpack.com/settings`, and the rule explains why.

## Related product discussion/links

* JETPACK-2329

## Does this pull request change what data or activity we track or use?

It restores one Tracks event that the legacy Backup dashboard already fires: `jetpack_backup_schedule_modify_click`, recorded when the reader clicks "Modify" beside the next-backup line. No new event type, no new properties, and no new data collected — the modernized dashboard simply stops being silent where legacy was not.

## Testing instructions

All of this sits behind the `rsm_jetpack_ui_modernization_backup` feature flag, which is off by default. Nothing below is reachable with the flag off.

Automated:

* `jp test js packages/backup` — 614 tests, all green. The relevant files are `tests/next-scheduled-backup.test.tsx`, `tests/first-run-state.test.tsx` and `tests/tracks-events.test.tsx`.
* `jp build packages/backup`
* `pnpm run lint-changed`

By hand, on a site with the flag on and a Backup plan:

1. Go to **Jetpack → Backup**, on a site that has at least one completed backup.
2. The "Next full backup: …" line above the activity list now ends in a **Modify** link. Click it — it opens `cloud.jetpack.com/settings` in a new tab, with `?site=` carrying this site's slug.
3. Confirm the link and the sentence are the same type size, and that the link is coloured as a link rather than muted grey.
4. With a Tracks debugger open, click **Modify** and confirm one `jetpack_backup_schedule_modify_click` event fires — and that nothing fires merely from the page loading.
5. On a site with **no backups yet** (or force the state by having `/jetpack/v4/backups` return an empty list), the first-run panel reads "Your first cloud backup will be ready soon" with a progress bar and "The first backup usually takes a few minutes, so it will become available soon." — and **no** "backup management on Jetpack.com" link below it.
6. On a site where every backup attempt has failed (`no-good-backups`), the panel still offers its **Get in touch with us** support link. Its `href` now carries `&site=<your slug>` — and on a site whose connection global reports no slug it ends at `?source=jetpack-contact-support` rather than `&site=undefined`.
7. In the storage section further down, "N days of backups saved" is still a link to `cloud.jetpack.com/settings`. Unchanged.
