### PR TITLE
Backup: port the review-request card to the modernized dashboard

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2302-k1-port-the-review-request-card
+++ b/projects/packages/backup/changelog/jetpack-2302-k1-port-the-review-request-card
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Modernized dashboard only, behind the flag: port the review-request card, gated on the standalone Backup plugin being active.
+
+

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -384,6 +384,13 @@ class Jetpack_Backup {
 					'option_name'    => array(
 						'required' => true,
 						'type'     => 'string',
+						// The two names `Jetpack_Options` recognises. Anything else
+						// falls through its allowlist to a `trigger_error()` and is
+						// stored nowhere, so an unlisted reason would dismiss
+						// nothing while answering as though it had — and on a site
+						// with `display_errors` on, the warning is printed ahead of
+						// the JSON and the response no longer parses.
+						'enum'     => array( 'restore', 'backups' ),
 					),
 					'should_dismiss' => array(
 						'required' => true,

--- a/projects/packages/backup/src/dashboard/components/review-request/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/review-request/index.tsx
@@ -10,19 +10,11 @@ import type { ReviewReason } from '../../data/api/review-request';
 /**
  * The question that opens the prompt.
  *
- * Two whole returns rather than one string chosen by a ternary. A `__()`
- * call whose argument is a conditional is a msgid-extraction hazard: the
- * minifier factors the shared call out and leaves `__( cond ? a : b )`,
- * which is no longer a string literal for the extractor to find.
- *
- * Both msgids are legacy's, character for character, so they arrive
- * already translated rather than waiting a GlotPress cycle.
- *
- * The backups line asserts *real-time* backups unconditionally, which may
- * be wrong for a site on a daily-backup tier. That is unverified, and it
- * is legacy's wording — so it is ported as-is rather than quietly
- * reworded here. If it is wrong it is wrong in legacy today too, and
- * fixing it is a copy change with a translation cost, not a port.
+ * Two whole returns, not one `__()` over a ternary: the minifier factors the
+ * shared call out and leaves a non-literal msgid the extractor cannot read.
+ * Both msgids are legacy's character for character, so they arrive already
+ * translated — including the backups line's unconditional "real-time", which is
+ * ported as-is rather than reworded at a translation cost.
  *
  * @param reason - Why the reader is being asked.
  * @return The question to show.
@@ -38,15 +30,9 @@ function reviewQuestion( reason: ReviewReason ): string {
 /**
  * Asks a reader the product has visibly worked for to review the plugin.
  *
- * Renders nothing unless `useReviewRequest` says there is a prompt to
- * show; that hook owns the whole decision, including the gate that keeps
- * this off a site without the standalone Backup plugin.
- *
- * The destination is the redirect service rather than a wordpress.org URL
- * written here, so the target stays maintainable outside this repo. It is
- * outbound but points at the plugin's own review page rather than
- * Calypso, so the rule about linking this dashboard into Calypso does not
- * reach it.
+ * `useReviewRequest` owns the whole decision, including the standalone-plugin
+ * gate. The destination goes through the redirect service so the wordpress.org
+ * target stays maintainable outside this repo.
  *
  * @return The rendered prompt, or nothing.
  */
@@ -58,17 +44,10 @@ export default function ReviewRequest() {
 		tracks.recordEvent( 'jetpack_backup_new_review_click' );
 	}, [ tracks ] );
 
-	// Which prompt this reader has already been recorded as refusing.
-	//
-	// The write can legitimately be attempted more than once — a failed
-	// dismissal leaves the card up precisely so the reader can try again —
-	// but a retry is not a second decision, and reporting it as one
-	// inflates the dismissal rate at the flag flip in a way that reads as
-	// behaviour and is not. The same hazard `screens/overview.tsx` guards
-	// the page view against.
-	//
-	// A ref rather than module state, and keyed on the reason: the two
-	// prompts are two separate refusals, and each deserves its own event.
+	// Which prompt this reader has already been recorded as refusing. A failed
+	// dismissal leaves the card up so they can retry, but a retry is not a second
+	// decision and reporting it as one inflates the rate at the flag flip. Keyed
+	// on the reason, since the two prompts are separate refusals.
 	const reportedRefusalFor = useRef< ReviewReason | null >( null );
 
 	// No in-flight check of its own: `disabled` below already stops a
@@ -118,17 +97,10 @@ export default function ReviewRequest() {
 					</Text>
 				</Stack>
 				{ /*
-				 * A button, not legacy's `<a role="button" href="#">`. It does
-				 * not navigate, and the anchor spelling needed a
-				 * `preventDefault` to stop it trying to.
-				 *
-				 * Disabled while the refusal is being written. `@wordpress/ui`'s
-				 * Button defaults to `focusableWhenDisabled`, so this marks it
-				 * `aria-disabled` and keeps it in the tab order rather than
-				 * taking the native attribute — and it does suppress the
-				 * click, so this is the visible half and the first guard at
-				 * once. Without it the card just sits there after a click,
-				 * which is what makes a reader click again.
+				 * A button, not legacy's `<a role="button" href="#">`, which needed a
+				 * `preventDefault` to stop it navigating. `@wordpress/ui`'s Button
+				 * defaults to `focusableWhenDisabled`, so disabling marks it
+				 * `aria-disabled`, keeps it focusable, and still suppresses the click.
 				 */ }
 				<Button
 					variant="minimal"

--- a/projects/packages/backup/src/dashboard/components/review-request/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/review-request/index.tsx
@@ -1,0 +1,107 @@
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, Card, Link, Stack, Text } from '@wordpress/ui';
+import { useAnalytics } from '../../hooks/use-analytics';
+import { useReviewRequest } from '../../hooks/use-review-request';
+import './style.scss';
+import type { ReviewReason } from '../../data/api/review-request';
+
+/**
+ * The question that opens the prompt.
+ *
+ * Two whole returns rather than one string chosen by a ternary. A `__()`
+ * call whose argument is a conditional is a msgid-extraction hazard: the
+ * minifier factors the shared call out and leaves `__( cond ? a : b )`,
+ * which is no longer a string literal for the extractor to find.
+ *
+ * Both msgids are legacy's, character for character, so they arrive
+ * already translated rather than waiting a GlotPress cycle.
+ *
+ * The backups line asserts *real-time* backups unconditionally, which may
+ * be wrong for a site on a daily-backup tier. That is unverified, and it
+ * is legacy's wording — so it is ported as-is rather than quietly
+ * reworded here. If it is wrong it is wrong in legacy today too, and
+ * fixing it is a copy change with a translation cost, not a port.
+ *
+ * @param reason - Why the reader is being asked.
+ * @return The question to show.
+ */
+function reviewQuestion( reason: ReviewReason ): string {
+	if ( reason === 'restore' ) {
+		return __( 'Was it easy to restore your site?', 'jetpack-backup-pkg' );
+	}
+
+	return __( 'Do you enjoy the peace of mind of having real-time backups?', 'jetpack-backup-pkg' );
+}
+
+/**
+ * Asks a reader the product has visibly worked for to review the plugin.
+ *
+ * Renders nothing unless `useReviewRequest` says there is a prompt to
+ * show; that hook owns the whole decision, including the gate that keeps
+ * this off a site without the standalone Backup plugin.
+ *
+ * The destination is the redirect service rather than a wordpress.org URL
+ * written here, so the target stays maintainable outside this repo. It is
+ * outbound but points at the plugin's own review page rather than
+ * Calypso, so the rule about linking this dashboard into Calypso does not
+ * reach it.
+ *
+ * @return The rendered prompt, or nothing.
+ */
+export default function ReviewRequest() {
+	const { reason, dismiss } = useReviewRequest();
+	const { tracks } = useAnalytics();
+
+	const trackReviewClick = useCallback( () => {
+		tracks.recordEvent( 'jetpack_backup_new_review_click' );
+	}, [ tracks ] );
+
+	const onDismiss = useCallback( () => {
+		tracks.recordEvent( 'jetpack_backup_dismiss_review_click' );
+		dismiss();
+	}, [ dismiss, tracks ] );
+
+	if ( reason === null ) {
+		return null;
+	}
+
+	return (
+		<Card.Root className="jpb-review-request">
+			<Stack direction="row" align="center" justify="space-between" gap="md">
+				<Stack direction="column" gap="xs">
+					<Text variant="body-sm">{ reviewQuestion( reason ) }</Text>
+					<Text variant="body-sm">
+						<Link
+							openInNewTab
+							href={ getRedirectUrl( 'jetpack-backup-new-review' ) }
+							onClick={ trackReviewClick }
+						>
+							{ /*
+							 * The `<strong>` is inside the msgid because that is
+							 * how legacy ships this string, and changing the msgid
+							 * would throw away its translations for a bold tag.
+							 */ }
+							{ createInterpolateElement(
+								__(
+									'<strong>Please leave a review and help us spread the word!</strong>',
+									'jetpack-backup-pkg'
+								),
+								{ strong: <strong /> }
+							) }
+						</Link>
+					</Text>
+				</Stack>
+				{ /*
+				 * A button, not legacy's `<a role="button" href="#">`. It does
+				 * not navigate, and the anchor spelling needed a
+				 * `preventDefault` to stop it trying to.
+				 */ }
+				<Button variant="minimal" tone="neutral" size="small" onClick={ onDismiss }>
+					{ __( 'Maybe later', 'jetpack-backup-pkg' ) }
+				</Button>
+			</Stack>
+		</Card.Root>
+	);
+}

--- a/projects/packages/backup/src/dashboard/components/review-request/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/review-request/index.tsx
@@ -1,5 +1,5 @@
 import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
-import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Card, Link, Stack, Text } from '@wordpress/ui';
 import { useAnalytics } from '../../hooks/use-analytics';
@@ -51,17 +51,41 @@ function reviewQuestion( reason: ReviewReason ): string {
  * @return The rendered prompt, or nothing.
  */
 export default function ReviewRequest() {
-	const { reason, dismiss } = useReviewRequest();
+	const { reason, dismiss, isDismissing } = useReviewRequest();
 	const { tracks } = useAnalytics();
 
 	const trackReviewClick = useCallback( () => {
 		tracks.recordEvent( 'jetpack_backup_new_review_click' );
 	}, [ tracks ] );
 
+	// Which prompt this reader has already been recorded as refusing.
+	//
+	// The write can legitimately be attempted more than once — a failed
+	// dismissal leaves the card up precisely so the reader can try again —
+	// but a retry is not a second decision, and reporting it as one
+	// inflates the dismissal rate at the flag flip in a way that reads as
+	// behaviour and is not. The same hazard `screens/overview.tsx` guards
+	// the page view against.
+	//
+	// A ref rather than module state, and keyed on the reason: the two
+	// prompts are two separate refusals, and each deserves its own event.
+	const reportedRefusalFor = useRef< ReviewReason | null >( null );
+
+	// No in-flight check of its own: `disabled` below already stops a
+	// second click reaching this handler, the latch above already stops a
+	// second event, and `dismiss()` already refuses a second write. A
+	// fourth guard here would be the only one no test could distinguish
+	// from the others.
 	const onDismiss = useCallback( () => {
-		tracks.recordEvent( 'jetpack_backup_dismiss_review_click' );
+		if ( reason === null ) {
+			return;
+		}
+		if ( reportedRefusalFor.current !== reason ) {
+			reportedRefusalFor.current = reason;
+			tracks.recordEvent( 'jetpack_backup_dismiss_review_click' );
+		}
 		dismiss();
-	}, [ dismiss, tracks ] );
+	}, [ dismiss, reason, tracks ] );
 
 	if ( reason === null ) {
 		return null;
@@ -97,8 +121,22 @@ export default function ReviewRequest() {
 				 * A button, not legacy's `<a role="button" href="#">`. It does
 				 * not navigate, and the anchor spelling needed a
 				 * `preventDefault` to stop it trying to.
+				 *
+				 * Disabled while the refusal is being written. `@wordpress/ui`'s
+				 * Button defaults to `focusableWhenDisabled`, so this marks it
+				 * `aria-disabled` and keeps it in the tab order rather than
+				 * taking the native attribute — and it does suppress the
+				 * click, so this is the visible half and the first guard at
+				 * once. Without it the card just sits there after a click,
+				 * which is what makes a reader click again.
 				 */ }
-				<Button variant="minimal" tone="neutral" size="small" onClick={ onDismiss }>
+				<Button
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					disabled={ isDismissing }
+					onClick={ onDismiss }
+				>
 					{ __( 'Maybe later', 'jetpack-backup-pkg' ) }
 				</Button>
 			</Stack>

--- a/projects/packages/backup/src/dashboard/components/review-request/style.scss
+++ b/projects/packages/backup/src/dashboard/components/review-request/style.scss
@@ -1,0 +1,9 @@
+// A sibling of `.jpb-overview` rather than a child: that element is a
+// two-column grid at >= 961px, so a third child would be auto-placed into
+// it.
+.jpb-review-request {
+	// `Card.Root` ships no padding of its own; `.jpb-file-info-card` sets
+	// its own for the same reason.
+	padding: 12px 16px;
+	margin-block-end: 16px;
+}

--- a/projects/packages/backup/src/dashboard/data/api/capabilities.ts
+++ b/projects/packages/backup/src/dashboard/data/api/capabilities.ts
@@ -4,20 +4,24 @@ export type Capabilities = {
 	hasBackupPlan: boolean;
 	hasScan: boolean;
 	/**
-	 * Whether the standalone Jetpack VaultPress Backup plugin is active.
+	 * Facts the site decided for itself, kept in their own branch so that
+	 * nothing here can be mistaken for something WordPress.com said. See
+	 * `Capabilities_Bridge`, which owns the same rule on the PHP side.
 	 *
-	 * Decided on the server — see `Capabilities_Bridge` — and carried on
-	 * this response because it is the one request every screen already
-	 * makes before it renders a body, so the answer is in hand before
-	 * anything it gates could appear.
+	 * They ride on this response because it is the one request every
+	 * screen already makes before it renders a body, so the answers are in
+	 * hand before anything depending on them could appear.
 	 *
-	 * Optional because the key can genuinely be absent: a site part-way
-	 * through an upgrade can serve a newer JS bundle against older PHP.
-	 * Consumers must read a missing value as closed rather than open —
-	 * everything this gates is an addition, so not showing it is always
-	 * the milder mistake.
+	 * The branch and its members are all optional, because they can
+	 * genuinely be absent: a site part-way through an upgrade can serve a
+	 * newer JS bundle against older PHP. Read a missing value as closed
+	 * rather than open — everything carried here gates an addition, so not
+	 * showing it is always the milder mistake.
 	 */
-	isStandalonePluginActive?: boolean;
+	local?: {
+		/** Whether the standalone Jetpack VaultPress Backup plugin is active. */
+		isStandalonePluginActive?: boolean;
+	};
 };
 
 /**

--- a/projects/packages/backup/src/dashboard/data/api/capabilities.ts
+++ b/projects/packages/backup/src/dashboard/data/api/capabilities.ts
@@ -4,19 +4,10 @@ export type Capabilities = {
 	hasBackupPlan: boolean;
 	hasScan: boolean;
 	/**
-	 * Facts the site decided for itself, kept in their own branch so that
-	 * nothing here can be mistaken for something WordPress.com said. See
-	 * `Capabilities_Bridge`, which owns the same rule on the PHP side.
-	 *
-	 * They ride on this response because it is the one request every
-	 * screen already makes before it renders a body, so the answers are in
-	 * hand before anything depending on them could appear.
-	 *
-	 * The branch and its members are all optional, because they can
-	 * genuinely be absent: a site part-way through an upgrade can serve a
-	 * newer JS bundle against older PHP. Read a missing value as closed
-	 * rather than open — everything carried here gates an addition, so not
-	 * showing it is always the milder mistake.
+	 * Facts the site decided for itself, branched so nothing here reads as
+	 * something WordPress.com said; `Capabilities_Bridge` owns the same rule in
+	 * PHP. All optional, since a part-upgraded site can serve a newer bundle
+	 * against older PHP — read a missing value as closed.
 	 */
 	local?: {
 		/** Whether the standalone Jetpack VaultPress Backup plugin is active. */

--- a/projects/packages/backup/src/dashboard/data/api/capabilities.ts
+++ b/projects/packages/backup/src/dashboard/data/api/capabilities.ts
@@ -3,6 +3,21 @@ import { apiCall, apiPath } from './_helpers';
 export type Capabilities = {
 	hasBackupPlan: boolean;
 	hasScan: boolean;
+	/**
+	 * Whether the standalone Jetpack VaultPress Backup plugin is active.
+	 *
+	 * Decided on the server — see `Capabilities_Bridge` — and carried on
+	 * this response because it is the one request every screen already
+	 * makes before it renders a body, so the answer is in hand before
+	 * anything it gates could appear.
+	 *
+	 * Optional because the key can genuinely be absent: a site part-way
+	 * through an upgrade can serve a newer JS bundle against older PHP.
+	 * Consumers must read a missing value as closed rather than open —
+	 * everything this gates is an addition, so not showing it is always
+	 * the milder mistake.
+	 */
+	isStandalonePluginActive?: boolean;
 };
 
 /**

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -77,28 +77,11 @@ const SETTLED_ROW_STATUSES = new Set( [
 /**
  * Spellings in that same vocabulary that mean the restore worked.
  *
- * Both, not just `finished`, and the pair is not a guess: the status
- * route's own `Restore_Bridge::STATUS_MAP` maps `success` to `finished`,
- * so WordPress.com is already known to say it both ways on this resource
- * family. `GET /jetpack/v4/restores` does no mapping at all — it
- * `json_decode`s WordPress.com's body and returns it — so whichever
- * spelling upstream picks arrives here raw. `SETTLED_ROW_STATUSES` above
- * hedges the same way for the same reason.
- *
- * Matching only `finished` would be wrong in a way nothing could see. If
- * upstream says `success`, no restore ever reads as successful, the
- * review prompt's restore trigger never fires for any site, and there is
- * no error and no complaint — an absent nudge generates neither.
- *
- * `success-with-errors` stays out deliberately. A restore that completed
- * but not cleanly is not a moment to follow with "was it easy to restore
- * your site?", and `STATUS_MAP` likewise keeps it distinct from both
- * neighbours rather than folding it into either.
- *
- * An unrecognised spelling counts as *not* succeeded. That is the
- * opposite default from `settled` above, and for the same reason: each
- * fails towards the harmless answer. There, the harmless answer is "keep
- * waiting"; here it is "do not ask this person for a review".
+ * Both, because `Restore_Bridge::STATUS_MAP` maps `success` to `finished` while
+ * `GET /jetpack/v4/restores` returns WordPress.com's body unmapped. Matching
+ * only `finished` would silence the review prompt's restore trigger site-wide
+ * with nothing to notice. `success-with-errors` stays out, and an unrecognised
+ * spelling counts as not succeeded — the harmless direction here is not asking.
  */
 const SUCCEEDED_ROW_STATUSES = new Set( [ 'finished', 'success' ] );
 

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -75,20 +75,32 @@ const SETTLED_ROW_STATUSES = new Set( [
 ] );
 
 /**
- * The spelling in that same vocabulary that means the restore worked.
+ * Spellings in that same vocabulary that mean the restore worked.
  *
- * One value rather than a set, and deliberately narrow. The legacy
- * dashboard's review prompt matched exactly this string, and every other
- * spelling in `SETTLED_ROW_STATUSES` either says the restore failed or —
- * like `success-with-errors` — says it half worked, which is not a state
- * to follow with "was it easy to restore your site?".
+ * Both, not just `finished`, and the pair is not a guess: the status
+ * route's own `Restore_Bridge::STATUS_MAP` maps `success` to `finished`,
+ * so WordPress.com is already known to say it both ways on this resource
+ * family. `GET /jetpack/v4/restores` does no mapping at all — it
+ * `json_decode`s WordPress.com's body and returns it — so whichever
+ * spelling upstream picks arrives here raw. `SETTLED_ROW_STATUSES` above
+ * hedges the same way for the same reason.
  *
- * An unrecognised spelling therefore counts as *not* succeeded. That is
- * the opposite default from `settled` above, and for the same reason:
- * each fails towards the harmless answer. There, the harmless answer is
- * "keep waiting"; here it is "do not ask this person for a review".
+ * Matching only `finished` would be wrong in a way nothing could see. If
+ * upstream says `success`, no restore ever reads as successful, the
+ * review prompt's restore trigger never fires for any site, and there is
+ * no error and no complaint — an absent nudge generates neither.
+ *
+ * `success-with-errors` stays out deliberately. A restore that completed
+ * but not cleanly is not a moment to follow with "was it easy to restore
+ * your site?", and `STATUS_MAP` likewise keeps it distinct from both
+ * neighbours rather than folding it into either.
+ *
+ * An unrecognised spelling counts as *not* succeeded. That is the
+ * opposite default from `settled` above, and for the same reason: each
+ * fails towards the harmless answer. There, the harmless answer is "keep
+ * waiting"; here it is "do not ask this person for a review".
  */
-const SUCCEEDED_ROW_STATUS = 'finished';
+const SUCCEEDED_ROW_STATUSES = new Set( [ 'finished', 'success' ] );
 
 /**
  * One row of `GET /jetpack/v4/restores` — the last ten restores, any state.
@@ -99,7 +111,7 @@ const SUCCEEDED_ROW_STATUS = 'finished';
  * just started, and recovery would fail for the whole session.
  *
  * `settled` and `succeeded` are the quarantined readings of the row's
- * `status` — see `SETTLED_ROW_STATUSES` and `SUCCEEDED_ROW_STATUS`. The
+ * `status` — see `SETTLED_ROW_STATUSES` and `SUCCEEDED_ROW_STATUSES`. The
  * raw spelling is deliberately not carried any further than this file.
  */
 export type RecentRestore = {
@@ -290,7 +302,7 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] | null > {
 			settled:
 				typeof row.status === 'string' && SETTLED_ROW_STATUSES.has( row.status.toLowerCase() ),
 			succeeded:
-				typeof row.status === 'string' && row.status.toLowerCase() === SUCCEEDED_ROW_STATUS,
+				typeof row.status === 'string' && SUCCEEDED_ROW_STATUSES.has( row.status.toLowerCase() ),
 		} ) )
 		.filter( row => row.restore_id > 0 );
 }

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -75,6 +75,22 @@ const SETTLED_ROW_STATUSES = new Set( [
 ] );
 
 /**
+ * The spelling in that same vocabulary that means the restore worked.
+ *
+ * One value rather than a set, and deliberately narrow. The legacy
+ * dashboard's review prompt matched exactly this string, and every other
+ * spelling in `SETTLED_ROW_STATUSES` either says the restore failed or —
+ * like `success-with-errors` — says it half worked, which is not a state
+ * to follow with "was it easy to restore your site?".
+ *
+ * An unrecognised spelling therefore counts as *not* succeeded. That is
+ * the opposite default from `settled` above, and for the same reason:
+ * each fails towards the harmless answer. There, the harmless answer is
+ * "keep waiting"; here it is "do not ask this person for a review".
+ */
+const SUCCEEDED_ROW_STATUS = 'finished';
+
+/**
  * One row of `GET /jetpack/v4/restores` — the last ten restores, any state.
  *
  * `when` is WordPress.com's own ISO-8601 timestamp and is compared only
@@ -82,15 +98,25 @@ const SETTLED_ROW_STATUSES = new Set( [
  * minutes ahead of the server would otherwise reject the restore it had
  * just started, and recovery would fail for the whole session.
  *
- * `settled` is the quarantined reading of the row's `status` — see
- * `SETTLED_ROW_STATUSES`. The raw spelling is deliberately not carried
- * any further than this file.
+ * `settled` and `succeeded` are the quarantined readings of the row's
+ * `status` — see `SETTLED_ROW_STATUSES` and `SUCCEEDED_ROW_STATUS`. The
+ * raw spelling is deliberately not carried any further than this file.
  */
 export type RecentRestore = {
 	restore_id: number;
 	rewind_id: string;
 	when: string;
 	settled: boolean;
+	/**
+	 * Whether this restore finished and worked.
+	 *
+	 * A separate reading from `settled` rather than a refinement of it,
+	 * because the two answer different questions: `settled` is "is there
+	 * anything left to wait for", which an aborted or failed restore also
+	 * satisfies, and this is "did the site actually come back". Only the
+	 * review prompt asks the second one.
+	 */
+	succeeded: boolean;
 };
 
 /** Statuses that mean the restore is still going, or might be. */
@@ -263,6 +289,8 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] | null > {
 			when: typeof row.when === 'string' ? row.when : '',
 			settled:
 				typeof row.status === 'string' && SETTLED_ROW_STATUSES.has( row.status.toLowerCase() ),
+			succeeded:
+				typeof row.status === 'string' && row.status.toLowerCase() === SUCCEEDED_ROW_STATUS,
 		} ) )
 		.filter( row => row.restore_id > 0 );
 }

--- a/projects/packages/backup/src/dashboard/data/api/review-request.ts
+++ b/projects/packages/backup/src/dashboard/data/api/review-request.ts
@@ -16,17 +16,10 @@ const DISMISSAL_PATH = '/site/dismissed-review-request';
 /**
  * Whether this prompt has already been dismissed.
  *
- * The route is `EDITABLE`, so the read is a POST carrying
- * `should_dismiss: false` — the legacy shape, kept because the option is
- * stored per reason under a name only this route knows how to build, and
- * a second route to read it would be a second thing to keep in step.
- *
- * Fails closed: anything other than a literal `false` reads as dismissed.
- * `false` is what an unset option returns, so it is the one answer that
- * positively means "this person has not said no yet" — and every other
- * outcome, including a shape we do not recognise, leaves us unable to
- * confirm that. Never prompting is the harmless mistake; prompting
- * someone who already declined is not.
+ * The route is `EDITABLE`, so the read is a POST carrying `should_dismiss:
+ * false` — legacy's shape, kept because only the route knows how to build the
+ * per-reason option name. Fails closed: only a literal `false`, what an unset
+ * option returns, means "has not said no yet".
  *
  * @param reason - Which prompt to ask about.
  * @return True when the prompt must not be shown.
@@ -44,17 +37,10 @@ export async function fetchReviewDismissed( reason: ReviewReason ): Promise< boo
 /**
  * Record that the reader declined this prompt.
  *
- * Resolves only when the server accepted the write, which is the whole
- * point: the legacy dashboard hid the card the moment the request was
- * sent rather than when it was accepted, so a failed dismissal took the
- * prompt off screen while the server recorded nothing — and it came back
- * on the next page load.
- *
- * The response body is deliberately ignored. `Jetpack_Options::update_option()`
- * forwards WordPress's own `update_option()` return value, which is
- * `false` when the stored value did not change — so a second dismissal of
- * an already-dismissed prompt answers `false` with everything working
- * exactly as intended. Resolution is the signal; the body is not.
+ * Resolves only on acceptance: legacy hid the card when the request was *sent*,
+ * so a failed dismissal took the prompt off screen and it returned on the next
+ * load. The body is ignored — `Jetpack_Options::update_option()` forwards
+ * `update_option()`, which answers `false` for an unchanged value.
  *
  * @param reason - Which prompt was declined.
  */

--- a/projects/packages/backup/src/dashboard/data/api/review-request.ts
+++ b/projects/packages/backup/src/dashboard/data/api/review-request.ts
@@ -1,0 +1,67 @@
+import { apiCall, apiPath } from './_helpers';
+
+/**
+ * Why the reader is being asked for a review.
+ *
+ * Doubles as the dismissal's storage key: the route appends it to
+ * `dismissed_backup_review_`, and `Jetpack_Options` recognises exactly
+ * the two names below — anything else is refused with a PHP warning and
+ * silently stores nothing. So this union is not merely a nicety; it is
+ * the set of values the server can actually persist.
+ */
+export type ReviewReason = 'restore' | 'backups';
+
+const DISMISSAL_PATH = '/site/dismissed-review-request';
+
+/**
+ * Whether this prompt has already been dismissed.
+ *
+ * The route is `EDITABLE`, so the read is a POST carrying
+ * `should_dismiss: false` — the legacy shape, kept because the option is
+ * stored per reason under a name only this route knows how to build, and
+ * a second route to read it would be a second thing to keep in step.
+ *
+ * Fails closed: anything other than a literal `false` reads as dismissed.
+ * `false` is what an unset option returns, so it is the one answer that
+ * positively means "this person has not said no yet" — and every other
+ * outcome, including a shape we do not recognise, leaves us unable to
+ * confirm that. Never prompting is the harmless mistake; prompting
+ * someone who already declined is not.
+ *
+ * @param reason - Which prompt to ask about.
+ * @return True when the prompt must not be shown.
+ */
+export async function fetchReviewDismissed( reason: ReviewReason ): Promise< boolean > {
+	const dismissed = await apiCall< unknown >( {
+		path: apiPath( DISMISSAL_PATH ),
+		method: 'POST',
+		data: { option_name: reason, should_dismiss: false },
+	} );
+
+	return dismissed !== false;
+}
+
+/**
+ * Record that the reader declined this prompt.
+ *
+ * Resolves only when the server accepted the write, which is the whole
+ * point: the legacy dashboard hid the card the moment the request was
+ * sent rather than when it was accepted, so a failed dismissal took the
+ * prompt off screen while the server recorded nothing — and it came back
+ * on the next page load.
+ *
+ * The response body is deliberately ignored. `Jetpack_Options::update_option()`
+ * forwards WordPress's own `update_option()` return value, which is
+ * `false` when the stored value did not change — so a second dismissal of
+ * an already-dismissed prompt answers `false` with everything working
+ * exactly as intended. Resolution is the signal; the body is not.
+ *
+ * @param reason - Which prompt was declined.
+ */
+export async function dismissReviewRequest( reason: ReviewReason ): Promise< void > {
+	await apiCall< unknown >( {
+		path: apiPath( DISMISSAL_PATH ),
+		method: 'POST',
+		data: { option_name: reason, should_dismiss: true },
+	} );
+}

--- a/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
@@ -52,8 +52,13 @@ describe( 'fetchRecentRestores', () => {
 	test.each( [
 		[ 'finished', true ],
 		[ 'FINISHED', true ],
-		// Settled, but not a restore anyone should be asked to praise.
-		[ 'success', false ],
+		// Both spellings, because the collection route maps nothing and
+		// `Restore_Bridge::STATUS_MAP` already equates these two. Pinning
+		// this to `finished` alone would silently kill the review prompt's
+		// restore trigger on any site whose upstream says `success`.
+		[ 'success', true ],
+		// Settled and not a failure, but not a restore to ask anyone to
+		// praise either — kept distinct here as `STATUS_MAP` keeps it.
 		[ 'success-with-errors', false ],
 		[ 'fail', false ],
 		[ 'aborted', false ],

--- a/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/restore.test.ts
@@ -49,6 +49,22 @@ describe( 'fetchRecentRestores', () => {
 		expect( rows?.[ 0 ].settled ).toBe( settled );
 	} );
 
+	test.each( [
+		[ 'finished', true ],
+		[ 'FINISHED', true ],
+		// Settled, but not a restore anyone should be asked to praise.
+		[ 'success', false ],
+		[ 'success-with-errors', false ],
+		[ 'fail', false ],
+		[ 'aborted', false ],
+		[ 'running', false ],
+		[ 'a-spelling-nobody-has-seen', false ],
+	] )( 'reads status %p as succeeded=%p', async ( status, succeeded ) => {
+		respondWith( [ { restore_id: 1, rewind_id: '1786512000.11', when: '', status } ] );
+		const rows = await fetchRecentRestores();
+		expect( rows?.[ 0 ].succeeded ).toBe( succeeded );
+	} );
+
 	test( 'treats a non-string status as not settled', async () => {
 		// Unknown means adoptable, and the confirmation decides. Guessing
 		// the other way would make an unrecognised spelling of "running"

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -77,4 +77,9 @@ export const keys = {
 	// The site's recent restores, not one restore's status: read to
 	// recover an id WordPress.com accepted but did not return.
 	recentRestores: () => [ 'backup', 'recent-restores' ] as const,
+	// Whether one review prompt has been dismissed. Keyed on the reason
+	// because the two prompts are dismissed independently — declining to
+	// review after a restore must not also spend the backups prompt — and
+	// the server stores them under separate options for the same reason.
+	reviewDismissal: ( reason: string ) => [ 'backup', 'review-dismissal', reason ] as const,
 };

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -819,6 +819,7 @@ describe( 'pickLiveRestore', () => {
 		rewind_id: REWIND_ID,
 		when: '2026-08-20T10:00:00+00:00',
 		settled: false,
+		succeeded: false,
 		...over,
 	} );
 

--- a/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
@@ -125,8 +125,19 @@ type Result = {
 	 * renders whenever this is non-null cannot get the order wrong.
 	 */
 	reason: ReviewReason | null;
-	/** Record the reader's refusal. A no-op when there is no prompt. */
+	/**
+	 * Record the reader's refusal. A no-op when there is no prompt, and
+	 * while a previous refusal is still being written.
+	 */
 	dismiss: () => void;
+	/**
+	 * True while a dismissal write is in flight.
+	 *
+	 * Exposed because the card stays on screen until the server confirms,
+	 * which also leaves its button live — so the caller has to be able to
+	 * tell the reader that the first click was heard. See `dismiss`.
+	 */
+	isDismissing: boolean;
 };
 
 /**
@@ -163,7 +174,7 @@ export function useReviewRequest(): Result {
 	// below `<Gates>`, which does not render a body until that read has
 	// resolved.
 	const { data: capabilities } = useCapabilities( { enabled: canQueryWpcom } );
-	const gateOpen = capabilities?.isStandalonePluginActive === true;
+	const gateOpen = capabilities?.local?.isStandalonePluginActive === true;
 
 	const restores = useQuery( {
 		queryKey: keys.recentRestores(),
@@ -196,7 +207,7 @@ export function useReviewRequest(): Result {
 	} );
 
 	const queryClient = useQueryClient();
-	const { mutate } = useMutation( {
+	const { mutate, isPending: isDismissing } = useMutation( {
 		mutationFn: ( reason: ReviewReason ) => dismissReviewRequest( reason ),
 		// Only on success, which is the point. The legacy dashboard hid the
 		// card as soon as the request was sent, so a failed write took the
@@ -209,11 +220,16 @@ export function useReviewRequest(): Result {
 	} );
 
 	const dismiss = useCallback( () => {
-		if ( candidate === null ) {
+		// Refuse a second write while the first is still going. Fixing
+		// legacy's unconfirmed dismissal means the card no longer vanishes
+		// on click, so on a slow connection nothing visibly happens and the
+		// reader clicks again. This is the write half only — what keeps
+		// Tracks from hearing one refusal twice is the caller's latch.
+		if ( candidate === null || isDismissing ) {
 			return;
 		}
 		mutate( candidate );
-	}, [ candidate, mutate ] );
+	}, [ candidate, isDismissing, mutate ] );
 
 	// `undefined` covers both "still asking" and "the ask failed", and both
 	// mean the same thing here: we cannot confirm this reader has not
@@ -223,5 +239,6 @@ export function useReviewRequest(): Result {
 	return {
 		reason: candidate !== null && ! isDismissed ? candidate : null,
 		dismiss,
+		isDismissing,
 	};
 }

--- a/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
@@ -155,9 +155,12 @@ type Result = {
  *
  * **The triggers.** See `pickReviewReason`.
  *
- * **The dismissal**, which is per reason. Declining after a restore
- * leaves the backups prompt available, because they are two different
- * questions and the server stores them under two different options.
+ * **The dismissal**, which is read for the winning reason only. On a site
+ * where both triggers fire, declining the restore prompt therefore takes
+ * the card off screen until that restore ages out — the backups trigger is
+ * never consulted. That is legacy's behaviour, kept deliberately: someone
+ * who just said "maybe later" should not be asked the same favour again in
+ * different words.
  *
  * Everything unknown reads as "do not prompt". A pending or failed
  * capabilities read, a pending or failed dismissal read, and a restores

--- a/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
@@ -24,17 +24,9 @@ const MS_PER_DAY = 86_400_000;
 /**
  * Whether the site's last restore worked and is recent enough to ask about.
  *
- * The age is measured against the browser's clock, which is the only
- * clock this side of the wire has. A machine set minutes fast or slow
- * shifts the boundary by minutes; nothing here is precise enough for
- * that to matter, and there is no cheap server-side alternative. Note
- * this is the one comparison in the restores data that *does* use the
- * local clock — `pickLiveRestore` deliberately does not, because there a
- * skewed clock loses a running restore.
- *
- * An unparseable timestamp answers false. Legacy reached the same
- * conclusion by accident (`NaN < 15` is false); here it is deliberate,
- * and it is the fail-closed direction.
+ * Measured against the browser clock — minutes of skew do not matter here,
+ * unlike in `pickLiveRestore`, which avoids it because skew loses a running
+ * restore. An unparseable timestamp answers false, the fail-closed direction.
  *
  * @param restores - The restores collection, newest first, or null when the read failed.
  * @return True when the newest restore succeeded within the window.
@@ -62,17 +54,10 @@ export function hasRecentSuccessfulRestore(
 /**
  * Whether the site's last five backups all produced a usable restore point.
  *
- * The predicate is `isUsableBackup`, the same one the rest of the
- * dashboard decides "is this backup any good" with, rather than a second
- * reading written here. That is a deliberate difference from legacy,
- * whose review trigger checked status and stats but not `discarded` —
- * even though legacy's own definition of a good backup does. A site whose
- * oldest backups are being aged out is now told so on this very screen,
- * and asking that reader whether they enjoy the peace of mind would put
- * two contradictory messages side by side.
- *
- * The length check is not redundant: `[].every()` is true, so a site with
- * three good backups would otherwise qualify on a run of five.
+ * Uses `isUsableBackup` rather than legacy's own reading, which ignored
+ * `discarded` — so a site being told its backups are aging out is no longer
+ * also asked about its peace of mind. The length check is not redundant:
+ * `[].every()` is true.
  *
  * @param backups - Normalized backups, newest first.
  * @return True when the newest five are all usable.
@@ -87,15 +72,9 @@ export function hasReviewableBackupRun( backups: Backup[] ): boolean {
 /**
  * Which review prompt this site has earned, if any.
  *
- * Restore wins when both apply, as in legacy. It is the more specific
- * thing to have just happened, and the reader who restored a site
- * remembers doing it.
- *
- * Both triggers ask the same question in two ways: has the product
- * visibly worked for you? That principle matters more than the numbers.
- * The run-of-five rule replaced a "you have been subscribed for 90 days"
- * test in 2022, moving deliberately from tenure to demonstrated value; a
- * future revision should keep that and is free to change 15 and 5.
+ * Restore wins when both apply, as in legacy — it is the more specific thing to
+ * have just happened. Both triggers ask whether the product has visibly worked;
+ * the 15 and 5 are tuning, that principle is not.
  *
  * @param restores - The restores collection, or null/undefined when unread.
  * @param backups  - Normalized backups, newest first.
@@ -143,30 +122,10 @@ type Result = {
 /**
  * Everything the review prompt needs to decide whether to appear.
  *
- * Three things have to line up, and the order matters because each is
- * cheaper than the next.
- *
- * **The plugin gate.** The card asks the reader to review the standalone
- * Jetpack VaultPress Backup plugin, so it must not render on a site that
- * does not have it — which a Backup page inside the Jetpack plugin will
- * be. The answer comes from the server on the capabilities response the
- * dashboard has already read by the time this mounts, so it costs
- * nothing and cannot be bypassed from here. See `Capabilities_Bridge`.
- *
- * **The triggers.** See `pickReviewReason`.
- *
- * **The dismissal**, which is read for the winning reason only. On a site
- * where both triggers fire, declining the restore prompt therefore takes
- * the card off screen until that restore ages out — the backups trigger is
- * never consulted. That is legacy's behaviour, kept deliberately: someone
- * who just said "maybe later" should not be asked the same favour again in
- * different words.
- *
- * Everything unknown reads as "do not prompt". A pending or failed
- * capabilities read, a pending or failed dismissal read, and a restores
- * read still in flight all keep the card off screen. The cost of that is
- * a card that appears a moment late; the cost of the other direction is
- * asking someone who already said no.
+ * Three gates, cheapest first: the standalone-plugin flag the capabilities
+ * response already carries, then `pickReviewReason`, then the dismissal for the
+ * winning reason only — so declining one trigger silences the other, as in
+ * legacy. Anything unknown or still in flight reads as "do not prompt".
  *
  * @return The prompt to show and the way to decline it.
  */

--- a/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-review-request.ts
@@ -1,0 +1,227 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from '@wordpress/element';
+import { fetchRecentRestores } from '../data/api/restore';
+import {
+	dismissReviewRequest,
+	fetchReviewDismissed,
+	type ReviewReason,
+} from '../data/api/review-request';
+import { keys } from '../data/query-client';
+import { isUsableBackup, useBackups } from './use-backups';
+import { useCapabilities } from './use-capabilities';
+import { useCanQueryWpcom } from './use-connection';
+import type { RecentRestore } from '../data/api/restore';
+import type { Backup } from '../types/backup';
+
+/** How recent a restore has to be for the reader to still remember it. */
+export const RECENT_RESTORE_MAX_AGE_DAYS = 15;
+
+/** How long a run of good backups counts as the product having worked. */
+export const REVIEWABLE_BACKUP_RUN = 5;
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * Whether the site's last restore worked and is recent enough to ask about.
+ *
+ * The age is measured against the browser's clock, which is the only
+ * clock this side of the wire has. A machine set minutes fast or slow
+ * shifts the boundary by minutes; nothing here is precise enough for
+ * that to matter, and there is no cheap server-side alternative. Note
+ * this is the one comparison in the restores data that *does* use the
+ * local clock — `pickLiveRestore` deliberately does not, because there a
+ * skewed clock loses a running restore.
+ *
+ * An unparseable timestamp answers false. Legacy reached the same
+ * conclusion by accident (`NaN < 15` is false); here it is deliberate,
+ * and it is the fail-closed direction.
+ *
+ * @param restores - The restores collection, newest first, or null when the read failed.
+ * @return True when the newest restore succeeded within the window.
+ */
+export function hasRecentSuccessfulRestore(
+	restores: RecentRestore[] | null | undefined
+): boolean {
+	// Index 0 rather than a scan for the newest, which is the legacy
+	// reading and the one this ports. WordPress.com returns the collection
+	// newest-first; `fetchRecentRestores` only ever drops rows, so it
+	// cannot reorder them.
+	const newest = restores?.[ 0 ];
+	if ( ! newest?.succeeded ) {
+		return false;
+	}
+
+	const when = Date.parse( newest.when );
+	if ( Number.isNaN( when ) ) {
+		return false;
+	}
+
+	return ( Date.now() - when ) / MS_PER_DAY < RECENT_RESTORE_MAX_AGE_DAYS;
+}
+
+/**
+ * Whether the site's last five backups all produced a usable restore point.
+ *
+ * The predicate is `isUsableBackup`, the same one the rest of the
+ * dashboard decides "is this backup any good" with, rather than a second
+ * reading written here. That is a deliberate difference from legacy,
+ * whose review trigger checked status and stats but not `discarded` —
+ * even though legacy's own definition of a good backup does. A site whose
+ * oldest backups are being aged out is now told so on this very screen,
+ * and asking that reader whether they enjoy the peace of mind would put
+ * two contradictory messages side by side.
+ *
+ * The length check is not redundant: `[].every()` is true, so a site with
+ * three good backups would otherwise qualify on a run of five.
+ *
+ * @param backups - Normalized backups, newest first.
+ * @return True when the newest five are all usable.
+ */
+export function hasReviewableBackupRun( backups: Backup[] ): boolean {
+	return (
+		backups.length >= REVIEWABLE_BACKUP_RUN &&
+		backups.slice( 0, REVIEWABLE_BACKUP_RUN ).every( isUsableBackup )
+	);
+}
+
+/**
+ * Which review prompt this site has earned, if any.
+ *
+ * Restore wins when both apply, as in legacy. It is the more specific
+ * thing to have just happened, and the reader who restored a site
+ * remembers doing it.
+ *
+ * Both triggers ask the same question in two ways: has the product
+ * visibly worked for you? That principle matters more than the numbers.
+ * The run-of-five rule replaced a "you have been subscribed for 90 days"
+ * test in 2022, moving deliberately from tenure to demonstrated value; a
+ * future revision should keep that and is free to change 15 and 5.
+ *
+ * @param restores - The restores collection, or null/undefined when unread.
+ * @param backups  - Normalized backups, newest first.
+ * @return The reason to prompt, or null.
+ */
+export function pickReviewReason(
+	restores: RecentRestore[] | null | undefined,
+	backups: Backup[]
+): ReviewReason | null {
+	if ( hasRecentSuccessfulRestore( restores ) ) {
+		return 'restore';
+	}
+
+	if ( hasReviewableBackupRun( backups ) ) {
+		return 'backups';
+	}
+
+	return null;
+}
+
+type Result = {
+	/**
+	 * The prompt to show, or null when there is nothing to ask.
+	 *
+	 * Already accounts for everything: the plugin gate, both triggers, and
+	 * whether this reader has dismissed this prompt before. A caller that
+	 * renders whenever this is non-null cannot get the order wrong.
+	 */
+	reason: ReviewReason | null;
+	/** Record the reader's refusal. A no-op when there is no prompt. */
+	dismiss: () => void;
+};
+
+/**
+ * Everything the review prompt needs to decide whether to appear.
+ *
+ * Three things have to line up, and the order matters because each is
+ * cheaper than the next.
+ *
+ * **The plugin gate.** The card asks the reader to review the standalone
+ * Jetpack VaultPress Backup plugin, so it must not render on a site that
+ * does not have it — which a Backup page inside the Jetpack plugin will
+ * be. The answer comes from the server on the capabilities response the
+ * dashboard has already read by the time this mounts, so it costs
+ * nothing and cannot be bypassed from here. See `Capabilities_Bridge`.
+ *
+ * **The triggers.** See `pickReviewReason`.
+ *
+ * **The dismissal**, which is per reason. Declining after a restore
+ * leaves the backups prompt available, because they are two different
+ * questions and the server stores them under two different options.
+ *
+ * Everything unknown reads as "do not prompt". A pending or failed
+ * capabilities read, a pending or failed dismissal read, and a restores
+ * read still in flight all keep the card off screen. The cost of that is
+ * a card that appears a moment late; the cost of the other direction is
+ * asking someone who already said no.
+ *
+ * @return The prompt to show and the way to decline it.
+ */
+export function useReviewRequest(): Result {
+	const canQueryWpcom = useCanQueryWpcom();
+	// Same query key and same `enabled` as `useGateState`, so this is a
+	// cache read rather than a second request. This hook only ever runs
+	// below `<Gates>`, which does not render a body until that read has
+	// resolved.
+	const { data: capabilities } = useCapabilities( { enabled: canQueryWpcom } );
+	const gateOpen = capabilities?.isStandalonePluginActive === true;
+
+	const restores = useQuery( {
+		queryKey: keys.recentRestores(),
+		queryFn: fetchRecentRestores,
+		enabled: gateOpen,
+	} );
+
+	// Already on screen: the Overview screen reads the same query, so this
+	// subscribes to a resolved cache entry rather than issuing a request.
+	const { backups } = useBackups();
+
+	// Held until the restores read has settled, either way. Restore beats
+	// backups, so a `backups` verdict reached while that read is still in
+	// flight can be overturned a moment later — which would swap the
+	// question under the reader and spend a dismissal round trip on a
+	// prompt that was never shown.
+	const restoresSettled = restores.isSuccess || restores.isError;
+	const candidate = gateOpen && restoresSettled ? pickReviewReason( restores.data, backups ) : null;
+
+	const dismissal = useQuery( {
+		// Never null: `enabled` keeps the placeholder from being fetched,
+		// and a stable key shape keeps the cache honest.
+		queryKey: keys.reviewDismissal( candidate ?? 'none' ),
+		queryFn: () => fetchReviewDismissed( candidate as ReviewReason ),
+		enabled: candidate !== null,
+		// The answer cannot change except through the mutation below, which
+		// writes it into the cache itself. Without this, navigating away and
+		// back re-asks a question already answered.
+		staleTime: Infinity,
+	} );
+
+	const queryClient = useQueryClient();
+	const { mutate } = useMutation( {
+		mutationFn: ( reason: ReviewReason ) => dismissReviewRequest( reason ),
+		// Only on success, which is the point. The legacy dashboard hid the
+		// card as soon as the request was sent, so a failed write took the
+		// prompt off screen while the server recorded nothing and it
+		// returned on the next load. Here a failed write leaves the card up,
+		// and clicking again retries it.
+		onSuccess: ( _data, reason ) => {
+			queryClient.setQueryData( keys.reviewDismissal( reason ), true );
+		},
+	} );
+
+	const dismiss = useCallback( () => {
+		if ( candidate === null ) {
+			return;
+		}
+		mutate( candidate );
+	}, [ candidate, mutate ] );
+
+	// `undefined` covers both "still asking" and "the ask failed", and both
+	// mean the same thing here: we cannot confirm this reader has not
+	// already declined, so we do not ask them again.
+	const isDismissed = dismissal.data ?? true;
+
+	return {
+		reason: candidate !== null && ! isDismissed ? candidate : null,
+		dismiss,
+	};
+}

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -261,17 +261,10 @@ export default function OverviewScreen() {
 			 */ }
 			<StorageSpace />
 			{ /*
-			 * Only on this path, never beside the takeover panel. That panel
-			 * renders when the site has no restore point to show, and asking
-			 * someone whose backups have not worked to review the plugin is
-			 * the wrong question — the restore trigger could still fire there
-			 * on a site whose backups broke after a successful restore.
-			 *
-			 * A sibling of the grid for the same reason the banners are, and
-			 * below the storage section because a reader whose storage is
-			 * full needs to read that first. The component decides for itself
-			 * whether there is anything to ask, so on the overwhelming
-			 * majority of loads this costs no layout.
+			 * Only on this path, never beside the takeover panel: the restore
+			 * trigger can still fire on a site whose backups have since broken, and
+			 * that reader is the wrong one to ask. Below the storage section, which
+			 * a reader whose storage is full needs to read first.
 			 */ }
 			<ReviewRequest />
 			<div className="jpb-overview">

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -11,6 +11,7 @@ import BackupStatusBanner, { BackupTroubleBanner } from '../components/backup-st
 import DashboardLayout from '../components/dashboard-layout';
 import NextScheduledBackup from '../components/next-scheduled-backup';
 import QueryError from '../components/query-error';
+import ReviewRequest from '../components/review-request';
 import StorageSpace from '../components/storage-space';
 import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
@@ -259,6 +260,20 @@ export default function OverviewScreen() {
 			 * pair of requests and no layout.
 			 */ }
 			<StorageSpace />
+			{ /*
+			 * Only on this path, never beside the takeover panel. That panel
+			 * renders when the site has no restore point to show, and asking
+			 * someone whose backups have not worked to review the plugin is
+			 * the wrong question — the restore trigger could still fire there
+			 * on a site whose backups broke after a successful restore.
+			 *
+			 * A sibling of the grid for the same reason the banners are, and
+			 * below the storage section because a reader whose storage is
+			 * full needs to read that first. The component decides for itself
+			 * whether there is anything to ask, so on the overwhelming
+			 * majority of loads this costs no layout.
+			 */ }
+			<ReviewRequest />
 			<div className="jpb-overview">
 				<ActivityList
 					selectedId={ selectedId }

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Capabilities REST bridge — proxies WPCOM's site rewind state.
+ * Capabilities REST bridge — WPCOM's site rewind state, plus the local
+ * facts the dashboard needs in the same breath.
  *
  * @package automattic/jetpack-backup-plugin
  */
@@ -16,16 +17,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Returns what the modernized dashboard is allowed to show: the site's
- * WordPress.com backup capabilities (`hasBackupPlan`, `hasScan`), which
- * back the `<Gates>` decision tree, plus `isStandalonePluginActive`,
- * which is decided here on the site rather than upstream.
+ * Returns what the modernized dashboard is allowed to show.
  *
- * The mixture is deliberate. This is the one request the dashboard always
- * makes before it renders a body, so a gate carried here costs no round
- * trip of its own and is settled before anything it gates could flash on
- * screen. Anything added alongside must be named so it cannot be mistaken
- * for a WordPress.com value.
+ * Two halves, and the response shape keeps them apart. The top level is
+ * WordPress.com's answer projected into the flags `<Gates>` reads —
+ * `hasBackupPlan`, `hasScan`. Everything under `local` was decided here
+ * on the site and never left it.
+ *
+ * The mixture is deliberate: this is the one request the dashboard always
+ * makes before it renders a body, so a fact carried here costs no round
+ * trip of its own and is settled before anything depending on it could
+ * flash on screen.
+ *
+ * The nesting is what keeps that honest. A naming convention would ask
+ * every future addition to remember the rule; a branch makes provenance
+ * structural, so a reader can see at a glance which half a value came
+ * from and nothing local can be mistaken for something WordPress.com
+ * said. Add locally-derived values under `local`, never beside the two
+ * projections.
  */
 class Capabilities_Bridge {
 
@@ -57,8 +66,9 @@ class Capabilities_Bridge {
 	 * the `capabilities` key is missing entirely, which produced a false
 	 * "no plan" gate for plans that do include Backup.
 	 *
-	 * `isStandalonePluginActive` rides along on the same response and is
-	 * decided locally; the class docblock says why it lives here.
+	 * The `local` branch rides along on the same response and is decided
+	 * here rather than upstream; the class docblock says why it lives on
+	 * this route and why it is nested.
 	 *
 	 * @return \WP_REST_Response|WP_Error The decoded capabilities, or WP_Error on failure.
 	 */
@@ -140,10 +150,13 @@ class Capabilities_Bridge {
 
 		return rest_ensure_response(
 			array(
-				'hasBackupPlan'            => in_array( 'backup', $capabilities, true ),
-				'hasScan'                  => in_array( 'scan', $capabilities, true ),
-				// Local, not upstream. See `is_standalone_plugin_active()`.
-				'isStandalonePluginActive' => self::is_standalone_plugin_active(),
+				'hasBackupPlan' => in_array( 'backup', $capabilities, true ),
+				'hasScan'       => in_array( 'scan', $capabilities, true ),
+				// Decided here, not upstream. See the class docblock for why
+				// these live in their own branch.
+				'local'         => array(
+					'isStandalonePluginActive' => self::is_standalone_plugin_active(),
+				),
 			)
 		);
 	}

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -16,8 +16,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Returns the site's backup capabilities (plan slug, hasBackupPlan,
- * hasScan). Backs the `<Gates>` decision tree.
+ * Returns what the modernized dashboard is allowed to show: the site's
+ * WordPress.com backup capabilities (`hasBackupPlan`, `hasScan`), which
+ * back the `<Gates>` decision tree, plus `isStandalonePluginActive`,
+ * which is decided here on the site rather than upstream.
+ *
+ * The mixture is deliberate. This is the one request the dashboard always
+ * makes before it renders a body, so a gate carried here costs no round
+ * trip of its own and is settled before anything it gates could flash on
+ * screen. Anything added alongside must be named so it cannot be mistaken
+ * for a WordPress.com value.
  */
 class Capabilities_Bridge {
 
@@ -48,6 +56,9 @@ class Capabilities_Bridge {
 	 * a capabilities list, and on some plan shapes (e.g. Jetpack Complete)
 	 * the `capabilities` key is missing entirely, which produced a false
 	 * "no plan" gate for plans that do include Backup.
+	 *
+	 * `isStandalonePluginActive` rides along on the same response and is
+	 * decided locally; the class docblock says why it lives here.
 	 *
 	 * @return \WP_REST_Response|WP_Error The decoded capabilities, or WP_Error on failure.
 	 */
@@ -129,9 +140,45 @@ class Capabilities_Bridge {
 
 		return rest_ensure_response(
 			array(
-				'hasBackupPlan' => in_array( 'backup', $capabilities, true ),
-				'hasScan'       => in_array( 'scan', $capabilities, true ),
+				'hasBackupPlan'            => in_array( 'backup', $capabilities, true ),
+				'hasScan'                  => in_array( 'scan', $capabilities, true ),
+				// Local, not upstream. See `is_standalone_plugin_active()`.
+				'isStandalonePluginActive' => self::is_standalone_plugin_active(),
 			)
 		);
+	}
+
+	/**
+	 * Whether the standalone Jetpack VaultPress Backup plugin is active.
+	 *
+	 * Answered on the server because the modernized page emits no
+	 * backup-specific global to read it from — `enqueue_admin_scripts()`
+	 * returns before `JPBACKUP_INITIAL_STATE` is rendered on the wp-build
+	 * path — and because a gate the client never decides cannot be
+	 * bypassed from the client either.
+	 *
+	 * `JETPACK_BACKUP_PLUGIN_DIR` is defined in exactly one place,
+	 * `jetpack-backup.php` in the standalone plugin, so it tracks *plugin
+	 * activation* and stays correct on a site where both plugins are
+	 * active and the autoloader resolved the Jetpack copy of this package.
+	 *
+	 * Note what is deliberately not used: the `connectedPlugins` list in
+	 * `JP_CONNECTION_INITIAL_STATE`. The `jetpack-backup` slug there is
+	 * registered by `Jetpack_Backup::initialize()`, which belongs to the
+	 * package and not to the plugin — so the moment the Jetpack plugin
+	 * gains a Backup page it will register the slug too, and the list will
+	 * report the standalone plugin as present on precisely the site that
+	 * does not have it.
+	 *
+	 * This is true on every site that can reach the modernized dashboard
+	 * today, since the dashboard ships only in the standalone plugin. It
+	 * is written now because the dashboard is intended to reach the
+	 * Jetpack plugin, where asking the reader to review the Backup plugin
+	 * makes no sense.
+	 *
+	 * @return bool True when the standalone Backup plugin is active.
+	 */
+	private static function is_standalone_plugin_active() {
+		return defined( 'JETPACK_BACKUP_PLUGIN_DIR' );
 	}
 }

--- a/projects/packages/backup/src/rest/class-capabilities-bridge.php
+++ b/projects/packages/backup/src/rest/class-capabilities-bridge.php
@@ -19,22 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Returns what the modernized dashboard is allowed to show.
  *
- * Two halves, and the response shape keeps them apart. The top level is
- * WordPress.com's answer projected into the flags `<Gates>` reads —
- * `hasBackupPlan`, `hasScan`. Everything under `local` was decided here
- * on the site and never left it.
- *
- * The mixture is deliberate: this is the one request the dashboard always
- * makes before it renders a body, so a fact carried here costs no round
- * trip of its own and is settled before anything depending on it could
- * flash on screen.
- *
- * The nesting is what keeps that honest. A naming convention would ask
- * every future addition to remember the rule; a branch makes provenance
- * structural, so a reader can see at a glance which half a value came
- * from and nothing local can be mistaken for something WordPress.com
- * said. Add locally-derived values under `local`, never beside the two
- * projections.
+ * Two halves kept apart by the response shape: the top level projects
+ * WordPress.com's answer into the flags `<Gates>` reads, while everything under
+ * `local` was decided on the site. They ride together because this is the one
+ * request every screen makes before rendering a body. Add locally-derived
+ * values under `local`, never beside the projections.
  */
 class Capabilities_Bridge {
 
@@ -164,30 +153,11 @@ class Capabilities_Bridge {
 	/**
 	 * Whether the standalone Jetpack VaultPress Backup plugin is active.
 	 *
-	 * Answered on the server because the modernized page emits no
-	 * backup-specific global to read it from — `enqueue_admin_scripts()`
-	 * returns before `JPBACKUP_INITIAL_STATE` is rendered on the wp-build
-	 * path — and because a gate the client never decides cannot be
-	 * bypassed from the client either.
-	 *
-	 * `JETPACK_BACKUP_PLUGIN_DIR` is defined in exactly one place,
-	 * `jetpack-backup.php` in the standalone plugin, so it tracks *plugin
-	 * activation* and stays correct on a site where both plugins are
-	 * active and the autoloader resolved the Jetpack copy of this package.
-	 *
-	 * Note what is deliberately not used: the `connectedPlugins` list in
-	 * `JP_CONNECTION_INITIAL_STATE`. The `jetpack-backup` slug there is
-	 * registered by `Jetpack_Backup::initialize()`, which belongs to the
-	 * package and not to the plugin — so the moment the Jetpack plugin
-	 * gains a Backup page it will register the slug too, and the list will
-	 * report the standalone plugin as present on precisely the site that
-	 * does not have it.
-	 *
-	 * This is true on every site that can reach the modernized dashboard
-	 * today, since the dashboard ships only in the standalone plugin. It
-	 * is written now because the dashboard is intended to reach the
-	 * Jetpack plugin, where asking the reader to review the Backup plugin
-	 * makes no sense.
+	 * Answered on the server: the modernized page emits no backup-specific global
+	 * to read, and a gate the client never decides cannot be bypassed from it.
+	 * `JETPACK_BACKUP_PLUGIN_DIR` tracks *plugin* activation, unlike the
+	 * `jetpack-backup` slug in `connectedPlugins`, which the package registers
+	 * and so would report the plugin present on the one site that lacks it.
 	 *
 	 * @return bool True when the standalone Backup plugin is active.
 	 */

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -627,4 +627,97 @@ class Jetpack_Backup_Test extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * The dismissal route refuses a reason `Jetpack_Options` cannot store.
+	 *
+	 * The option name is built by appending this parameter to
+	 * `dismissed_backup_review_`, and `Jetpack_Options` recognises exactly
+	 * two of those. Anything else falls through its allowlist to a
+	 * `trigger_error()` and is stored nowhere — so without the enum the
+	 * route answers 200 for a dismissal it did not record, and on a site
+	 * with `display_errors` on the warning is printed ahead of the JSON,
+	 * leaving a body the client cannot parse.
+	 *
+	 * @param string $option_name The reason to send.
+	 * @dataProvider provide_unstorable_review_reasons
+	 */
+	#[DataProvider( 'provide_unstorable_review_reasons' )]
+	public function test_dismissal_route_refuses_an_unstorable_reason( $option_name ) {
+		$this->sign_in_as_connected_admin();
+
+		rest_get_server();
+		Jetpack_Backup::register_rest_routes();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/site/dismissed-review-request' );
+		$request->set_body_params(
+			array(
+				'option_name'    => $option_name,
+				'should_dismiss' => false,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status(), $option_name );
+	}
+
+	/**
+	 * Reasons the route must refuse.
+	 *
+	 * @return array
+	 */
+	public static function provide_unstorable_review_reasons() {
+		return array(
+			// The shape a third prompt would arrive in if someone added one
+			// without also adding the option name upstream.
+			'a reason nobody registered' => array( 'scan' ),
+			'empty'                      => array( '' ),
+			// Not an injection risk — the value is concatenated into an
+			// option name that is then allowlisted — but it has no business
+			// reaching that concatenation at all.
+			'a path'                     => array( '../../etc/passwd' ),
+		);
+	}
+
+	/**
+	 * Both reasons the dashboard actually sends are accepted, and an
+	 * un-dismissed prompt reads as `false`.
+	 *
+	 * The client treats anything that is not literally `false` as dismissed,
+	 * so this pins the one answer that lets the card render at all.
+	 *
+	 * @param string $option_name The reason to send.
+	 * @dataProvider provide_review_reasons
+	 */
+	#[DataProvider( 'provide_review_reasons' )]
+	public function test_dismissal_route_accepts_the_reasons_the_dashboard_sends( $option_name ) {
+		$this->sign_in_as_connected_admin();
+
+		rest_get_server();
+		Jetpack_Backup::register_rest_routes();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/site/dismissed-review-request' );
+		$request->set_body_params(
+			array(
+				'option_name'    => $option_name,
+				'should_dismiss' => false,
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status(), $option_name );
+		$this->assertFalse( $response->get_data(), $option_name );
+	}
+
+	/**
+	 * The two reasons the review prompt can carry.
+	 *
+	 * @return array
+	 */
+	public static function provide_review_reasons() {
+		return array(
+			'restore' => array( 'restore' ),
+			'backups' => array( 'backups' ),
+		);
+	}
 }

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -631,13 +631,9 @@ class Jetpack_Backup_Test extends TestCase {
 	/**
 	 * The dismissal route refuses a reason `Jetpack_Options` cannot store.
 	 *
-	 * The option name is built by appending this parameter to
-	 * `dismissed_backup_review_`, and `Jetpack_Options` recognises exactly
-	 * two of those. Anything else falls through its allowlist to a
-	 * `trigger_error()` and is stored nowhere — so without the enum the
-	 * route answers 200 for a dismissal it did not record, and on a site
-	 * with `display_errors` on the warning is printed ahead of the JSON,
-	 * leaving a body the client cannot parse.
+	 * A reason outside `Jetpack_Options`' allowlist reaches a `trigger_error()`
+	 * and is stored nowhere, so without the enum the route answers 200 for a
+	 * dismissal it did not record — and prints a warning ahead of the JSON.
 	 *
 	 * @param string $option_name The reason to send.
 	 * @dataProvider provide_unstorable_review_reasons
@@ -683,8 +679,7 @@ class Jetpack_Backup_Test extends TestCase {
 	 * Both reasons the dashboard actually sends are accepted, and an
 	 * un-dismissed prompt reads as `false`.
 	 *
-	 * The client treats anything that is not literally `false` as dismissed,
-	 * so this pins the one answer that lets the card render at all.
+	 * The client treats anything but a literal `false` as dismissed.
 	 *
 	 * @param string $option_name The reason to send.
 	 * @dataProvider provide_review_reasons

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -112,8 +112,12 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 				array(),
 				array( array( 'body' => '{"capabilities":["backup","scan"]}' ) ),
 				array(
-					'hasBackupPlan' => true,
-					'hasScan'       => true,
+					'hasBackupPlan'            => true,
+					'hasScan'                  => true,
+					// Decided on the site, not upstream, and false without the
+					// standalone plugin's constant — which nothing in a package
+					// test run defines.
+					'isStandalonePluginActive' => false,
 				),
 			),
 			'/jetpack/v4/site/rewindable-activity'   => array(

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -112,12 +112,14 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 				array(),
 				array( array( 'body' => '{"capabilities":["backup","scan"]}' ) ),
 				array(
-					'hasBackupPlan'            => true,
-					'hasScan'                  => true,
-					// Decided on the site, not upstream, and false without the
-					// standalone plugin's constant — which nothing in a package
-					// test run defines.
-					'isStandalonePluginActive' => false,
+					'hasBackupPlan' => true,
+					'hasScan'       => true,
+					// Decided on the site, not upstream — hence its own branch —
+					// and false without the standalone plugin's constant, which
+					// nothing in a package test run defines.
+					'local'         => array(
+						'isStandalonePluginActive' => false,
+					),
 				),
 			),
 			'/jetpack/v4/site/rewindable-activity'   => array(

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -297,15 +297,9 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	/**
 	 * Without the standalone plugin's constant, the gate is closed.
 	 *
-	 * This is the case the gate exists for and the only one a package test
-	 * run reproduces naturally: the package loaded, the plugin absent. The
-	 * review prompt asks the reader to review the Backup *plugin*, so it
-	 * must not render on a site that only has the package — which is what
-	 * a Backup page inside the Jetpack plugin will be.
-	 *
-	 * Note this is not merely "the constant is undefined here": nothing in
-	 * the package can define it, so no reordering of these tests and no
-	 * future package-side change can quietly open the gate.
+	 * The case the gate exists for, and the one a package test run reproduces
+	 * naturally: package loaded, plugin absent. Nothing in the package can define
+	 * the constant, so no test ordering can quietly open the gate.
 	 */
 	public function test_gate_is_closed_without_the_standalone_plugin() {
 		$this->arrange_wpcom( array( 'capabilities' => array( 'backup' ) ) );
@@ -318,10 +312,8 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 	/**
 	 * With the constant defined, the gate is open.
 	 *
-	 * Run in a child process because `define()` cannot be undone: setting
-	 * the constant in the shared process would silently open the gate for
-	 * every test that runs after this one, including the closed-gate test
-	 * above, whichever order PHPUnit picks.
+	 * Run in a child process because `define()` cannot be undone, and the shared
+	 * process would leave the gate open for every later test.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -10,6 +10,8 @@ namespace Automattic\Jetpack\Backup\V0005\REST;
 use Automattic\Jetpack\Backup\V0005\Jetpack_Backup;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -132,8 +134,13 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 		$this->assertNotInstanceOf( WP_Error::class, $response );
 		$this->assertSame(
 			array(
-				'hasBackupPlan' => $has_backup,
-				'hasScan'       => $has_scan,
+				'hasBackupPlan'            => $has_backup,
+				'hasScan'                  => $has_scan,
+				// Local rather than upstream, and false in a package test
+				// run: nothing here defines the standalone plugin's
+				// constant. Asserted as part of the whole payload so a key
+				// added later cannot slip in unnoticed.
+				'isStandalonePluginActive' => false,
 			),
 			$response->get_data()
 		);
@@ -281,5 +288,48 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 			// map's *values*, so `{"backup":true}` reads as "no plan".
 			'a keyed capabilities map' => array( 'a keyed capabilities map', '{"capabilities":{"backup":true}}' ),
 		);
+	}
+
+	/**
+	 * Without the standalone plugin's constant, the gate is closed.
+	 *
+	 * This is the case the gate exists for and the only one a package test
+	 * run reproduces naturally: the package loaded, the plugin absent. The
+	 * review prompt asks the reader to review the Backup *plugin*, so it
+	 * must not render on a site that only has the package — which is what
+	 * a Backup page inside the Jetpack plugin will be.
+	 *
+	 * Note this is not merely "the constant is undefined here": nothing in
+	 * the package can define it, so no reordering of these tests and no
+	 * future package-side change can quietly open the gate.
+	 */
+	public function test_gate_is_closed_without_the_standalone_plugin() {
+		$this->arrange_wpcom( array( 'capabilities' => array( 'backup' ) ) );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertFalse( $response->get_data()['isStandalonePluginActive'] );
+	}
+
+	/**
+	 * With the constant defined, the gate is open.
+	 *
+	 * Run in a child process because `define()` cannot be undone: setting
+	 * the constant in the shared process would silently open the gate for
+	 * every test that runs after this one, including the closed-gate test
+	 * above, whichever order PHPUnit picks.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_gate_is_open_with_the_standalone_plugin() {
+		define( 'JETPACK_BACKUP_PLUGIN_DIR', '/plugins/jetpack-backup/' );
+		$this->arrange_wpcom( array( 'capabilities' => array( 'backup' ) ) );
+
+		$response = Capabilities_Bridge::get_capabilities();
+
+		$this->assertTrue( $response->get_data()['isStandalonePluginActive'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Capabilities_Bridge_Test.php
@@ -134,13 +134,17 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 		$this->assertNotInstanceOf( WP_Error::class, $response );
 		$this->assertSame(
 			array(
-				'hasBackupPlan'            => $has_backup,
-				'hasScan'                  => $has_scan,
-				// Local rather than upstream, and false in a package test
-				// run: nothing here defines the standalone plugin's
+				'hasBackupPlan' => $has_backup,
+				'hasScan'       => $has_scan,
+				// Decided on the site rather than upstream, which is why it
+				// sits in its own branch — and false in a package test run,
+				// since nothing here defines the standalone plugin's
 				// constant. Asserted as part of the whole payload so a key
-				// added later cannot slip in unnoticed.
-				'isStandalonePluginActive' => false,
+				// added later cannot slip in unnoticed, on either side of
+				// the provenance split.
+				'local'         => array(
+					'isStandalonePluginActive' => false,
+				),
 			),
 			$response->get_data()
 		);
@@ -308,7 +312,7 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 
 		$response = Capabilities_Bridge::get_capabilities();
 
-		$this->assertFalse( $response->get_data()['isStandalonePluginActive'] );
+		$this->assertFalse( $response->get_data()['local']['isStandalonePluginActive'] );
 	}
 
 	/**
@@ -330,6 +334,6 @@ class Rest_Capabilities_Bridge_Test extends TestCase {
 
 		$response = Capabilities_Bridge::get_capabilities();
 
-		$this->assertTrue( $response->get_data()['isStandalonePluginActive'] );
+		$this->assertTrue( $response->get_data()['local']['isStandalonePluginActive'] );
 	}
 }

--- a/projects/packages/backup/tests/php/bootstrap.php
+++ b/projects/packages/backup/tests/php/bootstrap.php
@@ -12,5 +12,11 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 define( 'WP_DEBUG', true );
 
+// PHPUnit's process-isolated children start with an empty SCRIPT_FILENAME (piped via stdin),
+// which wp_guess_url() feeds to strpos() and errors on PHP 7.x — give it a real path outside ABSPATH.
+if ( empty( $_SERVER['SCRIPT_FILENAME'] ) ) {
+	$_SERVER['SCRIPT_FILENAME'] = __FILE__;
+}
+
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -1,30 +1,11 @@
 // JETPACK-2302 (K1) — the review prompt on the modernized dashboard.
 //
-// Rendered through the real Overview stage rather than the component in
-// isolation, because most of what can go wrong here is wiring: the gate
-// arrives on the capabilities response, one trigger reads the restores
-// collection and the other reads the backup list, and the dismissal is a
-// third endpoint keyed on which trigger fired.
-//
-// EVERY "the card stays away" assertion in this file is paired with an
-// outside witness, and any test added here must keep that up. A bare
-// `queryByText( … ).not.toBeInTheDocument()` is decorative: it passes
-// just as happily when the stage threw, when the endpoints were
-// mis-mocked, or when the copy was reworded — and, proved by mutation,
-// it keeps passing when the plugin gate is flipped to fail *open*. Only
-// the `dismissalCalls` assertion on the following line caught that.
-//
-// The two witnesses used here:
-//
-//   - `renderSettledOverview()` waits for the activity list's own row,
-//     which proves the stage mounted, the endpoints answered, and the
-//     dashboard reached the state where the prompt would have rendered.
-//   - `dismissalCalls` records every request to the dismissal route, so
-//     a test can say not just "no card" but *why* — the gate refused
-//     before anything was asked, versus the trigger never fired, versus
-//     the server said it was already dismissed.
-//
-// A negative assertion with neither is vacuous. Add one.
+// Driven through the real Overview stage because most of what can go wrong here
+// is wiring. Every "the card stays away" assertion is paired with an outside
+// witness, and new ones must keep that up: a bare `not.toBeInTheDocument()`
+// passes when the stage threw and — proved by mutation — when the plugin gate
+// fails open. `renderSettledOverview()` witnesses the mount, `dismissalCalls`
+// witnesses which of the three refusals happened.
 
 const mockRecordEvent = jest.fn();
 
@@ -481,16 +462,9 @@ describe( 'review prompt — dismissal', () => {
 		expect( screen.getByText( RESTORE_QUESTION ) ).toBeInTheDocument();
 	} );
 
-	// Fixing legacy bug 3 has a cost: the card no longer vanishes on click,
-	// so on a slow connection nothing visibly happens and the reader clicks
-	// again. Unguarded that is a second POST and — worse — a second refusal
-	// reported for one decision.
-	//
-	// Asserts the outcome, not one mechanism. Three things hold it up (the
-	// disabled button, the report-once latch, and `dismiss()`'s own
-	// refusal), so removing any single one leaves this green; removing all
-	// three does not. That redundancy is deliberate, and the `aria-disabled`
-	// assertion is what pins the one of them the reader can actually see.
+	// The card no longer vanishes on click, so a slow connection invites a second
+	// click — and a second refusal reported for one decision. Three guards hold
+	// this up, so it asserts the outcome rather than any one of them.
 	it( 'ignores further clicks while the refusal is still being written', async () => {
 		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissalWriteHangs: true } );
 

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -1,0 +1,460 @@
+// JETPACK-2302 (K1) — the review prompt on the modernized dashboard.
+//
+// Rendered through the real Overview stage rather than the component in
+// isolation, because most of what can go wrong here is wiring: the gate
+// arrives on the capabilities response, one trigger reads the restores
+// collection and the other reads the backup list, and the dismissal is a
+// third endpoint keyed on which trigger fired.
+//
+// Every "the card stays away" assertion is paired with something that
+// *did* render — the activity list's own row, or the dismissal request
+// never being made. A bare `queryByText(...).not.toBeInTheDocument()`
+// passes just as happily when the stage threw, the endpoints were
+// mis-mocked, or the copy was reworded.
+
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: () => {},
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { resetAnalyticsForTesting } from '../src/dashboard/hooks/use-analytics';
+import { resetPageViewForTesting } from '../src/dashboard/screens/overview';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+// These stages render behind several sequential requests; Testing
+// Library's one-second default has not been enough on a loaded runner.
+const SETTLE = { timeout: 10000 };
+
+const RESTORE_QUESTION = 'Was it easy to restore your site?';
+const BACKUPS_QUESTION = 'Do you enjoy the peace of mind of having real-time backups?';
+// Matched loosely: `Link` appends its own "opens in a new tab" text to
+// the accessible name, so an exact match would pin this test to that
+// wording rather than to ours.
+const CTA = /Please leave a review and help us spread the word!/;
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * One rewindable-activity entry, so the list has a row to render and the
+ * first-run panel does not take the body over.
+ *
+ * @return A raw activity entry.
+ */
+function activityEntry() {
+	return {
+		activity_id: 'act-cloud',
+		gridicon: 'cloud',
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: '1786644531.123',
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '46 plugins, 23 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * One `/jetpack/v4/backups` row, in WordPress.com's stringly-typed shape.
+ *
+ * @param id   - Row id, only ever compared for uniqueness.
+ * @param over - Fields to override.
+ * @return A raw backup entry.
+ */
+function backupRow( id: number, over: Record< string, unknown > = {} ) {
+	return {
+		id: String( id ),
+		started: '2026-08-13 18:08:56',
+		last_updated: '2026-08-13 18:54:14',
+		status: 'finished',
+		period: String( 1786644531 + id ),
+		percent: '100',
+		is_backup: '1',
+		is_scan: '0',
+		discarded: '0',
+		stats: { prefix: 'wp_' },
+		...over,
+	};
+}
+
+/**
+ * A run of backups long enough to satisfy the five-in-a-row trigger.
+ *
+ * @param over - Fields to override on the newest row only.
+ * @return Five raw backup entries, newest first.
+ */
+function goodRun( over: Record< string, unknown > = {} ) {
+	return [ backupRow( 1, over ), backupRow( 2 ), backupRow( 3 ), backupRow( 4 ), backupRow( 5 ) ];
+}
+
+/**
+ * One `/jetpack/v4/restores` row.
+ *
+ * @param daysAgo - How long ago the restore ran.
+ * @param status  - The collection's own status spelling.
+ * @return A raw restore entry.
+ */
+function restoreRow( daysAgo: number, status = 'finished' ) {
+	return {
+		restore_id: 912682,
+		rewind_id: '1786644531.123',
+		when: new Date( Date.now() - daysAgo * 86_400_000 ).toISOString(),
+		status,
+	};
+}
+
+type Options = {
+	/**
+	 * Whether the capabilities response reports the standalone plugin.
+	 * `'absent'` leaves the key off entirely, which is what an older
+	 * server answering a newer client looks like.
+	 */
+	standalonePlugin?: boolean | 'absent';
+	backups?: unknown[];
+	restores?: unknown[];
+	/** What the dismissal read answers, per reason. */
+	dismissed?: Record< string, unknown >;
+	/** Make the dismissal read reject. */
+	dismissalReadFails?: boolean;
+	/** Make the dismissal write reject. */
+	dismissalWriteFails?: boolean;
+};
+
+/** Every dismissal request the stage made, in order. */
+let dismissalCalls: Array< { option_name: string; should_dismiss: boolean } > = [];
+
+/**
+ * Answer every endpoint the Overview reads.
+ *
+ * @param options                     - Overrides.
+ * @param options.standalonePlugin    - What the capabilities response says about the plugin gate.
+ * @param options.backups             - What `/jetpack/v4/backups` resolves with.
+ * @param options.restores            - What `/jetpack/v4/restores` resolves with.
+ * @param options.dismissed           - What the dismissal read answers, per reason.
+ * @param options.dismissalReadFails  - Make the dismissal read reject.
+ * @param options.dismissalWriteFails - Make the dismissal write reject.
+ */
+function mockEndpoints( {
+	standalonePlugin = true,
+	backups = [],
+	restores = [],
+	dismissed = {},
+	dismissalReadFails = false,
+	dismissalWriteFails = false,
+}: Options = {} ) {
+	mockApiFetch.mockImplementation(
+		( o: { path?: string; data?: { option_name: string; should_dismiss: boolean } } ) => {
+			const path = o?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				const capabilities: Record< string, unknown > = { hasBackupPlan: true, hasScan: false };
+				if ( standalonePlugin !== 'absent' ) {
+					capabilities.isStandalonePluginActive = standalonePlugin;
+				}
+				return Promise.resolve( capabilities );
+			}
+			if ( path.includes( '/site/dismissed-review-request' ) ) {
+				const data = o.data as { option_name: string; should_dismiss: boolean };
+				dismissalCalls.push( data );
+				if ( data.should_dismiss ) {
+					return dismissalWriteFails
+						? Promise.reject( new Error( 'Could not save the dismissal.' ) )
+						: Promise.resolve( true );
+				}
+				return dismissalReadFails
+					? Promise.reject( new Error( 'Could not read the dismissal.' ) )
+					: Promise.resolve( dismissed[ data.option_name ] ?? false );
+			}
+			if ( path.includes( '/site/rewindable-activity' ) ) {
+				return Promise.resolve( {
+					current: { orderedItems: [ activityEntry() ] },
+					totalItems: 1,
+					totalPages: 1,
+				} );
+			}
+			if ( path.includes( '/site/backup/size' ) ) {
+				return Promise.resolve( { ok: true, backups_stopped: false } );
+			}
+			if ( path === '/jetpack/v4/restores' ) {
+				return Promise.resolve( restores );
+			}
+			if ( path === '/jetpack/v4/backups' ) {
+				return Promise.resolve( backups );
+			}
+			return Promise.resolve( {} );
+		}
+	);
+}
+
+/**
+ * Render the Overview and wait until the activity list has a row in it.
+ *
+ * That row is the outside witness every negative assertion here leans
+ * on: it proves the stage mounted, the endpoints answered, and the
+ * dashboard reached the state where the prompt would have rendered if it
+ * were going to.
+ */
+async function renderSettledOverview() {
+	render( <OverviewStage /> );
+	await expect(
+		screen.findByText( 'Backup complete', undefined, SETTLE )
+	).resolves.toBeInTheDocument();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	dismissalCalls = [];
+	mockApiFetch.mockReset();
+	mockRecordEvent.mockReset();
+	resetAnalyticsForTesting();
+	resetPageViewForTesting();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'review prompt — the plugin gate', () => {
+	// The reason this gate exists. The card asks the reader to review the
+	// standalone Backup plugin, and the modernized dashboard is intended to
+	// reach the Jetpack plugin, where that request makes no sense.
+	//
+	// Dead today: the dashboard only ships in the standalone plugin, so the
+	// server always reports it active. That is exactly why it needs a test —
+	// nothing else would notice it breaking.
+	it( 'stays away when the standalone plugin is not active', async () => {
+		mockEndpoints( { standalonePlugin: false, backups: goodRun(), restores: [ restoreRow( 1 ) ] } );
+
+		await renderSettledOverview();
+
+		// Both triggers would have fired.
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		// And the gate is decided before anything is asked, rather than the
+		// card being rendered and then withdrawn.
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+
+	// The gate must not be readable as "the key is missing, so allow it".
+	// An older server answering a newer client is the shape this covers.
+	it( 'stays away when the response says nothing about the plugin', async () => {
+		mockEndpoints( {
+			standalonePlugin: 'absent',
+			backups: goodRun(),
+			restores: [ restoreRow( 1 ) ],
+		} );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+} );
+
+describe( 'review prompt — trigger A, a recent restore', () => {
+	it( 'asks after a restore that finished within the last 15 days', async () => {
+		mockEndpoints( { restores: [ restoreRow( 3 ) ] } );
+
+		await renderSettledOverview();
+
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: CTA } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'jetpack-backup-new-review' )
+		);
+	} );
+
+	it( 'stays away once the restore is older than 15 days', async () => {
+		mockEndpoints( { restores: [ restoreRow( 16 ) ] } );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+
+	// `settled` is not the same question. An aborted or failed restore is
+	// just as over as a finished one, and is the last reader to ask.
+	it.each( [ 'fail', 'aborted', 'success-with-errors', 'running' ] )(
+		'stays away when the newest restore reports %p',
+		async status => {
+			mockEndpoints( { restores: [ restoreRow( 1, status ) ] } );
+
+			await renderSettledOverview();
+
+			expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+			expect( dismissalCalls ).toEqual( [] );
+		}
+	);
+} );
+
+describe( 'review prompt — trigger B, a run of good backups', () => {
+	it( 'asks after five backups that all produced a restore point', async () => {
+		mockEndpoints( { backups: goodRun() } );
+
+		await renderSettledOverview();
+
+		await expect( screen.findByText( BACKUPS_QUESTION ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'stays away on four good backups', async () => {
+		mockEndpoints( { backups: goodRun().slice( 0, 4 ) } );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+
+	// The deliberate difference from legacy, whose review trigger checked
+	// status and stats but not `discarded`. A site whose oldest backups are
+	// being aged out is told so on this very screen, and "do you enjoy the
+	// peace of mind" beside that message reads as a taunt.
+	it( 'stays away when one of the five has been discarded', async () => {
+		mockEndpoints( { backups: goodRun( { discarded: '1' } ) } );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+
+	it( 'stays away when one of the five carries no stats', async () => {
+		mockEndpoints( { backups: goodRun( { stats: {} } ) } );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [] );
+	} );
+} );
+
+describe( 'review prompt — precedence', () => {
+	// Legacy's `if` / `else if`, kept. The restore is the more specific
+	// thing to have just happened, and the reader remembers doing it.
+	it( 'asks about the restore when both triggers fire', async () => {
+		mockEndpoints( { backups: goodRun(), restores: [ restoreRow( 1 ) ] } );
+
+		await renderSettledOverview();
+
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		// And only the winning reason is ever asked about, so a prompt that
+		// was never shown cannot be marked as seen.
+		expect( dismissalCalls.map( call => call.option_name ) ).toEqual( [ 'restore' ] );
+	} );
+} );
+
+describe( 'review prompt — dismissal', () => {
+	it( 'records the refusal against the reason that fired, and hides the card', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ] } );
+
+		await renderSettledOverview();
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Maybe later' } ) );
+
+		await waitFor( () => expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument() );
+		expect( dismissalCalls ).toContainEqual( { option_name: 'restore', should_dismiss: true } );
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_dismiss_review_click' );
+	} );
+
+	it( 'stays away when the server says this prompt was already dismissed', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissed: { restore: true } } );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+		// The witness that the read happened at all, so this is not passing
+		// because the trigger never fired.
+		expect( dismissalCalls ).toEqual( [ { option_name: 'restore', should_dismiss: false } ] );
+	} );
+
+	// Fail closed. We cannot confirm this reader has not already declined,
+	// so we do not ask them again.
+	it( 'stays away when the dismissal read fails', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissalReadFails: true } );
+
+		await renderSettledOverview();
+
+		await waitFor( () =>
+			expect( dismissalCalls ).toEqual( [ { option_name: 'restore', should_dismiss: false } ] )
+		);
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+	} );
+
+	// The third legacy bug: `.then( setDismissedReview( true ) )` *calls*
+	// the setter and passes `undefined` as the callback, so the card
+	// disappeared the moment the request was sent. A failed write then hid
+	// the prompt locally while the server recorded nothing, and it came
+	// back on the next load. Confirmation means the card stays put.
+	it( 'keeps the card up when the dismissal write fails', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissalWriteFails: true } );
+
+		await renderSettledOverview();
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Maybe later' } ) );
+
+		await waitFor( () =>
+			expect( dismissalCalls ).toContainEqual( { option_name: 'restore', should_dismiss: true } )
+		);
+		expect( screen.getByText( RESTORE_QUESTION ) ).toBeInTheDocument();
+	} );
+
+	// Two independent dismissals, not one. Declining after a restore must
+	// not spend the backups prompt, and the server stores them under two
+	// different options for the same reason.
+	it( 'still asks about backups on a site that dismissed the restore prompt', async () => {
+		mockEndpoints( { backups: goodRun(), dismissed: { restore: true } } );
+
+		await renderSettledOverview();
+
+		await expect( screen.findByText( BACKUPS_QUESTION ) ).resolves.toBeInTheDocument();
+		expect( dismissalCalls ).toEqual( [ { option_name: 'backups', should_dismiss: false } ] );
+	} );
+} );
+
+describe( 'review prompt — tracks', () => {
+	it( 'records the click through to the review page', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ] } );
+
+		await renderSettledOverview();
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'link', { name: CTA } ) );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_new_review_click' );
+	} );
+} );

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -6,11 +6,25 @@
 // collection and the other reads the backup list, and the dismissal is a
 // third endpoint keyed on which trigger fired.
 //
-// Every "the card stays away" assertion is paired with something that
-// *did* render — the activity list's own row, or the dismissal request
-// never being made. A bare `queryByText(...).not.toBeInTheDocument()`
-// passes just as happily when the stage threw, the endpoints were
-// mis-mocked, or the copy was reworded.
+// EVERY "the card stays away" assertion in this file is paired with an
+// outside witness, and any test added here must keep that up. A bare
+// `queryByText( … ).not.toBeInTheDocument()` is decorative: it passes
+// just as happily when the stage threw, when the endpoints were
+// mis-mocked, or when the copy was reworded — and, proved by mutation,
+// it keeps passing when the plugin gate is flipped to fail *open*. Only
+// the `dismissalCalls` assertion on the following line caught that.
+//
+// The two witnesses used here:
+//
+//   - `renderSettledOverview()` waits for the activity list's own row,
+//     which proves the stage mounted, the endpoints answered, and the
+//     dashboard reached the state where the prompt would have rendered.
+//   - `dismissalCalls` records every request to the dismissal route, so
+//     a test can say not just "no card" but *why* — the gate refused
+//     before anything was asked, versus the trigger never fired, versus
+//     the server said it was already dismissed.
+//
+// A negative assertion with neither is vacuous. Add one.
 
 const mockRecordEvent = jest.fn();
 
@@ -132,6 +146,20 @@ function restoreRow( daysAgo: number, status = 'finished' ) {
 	};
 }
 
+/**
+ * How many times the dismissal was reported to Tracks.
+ *
+ * Counted rather than asserted with `toHaveBeenCalledTimes`, because the
+ * Overview screen records its own page view through the same mock.
+ *
+ * @return The number of `jetpack_backup_dismiss_review_click` events.
+ */
+function dismissEventCount() {
+	return mockRecordEvent.mock.calls.filter(
+		( [ event ] ) => event === 'jetpack_backup_dismiss_review_click'
+	).length;
+}
+
 type Options = {
 	/**
 	 * Whether the capabilities response reports the standalone plugin.
@@ -147,6 +175,8 @@ type Options = {
 	dismissalReadFails?: boolean;
 	/** Make the dismissal write reject. */
 	dismissalWriteFails?: boolean;
+	/** Never settle the dismissal write, so it stays in flight. */
+	dismissalWriteHangs?: boolean;
 };
 
 /** Every dismissal request the stage made, in order. */
@@ -162,6 +192,7 @@ let dismissalCalls: Array< { option_name: string; should_dismiss: boolean } > = 
  * @param options.dismissed           - What the dismissal read answers, per reason.
  * @param options.dismissalReadFails  - Make the dismissal read reject.
  * @param options.dismissalWriteFails - Make the dismissal write reject.
+ * @param options.dismissalWriteHangs - Never settle the dismissal write.
  */
 function mockEndpoints( {
 	standalonePlugin = true,
@@ -170,6 +201,7 @@ function mockEndpoints( {
 	dismissed = {},
 	dismissalReadFails = false,
 	dismissalWriteFails = false,
+	dismissalWriteHangs = false,
 }: Options = {} ) {
 	mockApiFetch.mockImplementation(
 		( o: { path?: string; data?: { option_name: string; should_dismiss: boolean } } ) => {
@@ -177,7 +209,7 @@ function mockEndpoints( {
 			if ( path.includes( '/site/capabilities' ) ) {
 				const capabilities: Record< string, unknown > = { hasBackupPlan: true, hasScan: false };
 				if ( standalonePlugin !== 'absent' ) {
-					capabilities.isStandalonePluginActive = standalonePlugin;
+					capabilities.local = { isStandalonePluginActive: standalonePlugin };
 				}
 				return Promise.resolve( capabilities );
 			}
@@ -185,6 +217,9 @@ function mockEndpoints( {
 				const data = o.data as { option_name: string; should_dismiss: boolean };
 				dismissalCalls.push( data );
 				if ( data.should_dismiss ) {
+					if ( dismissalWriteHangs ) {
+						return new Promise( () => {} );
+					}
 					return dismissalWriteFails
 						? Promise.reject( new Error( 'Could not save the dismissal.' ) )
 						: Promise.resolve( true );
@@ -293,6 +328,19 @@ describe( 'review prompt — trigger A, a recent restore', () => {
 			'href',
 			expect.stringContaining( 'jetpack-backup-new-review' )
 		);
+	} );
+
+	// The collection route maps nothing — it `json_decode`s WordPress.com's
+	// body and returns it — and the sibling status route's `STATUS_MAP`
+	// equates `success` with `finished`. Matching only `finished` would
+	// mean this trigger never fires for anyone, silently, if upstream
+	// spells it the other way.
+	it( 'asks when the restore reports the other success spelling', async () => {
+		mockEndpoints( { restores: [ restoreRow( 3, 'success' ) ] } );
+
+		await renderSettledOverview();
+
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'stays away once the restore is older than 15 days', async () => {
@@ -430,6 +478,58 @@ describe( 'review prompt — dismissal', () => {
 		await waitFor( () =>
 			expect( dismissalCalls ).toContainEqual( { option_name: 'restore', should_dismiss: true } )
 		);
+		expect( screen.getByText( RESTORE_QUESTION ) ).toBeInTheDocument();
+	} );
+
+	// Fixing legacy bug 3 has a cost: the card no longer vanishes on click,
+	// so on a slow connection nothing visibly happens and the reader clicks
+	// again. Unguarded that is a second POST and — worse — a second refusal
+	// reported for one decision.
+	//
+	// Asserts the outcome, not one mechanism. Three things hold it up (the
+	// disabled button, the report-once latch, and `dismiss()`'s own
+	// refusal), so removing any single one leaves this green; removing all
+	// three does not. That redundancy is deliberate, and the `aria-disabled`
+	// assertion is what pins the one of them the reader can actually see.
+	it( 'ignores further clicks while the refusal is still being written', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissalWriteHangs: true } );
+
+		await renderSettledOverview();
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+
+		const button = screen.getByRole( 'button', { name: 'Maybe later' } );
+		await userEvent.click( button );
+		await userEvent.click( button );
+		await userEvent.click( button );
+
+		const writes = dismissalCalls.filter( call => call.should_dismiss );
+		expect( writes ).toHaveLength( 1 );
+		expect( dismissEventCount() ).toBe( 1 );
+		// And the reader can see why nothing else happened.
+		expect( button ).toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	// A retry is not a second decision. The write is allowed to be
+	// attempted again — that is the whole point of leaving the card up when
+	// it fails — but Tracks must not read one refusal as several, which
+	// would show as a step change in dismissal rate at the flag flip.
+	it( 'reports one refusal however many times the failing write is retried', async () => {
+		mockEndpoints( { restores: [ restoreRow( 1 ) ], dismissalWriteFails: true } );
+
+		await renderSettledOverview();
+		await expect( screen.findByText( RESTORE_QUESTION ) ).resolves.toBeInTheDocument();
+
+		const button = screen.getByRole( 'button', { name: 'Maybe later' } );
+		await userEvent.click( button );
+		await userEvent.click( button );
+		await userEvent.click( button );
+
+		await waitFor( () =>
+			expect( dismissalCalls.filter( call => call.should_dismiss ).length ).toBeGreaterThan( 1 )
+		);
+		expect( dismissEventCount() ).toBe( 1 );
+		// The witness: the card is still up, which is what makes retrying
+		// possible and is the behaviour the single event is measured against.
 		expect( screen.getByText( RESTORE_QUESTION ) ).toBeInTheDocument();
 	} );
 

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -533,16 +533,36 @@ describe( 'review prompt — dismissal', () => {
 		expect( screen.getByText( RESTORE_QUESTION ) ).toBeInTheDocument();
 	} );
 
-	// Two independent dismissals, not one. Declining after a restore must
-	// not spend the backups prompt, and the server stores them under two
-	// different options for the same reason.
-	it( 'still asks about backups on a site that dismissed the restore prompt', async () => {
+	// The dismissal is keyed per reason, so a stored `restore` refusal does
+	// not answer the backups question. Note this site has no restore at all
+	// — the case where both triggers fire is the next test, and differs.
+	it( 'asks about backups when only the unrelated restore prompt was dismissed', async () => {
 		mockEndpoints( { backups: goodRun(), dismissed: { restore: true } } );
 
 		await renderSettledOverview();
 
 		await expect( screen.findByText( BACKUPS_QUESTION ) ).resolves.toBeInTheDocument();
 		expect( dismissalCalls ).toEqual( [ { option_name: 'backups', should_dismiss: false } ] );
+	} );
+
+	// Restore wins when both fire, and only the winner's dismissal is read
+	// — so declining it silences the card until that restore ages out. This
+	// is legacy's behaviour and `useReviewRequest` documents it; the test is
+	// here so that changing it has to be deliberate.
+	it( 'asks nothing more on a site that declined the restore prompt while both triggers fire', async () => {
+		mockEndpoints( {
+			restores: [ restoreRow( 1 ) ],
+			backups: goodRun(),
+			dismissed: { restore: true },
+		} );
+
+		await renderSettledOverview();
+
+		expect( screen.queryByText( RESTORE_QUESTION ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( BACKUPS_QUESTION ) ).not.toBeInTheDocument();
+		// The witness: the backups trigger was never even asked about, which
+		// is what distinguishes this from the card being suppressed earlier.
+		expect( dismissalCalls ).toEqual( [ { option_name: 'restore', should_dismiss: false } ] );
 	} );
 } );
 


### PR DESCRIPTION
Fixes JETPACK-2302

## Proposed changes

Ports the legacy Backup dashboard's review-request card to the modernized (wp-build) dashboard, behind `rsm_jetpack_ui_modernization_backup`. The trigger rules are the ones the issue specifies rather than the ones legacy inherited, and none of legacy's three transcription bugs is carried over.

**Where it renders.** A sibling of the Overview's two-pane grid, below the storage section, on the main path only — never beside the first-run/takeover panel, where the reader's backups are not working.

**Two triggers, OR'd, restore taking precedence** (legacy's `if` / `else if`):

* **A — a restore that finished in the last 15 days.** Ported as written; this trigger is correct in legacy. The restores collection's `status` stays quarantined in `data/api/restore.ts`: it already exposes `settled`, and this adds a second reading, `succeeded`, rather than letting the raw spelling out of that file. `settled` and `succeeded` are different questions — an aborted restore is just as over as a finished one. `succeeded` matches **both** `finished` and `success`: `GET /jetpack/v4/restores` is a raw passthrough (`get_recent_restores()` `json_decode`s WordPress.com's body and returns it, mapping nothing), and the sibling status route's `Restore_Bridge::STATUS_MAP` already equates the two. Matching only `finished` would have meant this trigger never firing for anyone, silently, if upstream spells it the other way. `success-with-errors` stays excluded deliberately, as `STATUS_MAP` also keeps it distinct.
* **B — the last five backups all usable.** `backups.slice( 0, 5 ).every( isUsableBackup )`, reusing the predicate the dashboard already has rather than re-deriving it. That predicate includes `isDiscarded`, which legacy's review trigger did not check: #51679 now tells a discarding site that its oldest backups are being deleted, and "do you enjoy the peace of mind of having real-time backups?" beside that message reads as a taunt.

**The plugin gate.** The card renders only when the standalone Jetpack VaultPress Backup plugin is active. This is dead today — the modernized dashboard ships only in that plugin — and is written now because the dashboard is intended to reach the Jetpack plugin, where a "review the Backup plugin" nudge makes no sense.

* Signal: `defined( 'JETPACK_BACKUP_PLUGIN_DIR' )`, defined in exactly one file, the standalone plugin's own bootstrap.
* Transport: server-authoritative, on the existing `GET /jetpack/v4/site/capabilities` response as `local.isStandalonePluginActive`. No new endpoint, no new global, no extra round trip — and because that response is already in hand before `<Gates>` renders a body, the gate is settled before anything it gates could flash on screen. The client cannot bypass it.
* That response now has two halves and the shape keeps them apart: the top level is WordPress.com's answer projected into the flags `<Gates>` reads, and everything under `local` was decided on the site. A naming convention would ask every future addition to remember the rule; a branch makes provenance structural.
* `JP_CONNECTION_INITIAL_STATE.connectedPlugins` is deliberately **not** used. That list is populated by `Jetpack_Backup::initialize()`, which belongs to the package rather than the plugin — the moment the Jetpack plugin gains a Backup page it will register the slug too, so the list would report the standalone plugin as present on exactly the site the gate exists to protect.

**Preserved from legacy on purpose:**

* Dismissal is keyed per reason (`option_name`), so declining after a restore leaves the backups prompt available. The server already stores them as two separate options.
* Fail closed. A pending or failed capabilities read, a pending or failed dismissal read, and a restores read still in flight all keep the card off screen.
* Gated on `isFullyConnected` (via `<Gates>`), not on plan.
* Restore takes precedence over backups.
* Copy and Tracks events (`jetpack_backup_new_review_click`, `jetpack_backup_dismiss_review_click`) are legacy's, so the strings arrive already translated.

**Two things this port had to add that legacy did not need.** Both fall out of fixing bug 3 — because the card now stays on screen until the server confirms, its button stays live, where legacy's card vanished on click:

* The **Maybe later** button is disabled while the write is in flight, and the refusal is reported to Tracks once per prompt. The write itself stays retryable, because a retry is not a second decision — reporting it as one would show a step change in dismissal rate at the flag flip that is an artifact rather than behaviour, the same hazard `screens/overview.tsx` guards the page view against.
* `option_name` on the dismissal route gains `'enum' => array( 'restore', 'backups' )`. `Jetpack_Options` recognises exactly those two names; outside its allowlist the option is stored nowhere while the route answers as though it were, and on a site with `display_errors` on the resulting `trigger_error()` is printed ahead of the JSON and the body no longer parses.

**Legacy bugs deliberately not reproduced:**

1. `const ReviewMessage = connectionLoaded => …` receives the props object, so the `! connectionLoaded` guards never fire — and because that object is a fresh identity every parent render and sits in two `useEffect` dependency arrays, `GET /jetpack/v4/restores` and the dismissal `POST` re-fire on every parent render. Both reads are React Query here, keyed on data rather than on an object identity.
2. `! 'finished' === backup.status` collapses to `! backup.stats`; status is ignored entirely. Read as a value at the data-layer edge instead.
3. `.then( setDismissedReview( true ) )` *calls* the setter and passes `undefined` as the callback, so the card vanished the moment the request was sent — a failed dismissal hid it locally while the server recorded nothing, and it returned on the next load. The dismissal is now confirmed: the cache is only written on a successful mutation, so a failed write leaves the card up and clicking again retries.

**Open copy question, flagged rather than silently changed.** Trigger B's string asserts "real-time backups" unconditionally, which may be wrong for a site on a daily-backup tier. This is **unverified**. It is ported as-is because it is legacy's wording — if it is wrong, it is wrong in legacy today too, so fixing it is a copy change with a translation cost rather than part of this port. Happy to change it in this PR if someone can confirm the tiers.

## Related product discussion/links

* JETPACK-2302 (trigger rules and the plugin-gate reasoning were settled there on 28 Aug)
* Trigger A introduced in #24929; trigger B in #25979, which replaced a `subscriptionTimeInDays > 90` tenure test — the intent to preserve is "the product has visibly worked for you", not the numbers 15 and 5.
* #51679 for the discarded-backups copy that trigger B's `isDiscarded` condition avoids contradicting.

## Does this pull request change what data or activity we track or use?

No new events. The two existing Tracks events (`jetpack_backup_new_review_click`, `jetpack_backup_dismiss_review_click`) now also fire from the modernized dashboard, where previously they fired only from the legacy one. The dismissal continues to be stored in the same two `dismissed_backup_review_*` Jetpack options.

## Testing instructions

The card only renders behind the modernization flag, on a site with the standalone Backup plugin, and only when a trigger fires — so most of the behaviour is easiest to see in the automated tests, which cover both triggers, the precedence rule, the dismissal (including the fail-closed and unconfirmed-write paths) and the plugin gate.

```
jp build packages/backup
jp test js packages/backup     # or: cd projects/packages/backup && pnpm test -- review-request
jp test php packages/backup
jp phan packages/backup
```

Every negative assertion in `tests/review-request.test.tsx` carries an outside witness — the activity list's own row, or the record of which dismissal requests were made — because a bare `queryByText( … ).not.toBeInTheDocument()` keeps passing when the gate is flipped to fail *open*. The file header spells the rule out for anyone adding to it.

To see it on a site:

1. Enable `rsm_jetpack_ui_modernization_backup` on a site running the standalone Jetpack VaultPress Backup plugin with an active Backup plan, and go to **Jetpack → VaultPress Backup**.
2. **Trigger B** — on a site whose five most recent backups all completed with stats and are not discarded, the card appears below the storage section asking *"Do you enjoy the peace of mind of having real-time backups?"*
3. **Trigger A** — restore the site (or use a site restored within the last 15 days). The card should now ask *"Was it easy to restore your site?"* instead, even if trigger B also applies.
4. Click **Please leave a review and help us spread the word!** — it opens the plugin's review page in a new tab and records `jetpack_backup_new_review_click`.
5. Click **Maybe later** — the card disappears and stays gone across reloads. Confirm the dismissal was actually persisted (`jetpack_dismissed_backup_review_restore` / `…_backups`), not just hidden locally.
6. Confirm the dismissal is per reason: dismissing the restore prompt should still leave the backups prompt available on a site that later qualifies for it.
7. **The gate** — with the flag off, the legacy dashboard is unchanged (the modernized routes do not register at all). The gate itself cannot be exercised on a real site today, since the modernized dashboard only ships in the plugin that defines the constant; `Rest_Capabilities_Bridge_Test` covers both sides of it, the open case in a child process because `define()` cannot be undone.
