### PR TITLE
Backup: make the activity list's sort real and remove its dead filters

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-activity-list-sort-and-filter-controls
+++ b/projects/packages/backup/changelog/fix-backup-activity-list-sort-and-filter-controls
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: make the modernized dashboard's activity list sort for real — the Order control now reorders the whole log server-side rather than the rows on screen — remove the filter controls nothing could honour, and let the page size be changed without opening Order first. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -8,6 +8,7 @@ import { ACTIVITY_LOG_DEFAULT_PER_PAGE, useActivityLog } from '../../hooks/use-a
 import { isBackupItem } from '../../types/activity';
 import QueryError from '../query-error';
 import './style.scss';
+import type { ActivitySortOrder } from '../../data/api/activity-log';
 import type { ActivityItem, ActivityKind } from '../../types/activity';
 import type { Field, View } from '@wordpress/dataviews';
 
@@ -27,6 +28,25 @@ type Props = {
 	view: View;
 	onChangeView: ( next: View ) => void;
 };
+
+/**
+ * The sort direction a DataViews view is asking the server for.
+ *
+ * Exported because the Overview screen has to derive the same value for
+ * `useActivityById`: that lookup shares this list's cache entry, and the
+ * direction is part of its key.
+ *
+ * Only the direction is read. `view.sort.field` is fixed to the one
+ * sortable field (`description`, the timestamp) because WPCOM's
+ * `/activity/rewindable` sorts on the event timestamp and takes no field
+ * to sort by — so there is nothing a second sortable field could mean.
+ *
+ * @param view - DataViews view state.
+ * @return The direction to request, defaulting to newest-first.
+ */
+export function activitySortOrder( view: View ): ActivitySortOrder {
+	return view.sort?.direction === 'asc' ? 'asc' : 'desc';
+}
 
 /**
  * Returns the row's stable id for DataViews selection bookkeeping.
@@ -106,6 +126,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 	const { items, totalItems, totalPages, isLoading, isFetching, error, refetch } = useActivityLog( {
 		page,
 		pageSize: perPage,
+		sortOrder: activitySortOrder( view ),
 	} );
 
 	// DataViews shows its own "No results" whenever `data` is empty, and a
@@ -122,6 +143,18 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		/>
 	) : undefined;
 
+	// `filterBy: false` on every field, deliberately and load-bearing.
+	//
+	// DataViews derives one filter per filterable field, and a `text`
+	// field is filterable by default. Nothing here can honour a filter —
+	// the rows are one server-paginated page and `/activity/rewindable`
+	// takes no search term — so every filter offered would be inert. The
+	// funnel is also actively harmful: opening a filter reaches a private
+	// `@wordpress/components` API that recent versions no longer lock,
+	// which drops the whole dashboard to its error boundary, and adding
+	// one resets `page` to 1 under a reader who is on page 3. Zero
+	// filters makes DataViews' `FiltersToggle` render nothing, which puts
+	// all of that out of reach.
 	const fields: Field< ActivityItem >[] = useMemo(
 		() => [
 			{
@@ -131,15 +164,26 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				render: MediaCell,
 				enableHiding: false,
 				enableSorting: false,
+				filterBy: false,
 			},
 			{
+				// Not sortable: upstream orders by event timestamp and
+				// accepts no field to sort by, so a "Sort by: Title" the
+				// server can never honour would be a label that lies.
 				id: 'title',
 				type: 'text',
 				label: __( 'Title', 'jetpack-backup-pkg' ),
 				getValue: ( { item } ) => item.title,
 				enableGlobalSearch: true,
+				enableSorting: false,
+				filterBy: false,
 			},
 			{
+				// The one sortable field, and the one the server actually
+				// orders on. `INITIAL_VIEW.sort` names it so the cog reads
+				// "Sort by: When, descending" from first open — true of the
+				// rows as served, where an unset `sort` left the native
+				// select showing its first option instead.
 				id: 'description',
 				type: 'text',
 				label: __( 'When', 'jetpack-backup-pkg' ),
@@ -150,6 +194,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 					}`,
 				enableGlobalSearch: true,
 				enableHiding: false,
+				filterBy: false,
 			},
 		],
 		[]

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -30,22 +30,32 @@ type Props = {
 };
 
 /**
- * The sort direction a DataViews view is asking the server for.
+ * The query a DataViews view is asking the server for.
  *
- * Exported because the Overview screen has to derive the same value for
- * `useActivityById`: that lookup shares this list's cache entry, and the
- * direction is part of its key.
+ * Every value the activity-log query is keyed on, derived in one place.
+ * Exported because the Overview screen has to derive the *same* three for
+ * `useActivityById`: that lookup shares this list's cache entry, and all
+ * three are part of its key, so two copies of this arithmetic are two
+ * things that can drift into a second, needless request.
  *
- * Only the direction is read. `view.sort.field` is fixed to the one
- * sortable field (`description`, the timestamp) because WPCOM's
+ * Only the sort *direction* is read. `view.sort.field` is fixed to the
+ * one sortable field (`description`, the timestamp) because WPCOM's
  * `/activity/rewindable` sorts on the event timestamp and takes no field
  * to sort by — so there is nothing a second sortable field could mean.
  *
  * @param view - DataViews view state.
- * @return The direction to request, defaulting to newest-first.
+ * @return The page, page size and direction to request.
  */
-export function activitySortOrder( view: View ): ActivitySortOrder {
-	return view.sort?.direction === 'asc' ? 'asc' : 'desc';
+export function activityQueryArgs( view: View ): {
+	page: number;
+	pageSize: number;
+	sortOrder: ActivitySortOrder;
+} {
+	return {
+		page: view.page ?? 1,
+		pageSize: view.perPage ?? ACTIVITY_LOG_DEFAULT_PER_PAGE,
+		sortOrder: view.sort?.direction === 'asc' ? 'asc' : 'desc',
+	};
 }
 
 /**
@@ -121,13 +131,27 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
  * @return The rendered list.
  */
 export default function ActivityList( { selectedId, onSelect, view, onChangeView }: Props ) {
-	const page = view.page ?? 1;
-	const perPage = view.perPage ?? ACTIVITY_LOG_DEFAULT_PER_PAGE;
+	const { page, pageSize, sortOrder } = activityQueryArgs( view );
 	const { items, totalItems, totalPages, isLoading, isFetching, error, refetch } = useActivityLog( {
 		page,
-		pageSize: perPage,
-		sortOrder: activitySortOrder( view ),
+		pageSize,
+		sortOrder,
 	} );
+
+	// Reordering has to send the reader back to page 1, and DataViews will
+	// not do it. Its `SortDirectionControl` spreads `...view` and replaces
+	// only `sort`, where the `ItemsPerPageControl` beside it sets
+	// `page: 1` — so without this, flipping to ascending on page 3 keeps
+	// page 3 and lands the reader on items 21-30 counted from the oldest
+	// end instead. That destination corresponds to nothing they asked for,
+	// and page 1 of the new order is the only answer that does.
+	const handleChangeView = useCallback(
+		( next: View ) => {
+			const reordered = ( next.sort?.direction ?? 'desc' ) !== sortOrder;
+			onChangeView( reordered ? { ...next, page: 1 } : next );
+		},
+		[ onChangeView, sortOrder ]
+	);
 
 	// DataViews shows its own "No results" whenever `data` is empty, and a
 	// failed request leaves it empty — so without this a 5xx tells the
@@ -174,7 +198,6 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				type: 'text',
 				label: __( 'Title', 'jetpack-backup-pkg' ),
 				getValue: ( { item } ) => item.title,
-				enableGlobalSearch: true,
 				enableSorting: false,
 				filterBy: false,
 			},
@@ -192,7 +215,6 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 					`${ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }${
 						item.summary ? ` ${ item.summary }` : ''
 					}`,
-				enableGlobalSearch: true,
 				enableHiding: false,
 				filterBy: false,
 			},
@@ -235,7 +257,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				data={ items }
 				fields={ fields }
 				view={ view }
-				onChangeView={ onChangeView }
+				onChangeView={ handleChangeView }
 				paginationInfo={ { totalItems, totalPages } }
 				defaultLayouts={ { list: {} } }
 				getItemId={ getRowId }

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -32,16 +32,8 @@ type Props = {
 /**
  * The query a DataViews view is asking the server for.
  *
- * Every value the activity-log query is keyed on, derived in one place.
- * Exported because the Overview screen has to derive the *same* three for
- * `useActivityById`: that lookup shares this list's cache entry, and all
- * three are part of its key, so two copies of this arithmetic are two
- * things that can drift into a second, needless request.
- *
- * Only the sort *direction* is read. `view.sort.field` is fixed to the
- * one sortable field (`description`, the timestamp) because WPCOM's
- * `/activity/rewindable` sorts on the event timestamp and takes no field
- * to sort by — so there is nothing a second sortable field could mean.
+ * Exported so Overview derives the same cache key for `useActivityById` instead
+ * of repeating the arithmetic and drifting into a second, needless request.
  *
  * @param view - DataViews view state.
  * @return The page, page size and direction to request.
@@ -138,13 +130,9 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		sortOrder,
 	} );
 
-	// Reordering has to send the reader back to page 1, and DataViews will
-	// not do it. Its `SortDirectionControl` spreads `...view` and replaces
-	// only `sort`, where the `ItemsPerPageControl` beside it sets
-	// `page: 1` — so without this, flipping to ascending on page 3 keeps
-	// page 3 and lands the reader on items 21-30 counted from the oldest
-	// end instead. That destination corresponds to nothing they asked for,
-	// and page 1 of the new order is the only answer that does.
+	// DataViews' `SortDirectionControl` spreads `...view` and replaces only
+	// `sort`, so without this a reorder strands the reader on page 3 of an
+	// ordering they have not seen the start of.
 	const handleChangeView = useCallback(
 		( next: View ) => {
 			const reordered = ( next.sort?.direction ?? 'desc' ) !== sortOrder;
@@ -167,18 +155,11 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		/>
 	) : undefined;
 
-	// `filterBy: false` on every field, deliberately and load-bearing.
-	//
-	// DataViews derives one filter per filterable field, and a `text`
-	// field is filterable by default. Nothing here can honour a filter —
-	// the rows are one server-paginated page and `/activity/rewindable`
-	// takes no search term — so every filter offered would be inert. The
-	// funnel is also actively harmful: opening a filter reaches a private
-	// `@wordpress/components` API that recent versions no longer lock,
-	// which drops the whole dashboard to its error boundary, and adding
-	// one resets `page` to 1 under a reader who is on page 3. Zero
-	// filters makes DataViews' `FiltersToggle` render nothing, which puts
-	// all of that out of reach.
+	// Every field opts out of filtering, and all but `description` out of sorting:
+	// `/activity/rewindable` takes no search term and orders only on the event
+	// timestamp, so any other control would be a label the server cannot honour.
+	// Zero filters also keeps `FiltersToggle` unrendered, and with it a private
+	// `@wordpress/components` API that drops the dashboard to its error boundary.
 	const fields: Field< ActivityItem >[] = useMemo(
 		() => [
 			{
@@ -191,9 +172,6 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				filterBy: false,
 			},
 			{
-				// Not sortable: upstream orders by event timestamp and
-				// accepts no field to sort by, so a "Sort by: Title" the
-				// server can never honour would be a label that lies.
 				id: 'title',
 				type: 'text',
 				label: __( 'Title', 'jetpack-backup-pkg' ),
@@ -202,11 +180,6 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				filterBy: false,
 			},
 			{
-				// The one sortable field, and the one the server actually
-				// orders on. `INITIAL_VIEW.sort` names it so the cog reads
-				// "Sort by: When, descending" from first open — true of the
-				// rows as served, where an unset `sort` left the native
-				// select showing its first option instead.
 				id: 'description',
 				type: 'text',
 				label: __( 'When', 'jetpack-backup-pkg' ),

--- a/projects/packages/backup/src/dashboard/data/api/activity-log.ts
+++ b/projects/packages/backup/src/dashboard/data/api/activity-log.ts
@@ -22,13 +22,7 @@ export type WpcomActivityLogResponse = {
 	itemsPerPage?: number;
 };
 
-/**
- * Ordering the rewindable activity log can be asked for.
- *
- * Direction only. WPCOM's `/activity/rewindable` sorts on the event
- * timestamp and accepts no field to sort by, so there is nothing here to
- * widen into an `orderby` — see the bridge's `sort_order` arg.
- */
+/** Direction only: WPCOM sorts on the event timestamp and accepts no field. */
 export type ActivitySortOrder = 'asc' | 'desc';
 
 type FetchArgs = {

--- a/projects/packages/backup/src/dashboard/data/api/activity-log.ts
+++ b/projects/packages/backup/src/dashboard/data/api/activity-log.ts
@@ -22,9 +22,19 @@ export type WpcomActivityLogResponse = {
 	itemsPerPage?: number;
 };
 
+/**
+ * Ordering the rewindable activity log can be asked for.
+ *
+ * Direction only. WPCOM's `/activity/rewindable` sorts on the event
+ * timestamp and accepts no field to sort by, so there is nothing here to
+ * widen into an `orderby` — see the bridge's `sort_order` arg.
+ */
+export type ActivitySortOrder = 'asc' | 'desc';
+
 type FetchArgs = {
 	number?: number;
 	page?: number;
+	sort_order?: ActivitySortOrder;
 };
 
 /**
@@ -34,15 +44,23 @@ type FetchArgs = {
  * both to WPCOM, which returns `totalItems` / `totalPages` in the
  * envelope — those values drive DataViews' pagination footer.
  *
- * @param args        - Pagination args.
- * @param args.page   - 1-indexed page number.
- * @param args.number - Items per page.
+ * `sort_order` orders the whole result set server-side, so paging and
+ * ordering compose. Omitting it leaves WPCOM's own `desc` default.
+ *
+ * @param args            - Pagination args.
+ * @param args.page       - 1-indexed page number.
+ * @param args.number     - Items per page.
+ * @param args.sort_order - Sort direction.
  * @return The raw WPCOM-shaped response.
  */
 export async function fetchActivityLog(
 	args: FetchArgs = {}
 ): Promise< WpcomActivityLogResponse > {
 	return apiCall< WpcomActivityLogResponse >( {
-		path: apiPath( '/site/rewindable-activity', { number: args.number, page: args.page } ),
+		path: apiPath( '/site/rewindable-activity', {
+			number: args.number,
+			page: args.page,
+			sort_order: args.sort_order,
+		} ),
 	} );
 }

--- a/projects/packages/backup/src/dashboard/data/api/test/activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/activity-log.test.ts
@@ -29,9 +29,8 @@ describe( 'fetchActivityLog', () => {
 	} );
 
 	it( 'omits the direction when none is asked for', async () => {
-		// The bridge and WordPress.com both default to `desc`. Sending an
-		// empty `sort_order` would fail the route's `enum` validation with a
-		// 400 rather than falling through to that default.
+		// An empty `sort_order` fails the route's `enum` validation with a 400
+		// rather than falling through to the shared `desc` default.
 		await fetchActivityLog( { page: 1, number: 10 } );
 
 		expect( requestedPath() ).not.toContain( 'sort_order' );

--- a/projects/packages/backup/src/dashboard/data/api/test/activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/data/api/test/activity-log.test.ts
@@ -1,0 +1,39 @@
+import apiFetch from '@wordpress/api-fetch';
+import { fetchActivityLog } from '../activity-log';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * The path the last call was made against.
+ *
+ * @return The requested path.
+ */
+function requestedPath(): string {
+	return ( mockedApiFetch.mock.calls[ 0 ]?.[ 0 ] as { path?: string } )?.path ?? '';
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+	mockedApiFetch.mockResolvedValue( { current: { orderedItems: [] } } );
+} );
+
+describe( 'fetchActivityLog', () => {
+	it( 'sends the sort direction as a query param', async () => {
+		await fetchActivityLog( { page: 2, number: 20, sort_order: 'asc' } );
+
+		const path = requestedPath();
+		expect( path ).toContain( 'sort_order=asc' );
+		expect( path ).toContain( 'page=2' );
+		expect( path ).toContain( 'number=20' );
+	} );
+
+	it( 'omits the direction when none is asked for', async () => {
+		// The bridge and WordPress.com both default to `desc`. Sending an
+		// empty `sort_order` would fail the route's `enum` validation with a
+		// 400 rather than falling through to that default.
+		await fetchActivityLog( { page: 1, number: 10 } );
+
+		expect( requestedPath() ).not.toContain( 'sort_order' );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query';
+import type { ActivitySortOrder } from './api/activity-log';
 
 const STALE_TIME_DEFAULT_MS = 30_000;
 const GC_TIME_DEFAULT_MS = 5 * 60_000;
@@ -58,10 +59,11 @@ export const keys = {
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).
 	activityLogRoot: () => [ 'backup', 'activity-log' ] as const,
-	// Per-page key. `(page, pageSize)` is the only thing that
-	// distinguishes one fetch from another, so both must be in the key.
-	activityLogPage: ( page: number, pageSize: number ) =>
-		[ 'backup', 'activity-log', { page, pageSize } ] as const,
+	// Per-page key. `(page, pageSize, sortOrder)` is everything that
+	// distinguishes one fetch from another, so all three must be in the
+	// key — page 1 ascending and page 1 descending are different rows.
+	activityLogPage: ( page: number, pageSize: number, sortOrder: ActivitySortOrder ) =>
+		[ 'backup', 'activity-log', { page, pageSize, sortOrder } ] as const,
 	fileTree: ( rewindId: string, folderPath: string | null ) =>
 		[ 'backup', 'file-tree', rewindId, folderPath ] as const,
 	fileContents: ( rewindId: string, path: string ) =>

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -59,9 +59,8 @@ export const keys = {
 	// query-filter root to scan all cached pages (e.g. when looking up
 	// a row by id across pages).
 	activityLogRoot: () => [ 'backup', 'activity-log' ] as const,
-	// Per-page key. `(page, pageSize, sortOrder)` is everything that
-	// distinguishes one fetch from another, so all three must be in the
-	// key — page 1 ascending and page 1 descending are different rows.
+	// All three distinguish one fetch from another: page 1 ascending and page 1
+	// descending are different rows.
 	activityLogPage: ( page: number, pageSize: number, sortOrder: ActivitySortOrder ) =>
 		[ 'backup', 'activity-log', { page, pageSize, sortOrder } ] as const,
 	fileTree: ( rewindId: string, folderPath: string | null ) =>

--- a/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
@@ -1,0 +1,290 @@
+// JETPACK-2297 — `sort_order` reaches the bridge, and the four consumers
+// of `useActivityPageQuery` do not all follow the list into it.
+//
+// That last half is the whole point of this file. Three of the four
+// consumers take the direction from the list's view state; two must stay
+// pinned to newest-first no matter what the list is showing, because
+// they ask "what is the newest backup?" and "does this site have any
+// restore points?" — questions whose answers are read off the *first*
+// row, which only means "newest" while the server is sorting descending.
+//
+// Nothing in the running dashboard would report getting this wrong. The
+// default selection would silently become the oldest restore point the
+// reader has, on the one control that starts a destructive operation,
+// and the first-run takeover would appear on a site full of backups. So
+// the inversion is asserted directly here rather than left to a
+// screen-level test to notice.
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import {
+	ACTIVITY_LOG_DEFAULT_PER_PAGE,
+	useActivityById,
+	useActivityLog,
+	useDefaultBackupRewindId,
+	useHasRestorePoints,
+} from '../use-activity-log';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+/**
+ * One raw WPCOM rewindable-activity entry, shaped as a backup row.
+ *
+ * @param rewindId - The row's rewind id, which is also its selection id.
+ * @param when     - ISO publication timestamp.
+ * @return A raw entry.
+ */
+function backupEntry( rewindId: string, when: string ) {
+	return {
+		activity_id: `activity-${ rewindId }`,
+		name: 'rewind__backup_complete_full',
+		gridicon: 'cloud',
+		rewind_id: rewindId,
+		published: when,
+		summary: 'Backup complete',
+		is_rewindable: true,
+	};
+}
+
+// Two pages of the same three backups, in the two orders the server can
+// return them. The rewind ids deliberately differ at position 0: a
+// consumer that follows the list into ascending order reads NEWEST_ID
+// where it should read OLDEST_ID, and vice versa, so every assertion
+// below fails loudly rather than coincidentally passing.
+const NEWEST_ID = '1786600000';
+const MIDDLE_ID = '1786500000';
+const OLDEST_ID = '1786400000';
+
+const DESCENDING = {
+	current: {
+		orderedItems: [
+			backupEntry( NEWEST_ID, '2026-08-20T10:00:00+00:00' ),
+			backupEntry( MIDDLE_ID, '2026-08-19T10:00:00+00:00' ),
+			backupEntry( OLDEST_ID, '2026-08-18T10:00:00+00:00' ),
+		],
+	},
+	totalItems: 3,
+	totalPages: 1,
+};
+
+const ASCENDING = {
+	current: {
+		orderedItems: [
+			backupEntry( OLDEST_ID, '2026-08-18T10:00:00+00:00' ),
+			backupEntry( MIDDLE_ID, '2026-08-19T10:00:00+00:00' ),
+			backupEntry( NEWEST_ID, '2026-08-20T10:00:00+00:00' ),
+		],
+	},
+	totalItems: 3,
+	totalPages: 1,
+};
+
+/**
+ * Answer `/site/rewindable-activity` from the direction the caller asked
+ * for, so a hook reading the wrong order gets visibly wrong rows rather
+ * than the same rows twice.
+ */
+function mockBridge() {
+	mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( ! path.includes( '/site/rewindable-activity' ) ) {
+			return Promise.resolve( {} );
+		}
+		return Promise.resolve( path.includes( 'sort_order=asc' ) ? ASCENDING : DESCENDING );
+	} );
+}
+
+/**
+ * Every request the bridge mock has been given, in order.
+ *
+ * @return The requested paths.
+ */
+function requestedPaths(): string[] {
+	return mockedApiFetch.mock.calls
+		.map( ( [ options ] ) => ( options as { path?: string } )?.path ?? '' )
+		.filter( path => path.includes( '/site/rewindable-activity' ) );
+}
+
+/**
+ * Wrap a hook in an isolated QueryClient.
+ *
+ * Isolated per test so one test's cached page cannot satisfy another's
+ * query — the request counts below are load-bearing.
+ *
+ * @return A wrapper component.
+ */
+function wrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+	mockBridge();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		connectionStatus: CONNECTED,
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'useActivityLog', () => {
+	it( 'asks the bridge for the direction it was given, and shows those rows', async () => {
+		const { result } = renderHook(
+			() =>
+				useActivityLog( {
+					page: 1,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} ),
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.items ).toHaveLength( 3 ) );
+
+		// Ordering is the server's job: these are the rows as served, not a
+		// client-side re-sort of a descending page.
+		expect( requestedPaths()[ 0 ] ).toContain( 'sort_order=asc' );
+		expect( result.current.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } );
+	} );
+
+	it( 'refetches rather than reordering what is already on screen', async () => {
+		const { rerender, result } = renderHook(
+			( { sortOrder }: { sortOrder: 'asc' | 'desc' } ) =>
+				useActivityLog( { page: 1, pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE, sortOrder } ),
+			{ wrapper: wrapper(), initialProps: { sortOrder: 'desc' as const } }
+		);
+
+		await waitFor( () =>
+			expect( result.current.items[ 0 ] ).toMatchObject( { rewindId: NEWEST_ID } )
+		);
+
+		rerender( { sortOrder: 'asc' } );
+
+		await waitFor( () =>
+			expect( result.current.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } )
+		);
+		// Two distinct requests, because the direction is part of the cache
+		// key. Only one page of a multi-page log is ever in hand, so a
+		// client-side flip would reverse ten rows and call it a sort.
+		expect( requestedPaths() ).toHaveLength( 2 );
+		expect( requestedPaths()[ 1 ] ).toContain( 'sort_order=asc' );
+	} );
+} );
+
+describe( 'the newest-backup consumers', () => {
+	it( 'still finds the newest backup while the list is sorted ascending', async () => {
+		// The single most important assertion in this change. Both hooks
+		// read the first backup row of page 1; if either inherited the
+		// list's ascending order it would read OLDEST_ID here and nothing
+		// in the dashboard would say so.
+		const { result } = renderHook(
+			() => ( {
+				list: useActivityLog( {
+					page: 1,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} ),
+				defaultRewindId: useDefaultBackupRewindId(),
+				restorePoints: useHasRestorePoints(),
+			} ),
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.defaultRewindId ).not.toBeNull() );
+		await waitFor( () => expect( result.current.list.items ).toHaveLength( 3 ) );
+
+		// The list is showing oldest-first…
+		expect( result.current.list.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } );
+		// …and the default selection is still the newest backup.
+		expect( result.current.defaultRewindId ).toBe( NEWEST_ID );
+		expect( result.current.restorePoints.hasRestorePoints ).toBe( true );
+
+		// Proof the pinning is real rather than the mock returning one body:
+		// two requests went out, in opposite directions.
+		const paths = requestedPaths();
+		expect( paths ).toHaveLength( 2 );
+		expect( paths.filter( p => p.includes( 'sort_order=asc' ) ) ).toHaveLength( 1 );
+		expect( paths.filter( p => p.includes( 'sort_order=desc' ) ) ).toHaveLength( 1 );
+	} );
+
+	it( 'costs no extra request when the list is already newest-first', async () => {
+		const { result } = renderHook(
+			() => ( {
+				list: useActivityLog( {
+					page: 1,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'desc',
+				} ),
+				defaultRewindId: useDefaultBackupRewindId(),
+				restorePoints: useHasRestorePoints(),
+			} ),
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.defaultRewindId ).toBe( NEWEST_ID ) );
+
+		// All three share one cache entry in the default case, which is what
+		// keeps the pinning free.
+		expect( requestedPaths() ).toHaveLength( 1 );
+	} );
+
+	it( 'does not report a site as having no restore points when the list pages away', async () => {
+		// `useHasRestorePoints` gates the first-run takeover panel. Reading
+		// whichever page the list happens to be on would let page 2 of an
+		// ascending list answer "nothing here" and replace the dashboard.
+		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( 'page=2' ) ) {
+				return Promise.resolve( { current: { orderedItems: [] }, totalItems: 3, totalPages: 2 } );
+			}
+			return Promise.resolve( path.includes( 'sort_order=asc' ) ? ASCENDING : DESCENDING );
+		} );
+
+		const { result } = renderHook(
+			() => ( {
+				list: useActivityLog( {
+					page: 2,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} ),
+				restorePoints: useHasRestorePoints(),
+			} ),
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.restorePoints.isLoading ).toBe( false ) );
+		await waitFor( () => expect( result.current.list.items ).toHaveLength( 0 ) );
+
+		expect( result.current.restorePoints.hasRestorePoints ).toBe( true );
+	} );
+} );
+
+describe( 'useActivityById', () => {
+	it( 'shares the list page rather than opening a second query for it', async () => {
+		const { result } = renderHook(
+			() => ( {
+				list: useActivityLog( {
+					page: 1,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} ),
+				item: useActivityById( MIDDLE_ID, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+			} ),
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.item ).not.toBeNull() );
+
+		expect( result.current.item ).toMatchObject( { rewindId: MIDDLE_ID } );
+		// One ascending request between the two of them. Pinning this hook
+		// to `desc` would have fetched the same rows a second time.
+		expect( requestedPaths() ).toEqual( [ expect.stringContaining( 'sort_order=asc' ) ] );
+	} );
+} );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
@@ -1,19 +1,7 @@
-// JETPACK-2297 — `sort_order` reaches the bridge, and the four consumers
-// of `useActivityPageQuery` do not all follow the list into it.
-//
-// That last half is the whole point of this file. Three of the four
-// consumers take the direction from the list's view state; two must stay
-// pinned to newest-first no matter what the list is showing, because
-// they ask "what is the newest backup?" and "does this site have any
-// restore points?" — questions whose answers are read off the *first*
-// row, which only means "newest" while the server is sorting descending.
-//
-// Nothing in the running dashboard would report getting this wrong. The
-// default selection would silently become the oldest restore point the
-// reader has, on the one control that starts a destructive operation,
-// and the first-run takeover would appear on a site full of backups. So
-// the inversion is asserted directly here rather than left to a
-// screen-level test to notice.
+// JETPACK-2297 — `sort_order` reaches the bridge, and the two consumers that
+// read "the first row" stay pinned to newest-first whatever the list shows.
+// Nothing in the running dashboard reports getting that inversion wrong, so it
+// is asserted here rather than left to a screen-level test.
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -51,11 +39,8 @@ function backupEntry( rewindId: string, when: string ) {
 	};
 }
 
-// Two pages of the same three backups, in the two orders the server can
-// return them. The rewind ids deliberately differ at position 0: a
-// consumer that follows the list into ascending order reads NEWEST_ID
-// where it should read OLDEST_ID, and vice versa, so every assertion
-// below fails loudly rather than coincidentally passing.
+// The rewind ids differ at position 0 on purpose: a consumer that follows the
+// list into ascending order reads the wrong end and fails loudly.
 const NEWEST_ID = '1786600000';
 const MIDDLE_ID = '1786500000';
 const OLDEST_ID = '1786400000';
@@ -148,8 +133,7 @@ describe( 'useActivityLog', () => {
 
 		await waitFor( () => expect( result.current.items ).toHaveLength( 3 ) );
 
-		// Ordering is the server's job: these are the rows as served, not a
-		// client-side re-sort of a descending page.
+		// The rows as served — there is no client-side re-sort.
 		expect( requestedPaths()[ 0 ] ).toContain( 'sort_order=asc' );
 		expect( result.current.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } );
 	} );
@@ -170,9 +154,8 @@ describe( 'useActivityLog', () => {
 		await waitFor( () =>
 			expect( result.current.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } )
 		);
-		// Two distinct requests, because the direction is part of the cache
-		// key. Only one page of a multi-page log is ever in hand, so a
-		// client-side flip would reverse ten rows and call it a sort.
+		// Two requests: the direction is part of the cache key, and only one page
+		// of a multi-page log is ever in hand.
 		expect( requestedPaths() ).toHaveLength( 2 );
 		expect( requestedPaths()[ 1 ] ).toContain( 'sort_order=asc' );
 	} );
@@ -180,10 +163,8 @@ describe( 'useActivityLog', () => {
 
 describe( 'the newest-backup consumers', () => {
 	it( 'still finds the newest backup while the list is sorted ascending', async () => {
-		// The single most important assertion in this change. Both hooks
-		// read the first backup row of page 1; if either inherited the
-		// list's ascending order it would read OLDEST_ID here and nothing
-		// in the dashboard would say so.
+		// Both hooks read the first backup row of page 1: inheriting the list's
+		// ascending order would silently give them OLDEST_ID.
 		const { result } = renderHook(
 			() => ( {
 				list: useActivityLog( {
@@ -206,8 +187,8 @@ describe( 'the newest-backup consumers', () => {
 		expect( result.current.defaultRewindId ).toBe( NEWEST_ID );
 		expect( result.current.restorePoints.hasRestorePoints ).toBe( true );
 
-		// Proof the pinning is real rather than the mock returning one body:
-		// two requests went out, in opposite directions.
+		// Two requests in opposite directions — the pinning is real, not the mock
+		// returning one body.
 		const paths = requestedPaths();
 		expect( paths ).toHaveLength( 2 );
 		expect( paths.filter( p => p.includes( 'sort_order=asc' ) ) ).toHaveLength( 1 );
@@ -236,9 +217,8 @@ describe( 'the newest-backup consumers', () => {
 	} );
 
 	it( 'does not report a site as having no restore points when the list pages away', async () => {
-		// `useHasRestorePoints` gates the first-run takeover panel. Reading
-		// whichever page the list happens to be on would let page 2 of an
-		// ascending list answer "nothing here" and replace the dashboard.
+		// This gates the first-run takeover: read off the list's own page, page 2
+		// of an ascending list would answer "nothing here" and replace the dashboard.
 		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
 			const path = options?.path ?? '';
 			if ( path.includes( 'page=2' ) ) {
@@ -268,15 +248,9 @@ describe( 'the newest-backup consumers', () => {
 
 describe( 'the default selection on an ascending list', () => {
 	it( 'resolves the newest backup even though no visible row holds it', async () => {
-		// Pinned as intended, not tolerated. The reader sees the ten oldest
-		// events with nothing highlighted while the right pane describes the
-		// newest backup — populated via the cross-page cache scan, because
-		// `useDefaultBackupRewindId` keeps its own newest-first page-1 entry.
-		//
-		// The alternative is preselecting whatever sits at the top of the
-		// visible page, which on an ascending list is the OLDEST restore
-		// point, behind a Restore button, by default. This test exists so
-		// that "fix" fails loudly rather than looking like an improvement.
+		// The intended trade: an ascending list highlights no row, and the pane is
+		// still right via the cross-page cache scan. Re-deriving the default from
+		// the visible page would put the oldest restore point behind Restore.
 		const { result } = renderHook(
 			() => {
 				const list = useActivityLog( {
@@ -304,10 +278,8 @@ describe( 'the default selection on an ascending list', () => {
 	} );
 
 	it( 'leaves the selection off-screen rather than moving it onto the page', async () => {
-		// The mismatch made explicit, on a page that genuinely excludes the
-		// selection. Page 2 ascending holds neither end's newest row, so a
-		// consumer that quietly re-derived the default from the visible page
-		// would have to change one of these two assertions.
+		// Page 2 ascending holds neither end's newest row, so re-deriving the
+		// default from the visible page would have to change one of these.
 		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
 			const path = options?.path ?? '';
 			if ( path.includes( 'page=2' ) ) {
@@ -364,8 +336,7 @@ describe( 'useActivityById', () => {
 		await waitFor( () => expect( result.current.item ).not.toBeNull() );
 
 		expect( result.current.item ).toMatchObject( { rewindId: MIDDLE_ID } );
-		// One ascending request between the two of them. Pinning this hook
-		// to `desc` would have fetched the same rows a second time.
+		// One ascending request between them: pinning this hook would refetch.
 		expect( requestedPaths() ).toEqual( [ expect.stringContaining( 'sort_order=asc' ) ] );
 	} );
 } );

--- a/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
@@ -266,6 +266,87 @@ describe( 'the newest-backup consumers', () => {
 	} );
 } );
 
+describe( 'the default selection on an ascending list', () => {
+	it( 'resolves the newest backup even though no visible row holds it', async () => {
+		// Pinned as intended, not tolerated. The reader sees the ten oldest
+		// events with nothing highlighted while the right pane describes the
+		// newest backup — populated via the cross-page cache scan, because
+		// `useDefaultBackupRewindId` keeps its own newest-first page-1 entry.
+		//
+		// The alternative is preselecting whatever sits at the top of the
+		// visible page, which on an ascending list is the OLDEST restore
+		// point, behind a Restore button, by default. This test exists so
+		// that "fix" fails loudly rather than looking like an improvement.
+		const { result } = renderHook(
+			() => {
+				const list = useActivityLog( {
+					page: 1,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} );
+				const defaultRewindId = useDefaultBackupRewindId();
+				return {
+					list,
+					defaultRewindId,
+					item: useActivityById( defaultRewindId, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+				};
+			},
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.item ).not.toBeNull() );
+
+		// The pane resolves the newest backup…
+		expect( result.current.defaultRewindId ).toBe( NEWEST_ID );
+		expect( result.current.item ).toMatchObject( { rewindId: NEWEST_ID } );
+		// …and the list is showing rows that start from the other end.
+		expect( result.current.list.items[ 0 ] ).toMatchObject( { rewindId: OLDEST_ID } );
+	} );
+
+	it( 'leaves the selection off-screen rather than moving it onto the page', async () => {
+		// The mismatch made explicit, on a page that genuinely excludes the
+		// selection. Page 2 ascending holds neither end's newest row, so a
+		// consumer that quietly re-derived the default from the visible page
+		// would have to change one of these two assertions.
+		mockedApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( 'page=2' ) ) {
+				return Promise.resolve( {
+					current: { orderedItems: [ backupEntry( MIDDLE_ID, '2026-08-19T10:00:00+00:00' ) ] },
+					totalItems: 3,
+					totalPages: 2,
+				} );
+			}
+			return Promise.resolve( path.includes( 'sort_order=asc' ) ? ASCENDING : DESCENDING );
+		} );
+
+		const { result } = renderHook(
+			() => {
+				const list = useActivityLog( {
+					page: 2,
+					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
+					sortOrder: 'asc',
+				} );
+				const defaultRewindId = useDefaultBackupRewindId();
+				return {
+					list,
+					defaultRewindId,
+					item: useActivityById( defaultRewindId, 2, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+				};
+			},
+			{ wrapper: wrapper() }
+		);
+
+		await waitFor( () => expect( result.current.item ).not.toBeNull() );
+
+		const visibleIds = result.current.list.items.map( item =>
+			item.kind === 'backup' ? item.rewindId : item.id
+		);
+		expect( visibleIds ).not.toContain( NEWEST_ID );
+		expect( result.current.item ).toMatchObject( { rewindId: NEWEST_ID } );
+	} );
+} );
+
 describe( 'useActivityById', () => {
 	it( 'shares the list page rather than opening a second query for it', async () => {
 		const { result } = renderHook(

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -2,6 +2,7 @@ import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-quer
 import { useCallback, useMemo } from '@wordpress/element';
 import {
 	fetchActivityLog,
+	type ActivitySortOrder,
 	type WpcomActivityEntry,
 	type WpcomActivityLogResponse,
 } from '../data/api/activity-log';
@@ -14,6 +15,7 @@ import type { ActivityItem } from '../types/activity';
 type Args = {
 	page: number;
 	pageSize: number;
+	sortOrder: ActivitySortOrder;
 };
 
 type Result = {
@@ -41,6 +43,15 @@ type Result = {
 export const ACTIVITY_LOG_DEFAULT_PER_PAGE = 10;
 
 /**
+ * The order the list starts in, and the only order in which "the first
+ * backup row" means "the newest backup".
+ *
+ * `useDefaultBackupRewindId` and `useHasRestorePoints` are pinned to it
+ * for that reason — see their docblocks.
+ */
+export const ACTIVITY_LOG_NEWEST_FIRST: ActivitySortOrder = 'desc';
+
+/**
  * Shared `useQuery` for a single page of the rewindable activity log.
  *
  * `keepPreviousData` keeps the previous page visible while the next
@@ -53,15 +64,21 @@ export const ACTIVITY_LOG_DEFAULT_PER_PAGE = 10;
  * to not render it. Consumers inside the gated body get `enabled: true`
  * for free, since they only mount once the connection checks pass.
  *
- * @param page     - 1-indexed page number.
- * @param pageSize - Items per page.
+ * The ordering is a query parameter, not a client-side sort: WPCOM
+ * orders the whole result set and hands back one page of it. That is why
+ * `sortOrder` is in the cache key and why the two "newest backup"
+ * consumers below must not inherit the list's value.
+ *
+ * @param page      - 1-indexed page number.
+ * @param pageSize  - Items per page.
+ * @param sortOrder - Sort direction.
  * @return The page query.
  */
-function useActivityPageQuery( page: number, pageSize: number ) {
+function useActivityPageQuery( page: number, pageSize: number, sortOrder: ActivitySortOrder ) {
 	const enabled = useCanQueryWpcom();
 	return useQuery( {
-		queryKey: keys.activityLogPage( page, pageSize ),
-		queryFn: () => fetchActivityLog( { page, number: pageSize } ),
+		queryKey: keys.activityLogPage( page, pageSize, sortOrder ),
+		queryFn: () => fetchActivityLog( { page, number: pageSize, sort_order: sortOrder } ),
 		placeholderData: keepPreviousData,
 		enabled,
 	} );
@@ -75,13 +92,14 @@ function useActivityPageQuery( page: number, pageSize: number ) {
  * does the paging, `totalItems` / `totalPages` come back in the
  * envelope, and DataViews owns the footer.
  *
- * @param args          - Query args.
- * @param args.page     - 1-indexed page number.
- * @param args.pageSize - Items per page.
+ * @param args           - Query args.
+ * @param args.page      - 1-indexed page number.
+ * @param args.pageSize  - Items per page.
+ * @param args.sortOrder - Sort direction, from the list's Order control.
  * @return Items, total items, total pages, loading, error, refetch.
  */
-export function useActivityLog( { page, pageSize }: Args ): Result {
-	const query = useActivityPageQuery( page, pageSize );
+export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
+	const query = useActivityPageQuery( page, pageSize, sortOrder );
 	const { refetch } = query;
 	// Held across the retry: React Query rewinds this query to `pending`
 	// when it refetches after a failure, so without this the reason
@@ -121,19 +139,23 @@ export function useActivityLog( { page, pageSize }: Args ): Result {
  * hook returns null and the right pane shows the "Item not found"
  * fallback until the user paginates to that page.
  *
- * @param id       - Selection id: `rewindId` for backup items, `activity_id` otherwise.
- * @param page     - The page currently shown in the list.
- * @param pageSize - The per-page setting currently shown in the list.
+ * @param id        - Selection id: `rewindId` for backup items, `activity_id` otherwise.
+ * @param page      - The page currently shown in the list.
+ * @param pageSize  - The per-page setting currently shown in the list.
+ * @param sortOrder - The sort direction currently shown in the list.
  * @return The matching item, or null when nothing in the cached page(s) matches.
  */
 export function useActivityById(
 	id: string | null,
 	page: number,
-	pageSize: number
+	pageSize: number,
+	sortOrder: ActivitySortOrder
 ): ActivityItem | null {
 	// Subscribe to the same page query the list uses so this hook
-	// re-renders the moment the list's data resolves.
-	const query = useActivityPageQuery( page, pageSize );
+	// re-renders the moment the list's data resolves. `sortOrder` is
+	// part of the cache key, so it has to follow the list's — pinning it
+	// would open a second query for rows already on screen.
+	const query = useActivityPageQuery( page, pageSize, sortOrder );
 	const queryClient = useQueryClient();
 
 	return useMemo( () => {
@@ -170,14 +192,23 @@ export function useActivityById(
  * default selection reconciles to the newest backup the moment the
  * page-1 fetch resolves.
  *
- * Always reads page 1 with the default per-page size, regardless of
- * which page the list is currently on. When the list is also on page 1
- * with the default size, TanStack dedupes — no extra fetch.
+ * Always reads page 1 with the default per-page size and newest-first
+ * ordering, regardless of what the list is currently showing. When the
+ * list is also on page 1 with the default size and default order,
+ * TanStack dedupes — no extra fetch.
+ *
+ * The ordering is pinned, not inherited, and that is the whole
+ * correctness of this hook: "the first backup row" only means "the
+ * newest backup" while the server is sorting newest-first. Following the
+ * list into ascending order would silently preselect the *oldest*
+ * restore point the reader has — a wrong default with no error to
+ * notice, on the one control in this dashboard that starts a
+ * destructive operation.
  *
  * @return The newest backup item's rewindId, or null.
  */
 export function useDefaultBackupRewindId(): string | null {
-	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE );
+	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, ACTIVITY_LOG_NEWEST_FIRST );
 	return useMemo( () => {
 		const items = normalizeActivityLog( query.data?.current?.orderedItems );
 		for ( const item of items ) {
@@ -193,8 +224,13 @@ export function useDefaultBackupRewindId(): string | null {
  * Whether the newest page of rewindable activity holds any backup row,
  * and whether that is known yet.
  *
- * Shares the page-1 query with `useDefaultBackupRewindId`, so it costs
- * no extra request.
+ * Shares the page-1 newest-first query with `useDefaultBackupRewindId`,
+ * so it costs no extra request — and is pinned to that ordering for a
+ * second reason of its own. This answer gates the first-run takeover
+ * panel, so it must be asked of a fixed window: reading whichever page
+ * the list happens to be showing would let paginating away from page 1
+ * report "no restore points" and replace the dashboard with the
+ * first-backup screen on a site full of backups.
  *
  * This is a second, independent opinion on "does this site have a
  * restore point". `/jetpack/v4/backups` only reports VaultPress's most
@@ -218,7 +254,7 @@ export function useHasRestorePoints(): {
 	isLoading: boolean;
 	isError: boolean;
 } {
-	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE );
+	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, ACTIVITY_LOG_NEWEST_FIRST );
 	const hasRestorePoints = useMemo(
 		() =>
 			normalizeActivityLog( query.data?.current?.orderedItems ).some(

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -42,13 +42,7 @@ type Result = {
  */
 export const ACTIVITY_LOG_DEFAULT_PER_PAGE = 10;
 
-/**
- * The order the list starts in, and the only order in which "the first
- * backup row" means "the newest backup".
- *
- * `useDefaultBackupRewindId` and `useHasRestorePoints` are pinned to it
- * for that reason — see their docblocks.
- */
+/** The order the list starts in, and the only one where the first backup row is the newest. */
 export const ACTIVITY_LOG_NEWEST_FIRST: ActivitySortOrder = 'desc';
 
 /**
@@ -64,10 +58,8 @@ export const ACTIVITY_LOG_NEWEST_FIRST: ActivitySortOrder = 'desc';
  * to not render it. Consumers inside the gated body get `enabled: true`
  * for free, since they only mount once the connection checks pass.
  *
- * The ordering is a query parameter, not a client-side sort: WPCOM
- * orders the whole result set and hands back one page of it. That is why
- * `sortOrder` is in the cache key and why the two "newest backup"
- * consumers below must not inherit the list's value.
+ * WPCOM sorts the whole result set server-side, so `sortOrder` is part of the
+ * cache key rather than something applied to the page after it arrives.
  *
  * @param page      - 1-indexed page number.
  * @param pageSize  - Items per page.
@@ -133,17 +125,9 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
  * rewindable activity, falling through to any other cached pages of
  * the same family if not found.
  *
- * Selection happens by clicking a row, so a clicked item is guaranteed
- * to be in the page that's currently rendered. Two cases are not
- * clicks, and both rely on the cache scan below. A bookmarked
- * `?selected=` URL may name a row on a page nothing has loaded, and
- * this hook returns null so the right pane shows "Item not found" until
- * the reader paginates to it. And the first-load default selection is
- * pinned to the newest backup whatever the list is sorted by, so on an
- * ascending list it names a row that is genuinely off-screen — there the
- * scan finds it in the pinned page-1 entry `useDefaultBackupRewindId`
- * populated, and the pane is right even though no row is highlighted.
- * See that hook for why that trade is the intended one.
+ * A clicked row is always in the rendered page; the cache scan covers the two
+ * selections that are not clicks — a bookmarked `?selected=` on a page nothing
+ * has loaded, and the newest-backup default pinned by the hook below.
  *
  * @param id        - Selection id: `rewindId` for backup items, `activity_id` otherwise.
  * @param page      - The page currently shown in the list.
@@ -157,10 +141,8 @@ export function useActivityById(
 	pageSize: number,
 	sortOrder: ActivitySortOrder
 ): ActivityItem | null {
-	// Subscribe to the same page query the list uses so this hook
-	// re-renders the moment the list's data resolves. `sortOrder` is
-	// part of the cache key, so it has to follow the list's — pinning it
-	// would open a second query for rows already on screen.
+	// Follows the list's `sortOrder`: it is part of the cache key, so pinning it
+	// here would open a second query for rows already on screen.
 	const query = useActivityPageQuery( page, pageSize, sortOrder );
 	const queryClient = useQueryClient();
 
@@ -198,33 +180,10 @@ export function useActivityById(
  * default selection reconciles to the newest backup the moment the
  * page-1 fetch resolves.
  *
- * Always reads page 1 with the default per-page size and newest-first
- * ordering, regardless of what the list is currently showing. When the
- * list is also on page 1 with the default size and default order,
- * TanStack dedupes — no extra fetch.
- *
- * The ordering is pinned, not inherited, and that is the whole
- * correctness of this hook: "the first backup row" only means "the
- * newest backup" while the server is sorting newest-first. Following the
- * list into ascending order would silently preselect the *oldest*
- * restore point the reader has — a wrong default with no error to
- * notice, on the one control in this dashboard that starts a
- * destructive operation.
- *
- * The accepted consequence: on an ascending list, the row this returns
- * is usually not one of the rows on screen. The reader sees the ten
- * oldest events with nothing highlighted, while the right pane shows the
- * newest backup's detail card. `useActivityById` resolves it through its
- * cross-page cache scan, so the pane is populated and correct — it is
- * simply describing a row the list is not currently showing.
- *
- * That is deliberate, and the better of two bad options. Preselecting
- * whatever happens to be at the top of the visible page would put the
- * oldest restore point behind a Restore button by default, which is the
- * failure this pinning exists to prevent. Please do not "fix" the
- * missing highlight by making this follow the list; if the mismatch is
- * ever worth closing, close it by clearing the selection when it falls
- * off the visible page, never by changing what "default" means.
+ * Always page 1, newest-first, whatever the list is showing: inheriting an
+ * ascending sort would preselect the *oldest* restore point behind the Restore
+ * button. The cost is that an ascending list highlights no row, since the
+ * selection is off-screen; `useActivityById` still resolves it from the cache.
  *
  * @return The newest backup item's rewindId, or null.
  */
@@ -245,13 +204,9 @@ export function useDefaultBackupRewindId(): string | null {
  * Whether the newest page of rewindable activity holds any backup row,
  * and whether that is known yet.
  *
- * Shares the page-1 newest-first query with `useDefaultBackupRewindId`,
- * so it costs no extra request — and is pinned to that ordering for a
- * second reason of its own. This answer gates the first-run takeover
- * panel, so it must be asked of a fixed window: reading whichever page
- * the list happens to be showing would let paginating away from page 1
- * report "no restore points" and replace the dashboard with the
- * first-backup screen on a site full of backups.
+ * Shares the pinned page-1 query with `useDefaultBackupRewindId`, so it costs
+ * no extra request. Pinned because it gates the first-run takeover: read off
+ * the list's own page, paginating away would claim the site has no backups.
  *
  * This is a second, independent opinion on "does this site have a
  * restore point". `/jetpack/v4/backups` only reports VaultPress's most

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -133,11 +133,17 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
  * rewindable activity, falling through to any other cached pages of
  * the same family if not found.
  *
- * Selection happens by clicking a row, so the item is guaranteed to be
- * in the page that's currently rendered. When the user lands via a
- * bookmarked `?selected=` URL on a different page than the row, this
- * hook returns null and the right pane shows the "Item not found"
- * fallback until the user paginates to that page.
+ * Selection happens by clicking a row, so a clicked item is guaranteed
+ * to be in the page that's currently rendered. Two cases are not
+ * clicks, and both rely on the cache scan below. A bookmarked
+ * `?selected=` URL may name a row on a page nothing has loaded, and
+ * this hook returns null so the right pane shows "Item not found" until
+ * the reader paginates to it. And the first-load default selection is
+ * pinned to the newest backup whatever the list is sorted by, so on an
+ * ascending list it names a row that is genuinely off-screen — there the
+ * scan finds it in the pinned page-1 entry `useDefaultBackupRewindId`
+ * populated, and the pane is right even though no row is highlighted.
+ * See that hook for why that trade is the intended one.
  *
  * @param id        - Selection id: `rewindId` for backup items, `activity_id` otherwise.
  * @param page      - The page currently shown in the list.
@@ -204,6 +210,21 @@ export function useActivityById(
  * restore point the reader has — a wrong default with no error to
  * notice, on the one control in this dashboard that starts a
  * destructive operation.
+ *
+ * The accepted consequence: on an ascending list, the row this returns
+ * is usually not one of the rows on screen. The reader sees the ten
+ * oldest events with nothing highlighted, while the right pane shows the
+ * newest backup's detail card. `useActivityById` resolves it through its
+ * cross-page cache scan, so the pane is populated and correct — it is
+ * simply describing a row the list is not currently showing.
+ *
+ * That is deliberate, and the better of two bad options. Preselecting
+ * whatever happens to be at the top of the visible page would put the
+ * oldest restore point behind a Restore button by default, which is the
+ * failure this pinning exists to prevent. Please do not "fix" the
+ * missing highlight by making this follow the list; if the mismatch is
+ * ever worth closing, close it by clearing the selection when it falls
+ * off the visible page, never by changing what "default" means.
  *
  * @return The newest backup item's rewindId, or null.
  */

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -14,6 +14,7 @@ import QueryError from '../components/query-error';
 import StorageSpace from '../components/storage-space';
 import {
 	ACTIVITY_LOG_DEFAULT_PER_PAGE,
+	ACTIVITY_LOG_NEWEST_FIRST,
 	useActivityById,
 	useDefaultBackupRewindId,
 	useHasRestorePoints,
@@ -48,7 +49,7 @@ export const INITIAL_VIEW: View = {
 	// disables the whole items-per-page group until `view.sort.field` is
 	// set, freezing the list at ten rows for any reader who never opens
 	// Order (JETPACK-2298).
-	sort: { field: 'description', direction: 'desc' },
+	sort: { field: 'description', direction: ACTIVITY_LOG_NEWEST_FIRST },
 	titleField: 'title',
 	mediaField: 'icon',
 	descriptionField: 'description',

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -29,26 +29,16 @@ import type { View } from '@wordpress/dataviews';
 type OverviewSearch = Record< string, unknown > & { selected?: string };
 
 /**
- * The list's starting view state.
- *
- * Exported so the control-surface tests can pin what a reader sees on
- * first open — the seeded `sort` below is the whole of the fix for two
- * bugs, and both of them are only visible before anyone has clicked
- * anything.
+ * The list's starting view state, exported so tests can pin what a reader sees first.
  */
 export const INITIAL_VIEW: View = {
 	type: 'list',
 	page: 1,
 	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	filters: [],
-	// Seeded, not left undefined, and it has to name `description` — the
-	// only field this list makes sortable, and the timestamp WordPress.com
-	// actually orders on. Two things go wrong without it. The cog's "Sort
-	// by" is a native `<select>` with no value, so it displays its first
-	// option and claims an ordering the rows do not have; and DataViews
-	// disables the whole items-per-page group until `view.sort.field` is
-	// set, freezing the list at ten rows for any reader who never opens
-	// Order (JETPACK-2298).
+	// Seeding `sort` is the fix for JETPACK-2298: left undefined, the cog's "Sort
+	// by" select shows its first option whatever the real order, and DataViews
+	// disables items-per-page until `view.sort.field` is set.
 	sort: { field: 'description', direction: ACTIVITY_LOG_NEWEST_FIRST },
 	titleField: 'title',
 	mediaField: 'icon',
@@ -128,8 +118,8 @@ export default function OverviewScreen() {
 	// View state lives here so RightPane's `useActivityById` can
 	// subscribe to the same paginated query the list reads from.
 	const [ view, setView ] = useState< View >( INITIAL_VIEW );
-	// Derived by the same function `<ActivityList>` uses, so the right
-	// pane cannot ask for a different cache entry than the list filled.
+	// Same derivation `<ActivityList>` uses, so the right pane reads the cache
+	// entry the list filled rather than opening its own.
 	const { page, pageSize, sortOrder } = activityQueryArgs( view );
 	// Subscribe to page 1 of the activity log so the right pane
 	// reconciles to the newest backup the moment that page resolves.
@@ -323,8 +313,7 @@ function RightPane( {
 	pageSize: number;
 	sortOrder: ActivitySortOrder;
 } ) {
-	// All four must match what the list asked for: this is a read of the
-	// list's own cache entry, not a second request.
+	// All four must match the list's arguments — this reads its cache entry.
 	const item = useActivityById( selectedId, page, pageSize, sortOrder );
 	if ( ! selectedId ) {
 		return (

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Text } from '@wordpress/ui';
 import ActivityDetail from '../components/activity-detail';
-import ActivityList, { activitySortOrder } from '../components/activity-list';
+import ActivityList, { activityQueryArgs } from '../components/activity-list';
 import BackupDetail from '../components/backup-detail';
 import BackupNowButton from '../components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
@@ -127,8 +127,9 @@ export default function OverviewScreen() {
 	// View state lives here so RightPane's `useActivityById` can
 	// subscribe to the same paginated query the list reads from.
 	const [ view, setView ] = useState< View >( INITIAL_VIEW );
-	const page = view.page ?? 1;
-	const perPage = view.perPage ?? ACTIVITY_LOG_DEFAULT_PER_PAGE;
+	// Derived by the same function `<ActivityList>` uses, so the right
+	// pane cannot ask for a different cache entry than the list filled.
+	const { page, pageSize, sortOrder } = activityQueryArgs( view );
 	// Subscribe to page 1 of the activity log so the right pane
 	// reconciles to the newest backup the moment that page resolves.
 	// Until then, `defaultSelectedId` is null and the empty-state
@@ -287,8 +288,8 @@ export default function OverviewScreen() {
 				<RightPane
 					selectedId={ selectedId }
 					page={ page }
-					pageSize={ perPage }
-					sortOrder={ activitySortOrder( view ) }
+					pageSize={ pageSize }
+					sortOrder={ sortOrder }
 				/>
 			</div>
 		</DashboardLayout>

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Text } from '@wordpress/ui';
 import ActivityDetail from '../components/activity-detail';
-import ActivityList from '../components/activity-list';
+import ActivityList, { activitySortOrder } from '../components/activity-list';
 import BackupDetail from '../components/backup-detail';
 import BackupNowButton from '../components/backup-now-button';
 import BackupStatusPanel, { replacesOverview } from '../components/backup-status';
@@ -22,15 +22,33 @@ import { useAnalytics } from '../hooks/use-analytics';
 import { useBackups } from '../hooks/use-backups';
 import { useRefreshActivityOnBackupComplete } from '../hooks/use-refresh-activity-on-backup-complete';
 import { isBackupItem } from '../types/activity';
+import type { ActivitySortOrder } from '../data/api/activity-log';
 import type { View } from '@wordpress/dataviews';
 
 type OverviewSearch = Record< string, unknown > & { selected?: string };
 
-const INITIAL_VIEW: View = {
+/**
+ * The list's starting view state.
+ *
+ * Exported so the control-surface tests can pin what a reader sees on
+ * first open — the seeded `sort` below is the whole of the fix for two
+ * bugs, and both of them are only visible before anyone has clicked
+ * anything.
+ */
+export const INITIAL_VIEW: View = {
 	type: 'list',
 	page: 1,
 	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
 	filters: [],
+	// Seeded, not left undefined, and it has to name `description` — the
+	// only field this list makes sortable, and the timestamp WordPress.com
+	// actually orders on. Two things go wrong without it. The cog's "Sort
+	// by" is a native `<select>` with no value, so it displays its first
+	// option and claims an ordering the rows do not have; and DataViews
+	// disables the whole items-per-page group until `view.sort.field` is
+	// set, freezing the list at ten rows for any reader who never opens
+	// Order (JETPACK-2298).
+	sort: { field: 'description', direction: 'desc' },
 	titleField: 'title',
 	mediaField: 'icon',
 	descriptionField: 'description',
@@ -266,7 +284,12 @@ export default function OverviewScreen() {
 					view={ view }
 					onChangeView={ setView }
 				/>
-				<RightPane selectedId={ selectedId } page={ page } pageSize={ perPage } />
+				<RightPane
+					selectedId={ selectedId }
+					page={ page }
+					pageSize={ perPage }
+					sortOrder={ activitySortOrder( view ) }
+				/>
 			</div>
 		</DashboardLayout>
 	);
@@ -284,18 +307,23 @@ export default function OverviewScreen() {
  * @param props.selectedId - Currently selected row id, or null when nothing is selected.
  * @param props.page       - The page currently shown in the list.
  * @param props.pageSize   - The per-page setting currently shown in the list.
+ * @param props.sortOrder  - The sort direction currently shown in the list.
  * @return The rendered detail card or an empty-state placeholder.
  */
 function RightPane( {
 	selectedId,
 	page,
 	pageSize,
+	sortOrder,
 }: {
 	selectedId: string | null;
 	page: number;
 	pageSize: number;
+	sortOrder: ActivitySortOrder;
 } ) {
-	const item = useActivityById( selectedId, page, pageSize );
+	// All four must match what the list asked for: this is a read of the
+	// list's own cache entry, not a second request.
+	const item = useActivityById( selectedId, page, pageSize, sortOrder );
 	if ( ! selectedId ) {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -49,16 +49,24 @@ class Activity_Log_Bridge {
 				// with a useful message instead of a round-trip that WPCOM
 				// rejects.
 				'args'                => array(
-					'number' => array(
+					'number'     => array(
 						'description' => __( 'Number of items to return per page.', 'jetpack-backup-pkg' ),
 						'type'        => 'integer',
 						'minimum'     => 1,
 						'maximum'     => 1000,
 					),
-					'page'   => array(
+					'page'       => array(
 						'description' => __( '1-indexed page number.', 'jetpack-backup-pkg' ),
 						'type'        => 'integer',
 						'minimum'     => 1,
+					),
+					// Direction only. WPCOM's `get_stream_args()` sorts on
+					// `ts_utc` and takes no field, so there is no `orderby`
+					// to declare here and none to offer in the UI.
+					'sort_order' => array(
+						'description' => __( 'Sort direction.', 'jetpack-backup-pkg' ),
+						'type'        => 'string',
+						'enum'        => array( 'asc', 'desc' ),
 					),
 				),
 			)
@@ -74,6 +82,10 @@ class Activity_Log_Bridge {
 	 * pagination footer. Same param shape the `automattic/jetpack-activity-log`
 	 * package uses against the parent `/sites/{id}/activity` endpoint.
 	 *
+	 * `sort_order` is forwarded too, so the list's Order control reorders
+	 * the real result set rather than the ten rows already on screen.
+	 * Omitted when absent: WPCOM defaults it to `desc`.
+	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return \WP_REST_Response|WP_Error
 	 */
@@ -85,11 +97,12 @@ class Activity_Log_Bridge {
 
 		$query = array_filter(
 			array(
-				'number'  => $request->get_param( 'number' ),
-				'page'    => $request->get_param( 'page' ),
+				'number'     => $request->get_param( 'number' ),
+				'page'       => $request->get_param( 'page' ),
+				'sort_order' => $request->get_param( 'sort_order' ),
 				// Activity summaries are rendered by WPCOM. Without this they
 				// come back in English whatever the reader's language is.
-				'_locale' => get_user_locale(),
+				'_locale'    => get_user_locale(),
 			),
 			static function ( $value ) {
 				return null !== $value && '' !== $value;

--- a/projects/packages/backup/src/rest/class-activity-log-bridge.php
+++ b/projects/packages/backup/src/rest/class-activity-log-bridge.php
@@ -60,9 +60,8 @@ class Activity_Log_Bridge {
 						'type'        => 'integer',
 						'minimum'     => 1,
 					),
-					// Direction only. WPCOM's `get_stream_args()` sorts on
-					// `ts_utc` and takes no field, so there is no `orderby`
-					// to declare here and none to offer in the UI.
+					// Direction only: WPCOM's `get_stream_args()` sorts on `ts_utc`
+					// and takes no field, so there is no `orderby` to declare.
 					'sort_order' => array(
 						'description' => __( 'Sort direction.', 'jetpack-backup-pkg' ),
 						'type'        => 'string',

--- a/projects/packages/backup/tests/activity-list-controls.test.tsx
+++ b/projects/packages/backup/tests/activity-list-controls.test.tsx
@@ -1,22 +1,7 @@
-// JETPACK-2297 + JETPACK-2298 — the activity list's cog and funnel, as a
-// reader finds them on first open.
-//
-// Everything here is asserted *before* any interaction with the sort
-// controls, because that is where all three bugs lived:
-//
-//   - the funnel offered filters nothing could honour, and opening one
-//     dropped the whole dashboard to its error boundary;
-//   - "Sort by" displayed "Title" over date-ordered rows, because an
-//     unset `view.sort` leaves a native <select> showing its first
-//     option;
-//   - items-per-page was disabled until something set `view.sort.field`,
-//     so a reader who never opened Order was stuck at ten rows.
-//
-// The last one is the reason this file drives the real DataViews rather
-// than resting on `INITIAL_VIEW` alone: `disabled={ ! view.sort.field }`
-// is dataviews' own wiring, and only a render proves the seed reaches
-// it. The seed itself is still asserted directly where a rendered
-// control cannot distinguish it — see the first cog test.
+// JETPACK-2297 + JETPACK-2298 — the activity list's cog and funnel on first
+// open, before any interaction, which is where all three bugs lived. Drives the
+// real DataViews rather than `INITIAL_VIEW` alone because the items-per-page
+// gating is dataviews' own wiring, and only a render proves the seed reaches it.
 
 const mockApiFetch = jest.fn();
 
@@ -124,26 +109,21 @@ describe( 'the filter affordance', () => {
 		);
 		await waitFor( () => expect( requestedPaths().length ).toBeGreaterThan( 0 ) );
 
-		// `filterBy: false` on every field leaves DataViews no filters to
-		// offer, so `FiltersToggle` renders nothing — which is what puts the
-		// `ValidatedText` crash out of reach, and stops a filter click
-		// resetting a reader on page 3 back to page 1.
+		// `filterBy: false` on every field leaves DataViews nothing to offer, so
+		// `FiltersToggle` renders nothing and the `ValidatedText` crash is
+		// unreachable.
 		expect( screen.queryByRole( 'button', { name: /add filter/i } ) ).not.toBeInTheDocument();
 
-		// The witness. Without it this assertion would pass just as well
-		// against a list that failed to render any chrome at all — which is
-		// how a "renders nothing" test keeps passing for the wrong reason.
+		// Witness: without it the assertion above passes against a list that
+		// rendered no chrome at all.
 		expect( screen.getByRole( 'button', { name: 'View options' } ) ).toBeVisible();
 	} );
 } );
 
 describe( 'the cog, before anyone touches it', () => {
-	// Two assertions because the rendered control cannot stand in for the
-	// seed: with `enableSorting: false` on the title field, "When" is the
-	// only option left, and a valueless native <select> reports its first
-	// option — so `sortBy.value` reads `description` even with
-	// `INITIAL_VIEW.sort` deleted. The symptom and the seed need pinning
-	// separately.
+	// Two assertions: with only one sortable field left, a valueless <select>
+	// reports `description` anyway, so the rendered control cannot witness the
+	// seed and the two need pinning separately.
 	it( 'names the ordering the rows are actually in', async () => {
 		expect( INITIAL_VIEW.sort ).toEqual( {
 			field: 'description',
@@ -153,9 +133,7 @@ describe( 'the cog, before anyone touches it', () => {
 		await renderAndOpenViewOptions();
 
 		const sortBy = screen.getByLabelText( 'Sort by' ) as HTMLSelectElement;
-		// `description` is the "When" column — the event timestamp, which is
-		// what WordPress.com orders on. The bug was this reading "Title",
-		// which is fixed by `enableSorting: false` rather than by the seed.
+		// `description` is the "When" column. The bug was this reading "Title".
 		expect( sortBy.value ).toBe( 'description' );
 		expect( sortBy.selectedOptions[ 0 ] ).toHaveTextContent( 'When' );
 	} );
@@ -163,8 +141,8 @@ describe( 'the cog, before anyone touches it', () => {
 	it( 'does not offer a sort field the server cannot honour', async () => {
 		await renderAndOpenViewOptions();
 
-		// `/activity/rewindable` takes a direction and no field, so "When"
-		// is the only truthful option. Title is `enableSorting: false`.
+		// `/activity/rewindable` takes a direction and no field, so "When" is the
+		// only truthful option.
 		const options = Array.from(
 			( screen.getByLabelText( 'Sort by' ) as HTMLSelectElement ).options
 		).map( option => option.textContent );
@@ -172,10 +150,8 @@ describe( 'the cog, before anyone touches it', () => {
 	} );
 
 	it( 'lets a reader change the page size without touching Order first', async () => {
-		// JETPACK-2298. dataviews disables the whole items-per-page group
-		// while `view.sort.field` is unset; seeding `INITIAL_VIEW.sort` is
-		// what unblocks it. Asserted through the rendered control because
-		// that gating is dataviews' wiring, not ours.
+		// JETPACK-2298: dataviews disables items-per-page while `view.sort.field`
+		// is unset, so this has to go through the rendered control.
 		await renderAndOpenViewOptions();
 
 		const twenty = screen.getByRole( 'radio', { name: '20' } );
@@ -193,11 +169,7 @@ describe( 'the cog, before anyone touches it', () => {
 describe( 'the Order control', () => {
 	it( 'sends the reader back to page 1 when the order flips', async () => {
 		// DataViews will not do this itself: `SortDirectionControl` spreads
-		// `...view` and replaces only `sort`, where the `ItemsPerPageControl`
-		// next to it sets `page: 1`. Left alone, a reader on page 3 of a
-		// descending log flips to ascending and stays on page 3 — now
-		// items 21-30 counted from the oldest end, a destination that
-		// corresponds to nothing they asked for.
+		// `...view` and replaces only `sort`, stranding a reader on page 3.
 		await renderAndOpenViewOptions();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
@@ -235,9 +207,8 @@ describe( 'the Order control', () => {
 
 		await userEvent.click( screen.getByRole( 'radio', { name: /ascending/i } ) );
 
-		// The list holds one page of forty items, so flipping it locally
-		// would reorder ten rows and mislabel that a sort. A new request is
-		// the only correct answer.
+		// The list holds one page of forty items, so a local flip would reorder ten
+		// rows and call that a sort.
 		await waitFor( () =>
 			expect( requestedPaths().some( path => path.includes( 'sort_order=asc' ) ) ).toBe( true )
 		);

--- a/projects/packages/backup/tests/activity-list-controls.test.tsx
+++ b/projects/packages/backup/tests/activity-list-controls.test.tsx
@@ -13,9 +13,10 @@
 //     so a reader who never opened Order was stuck at ten rows.
 //
 // The last one is the reason this file drives the real DataViews rather
-// than asserting on `INITIAL_VIEW` directly: `disabled={ ! view.sort
-// .field }` is dataviews' own wiring, and only a render proves the seed
-// reaches it.
+// than resting on `INITIAL_VIEW` alone: `disabled={ ! view.sort.field }`
+// is dataviews' own wiring, and only a render proves the seed reaches
+// it. The seed itself is still asserted directly where a rendered
+// control cannot distinguish it — see the first cog test.
 
 const mockApiFetch = jest.fn();
 
@@ -30,6 +31,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import ActivityList from '../src/dashboard/components/activity-list';
+import { ACTIVITY_LOG_NEWEST_FIRST } from '../src/dashboard/hooks/use-activity-log';
 import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
 import type { View } from '@wordpress/dataviews';
 
@@ -136,12 +138,24 @@ describe( 'the filter affordance', () => {
 } );
 
 describe( 'the cog, before anyone touches it', () => {
+	// Two assertions because the rendered control cannot stand in for the
+	// seed: with `enableSorting: false` on the title field, "When" is the
+	// only option left, and a valueless native <select> reports its first
+	// option — so `sortBy.value` reads `description` even with
+	// `INITIAL_VIEW.sort` deleted. The symptom and the seed need pinning
+	// separately.
 	it( 'names the ordering the rows are actually in', async () => {
+		expect( INITIAL_VIEW.sort ).toEqual( {
+			field: 'description',
+			direction: ACTIVITY_LOG_NEWEST_FIRST,
+		} );
+
 		await renderAndOpenViewOptions();
 
 		const sortBy = screen.getByLabelText( 'Sort by' ) as HTMLSelectElement;
 		// `description` is the "When" column — the event timestamp, which is
-		// what WordPress.com orders on. The bug was this reading "Title".
+		// what WordPress.com orders on. The bug was this reading "Title",
+		// which is fixed by `enableSorting: false` rather than by the seed.
 		expect( sortBy.value ).toBe( 'description' );
 		expect( sortBy.selectedOptions[ 0 ] ).toHaveTextContent( 'When' );
 	} );

--- a/projects/packages/backup/tests/activity-list-controls.test.tsx
+++ b/projects/packages/backup/tests/activity-list-controls.test.tsx
@@ -177,6 +177,43 @@ describe( 'the cog, before anyone touches it', () => {
 } );
 
 describe( 'the Order control', () => {
+	it( 'sends the reader back to page 1 when the order flips', async () => {
+		// DataViews will not do this itself: `SortDirectionControl` spreads
+		// `...view` and replaces only `sort`, where the `ItemsPerPageControl`
+		// next to it sets `page: 1`. Left alone, a reader on page 3 of a
+		// descending log flips to ascending and stays on page 3 — now
+		// items 21-30 counted from the oldest end, a destination that
+		// corresponds to nothing they asked for.
+		await renderAndOpenViewOptions();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await waitFor( () =>
+			expect( requestedPaths().some( path => path.includes( 'page=2' ) ) ).toBe( true )
+		);
+
+		await userEvent.click( screen.getByRole( 'radio', { name: /ascending/i } ) );
+
+		await waitFor( () =>
+			expect( requestedPaths().some( path => path.includes( 'sort_order=asc' ) ) ).toBe( true )
+		);
+		const ascending = requestedPaths().filter( path => path.includes( 'sort_order=asc' ) );
+		expect( ascending ).toHaveLength( 1 );
+		expect( ascending[ 0 ] ).toContain( 'page=1' );
+		expect( ascending[ 0 ] ).not.toContain( 'page=2' );
+	} );
+
+	it( 'leaves the page alone when something other than the order changes', async () => {
+		// The reset is scoped to a reorder. Paging must not reset itself to
+		// page 1, which would make the Next button inert.
+		await renderAndOpenViewOptions();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+
+		await waitFor( () =>
+			expect( requestedPaths().some( path => path.includes( 'page=2' ) ) ).toBe( true )
+		);
+	} );
+
 	it( 'reorders the whole log server-side rather than the rows on screen', async () => {
 		await renderAndOpenViewOptions();
 

--- a/projects/packages/backup/tests/activity-list-controls.test.tsx
+++ b/projects/packages/backup/tests/activity-list-controls.test.tsx
@@ -1,0 +1,194 @@
+// JETPACK-2297 + JETPACK-2298 — the activity list's cog and funnel, as a
+// reader finds them on first open.
+//
+// Everything here is asserted *before* any interaction with the sort
+// controls, because that is where all three bugs lived:
+//
+//   - the funnel offered filters nothing could honour, and opening one
+//     dropped the whole dashboard to its error boundary;
+//   - "Sort by" displayed "Title" over date-ordered rows, because an
+//     unset `view.sort` leaves a native <select> showing its first
+//     option;
+//   - items-per-page was disabled until something set `view.sort.field`,
+//     so a reader who never opened Order was stuck at ten rows.
+//
+// The last one is the reason this file drives the real DataViews rather
+// than asserting on `INITIAL_VIEW` directly: `disabled={ ! view.sort
+// .field }` is dataviews' own wiring, and only a render proves the seed
+// reaches it.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
+import type { View } from '@wordpress/dataviews';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+/**
+ * One rewindable-activity page, newest first.
+ */
+const PAGE = {
+	current: {
+		orderedItems: [
+			{
+				activity_id: 'a1',
+				name: 'rewind__backup_complete_full',
+				gridicon: 'cloud',
+				rewind_id: '1786600000',
+				published: '2026-08-20T10:00:00+00:00',
+				summary: 'Backup complete',
+				is_rewindable: true,
+			},
+		],
+	},
+	totalItems: 40,
+	totalPages: 4,
+};
+
+/**
+ * Every rewindable-activity path requested so far.
+ *
+ * @return The requested paths.
+ */
+function requestedPaths(): string[] {
+	return mockApiFetch.mock.calls
+		.map( ( [ options ] ) => ( options as { path?: string } )?.path ?? '' )
+		.filter( path => path.includes( '/site/rewindable-activity' ) );
+}
+
+/**
+ * No-op selection handler. Hoisted so the harness does not hand
+ * `<ActivityList>` a fresh function on every render.
+ */
+function noop() {}
+
+/**
+ * Render the list with its real starting view, in controlled state so
+ * the cog's own controls drive it exactly as they do on the screen.
+ *
+ * @return The rendered list.
+ */
+function ListHarness() {
+	const [ view, setView ] = useState< View >( INITIAL_VIEW );
+	return (
+		<ActivityList selectedId={ null } onSelect={ noop } view={ view } onChangeView={ setView } />
+	);
+}
+
+/**
+ * Render the harness and open the cog.
+ */
+async function renderAndOpenViewOptions() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	render(
+		<QueryClientProvider client={ client }>
+			<ListHarness />
+		</QueryClientProvider>
+	);
+	await waitFor( () => expect( requestedPaths().length ).toBeGreaterThan( 0 ) );
+	await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( PAGE );
+	window.JP_CONNECTION_INITIAL_STATE = {
+		connectionStatus: CONNECTED,
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'the filter affordance', () => {
+	it( 'is not on screen at all', async () => {
+		const client = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+		render(
+			<QueryClientProvider client={ client }>
+				<ListHarness />
+			</QueryClientProvider>
+		);
+		await waitFor( () => expect( requestedPaths().length ).toBeGreaterThan( 0 ) );
+
+		// `filterBy: false` on every field leaves DataViews no filters to
+		// offer, so `FiltersToggle` renders nothing — which is what puts the
+		// `ValidatedText` crash out of reach, and stops a filter click
+		// resetting a reader on page 3 back to page 1.
+		expect( screen.queryByRole( 'button', { name: /add filter/i } ) ).not.toBeInTheDocument();
+
+		// The witness. Without it this assertion would pass just as well
+		// against a list that failed to render any chrome at all — which is
+		// how a "renders nothing" test keeps passing for the wrong reason.
+		expect( screen.getByRole( 'button', { name: 'View options' } ) ).toBeVisible();
+	} );
+} );
+
+describe( 'the cog, before anyone touches it', () => {
+	it( 'names the ordering the rows are actually in', async () => {
+		await renderAndOpenViewOptions();
+
+		const sortBy = screen.getByLabelText( 'Sort by' ) as HTMLSelectElement;
+		// `description` is the "When" column — the event timestamp, which is
+		// what WordPress.com orders on. The bug was this reading "Title".
+		expect( sortBy.value ).toBe( 'description' );
+		expect( sortBy.selectedOptions[ 0 ] ).toHaveTextContent( 'When' );
+	} );
+
+	it( 'does not offer a sort field the server cannot honour', async () => {
+		await renderAndOpenViewOptions();
+
+		// `/activity/rewindable` takes a direction and no field, so "When"
+		// is the only truthful option. Title is `enableSorting: false`.
+		const options = Array.from(
+			( screen.getByLabelText( 'Sort by' ) as HTMLSelectElement ).options
+		).map( option => option.textContent );
+		expect( options ).toEqual( [ 'When' ] );
+	} );
+
+	it( 'lets a reader change the page size without touching Order first', async () => {
+		// JETPACK-2298. dataviews disables the whole items-per-page group
+		// while `view.sort.field` is unset; seeding `INITIAL_VIEW.sort` is
+		// what unblocks it. Asserted through the rendered control because
+		// that gating is dataviews' wiring, not ours.
+		await renderAndOpenViewOptions();
+
+		const twenty = screen.getByRole( 'radio', { name: '20' } );
+		expect( twenty ).toBeEnabled();
+		expect( twenty ).not.toHaveAttribute( 'aria-disabled', 'true' );
+
+		await userEvent.click( twenty );
+
+		await waitFor( () =>
+			expect( requestedPaths().some( path => path.includes( 'number=20' ) ) ).toBe( true )
+		);
+	} );
+} );
+
+describe( 'the Order control', () => {
+	it( 'reorders the whole log server-side rather than the rows on screen', async () => {
+		await renderAndOpenViewOptions();
+
+		expect( requestedPaths()[ 0 ] ).toContain( 'sort_order=desc' );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: /ascending/i } ) );
+
+		// The list holds one page of forty items, so flipping it locally
+		// would reorder ten rows and mislabel that a sort. A new request is
+		// the only correct answer.
+		await waitFor( () =>
+			expect( requestedPaths().some( path => path.includes( 'sort_order=asc' ) ) ).toBe( true )
+		);
+	} );
+} );

--- a/projects/packages/backup/tests/error-persists-during-retry.test.tsx
+++ b/projects/packages/backup/tests/error-persists-during-retry.test.tsx
@@ -37,26 +37,15 @@ import { useState } from '@wordpress/element';
 import ActivityList from '../src/dashboard/components/activity-list';
 import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
 import { queryClient } from '../src/dashboard/data/query-client';
-import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';
 import { useBackups } from '../src/dashboard/hooks/use-backups';
 import { useStickyError } from '../src/dashboard/hooks/use-sticky-error';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
 import type { View } from '@wordpress/dataviews';
 
 const noop = () => {};
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
-
-const INITIAL_VIEW: View = {
-	type: 'list',
-	page: 1,
-	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
-	filters: [],
-	titleField: 'title',
-	mediaField: 'icon',
-	descriptionField: 'description',
-	fields: [],
-};
 
 /**
  * One raw rewindable-activity row, so a successful retry has something

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -165,10 +165,8 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	/**
 	 * The sort direction reaches WordPress.com.
 	 *
-	 * Ordering is a server concern: the dashboard holds one page of a
-	 * paginated log, so a direction that stopped at the bridge would leave
-	 * the reader's Order control reversing ten rows and calling that a
-	 * sort. Asserted on the outgoing URL for that reason.
+	 * Asserted on the outgoing URL: the dashboard holds one page of a paginated
+	 * log, so a direction that stopped at the bridge would only sort ten rows.
 	 */
 	public function test_forwards_the_sort_direction() {
 		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
@@ -185,9 +183,8 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	/**
 	 * Absent means absent, not empty.
 	 *
-	 * `array_filter` drops the key entirely when nothing asked for a
-	 * direction, so WordPress.com applies its own `desc` default. Sending
-	 * `sort_order=` instead would fail the route's own `enum`.
+	 * `array_filter` drops the key so WordPress.com applies its own `desc`
+	 * default; sending `sort_order=` would fail the route's `enum`.
 	 */
 	public function test_omits_the_sort_direction_when_none_is_given() {
 		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
@@ -201,12 +198,9 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A direction outside the enum is refused here rather than by
-	 * WordPress.com, so the reason names the parameter.
+	 * A direction outside the enum is refused here, not by WordPress.com.
 	 *
-	 * Dispatched through the REST server on purpose: `args` validation is
-	 * the server's job, and calling the callback directly would skip the
-	 * very thing under test.
+	 * Dispatched through the REST server because `args` validation is its job.
 	 */
 	public function test_rejects_a_direction_outside_the_enum() {
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );

--- a/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Activity_Log_Bridge_Test.php
@@ -163,6 +163,61 @@ class Rest_Activity_Log_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * The sort direction reaches WordPress.com.
+	 *
+	 * Ordering is a server concern: the dashboard holds one page of a
+	 * paginated log, so a direction that stopped at the bridge would leave
+	 * the reader's Order control reversing ten rows and calling that a
+	 * sort. Asserted on the outgoing URL for that reason.
+	 */
+	public function test_forwards_the_sort_direction() {
+		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'number', 10 );
+		$request->set_param( 'sort_order', 'asc' );
+		Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertStringContainsString( 'sort_order=asc', $this->captured_url );
+	}
+
+	/**
+	 * Absent means absent, not empty.
+	 *
+	 * `array_filter` drops the key entirely when nothing asked for a
+	 * direction, so WordPress.com applies its own `desc` default. Sending
+	 * `sort_order=` instead would fail the route's own `enum`.
+	 */
+	public function test_omits_the_sort_direction_when_none_is_given() {
+		$this->arrange_wpcom( array( 'current' => array( 'orderedItems' => array() ) ) );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$request->set_param( 'page', 1 );
+		$request->set_param( 'number', 10 );
+		Activity_Log_Bridge::get_activity_log( $request );
+
+		$this->assertStringNotContainsString( 'sort_order', $this->captured_url );
+	}
+
+	/**
+	 * A direction outside the enum is refused here rather than by
+	 * WordPress.com, so the reason names the parameter.
+	 *
+	 * Dispatched through the REST server on purpose: `args` validation is
+	 * the server's job, and calling the callback directly would skip the
+	 * very thing under test.
+	 */
+	public function test_rejects_a_direction_outside_the_enum() {
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/site/rewindable-activity' );
+		$request->set_param( 'sort_order', 'sideways' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+
+	/**
 	 * A success code reported as a string is a success.
 	 *
 	 * `wp_remote_retrieve_response_code()` hands back whatever the

--- a/projects/packages/backup/tests/stale-rows-feedback.test.tsx
+++ b/projects/packages/backup/tests/stale-rows-feedback.test.tsx
@@ -35,24 +35,13 @@ import userEvent from '@testing-library/user-event';
 import { useCallback, useState } from '@wordpress/element';
 import ActivityList from '../src/dashboard/components/activity-list';
 import { queryClient } from '../src/dashboard/data/query-client';
-import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
 import type { View } from '@wordpress/dataviews';
 
 const noop = () => {};
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
-
-const INITIAL_VIEW: View = {
-	type: 'list',
-	page: 1,
-	perPage: ACTIVITY_LOG_DEFAULT_PER_PAGE,
-	filters: [],
-	titleField: 'title',
-	mediaField: 'icon',
-	descriptionField: 'description',
-	fields: [],
-};
 
 /**
  * One raw rewindable-activity row for the page under test.


### PR DESCRIPTION
Fixes JETPACK-2297
Fixes JETPACK-2298

## Proposed changes

The modernized Backup Overview's activity list rendered a sort field selector, a direction toggle and a filter funnel. None of them acted on the data: DataViews was handed a server-paginated page verbatim, the query read only page and size, and the bridge forwarded only `number`, `page` and `_locale`.

**Sorting is now real — in the only shape upstream supports.** WordPress.com's `/activity/rewindable` accepts `sort_order` (`asc|desc`) and **no `sort_field`/`orderby`**: it sorts on the event timestamp and takes no field to sort by. So the direction is made to work end to end and the *field* selector is disabled rather than made functional — "Sort by: Title" is something the server can never honour, and a label that lies is worse than one option.

* `class-activity-log-bridge.php` declares `sort_order` with `enum: asc|desc` and forwards it, mirroring the sibling `packages/activity-log/src/class-rest-controller.php:88`. Absent stays absent, so WordPress.com applies its own `desc` default.
* The direction travels through `fetchActivityLog` → the `activityLogPage` cache key → `useActivityPageQuery`. It is a query parameter, not a client-side sort: the list only ever holds one page of a multi-page log, so flipping it locally would reverse ten rows and call that a sort.
* `enableSorting: false` on `title`, leaving "When" as the only offered field — the one the server actually orders on.
* Flipping the direction resets `page` to 1. DataViews will not do this itself: `SortDirectionControl` spreads `...view` and replaces only `sort`, where the `ItemsPerPageControl` beside it sets `page: 1`. Without it, a reader on page 3 of a descending log flips to ascending and stays on page 3 — items 21-30 counted from the oldest end, a destination corresponding to nothing they asked for.
* `enableGlobalSearch` is dropped from both text fields. Only `filterSortAndPaginate` reads it and this package never calls it, and `search={ false }` removes the box — dead config, on the PR auditing which field flags are honest.

**Filters are removed outright**, with `filterBy: false` on all three fields. Nothing here could honour a filter, and the funnel was not merely inert:

* Opening a filter reaches a private `@wordpress/components` API that recent versions no longer lock (`ValidatedInputControl` was graduated to a public export and dropped from the private lock), which drops the whole dashboard to its error boundary. `filterBy: false` makes `filters.length === 0`, so DataViews' `FiltersToggle` returns null and the crash becomes unreachable.
* Adding a filter also sets `page: 1`, silently yanking a reader off page 3.

**Seeding `INITIAL_VIEW.sort` fixes two things at once**, and this is the JETPACK-2298 half:

* The cog's "Sort by" is a native `<select>`. With no `view.sort` it displayed its first option, so the panel read **"Sort by: Title" over date-ordered rows before anyone clicked anything**.
* DataViews passes `disabled={ ! view?.sort?.field }` to the items-per-page group, so **page size was frozen at 10** until a reader happened to touch Order — and touching Order was exactly what planted the false "Title" label.

### The four-consumer trap

`useActivityPageQuery` has four consumers, and they must not all follow the list:

* `useActivityById` **follows** the list's direction, so it keeps sharing the list's cache entry rather than opening a second query for rows already on screen.
* `useDefaultBackupRewindId` and `useHasRestorePoints` stay **pinned to `desc`**. Both read the first backup row of page 1, and that only means "the newest backup" while the server sorts descending. Following the list would silently preselect the *oldest* restore point — on the one control in this dashboard that starts a destructive operation — and let paginating away raise the first-run takeover panel on a site full of backups. Nothing in the running dashboard would report either. Tests pin the inversion directly.

### The accepted consequence of that pinning

On an **ascending** list the default selection is not one of the visible rows: the reader sees the ten oldest events with nothing highlighted, while the right pane shows the newest backup's detail card — resolved through `useActivityById`'s cross-page cache scan, so the pane is populated and correct, just describing a row the list is not currently showing.

That is deliberate, and the better of two bad options: preselecting whatever sits at the top of the visible page puts the *oldest* restore point behind a Restore button by default. Because this is a new consequence on a screen whose primary action destroys data, it is pinned by two tests and explained in both hook docblocks — including how to close the gap correctly if it is ever worth closing (clear the selection when it falls off the page; never change what "default" means).

### A correction to JETPACK-2298

That issue concluded the `disabled` prop DataViews passes is inert, based on a jsdom render probe. **It is not.** Driving the real DataViews in jsdom reproduces the live symptom exactly — with no `view.sort`, the items-per-page group renders `aria-disabled="true"` with all four options `disabled`; with `sort.field` seeded, all four are enabled. The new `lets a reader change the page size without touching Order first` test asserts this through the rendered control for that reason.

## Related product discussion/links

* JETPACK-2297, JETPACK-2298 (both closed by this PR — they are one bug chain, and splitting them would mean two PRs touching the same six files).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Everything here is behind `rsm_jetpack_ui_modernization_backup`, which defaults to off. Turn it on:

```php
add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
```

Then go to **Jetpack → Backup** on a site with a Backup plan and some restore points.

**The cog, before touching anything** (this is where three of the bugs lived):

1. Open the cog ("View options") on the activity list.
2. "Sort by" reads **"When"**, not "Title" — and "Title" is not among the options. On trunk it reads "Title" over date-ordered rows.
3. **Items per page** is enabled, not greyed out. Click **20** — the list grows to 20 rows. On trunk the whole group is disabled until you touch Order first.

**Sorting:**

4. Set **Order → ascending**. The list reloads with the site's *oldest* activity first, and the pagination footer still reports the full total. Watch the network tab: a new `/jetpack/v4/site/rewindable-activity?…&sort_order=asc` request goes out — the rows are reordered by the server, not shuffled in the browser.
5. Page to 2 and 3 while ascending; the ordering holds across pages.
5b. Go to page 3, then flip Order back to descending — you land on **page 1**, not page 3 of the reversed log.
6. **The important one:** while the list is ascending, confirm the right-hand pane still preselects the **newest** backup on a fresh load (clear `?selected=` from the URL and reload). It must not select the oldest. Expect no row to be highlighted in the list — that is the intended trade described above, not a bug.
7. Paginate away from page 1 while ascending. The first-run "your first backup is on its way" panel must **not** appear.

**Filters:**

8. There is no funnel / "Add filter" button anywhere on the list. On trunk it is there, and on a site with a recent Gutenberg plugin active, clicking a filter drops the entire dashboard to "Something went wrong … Element type is invalid … `ValidatedText`".

**Automated:**

```bash
jp test js packages/backup
jp test php packages/backup
jp phan packages/backup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019b14VRc5hgUfdDFuvwp5Dw
