### PR TITLE
Backup: carry the file-browser selection to the Download screen

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2296-c4a-thread-the-file-browser-selection-into-the-download
+++ b/projects/packages/backup/changelog/jetpack-2296-c4a-thread-the-file-browser-selection-into-the-download
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Modernized dashboard only, behind the flag: carry the file browser's selection to the Download screen, which then skips the category checklist.
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -53,23 +53,11 @@ function downloadLabel( count: number ): string {
  */
 export default function BackupDetail( { item }: Props ) {
 	const [ selection, setSelection ] = useState< FileSelection >( EMPTY_FILE_SELECTION );
-	// The ids drive the Download action only — Restore beside it is
-	// deliberately untouched by the selection, see its call site.
-	//
-	// One id per opaque server-side download unit the current selection
-	// covers: files, plus folders whose contents haven't been loaded yet
-	// (each of those is one unit standing for its whole subtree). Loaded
-	// folders contribute via their leaves, not themselves; indeterminate
-	// folders contribute only the selected descendants beneath them.
-	// FileBrowser owns the loaded children, so it reports the list here.
-	//
-	// The label and the link are both built from this one list, and that
-	// is deliberate rather than incidental. The tree can hold a selected
-	// entry upstream gave no `id`, which no request can name — counting
-	// the tree instead would label the action "Download 1 selected item"
-	// beside a link carrying nothing, and hand the reader a whole-site
-	// archive they were told was scoped. That is the wrong-promise
-	// failure JETPACK-2305 removes from Restore; it must not appear here.
+	// Download only; Restore beside it is deliberately untouched by the selection.
+	// One id per server-side download unit: files, plus unloaded folders standing
+	// for their subtrees. Label and link are both built from this one list — the
+	// tree can hold a selected entry upstream gave no `id`, so counting the tree
+	// would promise a scoped download over a link carrying nothing.
 	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
 
 	// FileBrowser rebuilds the array on every recompute, so a plain

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -1,13 +1,13 @@
 import { dateI18n } from '@wordpress/date';
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, rotateLeft } from '@wordpress/icons';
 import { Link } from '@wordpress/route';
 import { Card, Stack, Text } from '@wordpress/ui';
-import FileBrowser, { EMPTY_FILE_SELECTION } from '../file-browser';
+import FileBrowser, { EMPTY_FILE_SELECTION, EMPTY_SELECTION_SUMMARY } from '../file-browser';
 import './style.scss';
 import type { BackupActivityItem } from '../../types/activity';
-import type { FileSelection } from '../file-browser';
+import type { FileSelection, SelectionSummary } from '../file-browser';
 
 type Props = {
 	item: BackupActivityItem;
@@ -40,8 +40,9 @@ function downloadLabel( count: number ): string {
  * matching sibling routes, the backup's summary line, a timestamp by-line,
  * and the file browser. File selection state lives here so the Download
  * action can switch between "Download backup" and "Download %d selected
- * item" based on what the visitor has checked in the tree. Restore does
- * not switch — see its call site.
+ * item" based on what the visitor has checked in the tree, and so its
+ * link can carry that selection to the Download screen. Restore does
+ * neither — see its call site.
  *
  * @param props      - Component props.
  * @param props.item - The selected backup activity item.
@@ -49,18 +50,31 @@ function downloadLabel( count: number ): string {
  */
 export default function BackupDetail( { item }: Props ) {
 	const [ selection, setSelection ] = useState< FileSelection >( EMPTY_FILE_SELECTION );
-	// `count` labels the Download action only — Restore beside it is
-	// deliberately unlabelled by selection, see its call site.
+	// The summary drives the Download action only — Restore beside it is
+	// deliberately untouched by the selection, see its call site.
 	//
 	// `count` tracks how many opaque server-side download units the
 	// current selection covers — files plus folders whose contents
 	// haven't been loaded yet (each treated as one unit). Loaded
 	// folders contribute via their leaves, not themselves;
 	// indeterminate folders don't add to the count. FileBrowser owns
-	// the loaded children, so it reports the count back here for the
+	// the loaded children, so it reports the summary back here for the
 	// Download label to swap between "Download backup" and "Download %d
-	// selected item".
-	const [ count, setCount ] = useState( 0 );
+	// selected item". `ids` names those same units for the request.
+	const [ summary, setSummary ] = useState< SelectionSummary >( EMPTY_SELECTION_SUMMARY );
+
+	// Comma-joined into one string rather than repeated params, because
+	// that is the form upstream's `include_path_list` takes — and it has
+	// to be a string: a single `ls` entry id can itself contain a comma,
+	// which works precisely because upstream flattens on comma.
+	//
+	// Absent when nothing is ticked, so a whole-backup download links
+	// exactly as it did before. JETPACK-2321 turns what arrives on the
+	// Download screen into the granular request.
+	const downloadSearch = useMemo(
+		() => ( summary.ids.length > 0 ? { files: summary.ids.join( ',' ) } : undefined ),
+		[ summary.ids ]
+	);
 
 	return (
 		<Card.Root className="jpb-backup-detail">
@@ -88,17 +102,25 @@ export default function BackupDetail( { item }: Props ) {
 						gap="sm"
 						align="center"
 					>
-						<Link to={ `/download/${ item.rewindId }` } className="jpb-backup-detail__download">
+						<Link
+							to={ `/download/${ item.rewindId }` }
+							// Cast for the same reason `screens/overview.tsx` casts
+							// its `navigate` call: nothing registers a typed route
+							// tree, so TanStack's search types collapse to shapes a
+							// plain object cannot satisfy.
+							search={ downloadSearch as never }
+							className="jpb-backup-detail__download"
+						>
 							<Icon icon={ downloadIcon } size={ 18 } />
-							{ downloadLabel( count ) }
+							{ downloadLabel( summary.count ) }
 						</Link>
 						{ /*
-						 * Deliberately not labelled from the file selection.
+						 * Deliberately not labelled from the file selection, and its
+						 * link carries none.
 						 *
-						 * Download beside it does not honour the selection yet
-						 * either — JETPACK-2296 is what wires it. The difference is
-						 * that its count is keepable in principle and this one is
-						 * not: a restore point is restored whole, and there is no
+						 * Download beside it now does both. The difference is that
+						 * its count is keepable and this one is not: a restore
+						 * point is restored whole, and there is no
 						 * upstream shape for restoring a subset of files. So a
 						 * count here could only ever promise a scope no layer can
 						 * deliver, and the reader who trusts "Restore 3 selected
@@ -130,7 +152,7 @@ export default function BackupDetail( { item }: Props ) {
 						rewindId={ item.rewindId }
 						selection={ selection }
 						onSelectionChange={ setSelection }
-						onSelectionCountChange={ setCount }
+						onSelectionSummaryChange={ setSummary }
 					/>
 				</div>
 			</Card.Content>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -1,13 +1,13 @@
 import { dateI18n } from '@wordpress/date';
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, rotateLeft } from '@wordpress/icons';
 import { Link } from '@wordpress/route';
 import { Card, Stack, Text } from '@wordpress/ui';
-import FileBrowser, { EMPTY_FILE_SELECTION, EMPTY_SELECTION_SUMMARY } from '../file-browser';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../file-browser';
 import './style.scss';
 import type { BackupActivityItem } from '../../types/activity';
-import type { FileSelection, SelectionSummary } from '../file-browser';
+import type { FileSelection } from '../file-browser';
 
 type Props = {
 	item: BackupActivityItem;
@@ -15,11 +15,14 @@ type Props = {
 
 /**
  * Returns the appropriate "Download" header-label given how many items
- * the visitor has selected in the file browser. With zero selections we
- * default to the whole-backup download; otherwise we count the selected
- * items (files + folders) currently visible in the loaded tree.
+ * the visitor has selected in the file browser. With zero we default to
+ * the whole-backup download.
  *
- * @param count - Number of currently selected items.
+ * The count is of *nameable* items — the entries the link can actually
+ * carry — not of ticked rows. The two differ only when upstream gave an
+ * entry no id, and in that case the whole-backup label is the true one.
+ *
+ * @param count - Number of selected items the download request can name.
  * @return Localized button label.
  */
 function downloadLabel( count: number ): string {
@@ -50,18 +53,35 @@ function downloadLabel( count: number ): string {
  */
 export default function BackupDetail( { item }: Props ) {
 	const [ selection, setSelection ] = useState< FileSelection >( EMPTY_FILE_SELECTION );
-	// The summary drives the Download action only — Restore beside it is
+	// The ids drive the Download action only — Restore beside it is
 	// deliberately untouched by the selection, see its call site.
 	//
-	// `count` tracks how many opaque server-side download units the
-	// current selection covers — files plus folders whose contents
-	// haven't been loaded yet (each treated as one unit). Loaded
-	// folders contribute via their leaves, not themselves;
-	// indeterminate folders don't add to the count. FileBrowser owns
-	// the loaded children, so it reports the summary back here for the
-	// Download label to swap between "Download backup" and "Download %d
-	// selected item". `ids` names those same units for the request.
-	const [ summary, setSummary ] = useState< SelectionSummary >( EMPTY_SELECTION_SUMMARY );
+	// One id per opaque server-side download unit the current selection
+	// covers: files, plus folders whose contents haven't been loaded yet
+	// (each of those is one unit standing for its whole subtree). Loaded
+	// folders contribute via their leaves, not themselves; indeterminate
+	// folders contribute only the selected descendants beneath them.
+	// FileBrowser owns the loaded children, so it reports the list here.
+	//
+	// The label and the link are both built from this one list, and that
+	// is deliberate rather than incidental. The tree can hold a selected
+	// entry upstream gave no `id`, which no request can name — counting
+	// the tree instead would label the action "Download 1 selected item"
+	// beside a link carrying nothing, and hand the reader a whole-site
+	// archive they were told was scoped. That is the wrong-promise
+	// failure JETPACK-2305 removes from Restore; it must not appear here.
+	const [ selectedIds, setSelectedIds ] = useState< string[] >( [] );
+
+	// FileBrowser rebuilds the array on every recompute, so a plain
+	// setter would re-render this subtree on selections that changed
+	// nothing. Returning `prev` unchanged lets React bail out instead.
+	const handleSelectionIdsChange = useCallback( ( next: string[] ) => {
+		setSelectedIds( prev =>
+			prev.length === next.length && prev.every( ( id, index ) => id === next[ index ] )
+				? prev
+				: next
+		);
+	}, [] );
 
 	// Comma-joined into one string rather than repeated params, because
 	// that is the form upstream's `include_path_list` takes — and it has
@@ -72,8 +92,8 @@ export default function BackupDetail( { item }: Props ) {
 	// exactly as it did before. JETPACK-2321 turns what arrives on the
 	// Download screen into the granular request.
 	const downloadSearch = useMemo(
-		() => ( summary.ids.length > 0 ? { files: summary.ids.join( ',' ) } : undefined ),
-		[ summary.ids ]
+		() => ( selectedIds.length > 0 ? { files: selectedIds.join( ',' ) } : undefined ),
+		[ selectedIds ]
 	);
 
 	return (
@@ -112,7 +132,7 @@ export default function BackupDetail( { item }: Props ) {
 							className="jpb-backup-detail__download"
 						>
 							<Icon icon={ downloadIcon } size={ 18 } />
-							{ downloadLabel( summary.count ) }
+							{ downloadLabel( selectedIds.length ) }
 						</Link>
 						{ /*
 						 * Deliberately not labelled from the file selection, and its
@@ -152,7 +172,7 @@ export default function BackupDetail( { item }: Props ) {
 						rewindId={ item.rewindId }
 						selection={ selection }
 						onSelectionChange={ setSelection }
-						onSelectionSummaryChange={ setSummary }
+						onSelectionIdsChange={ handleSelectionIdsChange }
 					/>
 				</div>
 			</Card.Content>

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -40,11 +40,27 @@ export const EMPTY_FILE_SELECTION: FileSelection = {
 	deselected: new Set(),
 };
 
+/**
+ * What the current selection amounts to, reported up to the parent.
+ *
+ * `count` and `ids` describe the same leaves but need not be the same
+ * length: an entry upstream gave no `id` still counts as selected in the
+ * tree, and simply cannot be named in a download request.
+ */
+export type SelectionSummary = {
+	/** Selected leaves in the loaded tree — see `collectSelectedInLoadedTree`. */
+	count: number;
+	/** Their opaque `ls` entry ids, in tree order, skipping any entry without one. */
+	ids: string[];
+};
+
+export const EMPTY_SELECTION_SUMMARY: SelectionSummary = { count: 0, ids: [] };
+
 type Props = {
 	rewindId: string;
 	selection: FileSelection;
 	onSelectionChange: ( next: FileSelection ) => void;
-	onSelectionCountChange?: ( count: number ) => void;
+	onSelectionSummaryChange?: ( summary: SelectionSummary ) => void;
 };
 
 /**
@@ -261,7 +277,8 @@ function propagateSelectUp(
 }
 
 /**
- * Counts effectively-selected leaves in the loaded subtree of `roots`.
+ * Collects the effectively-selected leaves in the loaded subtree of
+ * `roots`, in tree order.
  *
  * A "leaf" here is what the server would download as one opaque unit:
  * a file, or a folder whose children we haven't loaded yet (whatever
@@ -271,18 +288,23 @@ function propagateSelectUp(
  * descendants underneath them — neither the partial folder nor the
  * deselected branches count.
  *
+ * A ticked but unexpanded folder is therefore one entry standing for
+ * however many files it holds. That is what upstream wants — the same
+ * shape Calypso builds — so this list is both the label's count and the
+ * download's include list.
+ *
  * @param roots          - Top-level nodes to start from.
  * @param selection      - Current selection sets.
  * @param loadedChildren - Map of folder path → loaded children list.
- * @return Count of effectively-selected leaves.
+ * @return The effectively-selected leaf nodes.
  */
-function countSelectedInLoadedTree(
+function collectSelectedInLoadedTree(
 	roots: FileNode[],
 	selection: FileSelection,
 	loadedChildren: ReadonlyMap< string, FileNode[] >
-): number {
+): FileNode[] {
 	const { selected, deselected } = selection;
-	let count = 0;
+	const leaves: FileNode[] = [];
 	const walk = ( nodes: FileNode[], inheritedSelected: boolean ) => {
 		for ( const node of nodes ) {
 			const ownSelected = selected.has( node.path );
@@ -295,12 +317,12 @@ function countSelectedInLoadedTree(
 			} else if ( eff ) {
 				// File, or a folder whose contents we haven't loaded:
 				// the server treats either as a single downloadable unit.
-				count += 1;
+				leaves.push( node );
 			}
 		}
 	};
 	walk( roots, false );
-	return count;
+	return leaves;
 }
 
 /**
@@ -313,18 +335,18 @@ function countSelectedInLoadedTree(
  * buttons can swap between "Download backup" and "Download N selected
  * files" using the same `FileSelection` shape that this tree drives.
  *
- * @param props                        - Component props.
- * @param props.rewindId               - The selected backup's rewindId; surfaced as a data attribute today, the future REST hook will use it.
- * @param props.selection              - Current selection state (selected + deselected sets).
- * @param props.onSelectionChange      - Called with the next state when any row toggles.
- * @param props.onSelectionCountChange - Called whenever the visible-selected leaf count changes.
+ * @param props                          - Component props.
+ * @param props.rewindId                 - The selected backup's rewindId; surfaced as a data attribute today, the future REST hook will use it.
+ * @param props.selection                - Current selection state (selected + deselected sets).
+ * @param props.onSelectionChange        - Called with the next state when any row toggles.
+ * @param props.onSelectionSummaryChange - Called whenever the visible-selected leaves change, with their count and their `ls` entry ids.
  * @return The rendered tree.
  */
 export default function FileBrowser( {
 	rewindId,
 	selection,
 	onSelectionChange,
-	onSelectionCountChange,
+	onSelectionSummaryChange,
 }: Props ) {
 	const [ openFile, setOpenFile ] = useState< FileNodeFile | null >( null );
 	const {
@@ -401,14 +423,20 @@ export default function FileBrowser( {
 		[ selected, deselected, loadedChildren, onSelectionChange ]
 	);
 
-	const selectedCount = useMemo(
-		() => countSelectedInLoadedTree( roots, selection, loadedChildren ),
-		[ roots, selection, loadedChildren ]
-	);
+	const summary = useMemo< SelectionSummary >( () => {
+		const leaves = collectSelectedInLoadedTree( roots, selection, loadedChildren );
+		return {
+			count: leaves.length,
+			ids: leaves
+				.map( leaf => leaf.id )
+				.filter( ( id ): id is string => typeof id === 'string' && id !== '' ),
+		};
+	}, [ roots, selection, loadedChildren ] );
+	const selectedCount = summary.count;
 
 	useEffect( () => {
-		onSelectionCountChange?.( selectedCount );
-	}, [ selectedCount, onSelectionCountChange ] );
+		onSelectionSummaryChange?.( summary );
+	}, [ summary, onSelectionSummaryChange ] );
 
 	// The selection summary's checkbox doubles as a "select all / clear"
 	// toggle: clicking it with anything selected clears both sets,

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -40,27 +40,11 @@ export const EMPTY_FILE_SELECTION: FileSelection = {
 	deselected: new Set(),
 };
 
-/**
- * What the current selection amounts to, reported up to the parent.
- *
- * `count` and `ids` describe the same leaves but need not be the same
- * length: an entry upstream gave no `id` still counts as selected in the
- * tree, and simply cannot be named in a download request.
- */
-export type SelectionSummary = {
-	/** Selected leaves in the loaded tree — see `collectSelectedInLoadedTree`. */
-	count: number;
-	/** Their opaque `ls` entry ids, in tree order, skipping any entry without one. */
-	ids: string[];
-};
-
-export const EMPTY_SELECTION_SUMMARY: SelectionSummary = { count: 0, ids: [] };
-
 type Props = {
 	rewindId: string;
 	selection: FileSelection;
 	onSelectionChange: ( next: FileSelection ) => void;
-	onSelectionSummaryChange?: ( summary: SelectionSummary ) => void;
+	onSelectionIdsChange?: ( ids: string[] ) => void;
 };
 
 /**
@@ -335,18 +319,18 @@ function collectSelectedInLoadedTree(
  * buttons can swap between "Download backup" and "Download N selected
  * files" using the same `FileSelection` shape that this tree drives.
  *
- * @param props                          - Component props.
- * @param props.rewindId                 - The selected backup's rewindId; surfaced as a data attribute today, the future REST hook will use it.
- * @param props.selection                - Current selection state (selected + deselected sets).
- * @param props.onSelectionChange        - Called with the next state when any row toggles.
- * @param props.onSelectionSummaryChange - Called whenever the visible-selected leaves change, with their count and their `ls` entry ids.
+ * @param props                      - Component props.
+ * @param props.rewindId             - The selected backup's rewindId; surfaced as a data attribute today, the future REST hook will use it.
+ * @param props.selection            - Current selection state (selected + deselected sets).
+ * @param props.onSelectionChange    - Called with the next state when any row toggles.
+ * @param props.onSelectionIdsChange - Called whenever the selected leaves change, with the `ls` entry ids a download request could name them by.
  * @return The rendered tree.
  */
 export default function FileBrowser( {
 	rewindId,
 	selection,
 	onSelectionChange,
-	onSelectionSummaryChange,
+	onSelectionIdsChange,
 }: Props ) {
 	const [ openFile, setOpenFile ] = useState< FileNodeFile | null >( null );
 	const {
@@ -423,20 +407,28 @@ export default function FileBrowser( {
 		[ selected, deselected, loadedChildren, onSelectionChange ]
 	);
 
-	const summary = useMemo< SelectionSummary >( () => {
-		const leaves = collectSelectedInLoadedTree( roots, selection, loadedChildren );
-		return {
-			count: leaves.length,
-			ids: leaves
+	const selectedLeaves = useMemo(
+		() => collectSelectedInLoadedTree( roots, selection, loadedChildren ),
+		[ roots, selection, loadedChildren ]
+	);
+	// The header below counts the tree, so it counts every selected leaf.
+	// The ids reported upward are what a *request* can name, which is not
+	// always the same list — an entry upstream gave no `id` is genuinely
+	// selected here and genuinely unnameable there. The caller labels its
+	// Download action from the ids for exactly that reason; see
+	// `backup-detail`.
+	const selectedCount = selectedLeaves.length;
+	const selectedIds = useMemo(
+		() =>
+			selectedLeaves
 				.map( leaf => leaf.id )
 				.filter( ( id ): id is string => typeof id === 'string' && id !== '' ),
-		};
-	}, [ roots, selection, loadedChildren ] );
-	const selectedCount = summary.count;
+		[ selectedLeaves ]
+	);
 
 	useEffect( () => {
-		onSelectionSummaryChange?.( summary );
-	}, [ summary, onSelectionSummaryChange ] );
+		onSelectionIdsChange?.( selectedIds );
+	}, [ selectedIds, onSelectionIdsChange ] );
 
 	// The selection summary's checkbox doubles as a "select all / clear"
 	// toggle: clicking it with anything selected clears both sets,

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -411,12 +411,9 @@ export default function FileBrowser( {
 		() => collectSelectedInLoadedTree( roots, selection, loadedChildren ),
 		[ roots, selection, loadedChildren ]
 	);
-	// The header below counts the tree, so it counts every selected leaf.
-	// The ids reported upward are what a *request* can name, which is not
-	// always the same list — an entry upstream gave no `id` is genuinely
-	// selected here and genuinely unnameable there. The caller labels its
-	// Download action from the ids for exactly that reason; see
-	// `backup-detail`.
+	// The header counts every selected leaf; the ids reported upward are only what
+	// a request can name. An entry upstream gave no `id` is in the first list and
+	// not the second, which is why the caller labels from the ids.
 	const selectedCount = selectedLeaves.length;
 	const selectedIds = useMemo(
 		() =>

--- a/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
@@ -65,4 +65,20 @@ describe( 'toFileNode', () => {
 			path: '/wp-content/mu-plugins',
 		} );
 	} );
+
+	// The display `path` is ours; `id` is upstream's, and it is the only
+	// value a granular download can name an entry by. This transform used
+	// to drop it from both branches, which left the file selection
+	// unsendable however carefully the tree tracked it.
+	test.each( [
+		[ 'file', file( { id: 'ZjY6L2luZGV4LnBocA==' } ), 'ZjY6L2luZGV4LnBocA==' ],
+		// `cjI6,ZjI6Lw==` is a real fixture shape: an id can contain a
+		// comma, which is why the include list is a comma-joined string
+		// upstream flattens rather than a list of discrete values.
+		[ 'folder', file( { type: 'dir', id: 'cjI6,ZjI6Lw==' } ), 'cjI6,ZjI6Lw==' ],
+	] )( 'carries the ls entry id through for a %s', ( _label, raw, expected ) => {
+		expect( toFileNode( 'index.php', raw as WpcomFileNode, '/' ) ).toMatchObject( {
+			id: expected,
+		} );
+	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -71,12 +71,9 @@ export function useDownload( rewindId: string ): Result {
 		resetMutation();
 	}, [ resetMutation ] );
 
-	// `downloadId` is read before `isInitiating` deliberately. A mutation
-	// started from a mount effect can leave `isPending` latched true for
-	// good: StrictMode's remount detaches the observer from the in-flight
-	// mutation and never reattaches it, so the settle never reaches this
-	// hook — while the mutation's own `onSuccess` still lands the id. The
-	// id is the honest signal that the POST is done; `isPending` is not.
+	// `downloadId` is read before `isInitiating`: StrictMode's remount detaches
+	// the observer from the in-flight mutation and never reattaches it, so
+	// `isPending` latches true while `onSuccess` still lands the id.
 	let state: DownloadState = { phase: 'idle' };
 	if ( errorMessage ) {
 		state = { phase: 'error', message: errorMessage };

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -71,11 +71,15 @@ export function useDownload( rewindId: string ): Result {
 		resetMutation();
 	}, [ resetMutation ] );
 
+	// `downloadId` is read before `isInitiating` deliberately. A mutation
+	// started from a mount effect can leave `isPending` latched true for
+	// good: StrictMode's remount detaches the observer from the in-flight
+	// mutation and never reattaches it, so the settle never reaches this
+	// hook — while the mutation's own `onSuccess` still lands the id. The
+	// id is the honest signal that the POST is done; `isPending` is not.
 	let state: DownloadState = { phase: 'idle' };
 	if ( errorMessage ) {
 		state = { phase: 'error', message: errorMessage };
-	} else if ( isInitiating ) {
-		state = { phase: 'submitting' };
 	} else if ( statusQuery.data?.status === 'finished' && statusQuery.data.url ) {
 		state = {
 			phase: 'success',
@@ -107,16 +111,17 @@ export function useDownload( rewindId: string ): Result {
 				statusQuery.error.message ||
 				__( 'Lost connection while preparing download.', 'jetpack-backup-pkg' ),
 		};
-	} else if ( downloadId !== null && statusQuery.data ) {
+	} else if ( downloadId !== null ) {
 		state = {
 			// `progress` is already 0–100 — WPCOM coerces it to an
 			// integer, which a 0–1 float could not survive. Multiplying by
-			// 100 fed the ProgressBar values up to 10000.
+			// 100 fed the ProgressBar values up to 10000. Absent until the
+			// first poll answers, which is the bar's 0% opening frame.
 			phase: 'progress',
-			percent: statusQuery.data.progress ?? 0,
+			percent: statusQuery.data?.progress ?? 0,
 		};
-	} else if ( downloadId !== null ) {
-		state = { phase: 'progress', percent: 0 };
+	} else if ( isInitiating ) {
+		state = { phase: 'submitting' };
 	}
 
 	return { state, submit, reset };

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -36,6 +36,11 @@ type Result = {
  * we surface it as `lastModified` so the FileInfoCard can render the
  * date without a separate path-info call.
  *
+ * `id` is copied through untouched. It is the only value a granular
+ * download can name an entry by, so dropping it here — which is what
+ * this transform used to do — makes the file selection unsendable
+ * however carefully the tree tracks it.
+ *
  * Exported for tests: it's a pure transform of one untrusted WPCOM entry,
  * and the timestamp guard below is worth asserting directly.
  *
@@ -53,6 +58,7 @@ export function toFileNode( name: string, raw: WpcomFileNode, parentPath: string
 			type: 'folder',
 			name,
 			path: fullPath,
+			id: raw.id,
 		};
 	}
 
@@ -81,6 +87,7 @@ export function toFileNode( name: string, raw: WpcomFileNode, parentPath: string
 		type: 'file',
 		name,
 		path: fullPath,
+		id: raw.id,
 		lastModified,
 		period: raw.period,
 		manifestPath: raw.manifest_path,

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -117,14 +117,9 @@ function deriveState( input: DeriveInput ): RestoreState {
 	if ( errorMessage ) {
 		return { phase: 'error', message: errorMessage };
 	}
-	// `startedRewindId` is read before `isPending`, so a stale `isPending`
-	// cannot shadow an accepted restore. React Query detaches a
-	// MutationObserver from its in-flight mutation on unsubscribe and
-	// never reattaches it, latching `isPending` true for good if the
-	// screen remounts mid-submit — while the mutation's own callbacks
-	// still record the acceptance here. Restore only submits on a click
-	// today, so this is defence rather than a live bug; `useDownload`
-	// shipped the reachable version of it.
+	// `startedRewindId` is read before `isPending`: React Query never reattaches a
+	// MutationObserver detached mid-flight, so a remount latches `isPending` true
+	// while the mutation's own callbacks still record the acceptance.
 	if ( startedRewindId === null ) {
 		if ( isPending ) {
 			return { phase: 'submitting' };

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -117,10 +117,18 @@ function deriveState( input: DeriveInput ): RestoreState {
 	if ( errorMessage ) {
 		return { phase: 'error', message: errorMessage };
 	}
-	if ( isPending ) {
-		return { phase: 'submitting' };
-	}
+	// `startedRewindId` is read before `isPending`, so a stale `isPending`
+	// cannot shadow an accepted restore. React Query detaches a
+	// MutationObserver from its in-flight mutation on unsubscribe and
+	// never reattaches it, latching `isPending` true for good if the
+	// screen remounts mid-submit — while the mutation's own callbacks
+	// still record the acceptance here. Restore only submits on a click
+	// today, so this is defence rather than a live bug; `useDownload`
+	// shipped the reachable version of it.
 	if ( startedRewindId === null ) {
+		if ( isPending ) {
+			return { phase: 'submitting' };
+		}
 		// Nothing of our own, and we may not yet know whether the site has
 		// a restore running from somewhere else. Withholding the form is
 		// the whole point: see `useAdoptedRestore`.

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -1,9 +1,9 @@
 import { Notice, ProgressBar, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/icons';
-import { Link, useParams } from '@wordpress/route';
+import { Link, useParams, useSearch } from '@wordpress/route';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import InvalidRewindId from '../components/invalid-rewind-id';
@@ -18,21 +18,80 @@ import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
 const SELECTION_HINT_ID = 'jpb-download__selection-hint';
 
 /**
+ * The Download route's own search params.
+ *
+ * `files` carries the file browser's selection as the comma-joined `ls`
+ * entry ids the detail pane built — the same string upstream's
+ * `include_path_list` takes.
+ */
+type DownloadSearch = Record< string, unknown > & { files?: string };
+
+/**
  * Download screen — same narrow layout as the Restore screen minus the
  * warning notice. Submission runs through a real state machine via the
  * `/jetpack/v4/backups/download/$rewindId` bridge; the success branch
  * surfaces the signed download URL as a link.
  *
+ * The screen has two modes, decided by whether the reader arrived with a
+ * file selection. Without one it asks which of the six categories to
+ * include, as it always has. With one it asks nothing and starts
+ * building the archive, because upstream models `paths` as one *of* those
+ * six categories rather than a filter across them — a request naming
+ * files cannot also name categories, so the checklist would be offering
+ * choices the request has no way to express.
+ *
  * @return The rendered Download screen.
  */
 export default function DownloadScreen() {
 	const { rewindId } = useParams( { from: '/download/$rewindId' } );
+	const search = useSearch( {
+		from: '/download/$rewindId' as unknown as never,
+		strict: false,
+	} ) as DownloadSearch;
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useDownload( rewindId );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would ask WPCOM for the *whole* archive, not for
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
+
+	// Only the presence of a selection is read here; the entries
+	// themselves are what JETPACK-2321 forwards to WordPress.com.
+	const selectedFileIds = useMemo(
+		() => ( typeof search.files === 'string' ? search.files.split( ',' ).filter( Boolean ) : [] ),
+		[ search.files ]
+	);
+	const hasFileSelection = selectedFileIds.length > 0;
+
+	// A `useRef` rather than the module latch the Overview screen uses for
+	// its page view: there, a second *mount* means the same visit and must
+	// not be recorded twice; here, a second mount means the reader
+	// navigated to Download again and does want a second archive. The ref
+	// exists only to keep StrictMode's double-invoked effect from asking
+	// for two.
+	const hasAutoStarted = useRef( false );
+	useEffect( () => {
+		if ( ! hasFileSelection || hasAutoStarted.current || ! isValidRewindId( rewindId ) ) {
+			return;
+		}
+		hasAutoStarted.current = true;
+		submit( items );
+	}, [ hasFileSelection, rewindId, submit, items ] );
+
+	// With a file selection there is no checklist to send the reader back
+	// to, so a failed attempt has to re-submit rather than return to a
+	// form. `reset()` first, because the hook keeps reporting `error`
+	// until something succeeds.
+	const handleRetry = useCallback( () => {
+		reset();
+		submit( items );
+	}, [ reset, submit, items ] );
+
+	// A file selection has no form stage: the screen is waiting from the
+	// moment it mounts, before the mutation has even been sent.
+	const isPreparing =
+		state.phase === 'progress' ||
+		( hasFileSelection && ( state.phase === 'idle' || state.phase === 'submitting' ) );
 
 	// A malformed id can only produce a failed download, so the screen
 	// offers the way back and nothing else — see `InvalidRewindId`.
@@ -71,7 +130,7 @@ export default function DownloadScreen() {
 							</Text>
 						</Stack>
 					</Stack>
-					{ ( state.phase === 'idle' || state.phase === 'submitting' ) && (
+					{ ! hasFileSelection && ( state.phase === 'idle' || state.phase === 'submitting' ) && (
 						<>
 							<Text>
 								{ __(
@@ -123,13 +182,27 @@ export default function DownloadScreen() {
 							</Button>
 						</>
 					) }
-					{ state.phase === 'progress' && (
+					{ /*
+					 * One block for the whole wait, so the heading does not
+					 * unmount and remount underneath the reader when the first
+					 * status poll lands. A reader who arrived with files ticked
+					 * enters it immediately — the effect above has already asked
+					 * for the archive, and there is no checklist to show them —
+					 * and sees the spinner until there is a percentage to
+					 * report. Reaching for a progress bar pinned at 0% instead
+					 * would read as a stall.
+					 */ }
+					{ isPreparing && (
 						<Stack direction="column" gap="sm">
 							<Text>{ __( 'Preparing download…', 'jetpack-backup-pkg' ) }</Text>
-							<ProgressBar
-								value={ state.percent }
-								aria-label={ __( 'Preparing your download', 'jetpack-backup-pkg' ) }
-							/>
+							{ state.phase === 'progress' ? (
+								<ProgressBar
+									value={ state.percent }
+									aria-label={ __( 'Preparing your download', 'jetpack-backup-pkg' ) }
+								/>
+							) : (
+								<Spinner />
+							) }
 						</Stack>
 					) }
 					{ state.phase === 'success' && (
@@ -166,7 +239,11 @@ export default function DownloadScreen() {
 							<Notice status="error" isDismissible={ false }>
 								{ state.message }
 							</Notice>
-							<Button className="jpb-download__confirm" variant="outline" onClick={ reset }>
+							<Button
+								className="jpb-download__confirm"
+								variant="outline"
+								onClick={ hasFileSelection ? handleRetry : reset }
+							>
 								{ __( 'Try again', 'jetpack-backup-pkg' ) }
 							</Button>
 						</Stack>

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -32,13 +32,10 @@ type DownloadSearch = Record< string, unknown > & { files?: string };
  * `/jetpack/v4/backups/download/$rewindId` bridge; the success branch
  * surfaces the signed download URL as a link.
  *
- * The screen has two modes, decided by whether the reader arrived with a
- * file selection. Without one it asks which of the six categories to
- * include, as it always has. With one it asks nothing and starts
- * building the archive, because upstream models `paths` as one *of* those
- * six categories rather than a filter across them — a request naming
- * files cannot also name categories, so the checklist would be offering
- * choices the request has no way to express.
+ * Two modes, decided by whether the reader arrived with a file selection. With
+ * one, the category checklist is skipped: upstream models `paths` as one *of*
+ * the six categories rather than a filter across them, so a request naming files
+ * cannot also name categories.
  *
  * @return The rendered Download screen.
  */
@@ -56,21 +53,14 @@ export default function DownloadScreen() {
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
 
-	// Kept as the one string it arrived as. That string is already the
-	// exact `include_path_list` value JETPACK-2321 has to forward, and
-	// splitting it here would be both something 2321 must undo and wrong
-	// besides: a single `ls` entry id can contain a comma, so the pieces
-	// between commas are not entries. Only whether it names anything is
-	// read today, which needs no split.
+	// Kept as one string: it is already the `include_path_list` value
+	// JETPACK-2321 forwards, and a single `ls` entry id can contain a comma, so
+	// the pieces between commas are not entries.
 	const files = typeof search.files === 'string' ? search.files : '';
 	const hasFileSelection = files.replace( /,/g, '' ) !== '';
 
-	// A `useRef` rather than the module latch the Overview screen uses for
-	// its page view: there, a second *mount* means the same visit and must
-	// not be recorded twice; here, a second mount means the reader
-	// navigated to Download again and does want a second archive. The ref
-	// exists only to keep StrictMode's double-invoked effect from asking
-	// for two.
+	// A ref, not Overview's module latch: a second mount here means the reader
+	// came back for a second archive. This only stops StrictMode asking twice.
 	const hasAutoStarted = useRef( false );
 	useEffect( () => {
 		if ( ! hasFileSelection || hasAutoStarted.current || ! isValidRewindId( rewindId ) ) {
@@ -185,22 +175,10 @@ export default function DownloadScreen() {
 						</>
 					) }
 					{ /*
-					 * One block for the whole wait, so the heading does not
-					 * unmount and remount underneath the reader when the POST
-					 * resolves. A reader who arrived with files ticked enters it
-					 * immediately — the effect above has already asked for the
-					 * archive, and there is no checklist to show them.
-					 *
-					 * The spinner covers only the window before there is a
-					 * download id to poll; `useDownload` enters `progress` the
-					 * moment the POST resolves, so the bar below takes over from
-					 * there and does sit at 0% while WPCOM has the job queued.
-					 *
-					 * The spinner is left unnamed on purpose. `@wordpress/components`
-					 * ships it as `role="presentation"`, the text above is its
-					 * label, and giving it an `aria-label` would both defeat that
-					 * role — a global ARIA attribute cancels `presentation` — and
-					 * announce the same sentence twice.
+					 * One block for the whole wait, so the heading does not remount when
+					 * the POST resolves. The spinner covers only the window before there
+					 * is a download id to poll, and is left unnamed: it ships as
+					 * `role="presentation"`, which an `aria-label` would cancel.
 					 */ }
 					{ isPreparing && (
 						<Stack direction="column" gap="sm">

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -1,6 +1,6 @@
 import { Notice, ProgressBar, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams, useSearch } from '@wordpress/route';
@@ -44,10 +44,11 @@ type DownloadSearch = Record< string, unknown > & { files?: string };
  */
 export default function DownloadScreen() {
 	const { rewindId } = useParams( { from: '/download/$rewindId' } );
-	const search = useSearch( {
-		from: '/download/$rewindId' as unknown as never,
-		strict: false,
-	} ) as DownloadSearch;
+	// `strict: false` is the unvalidated read, and it is the whole option:
+	// passing `from` as well would send it down the route-id lookup that
+	// throws on a mismatch, which is the opposite of what is wanted for a
+	// param no route declares.
+	const search = useSearch( { strict: false } ) as DownloadSearch;
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
 	const { state, submit, reset } = useDownload( rewindId );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
@@ -55,13 +56,14 @@ export default function DownloadScreen() {
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
 
-	// Only the presence of a selection is read here; the entries
-	// themselves are what JETPACK-2321 forwards to WordPress.com.
-	const selectedFileIds = useMemo(
-		() => ( typeof search.files === 'string' ? search.files.split( ',' ).filter( Boolean ) : [] ),
-		[ search.files ]
-	);
-	const hasFileSelection = selectedFileIds.length > 0;
+	// Kept as the one string it arrived as. That string is already the
+	// exact `include_path_list` value JETPACK-2321 has to forward, and
+	// splitting it here would be both something 2321 must undo and wrong
+	// besides: a single `ls` entry id can contain a comma, so the pieces
+	// between commas are not entries. Only whether it names anything is
+	// read today, which needs no split.
+	const files = typeof search.files === 'string' ? search.files : '';
+	const hasFileSelection = files.replace( /,/g, '' ) !== '';
 
 	// A `useRef` rather than the module latch the Overview screen uses for
 	// its page view: there, a second *mount* means the same visit and must
@@ -184,13 +186,21 @@ export default function DownloadScreen() {
 					) }
 					{ /*
 					 * One block for the whole wait, so the heading does not
-					 * unmount and remount underneath the reader when the first
-					 * status poll lands. A reader who arrived with files ticked
-					 * enters it immediately — the effect above has already asked
-					 * for the archive, and there is no checklist to show them —
-					 * and sees the spinner until there is a percentage to
-					 * report. Reaching for a progress bar pinned at 0% instead
-					 * would read as a stall.
+					 * unmount and remount underneath the reader when the POST
+					 * resolves. A reader who arrived with files ticked enters it
+					 * immediately — the effect above has already asked for the
+					 * archive, and there is no checklist to show them.
+					 *
+					 * The spinner covers only the window before there is a
+					 * download id to poll; `useDownload` enters `progress` the
+					 * moment the POST resolves, so the bar below takes over from
+					 * there and does sit at 0% while WPCOM has the job queued.
+					 *
+					 * The spinner is left unnamed on purpose. `@wordpress/components`
+					 * ships it as `role="presentation"`, the text above is its
+					 * label, and giving it an `aria-label` would both defeat that
+					 * role — a global ARIA attribute cancels `presentation` — and
+					 * announce the same sentence twice.
 					 */ }
 					{ isPreparing && (
 						<Stack direction="column" gap="sm">

--- a/projects/packages/backup/src/dashboard/types/file-tree.ts
+++ b/projects/packages/backup/src/dashboard/types/file-tree.ts
@@ -1,6 +1,14 @@
 export type FileNodeBase = {
 	name: string;
 	path: string;
+	// The opaque per-entry `id` from `/rewind/backup/ls` — base64 of the
+	// volume-prefixed manifest path (`ZjY6L2luZGV4LnBocA==` decodes to
+	// `f6:/index.php`). It is what a granular download names its entries
+	// by; the display `path` above is not a value upstream accepts.
+	//
+	// Optional because the ls entry declares it optional, and an entry
+	// that arrives without one cannot be named in a download request.
+	id?: string;
 };
 
 export type FolderNode = FileNodeBase & {

--- a/projects/packages/backup/src/dashboard/types/file-tree.ts
+++ b/projects/packages/backup/src/dashboard/types/file-tree.ts
@@ -1,13 +1,9 @@
 export type FileNodeBase = {
 	name: string;
 	path: string;
-	// The opaque per-entry `id` from `/rewind/backup/ls` — base64 of the
-	// volume-prefixed manifest path (`ZjY6L2luZGV4LnBocA==` decodes to
-	// `f6:/index.php`). It is what a granular download names its entries
-	// by; the display `path` above is not a value upstream accepts.
-	//
-	// Optional because the ls entry declares it optional, and an entry
-	// that arrives without one cannot be named in a download request.
+	// The opaque `id` from `/rewind/backup/ls` — base64 of the volume-prefixed
+	// manifest path, and the only form a granular download can name entries by.
+	// Optional upstream, and an entry without one cannot be requested.
 	id?: string;
 };
 

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -1,0 +1,263 @@
+// The file browser's selection has to survive the trip to the Download
+// screen, and the Download screen has to act on it.
+//
+// Both halves are one behaviour. The detail pane relabels its Download
+// action from the selection — "Download 3 selected items" — but until now
+// the link carried only the rewind id, so the selection was dropped on
+// navigation and the screen seeded the whole-site checklist regardless.
+//
+// What travels is not the display path. It is the opaque `id` off each
+// `/rewind/backup/ls` entry (base64 of a volume-prefixed manifest path),
+// comma-joined, because that is the form upstream's `include_path_list`
+// takes — and it has to be a string, since a single id can itself contain
+// a comma.
+//
+// The screen behaviour follows from the upstream shape: granular download
+// is `types: { paths: true }`, one *of* the six categories rather than a
+// filter across them. A request naming files cannot also name categories,
+// so with a selection the checklist is not merely redundant — it offers
+// choices the request cannot express, and is skipped.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockParams = jest.fn< { rewindId: string }, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => mockParams(),
+	// Unlike the bare `<a { ...rest }>` mock the other suites use, this one
+	// models `search`: the real Link renders it into the href rather than
+	// onto the DOM node, and the href is exactly what these tests are about.
+	Link: ( {
+		children,
+		to,
+		search,
+		...rest
+	}: {
+		children: React.ReactNode;
+		to: string;
+		search?: Record< string, string >;
+	} ) => (
+		<a href={ search ? `${ to }?${ new URLSearchParams( search ).toString() }` : to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as DownloadStage } from '../routes/download/stage';
+import BackupDetail from '../src/dashboard/components/backup-detail';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { BackupActivityItem } from '../src/dashboard/types/activity';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+const SETTLE = { timeout: 10000 };
+
+const ITEM: BackupActivityItem = {
+	id: 'act-cloud',
+	kind: 'backup',
+	title: 'Backup complete',
+	publishedAt: '2026-08-13T18:08:56+00:00',
+	actor: { type: 'Application', name: 'Jetpack' },
+	rewindId: '1786644531.123',
+	stats: '46 plugins, 23 themes',
+	isComplete: true,
+};
+
+// `ZjU6L3dwLWNvbmZpZy5waHA=` decodes to `f5:/wp-config.php`, and
+// `ZjI6L3JlYWRtZS5odG1s` to `f2:/readme.html` — the volume-prefixed
+// manifest paths upstream identifies entries by. The `=` padding is here
+// on purpose: it is the character a query-string round trip is most
+// likely to mangle.
+const WP_CONFIG_ID = 'ZjU6L3dwLWNvbmZpZy5waHA=';
+const README_ID = 'ZjI6L3JlYWRtZS5odG1s';
+
+/** Every box in the shared category checklist, by its accessible name. */
+const ITEM_LABELS = [
+	'WordPress themes',
+	'WordPress plugins',
+	'WordPress root',
+	'WP-content directory',
+	'Site database',
+	'Media uploads',
+];
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			return Promise.resolve( {
+				contents: {
+					'wp-config.php': {
+						type: 'file',
+						period: '1786644531',
+						manifest_path: 'f5:/wp-config.php',
+						id: WP_CONFIG_ID,
+					},
+					'readme.html': {
+						type: 'file',
+						period: '1786644531',
+						manifest_path: 'f2:/readme.html',
+						id: README_ID,
+					},
+				},
+			} );
+		}
+		if ( path.includes( '/backups/download/' ) ) {
+			return Promise.resolve( { id: 4242 } );
+		}
+		return Promise.resolve( {} );
+	} );
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
+	mockParams.mockReset();
+	mockParams.mockReturnValue( { rewindId: ITEM.rewindId } );
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+/**
+ * Every POST the dashboard issued, in call order. The download mutation
+ * is the only POST this screen makes, so an empty list means nothing was
+ * submitted.
+ *
+ * @return The matching apiFetch option objects.
+ */
+function postCalls() {
+	return mockApiFetch.mock.calls
+		.map( ( [ options ] ) => options as { method?: string; path?: string } | undefined )
+		.filter( options => options?.method === 'POST' );
+}
+
+describe( 'Download link carrying the file selection', () => {
+	it( 'leaves the link bare when nothing is selected', async () => {
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		expect( screen.getByRole( 'link', { name: /Download backup/ } ) ).toHaveAttribute(
+			'href',
+			'/download/1786644531.123'
+		);
+	} );
+
+	it( 'carries the ls entry ids once files are ticked', async () => {
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+		await expect(
+			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } ) );
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select readme.html' } ) );
+
+		const link = await screen.findByRole( 'link', { name: /Download 2 selected items/ } );
+		const href = link.getAttribute( 'href' ) ?? '';
+		const query = new URLSearchParams( href.slice( href.indexOf( '?' ) ) );
+		// Comma-joined as one string, not repeated params: upstream flattens
+		// on comma, and an id can contain one.
+		expect( query.get( 'files' ) ).toBe( `${ WP_CONFIG_ID },${ README_ID }` );
+
+		// Restore is the outside witness. It sits beside Download and looks
+		// symmetric, but a restore point is restored whole — so its link
+		// must stay bare however Download's is built.
+		expect( screen.getByRole( 'link', { name: /Restore to this point/ } ) ).toHaveAttribute(
+			'href',
+			'/restore/1786644531.123'
+		);
+	} );
+} );
+
+describe( 'Download screen without a file selection', () => {
+	it( 'still offers the category checklist and submits nothing on its own', async () => {
+		render( <DownloadStage /> );
+
+		// The witness for "the checklist is here" is the control that acts
+		// on it: the button exists and is armed, which only makes sense
+		// alongside a list of categories to arm it.
+		await expect(
+			screen.findByRole( 'button', { name: /Generate download/ }, SETTLE )
+		).resolves.toBeInTheDocument();
+		for ( const label of ITEM_LABELS ) {
+			expect( screen.getByRole( 'checkbox', { name: label } ) ).toBeChecked();
+		}
+
+		expect( postCalls() ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'Download screen with a file selection', () => {
+	beforeEach( () => {
+		mockSearch.mockReturnValue( { files: `${ WP_CONFIG_ID },${ README_ID }` } );
+	} );
+
+	it( 'skips the checklist and starts building the archive', async () => {
+		render( <DownloadStage /> );
+
+		// Sibling witness rather than bare absence: the screen has moved on
+		// to preparing the archive, which is the state that replaces the
+		// checklist. A screen that rendered nothing at all would fail here.
+		await expect(
+			screen.findByText( 'Preparing download…', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		for ( const label of ITEM_LABELS ) {
+			expect( screen.queryByRole( 'checkbox', { name: label } ) ).not.toBeInTheDocument();
+		}
+		expect( screen.queryByRole( 'button', { name: /Generate download/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks WordPress.com for the archive once, without being clicked', async () => {
+		render( <DownloadStage /> );
+
+		await expect(
+			screen.findByText( 'Preparing download…', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		const posts = postCalls();
+		expect( posts ).toHaveLength( 1 );
+		expect( posts[ 0 ]?.path ).toContain( '/backups/download/1786644531.123' );
+	} );
+
+	it( 'does not start when the rewind id is malformed', async () => {
+		mockSearch.mockReturnValue( { files: WP_CONFIG_ID } );
+		mockParams.mockReturnValue( { rewindId: 'not-a-rewind-id' } );
+
+		render( <DownloadStage /> );
+
+		await expect(
+			screen.findByText( "This download link isn't valid.", undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( postCalls() ).toHaveLength( 0 );
+	} );
+} );

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -1,22 +1,9 @@
-// The file browser's selection has to survive the trip to the Download
-// screen, and the Download screen has to act on it.
-//
-// Both halves are one behaviour. The detail pane relabels its Download
-// action from the selection — "Download 3 selected items" — but until now
-// the link carried only the rewind id, so the selection was dropped on
-// navigation and the screen seeded the whole-site checklist regardless.
-//
-// What travels is not the display path. It is the opaque `id` off each
-// `/rewind/backup/ls` entry (base64 of a volume-prefixed manifest path),
-// comma-joined, because that is the form upstream's `include_path_list`
-// takes — and it has to be a string, since a single id can itself contain
-// a comma.
-//
-// The screen behaviour follows from the upstream shape: granular download
-// is `types: { paths: true }`, one *of* the six categories rather than a
-// filter across them. A request naming files cannot also name categories,
-// so with a selection the checklist is not merely redundant — it offers
-// choices the request cannot express, and is skipped.
+// The file browser's selection has to survive the trip to the Download screen,
+// and the screen has to act on it. What travels is the opaque per-entry `id`
+// from `/rewind/backup/ls`, comma-joined as one string, since an id can itself
+// contain a comma. The checklist is skipped when files are named because
+// upstream models `paths` as one *of* the six categories, not a filter across
+// them — so a request naming files cannot also name categories.
 
 const mockApiFetch = jest.fn();
 const mockSearch = jest.fn< Record< string, unknown >, [] >();
@@ -32,17 +19,10 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => mockSearch(),
 	useNavigate: () => mockNavigate,
 	useParams: () => mockParams(),
-	// Models `search`, which the real Link renders into the href rather
-	// than onto the DOM node — and the href is what these tests are about.
-	//
-	// The suites still using a bare `<a { ...rest }>` mock get away with it
-	// only because their `ls` fixtures carry no `id`, so `search` stays
-	// undefined and React drops it. Give one of those fixtures an id and
-	// the object reaches a DOM node, and `@wordpress/jest-console` fails
-	// the suite on React's unknown-prop warning —
-	// `restore-label-scope.test.tsx` and
-	// `switching-backups-resets-detail.test.tsx` needed ids, so they carry
-	// this same mock now.
+	// Models `search`, which the real Link renders into the href rather than onto
+	// the DOM node. A bare `<a { ...rest }>` mock only survives while the `ls`
+	// fixtures carry no `id`; give one an id and the object reaches a DOM node
+	// and `@wordpress/jest-console` fails the suite on React's unknown-prop warning.
 	Link: ( {
 		children,
 		to,
@@ -264,12 +244,9 @@ describe( 'Download link carrying the file selection', () => {
 		);
 	} );
 
-	// The label and the link are built from the same list on purpose. An
-	// entry upstream gave no `id` can be ticked in the tree and cannot be
-	// named in a request — so counting ticked rows instead would promise
-	// "Download 1 selected item" over a link carrying nothing, and hand
-	// back a whole-site archive. That is the wrong-promise failure
-	// JETPACK-2305 removes from Restore.
+	// Label and link come from the same list: an entry upstream gave no `id` is
+	// tickable but unnameable, so counting ticked rows would promise a scoped
+	// download over a link carrying nothing (the JETPACK-2305 failure).
 	it( 'does not promise a scope for entries the link cannot carry', async () => {
 		lsContents = {
 			// No `id`, as upstream is free to return.
@@ -382,17 +359,9 @@ describe( 'Download screen with a file selection', () => {
 		expect( posts[ 0 ]?.path ).toContain( '/backups/download/1786644531.123' );
 	} );
 
-	// The wait has two frames, and the handover is the whole of it: a
-	// spinner only until there is a download id to poll, then the bar.
-	//
-	// StrictMode is load-bearing, not decoration. The archive is asked for
-	// from a mount effect, and React Query detaches the mutation observer
-	// on StrictMode's simulated unmount without ever reattaching it — so
-	// the settle never reaches the hook and `isPending` stays true for
-	// good, while the mutation's own `onSuccess` still lands the id and
-	// starts the poll. That is the shape this screen shipped in: a healthy
-	// poll climbing behind a spinner that never became a bar. Drop the
-	// wrapper and this test passes either way.
+	// StrictMode is load-bearing: its simulated unmount detaches React Query's
+	// mutation observer and never reattaches it, latching `isPending` true while
+	// `onSuccess` still lands the id. Drop the wrapper and this passes either way.
 	it( 'hands the wait over to the progress bar once the poll answers', async () => {
 		render(
 			<StrictMode>
@@ -414,13 +383,8 @@ describe( 'Download screen with a file selection', () => {
 		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
 	} );
 
-	// The same latch that hid the bar also hid the ending. `isPending` was
-	// read above every other branch, so a frozen one shadowed `success`
-	// and `failed` too: the archive could finish, signed URL and all, and
-	// the screen would still be sitting on the spinner with nothing to
-	// click. Reported as "upon finishing, the spinner remains there and
-	// nothing happened" — the same defect as the missing bar, one branch
-	// further on.
+	// The same latch hid the ending: `isPending` was read above every other
+	// branch, so a frozen one shadowed `success` and `failed` too.
 	it( 'shows the finished archive rather than staying on the spinner', async () => {
 		render(
 			<StrictMode>

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -60,8 +60,9 @@ jest.mock( '@wordpress/route', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { StrictMode } from 'react';
 import { stage as DownloadStage } from '../routes/download/stage';
 import BackupDetail from '../src/dashboard/components/backup-detail';
 import { queryClient } from '../src/dashboard/data/query-client';
@@ -101,6 +102,12 @@ const THEMES_DIR_ID = 'cjI6,ZjI6Lw==';
  */
 let lsContents: Record< string, Record< string, unknown > >;
 
+/**
+ * What the status poll answers with. Reassigned mid-test to let a
+ * download finish, which is the only way to reach the success branch.
+ */
+let downloadStatus: Record< string, unknown >;
+
 const TWO_FILES = {
 	'wp-config.php': {
 		type: 'file',
@@ -131,6 +138,14 @@ beforeEach( () => {
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
 
 	lsContents = TWO_FILES;
+	downloadStatus = {
+		id: 4242,
+		status: 'running',
+		progress: 36,
+		url: '',
+		valid_until: '',
+		error: '',
+	};
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
 		const path = o?.path ?? '';
@@ -139,6 +154,12 @@ beforeEach( () => {
 		}
 		if ( path.includes( '/rewind/backup/ls' ) ) {
 			return Promise.resolve( { contents: lsContents } );
+		}
+		// Ordered before the initiate branch: the poll path is a suffix of
+		// the initiate path, so a single `/backups/download/` test would
+		// answer the poll with the initiate payload and no `status` at all.
+		if ( path.includes( '/backups/download/' ) && path.includes( '/status' ) ) {
+			return Promise.resolve( downloadStatus );
 		}
 		if ( path.includes( '/backups/download/' ) ) {
 			return Promise.resolve( { id: 4242 } );
@@ -359,6 +380,80 @@ describe( 'Download screen with a file selection', () => {
 		const posts = postCalls();
 		expect( posts ).toHaveLength( 1 );
 		expect( posts[ 0 ]?.path ).toContain( '/backups/download/1786644531.123' );
+	} );
+
+	// The wait has two frames, and the handover is the whole of it: a
+	// spinner only until there is a download id to poll, then the bar.
+	//
+	// StrictMode is load-bearing, not decoration. The archive is asked for
+	// from a mount effect, and React Query detaches the mutation observer
+	// on StrictMode's simulated unmount without ever reattaching it — so
+	// the settle never reaches the hook and `isPending` stays true for
+	// good, while the mutation's own `onSuccess` still lands the id and
+	// starts the poll. That is the shape this screen shipped in: a healthy
+	// poll climbing behind a spinner that never became a bar. Drop the
+	// wrapper and this test passes either way.
+	it( 'hands the wait over to the progress bar once the poll answers', async () => {
+		render(
+			<StrictMode>
+				<DownloadStage />
+			</StrictMode>
+		);
+
+		// The bar arrives at 0% — its opening frame, while WPCOM still has
+		// the job queued — so waiting on the element alone would pass on a
+		// bar that never took a number from the poll. The polled value is
+		// the assertion that matters.
+		const bar = await screen.findByRole( 'progressbar', undefined, SETTLE );
+		// A number, not a string: `toHaveValue` on `<progress>` reads
+		// `element.value`, which the DOM has already coerced.
+		await waitFor( () => expect( bar ).toHaveValue( 36 ), SETTLE );
+		// The spinner is the state the bar replaces, so its departure is
+		// half the behaviour. `Spinner` renders an explicit
+		// `role="presentation"`, which is the handle on it.
+		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+	} );
+
+	// The same latch that hid the bar also hid the ending. `isPending` was
+	// read above every other branch, so a frozen one shadowed `success`
+	// and `failed` too: the archive could finish, signed URL and all, and
+	// the screen would still be sitting on the spinner with nothing to
+	// click. Reported as "upon finishing, the spinner remains there and
+	// nothing happened" — the same defect as the missing bar, one branch
+	// further on.
+	it( 'shows the finished archive rather than staying on the spinner', async () => {
+		render(
+			<StrictMode>
+				<DownloadStage />
+			</StrictMode>
+		);
+
+		// Wait for a live poll first, so the flip below lands on a screen
+		// that is genuinely waiting rather than one still mid-POST.
+		await expect(
+			screen.findByRole( 'progressbar', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		downloadStatus = {
+			id: 4242,
+			status: 'finished',
+			progress: 100,
+			url: 'https://example.com/archive.zip',
+			valid_until: '2026-09-04T00:00:00+00:00',
+			error: '',
+		};
+
+		const link = await screen.findByRole( 'link', { name: 'Download the file' }, SETTLE );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/archive.zip' );
+		// `Notice` also speaks its text through `wp.a11y.speak`, which
+		// mirrors the string into a live region — so an unscoped query
+		// matches twice. The visible notice is the one under assertion.
+		expect(
+			screen.getByText( 'Your download is ready.', {
+				ignore: '.a11y-speak-region, script, style',
+			} )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not start when the rewind id is malformed', async () => {

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -32,9 +32,17 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => mockSearch(),
 	useNavigate: () => mockNavigate,
 	useParams: () => mockParams(),
-	// Unlike the bare `<a { ...rest }>` mock the other suites use, this one
-	// models `search`: the real Link renders it into the href rather than
-	// onto the DOM node, and the href is exactly what these tests are about.
+	// Models `search`, which the real Link renders into the href rather
+	// than onto the DOM node — and the href is what these tests are about.
+	//
+	// The suites still using a bare `<a { ...rest }>` mock get away with it
+	// only because their `ls` fixtures carry no `id`, so `search` stays
+	// undefined and React drops it. Give one of those fixtures an id and
+	// the object reaches a DOM node, and `@wordpress/jest-console` fails
+	// the suite on React's unknown-prop warning —
+	// `restore-label-scope.test.tsx` and
+	// `switching-backups-resets-detail.test.tsx` needed ids, so they carry
+	// this same mock now.
 	Link: ( {
 		children,
 		to,
@@ -77,11 +85,36 @@ const ITEM: BackupActivityItem = {
 
 // `ZjU6L3dwLWNvbmZpZy5waHA=` decodes to `f5:/wp-config.php`, and
 // `ZjI6L3JlYWRtZS5odG1s` to `f2:/readme.html` — the volume-prefixed
-// manifest paths upstream identifies entries by. The `=` padding is here
-// on purpose: it is the character a query-string round trip is most
-// likely to mangle.
+// manifest paths upstream identifies entries by. Base64 padding and all,
+// since that is what the real ids look like; the serializer itself is
+// mocked out here, so these do not exercise a URL round trip.
 const WP_CONFIG_ID = 'ZjU6L3dwLWNvbmZpZy5waHA=';
 const README_ID = 'ZjI6L3JlYWRtZS5odG1s';
+// A directory id, which is itself a comma-joined token pair (`base64("r2:")
+// + "," + base64("f2:/")`). It is why the include list is one comma-joined
+// string upstream flattens, rather than a list of discrete values.
+const THEMES_DIR_ID = 'cjI6,ZjI6Lw==';
+
+/**
+ * The root `ls` listing each test renders against. Reassigned before the
+ * few tests that need a different tree — an id-less entry, or a folder.
+ */
+let lsContents: Record< string, Record< string, unknown > >;
+
+const TWO_FILES = {
+	'wp-config.php': {
+		type: 'file',
+		period: '1786644531',
+		manifest_path: 'f5:/wp-config.php',
+		id: WP_CONFIG_ID,
+	},
+	'readme.html': {
+		type: 'file',
+		period: '1786644531',
+		manifest_path: 'f2:/readme.html',
+		id: README_ID,
+	},
+};
 
 /** Every box in the shared category checklist, by its accessible name. */
 const ITEM_LABELS = [
@@ -97,6 +130,7 @@ beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
 
+	lsContents = TWO_FILES;
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
 		const path = o?.path ?? '';
@@ -104,22 +138,7 @@ beforeEach( () => {
 			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
 		}
 		if ( path.includes( '/rewind/backup/ls' ) ) {
-			return Promise.resolve( {
-				contents: {
-					'wp-config.php': {
-						type: 'file',
-						period: '1786644531',
-						manifest_path: 'f5:/wp-config.php',
-						id: WP_CONFIG_ID,
-					},
-					'readme.html': {
-						type: 'file',
-						period: '1786644531',
-						manifest_path: 'f2:/readme.html',
-						id: README_ID,
-					},
-				},
-			} );
+			return Promise.resolve( { contents: lsContents } );
 		}
 		if ( path.includes( '/backups/download/' ) ) {
 			return Promise.resolve( { id: 4242 } );
@@ -196,6 +215,76 @@ describe( 'Download link carrying the file selection', () => {
 			'/restore/1786644531.123'
 		);
 	} );
+
+	// A ticked folder whose children were never expanded is ONE unit, not
+	// an enumeration: upstream takes the folder's own id and pulls the
+	// whole subtree. Both the label and the link depend on that rule, and
+	// nothing pinned it before.
+	it( 'sends one entry for a ticked folder nobody expanded', async () => {
+		lsContents = {
+			themes: { type: 'dir', has_children: true, id: THEMES_DIR_ID },
+			'wp-config.php': TWO_FILES[ 'wp-config.php' ],
+		};
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+		await expect(
+			screen.findByRole( 'button', { name: 'Folder: themes' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select themes' } ) );
+
+		const link = await screen.findByRole( 'link', { name: /Download 1 selected item/ } );
+		const href = link.getAttribute( 'href' ) ?? '';
+		expect( new URLSearchParams( href.slice( href.indexOf( '?' ) ) ).get( 'files' ) ).toBe(
+			THEMES_DIR_ID
+		);
+	} );
+
+	// The label and the link are built from the same list on purpose. An
+	// entry upstream gave no `id` can be ticked in the tree and cannot be
+	// named in a request — so counting ticked rows instead would promise
+	// "Download 1 selected item" over a link carrying nothing, and hand
+	// back a whole-site archive. That is the wrong-promise failure
+	// JETPACK-2305 removes from Restore.
+	it( 'does not promise a scope for entries the link cannot carry', async () => {
+		lsContents = {
+			// No `id`, as upstream is free to return.
+			'orphan.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/orphan.php' },
+			'wp-config.php': TWO_FILES[ 'wp-config.php' ],
+		};
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+		await expect(
+			screen.findByRole( 'button', { name: 'File: orphan.php' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select orphan.php' } ) );
+
+		// The tree still shows it as selected — that is the row's truth.
+		expect( screen.getByRole( 'checkbox', { name: 'Select orphan.php' } ) ).toBeChecked();
+		// The action does not claim a scope it cannot deliver.
+		expect( screen.getByRole( 'link', { name: /Download backup/ } ) ).toHaveAttribute(
+			'href',
+			'/download/1786644531.123'
+		);
+		expect( screen.queryByText( /Download \d+ selected item/ ) ).not.toBeInTheDocument();
+
+		// And it recovers: ticking a nameable entry alongside counts only
+		// that one, so the label and the link agree again.
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } ) );
+
+		const link = await screen.findByRole( 'link', { name: /Download 1 selected item/ } );
+		const href = link.getAttribute( 'href' ) ?? '';
+		expect( new URLSearchParams( href.slice( href.indexOf( '?' ) ) ).get( 'files' ) ).toBe(
+			WP_CONFIG_ID
+		);
+	} );
 } );
 
 describe( 'Download screen without a file selection', () => {
@@ -212,6 +301,29 @@ describe( 'Download screen without a file selection', () => {
 			expect( screen.getByRole( 'checkbox', { name: label } ) ).toBeChecked();
 		}
 
+		// The other half of "unchanged": the waiting state the selection
+		// path jumps straight into must not appear here. Without this the
+		// no-selection path could start auto-generating and every
+		// assertion above would still pass.
+		expect( screen.queryByText( 'Preparing download…' ) ).not.toBeInTheDocument();
+		expect( postCalls() ).toHaveLength( 0 );
+	} );
+
+	// A `files` param naming nothing is not a selection. Commas alone can
+	// survive a hand-edited or truncated URL, and treating that as a
+	// selection would skip the checklist and submit with no way back.
+	it.each( [
+		[ 'empty', '' ],
+		[ 'commas only', ',,' ],
+	] )( 'treats a %s files param as no selection', async ( _label, files ) => {
+		mockSearch.mockReturnValue( { files } );
+
+		render( <DownloadStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: /Generate download/ }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Preparing download…' ) ).not.toBeInTheDocument();
 		expect( postCalls() ).toHaveLength( 0 );
 	} );
 } );

--- a/projects/packages/backup/tests/restore-label-scope.test.tsx
+++ b/projects/packages/backup/tests/restore-label-scope.test.tsx
@@ -12,7 +12,24 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 jest.mock( '@wordpress/route', () => ( {
-	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+	// `search` is folded into the href rather than spread onto the node: the
+	// Download action carries the file selection there now, and React would
+	// warn about an object-valued attribute on an `<a>` — which
+	// `@wordpress/jest-console` turns into a suite failure.
+	Link: ( {
+		children,
+		to,
+		search,
+		...rest
+	}: {
+		children: React.ReactNode;
+		to: string;
+		search?: Record< string, string >;
+	} ) => (
+		<a href={ search ? `${ to }?${ new URLSearchParams( search ).toString() }` : to } { ...rest }>
+			{ children }
+		</a>
+	),
 } ) );
 
 // Imports must come after the jest.mock factories above.
@@ -54,7 +71,16 @@ beforeEach( () => {
 	mockApiFetch.mockReset();
 	mockApiFetch.mockResolvedValue( {
 		contents: {
-			'wp-config.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-config.php' },
+			// `id` is what a granular download names the entry by — base64 of
+			// the manifest path — and without it the Download action has
+			// nothing to count, so the asymmetry this suite asserts would not
+			// be observable.
+			'wp-config.php': {
+				type: 'file',
+				period: '1786644531',
+				manifest_path: 'f5:/wp-config.php',
+				id: 'ZjU6L3dwLWNvbmZpZy5waHA=',
+			},
 		},
 	} );
 } );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -17,7 +17,24 @@ jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => mockSearch(),
 	useNavigate: () => mockNavigate,
 	useParams: () => ( {} ),
-	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+	// `search` is folded into the href rather than spread onto the node: the
+	// Download action carries the file selection there now, and React would
+	// warn about an object-valued attribute on an `<a>` — which
+	// `@wordpress/jest-console` turns into a suite failure.
+	Link: ( {
+		children,
+		to,
+		search,
+		...rest
+	}: {
+		children: React.ReactNode;
+		to: string;
+		search?: Record< string, string >;
+	} ) => (
+		<a href={ search ? `${ to }?${ new URLSearchParams( search ).toString() }` : to } { ...rest }>
+			{ children }
+		</a>
+	),
 } ) );
 
 // Imports must come after the jest.mock factories above.
@@ -95,7 +112,14 @@ beforeEach( () => {
 			// Both backups carry the same root file — the same file
 			// surviving between backups is the ordinary case, not an edge
 			// one.
-			return Promise.resolve( { contents: { 'wp-config.php': { type: 'file', period: '123' } } } );
+			// `id` is what a granular download names the entry by. The
+			// Download label counts nameable entries, so without it the
+			// selection this suite tracks would be invisible.
+			return Promise.resolve( {
+				contents: {
+					'wp-config.php': { type: 'file', period: '123', id: 'ZjU6L3dwLWNvbmZpZy5waHA=' },
+				},
+			} );
 		}
 		return Promise.resolve( {} );
 	} );


### PR DESCRIPTION
Fixes JETPACK-2296

## Proposed changes

The modernized Backup dashboard's detail pane relabels its Download action from the file-browser selection — "Download 3 selected items" — but the link carried only the rewind id. The selection was discarded on navigation, and the Download screen seeded the whole-site category checklist regardless.

* **Carry the `ls` entry id onto `FileNode`.** `toFileNode` copied neither `id` nor `total_items`, so the selection could only key on the *display* path, which upstream does not accept. `id` is now copied through for files and folders alike. It is the opaque per-entry id from `/rewind/backup/ls` — base64 of a volume-prefixed manifest path (`ZjY6L2luZGV4LnBocA==` decodes to `f6:/index.php`).
* **Report the selection's ids upward.** `FileBrowser` already walked the loaded tree to count selected leaves; it now collects those leaves and reports their ids through `onSelectionIdsChange`. Same leaves, same rules — a ticked but unexpanded folder is still one unit, standing for its whole subtree.
* **Put them on the Download link** as `?files=<csv>`. Comma-joined into one string rather than repeated params, because that is the form upstream's `include_path_list` takes — and it has to be a string: a single id can itself contain a comma, which works precisely because upstream flattens on comma. Absent when nothing is ticked, so a whole-backup download links exactly as before.
* **The label and the link are built from the same list.** The tree can hold a ticked entry upstream gave no `id`, which no request can name. Counting ticked rows instead would read "Download 1 selected item" over a link carrying nothing, and hand back a whole-site archive — the wrong-promise failure JETPACK-2305 removes from Restore. The browser's own "N items selected" header still counts the tree, which is the tree's truth; the action counts what it can deliver.
* **The Download screen skips the category checklist when a selection arrives**, and starts building the archive instead of asking. This is the JETPACK-2350 decision: upstream models `paths` as one *of* the six categories (`types: { paths: true }` with `include_path_list`), not a filter across them — so a request naming files cannot also name categories, and the checklist was offering choices the request has no way to express. With no selection the checklist behaves exactly as it does today.
* The "Preparing download…" heading is now one block for the whole wait rather than two, so it does not unmount and remount underneath the reader when the first status poll lands. A reader who arrived with files ticked sees a spinner until there is a percentage to report; a progress bar pinned at 0% reads as a stall.
* **Restore is deliberately untouched.** Its link stays bare and its label stays unchanged. A restore point is restored whole and there is no upstream shape for restoring a subset of files, so the two buttons treating the same gesture differently is intentional — see JETPACK-2305.

### Out of scope

Forwarding the entries to WordPress.com is **JETPACK-2321**. The PHP bridge does not register `include_path_list` / `exclude_path_list`, and the request body is unchanged by this PR: the selection reaches `/download/$rewindId` and no further. Until 2321 lands, the archive that gets built is still the whole one — as it is on trunk today, where the button already says "Download 3 selected items".

### Upstream finding, recorded here because someone will ask

**Does upstream accept `include_path_list` alongside non-`paths` categories? Yes — and silently ignores it.**

WordPress.com's `POST /sites/{id}/rewind/downloads` reads `include_path_list` / `exclude_path_list` independently of `types` (array *or* comma-joined string) and forwards both to VaultPress with no gate, so nothing 400s. VaultPress documents both as "Only used for paths type", and WordPress.com's own restore endpoint carries the same note in a comment; WordPress.com's internal Site Studio caller gates on `in_array( 'paths', $options, true )` before attaching the list at all.

So a request pairing a path list with, say, `types: { sqls: true }` is accepted and quietly returns the *whole* database category. Whether `types: { paths: true, sqls: true }` plus a path list yields a real "these files **plus** the database" archive is not settled by anything readable: the union is implied by the docs but demonstrated by no caller anywhere. Either way it fails silently rather than loudly, which is the more useful half of the answer.

### Known limitation: URL length

Nothing caps the number of ids in `?files=`. At roughly 97 bytes per individually-ticked file, the URL crosses Apache's default `LimitRequestLine` (8190 bytes) at about **85 files**. Clicking the link always works — TanStack navigates with `pushState` — but reloading, bookmarking or pasting such a URL gets a 414 from the web server rather than a Jetpack screen.

Reaching it takes ticking most-but-not-all children of a large folder; ticking *all* of them collapses to the parent's single id. Flagging it rather than guarding it, since the right guard depends on what JETPACK-2321 decides to send.

## Related product discussion/links

* JETPACK-2296 (this issue), JETPACK-2350 (the screen-behaviour decision), JETPACK-2321 (sending the paths upstream), JETPACK-2305 (why Restore goes the other way)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The modernized dashboard is behind `rsm_jetpack_ui_modernization_backup`, which is **off** by default. Turn it on for the site you test against.

* Go to **Jetpack → Backup** on a site with backups and pick a restore point in the left-hand list.
* Expand the file browser in the detail pane and tick a couple of files.
  * The Download action relabels to "Download N selected items", as it did before.
  * Hover it (or inspect the link): the href now carries `?files=<comma-joined base64 ids>`. Untick everything and it goes back to a bare `/download/<rewindId>`.
* Click **Download N selected items**.
  * The screen goes straight to "Preparing download…" — no category checklist, no Generate button.
  * A `POST` to `/jetpack/v4/backups/download/<rewindId>` fires once, without you clicking anything.
* Go back, tick **nothing**, and click **Download backup**.
  * The six-category checklist renders exactly as before, all boxes ticked, and nothing is submitted until you press **Generate download**.
* Visit `/download/<rewindId>?files=<anything>` with a malformed rewind id — the "This download link isn't valid." screen still wins, and no request is made.
* The Restore action beside Download should be unchanged throughout: label stays "Restore to this point", link stays bare.

Automated coverage: `jp test js packages/backup` — 69 suites, 687 tests. `tests/download-file-selection.test.tsx` covers both branches plus the id-less entry, the ticked unexpanded folder, and a `files` param naming nothing; `src/dashboard/hooks/test/use-file-tree.test.ts` covers the id passthrough. `restore-label-scope.test.tsx` and `switching-backups-resets-detail.test.tsx` gained real `ls` ids so their selections are nameable.

