### PR TITLE
Forms: stop the form block from dirtying posts and templates on load

### DIFF
--- a/projects/packages/forms/changelog/forms-block-dirties-templates
+++ b/projects/packages/forms/changelog/forms-block-dirties-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the form block from marking a post, template, or template part as having unsaved changes the moment it loads.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -69,7 +69,9 @@ import { useCreateSyncedFormOnInsertion } from './hooks/use-create-synced-form-o
 import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
+import useDeprecatedThankYouMigration from './shared/hooks/use-deprecated-thank-you-migration.js';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults.js';
+import useSingleInputFieldRequired from './shared/hooks/use-single-input-field-required.js';
 import { getAutoRecipient } from './util/auto-recipient.ts';
 import { getEditorContext } from './util/get-editor-context.ts';
 import { isCollectingResponses } from './util/is-collecting-responses.ts';
@@ -146,23 +148,6 @@ const PRIORITIZED_INSERTER_BLOCKS = ( () => {
 	];
 } )();
 
-// Determine if a block has a required attribute. Exclude hidden fields.
-const isInputWithRequiredField = ( fullName?: string ): boolean => {
-	if ( ! fullName || ! fullName.startsWith( 'jetpack/' ) ) return false;
-	const baseName = fullName.slice( 'jetpack/'.length );
-	const field = childBlocks.find( block => block.name === baseName );
-	// @ts-expect-error: childBlocks are defined in JS without explicit types.
-	// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
-	const hasRequired = field && field?.settings?.attributes?.required !== undefined;
-	const isHidden = field?.name === 'field-hidden';
-	const isImplicitConsent =
-		field?.name === 'field-consent' &&
-		// @ts-expect-error: childBlocks are defined in JS without explicit types.
-		// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
-		field?.settings?.attributes?.consentType !== 'explicit';
-	return hasRequired && ! isHidden && ! isImplicitConsent;
-};
-
 type CustomThankyouType =
 	| '' // default message
 	| 'noSummary' // default message without a summary
@@ -228,7 +213,6 @@ function JetpackContactFormEdit( {
 		ref,
 		to,
 		subject,
-		customThankyou,
 		customThankyouHeading,
 		customThankyouMessage,
 		customThankyouRedirect,
@@ -266,34 +250,7 @@ function JetpackContactFormEdit( {
 	// Backward compatibility for the deprecated customThankyou attribute.
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
 	// and not a disableSummary attribute, so we need to set it here.
-	useEffect( () => {
-		const migrated: Partial< JetpackContactFormAttributes > = {};
-
-		// Migrate redirect setting from deprecated customThankyou attribute
-		if ( customThankyou === 'redirect' && confirmationType !== 'redirect' ) {
-			migrated.confirmationType = 'redirect';
-		}
-
-		// Migrate disableSummary from deprecated customThankyou attribute
-		if ( [ 'noSummary', 'message' ].includes( customThankyou ) && ! disableSummary ) {
-			migrated.disableSummary = true;
-		}
-
-		if ( ! Object.keys( migrated ).length ) {
-			return;
-		}
-
-		// Migrating an old attribute is not a user edit, so it must not mark the
-		// post, template, or template part holding the form as having changes.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( migrated );
-	}, [
-		confirmationType,
-		customThankyou,
-		disableSummary,
-		setAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
-	] );
+	useDeprecatedThankYouMigration( { attributes, setAttributes } );
 
 	const steps = useFormSteps( clientId );
 
@@ -504,26 +461,6 @@ function JetpackContactFormEdit( {
 	// Track previous block count to detect insertions
 	const previousBlockCountRef = useRef( currentInnerBlocks.length );
 
-	// Helper function to identify input field blocks
-	const getInputFieldBlocks = useCallback( blocks => {
-		const inputFields = [];
-
-		const findInputFields = blockList => {
-			blockList.forEach( block => {
-				if ( isInputWithRequiredField( block.name ) ) {
-					inputFields.push( block );
-				}
-				// Recursively check inner blocks (for multistep forms)
-				if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
-					findInputFields( block.innerBlocks );
-				}
-			} );
-		};
-
-		findInputFields( blocks );
-		return inputFields;
-	}, [] );
-
 	// Effect to handle block insertion and reordering
 	useEffect( () => {
 		const currentBlockCount = currentInnerBlocks.length;
@@ -564,31 +501,8 @@ function JetpackContactFormEdit( {
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
 
-	// Effect to automatically make single input fields required
-	useEffect( () => {
-		const inputFields = getInputFieldBlocks( currentInnerBlocks );
-
-		// Only proceed if there's exactly one input field
-		if ( inputFields.length === 1 ) {
-			const singleField = inputFields[ 0 ];
-
-			// Check if the field is not already required
-			if ( ! singleField.attributes?.required ) {
-				/*
-				 * Nobody asked for this, so it must not count as an edit. Otherwise a
-				 * one-field form -- a footer newsletter signup, say -- opens its post,
-				 * template, or template part with unsaved changes on every load.
-				 */
-				__unstableMarkNextChangeAsNotPersistent();
-				updateBlockAttributes( singleField.clientId, { required: true } );
-			}
-		}
-	}, [
-		currentInnerBlocks,
-		getInputFieldBlocks,
-		updateBlockAttributes,
-		__unstableMarkNextChangeAsNotPersistent,
-	] );
+	// A form with a single field has nothing to submit unless that field is filled in.
+	useSingleInputFieldRequired( { innerBlocks: currentInnerBlocks } );
 
 	// Helper function to get all field blocks (blocks with width attribute)
 	const getFieldBlocks = useCallback( ( blocks: typeof currentInnerBlocks ) => {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -260,20 +260,40 @@ function JetpackContactFormEdit( {
 		errorType: syncedFormErrorType,
 	} = useSyncedForm( ref );
 
+	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
+		useDispatch( blockEditorStore );
+
 	// Backward compatibility for the deprecated customThankyou attribute.
 	// Older forms will have a customThankyou attribute set, but not a confirmationType attribute
 	// and not a disableSummary attribute, so we need to set it here.
 	useEffect( () => {
+		const migrated: Partial< JetpackContactFormAttributes > = {};
+
 		// Migrate redirect setting from deprecated customThankyou attribute
 		if ( customThankyou === 'redirect' && confirmationType !== 'redirect' ) {
-			setAttributes( { confirmationType: 'redirect' } );
+			migrated.confirmationType = 'redirect';
 		}
 
 		// Migrate disableSummary from deprecated customThankyou attribute
 		if ( [ 'noSummary', 'message' ].includes( customThankyou ) && ! disableSummary ) {
-			setAttributes( { disableSummary: true } );
+			migrated.disableSummary = true;
 		}
-	}, [ confirmationType, customThankyou, disableSummary, setAttributes ] );
+
+		if ( ! Object.keys( migrated ).length ) {
+			return;
+		}
+
+		// Migrating an old attribute is not a user edit, so it must not mark the
+		// post, template, or template part holding the form as having changes.
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( migrated );
+	}, [
+		confirmationType,
+		customThankyou,
+		disableSummary,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	const steps = useFormSteps( clientId );
 
@@ -437,9 +457,6 @@ function JetpackContactFormEdit( {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'contact-form' );
 
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
-
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { setActiveStep } = useDispatch( singleStepStore );
 
@@ -557,11 +574,21 @@ function JetpackContactFormEdit( {
 
 			// Check if the field is not already required
 			if ( ! singleField.attributes?.required ) {
-				// Update the field to be required
+				/*
+				 * Nobody asked for this, so it must not count as an edit. Otherwise a
+				 * one-field form -- a footer newsletter signup, say -- opens its post,
+				 * template, or template part with unsaved changes on every load.
+				 */
+				__unstableMarkNextChangeAsNotPersistent();
 				updateBlockAttributes( singleField.clientId, { required: true } );
 			}
 		}
-	}, [ currentInnerBlocks, getInputFieldBlocks, updateBlockAttributes ] );
+	}, [
+		currentInnerBlocks,
+		getInputFieldBlocks,
+		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	// Helper function to get all field blocks (blocks with width attribute)
 	const getFieldBlocks = useCallback( ( blocks: typeof currentInnerBlocks ) => {

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-deprecated-thank-you-migration.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-deprecated-thank-you-migration.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+const markNextChangeAsNotPersistent = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		__unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent,
+	} ),
+} ) );
+
+const { default: useDeprecatedThankYouMigration } = await import(
+	'../use-deprecated-thank-you-migration.js'
+);
+
+describe( 'useDeprecatedThankYouMigration', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'derives confirmationType from a redirect customThankyou', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useDeprecatedThankYouMigration( {
+				attributes: { customThankyou: 'redirect' },
+				setAttributes,
+			} )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( { confirmationType: 'redirect' } );
+	} );
+
+	it.each( [ 'noSummary', 'message' ] )(
+		'derives disableSummary from a %s customThankyou',
+		customThankyou => {
+			const setAttributes = jest.fn();
+
+			renderHook( () =>
+				useDeprecatedThankYouMigration( { attributes: { customThankyou }, setAttributes } )
+			);
+
+			expect( setAttributes ).toHaveBeenCalledWith( { disableSummary: true } );
+		}
+	);
+
+	it( 'marks the migration as not persistent so the entity stays clean', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useDeprecatedThankYouMigration( {
+				attributes: { customThankyou: 'redirect' },
+				setAttributes,
+			} )
+		);
+
+		expect( markNextChangeAsNotPersistent ).toHaveBeenCalledTimes( 1 );
+		expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			setAttributes.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'writes nothing when the newer attributes already say the same thing', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useDeprecatedThankYouMigration( {
+				attributes: {
+					customThankyou: 'redirect',
+					confirmationType: 'redirect',
+					disableSummary: false,
+				},
+				setAttributes,
+			} )
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( markNextChangeAsNotPersistent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes nothing for a form that never used customThankyou', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useDeprecatedThankYouMigration( { attributes: { customThankyou: '' }, setAttributes } )
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'tolerates missing attributes', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () => useDeprecatedThankYouMigration( { attributes: undefined, setAttributes } ) );
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-form-block-defaults.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-form-block-defaults.test.js
@@ -1,0 +1,141 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+const INTEGRATIONS_STORE = 'jetpack/forms-integrations';
+
+let integrations = [];
+let isLoading = false;
+
+const markNextChangeAsNotPersistent = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		__unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent,
+	} ),
+	useSelect: mapSelect =>
+		mapSelect( () => ( {
+			getIntegrations: () => integrations,
+			isIntegrationsLoading: () => isLoading,
+		} ) ),
+} ) );
+
+await jest.unstable_mockModule( '../../../../../store/integrations/index.ts', () => ( {
+	INTEGRATIONS_STORE,
+} ) );
+
+const { default: useFormBlockDefaults } = await import( '../use-form-block-defaults.js' );
+
+const allIntegrations = ( { crm = false, mailpoet = false, salesforce = false } = {} ) => [
+	{ id: 'zero-bs-crm', enabledByDefault: crm },
+	{ id: 'mailpoet', enabledByDefault: mailpoet },
+	{ id: 'salesforce', enabledByDefault: salesforce },
+];
+
+// The attribute shape a form carries when it comes from theme markup, a pattern,
+// or any post saved before the integration flags existed: the object attributes
+// have their schema defaults, and none of the three flags are present.
+const unconfiguredAttributes = () => ( {
+	mailpoet: { listId: null, listName: null },
+	salesforceData: { organizationId: '' },
+} );
+
+describe( 'useFormBlockDefaults', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		integrations = allIntegrations();
+		isLoading = false;
+	} );
+
+	it( 'seeds every missing flag in a single setAttributes call', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useFormBlockDefaults( { attributes: unconfiguredAttributes(), setAttributes } )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			jetpackCRM: false,
+			mailpoet: { listId: null, listName: null, enabledForForm: false },
+			salesforceData: { organizationId: '', sendToSalesforce: false },
+		} );
+	} );
+
+	it( 'marks the seeding as not persistent so the entity stays clean', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useFormBlockDefaults( { attributes: unconfiguredAttributes(), setAttributes } )
+		);
+
+		// A single non-persistent mark has to precede the single update, otherwise
+		// the write lands as a content edit and the post, template, or template
+		// part holding the form opens with unsaved changes nobody made.
+		expect( markNextChangeAsNotPersistent ).toHaveBeenCalledTimes( 1 );
+		expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			setAttributes.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'carries the enabledByDefault value through', () => {
+		const setAttributes = jest.fn();
+		integrations = allIntegrations( { crm: true, mailpoet: true, salesforce: true } );
+
+		renderHook( () =>
+			useFormBlockDefaults( { attributes: unconfiguredAttributes(), setAttributes } )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			jetpackCRM: true,
+			mailpoet: { listId: null, listName: null, enabledForForm: true },
+			salesforceData: { organizationId: '', sendToSalesforce: true },
+		} );
+	} );
+
+	it( 'writes nothing when every flag is already set', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useFormBlockDefaults( {
+				attributes: {
+					jetpackCRM: true,
+					mailpoet: { listId: null, listName: null, enabledForForm: true },
+					salesforceData: { organizationId: '', sendToSalesforce: false },
+				},
+				setAttributes,
+			} )
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( markNextChangeAsNotPersistent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes nothing while the integrations store is still loading', () => {
+		const setAttributes = jest.fn();
+		isLoading = true;
+
+		renderHook( () =>
+			useFormBlockDefaults( { attributes: unconfiguredAttributes(), setAttributes } )
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( markNextChangeAsNotPersistent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'skips integrations the site does not offer', () => {
+		const setAttributes = jest.fn();
+		integrations = [ { id: 'mailpoet', enabledByDefault: false } ];
+
+		renderHook( () =>
+			useFormBlockDefaults( { attributes: unconfiguredAttributes(), setAttributes } )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			mailpoet: { listId: null, listName: null, enabledForForm: false },
+		} );
+	} );
+} );

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-single-input-field-required.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/test/use-single-input-field-required.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+const updateBlockAttributes = jest.fn();
+const markNextChangeAsNotPersistent = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		updateBlockAttributes,
+		__unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent,
+	} ),
+} ) );
+
+// Standing in for the real predicate keeps this test about the hook's decision,
+// not about which blocks child-blocks.js happens to register.
+await jest.unstable_mockModule( '../../../util/get-input-fields.ts', () => ( {
+	getInputFields: blocks =>
+		( blocks || [] ).flatMap( block =>
+			block.name === 'jetpack/field-email' || block.name === 'jetpack/field-name' ? [ block ] : []
+		),
+} ) );
+
+const { default: useSingleInputFieldRequired } = await import(
+	'../use-single-input-field-required.js'
+);
+
+const field = ( name, clientId, attributes = {} ) => ( { name, clientId, attributes } );
+
+describe( 'useSingleInputFieldRequired', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'makes a lone optional field required', () => {
+		renderHook( () =>
+			useSingleInputFieldRequired( {
+				innerBlocks: [ field( 'jetpack/field-email', 'email-1' ), field( 'core/button', 'btn' ) ],
+			} )
+		);
+
+		expect( updateBlockAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( updateBlockAttributes ).toHaveBeenCalledWith( 'email-1', { required: true } );
+	} );
+
+	it( 'marks the change as not persistent so the entity stays clean', () => {
+		renderHook( () =>
+			useSingleInputFieldRequired( {
+				innerBlocks: [ field( 'jetpack/field-email', 'email-1' ) ],
+			} )
+		);
+
+		// The mark has to land before the write, or a one-field form opens its
+		// post, template, or template part with unsaved changes nobody made.
+		expect( markNextChangeAsNotPersistent ).toHaveBeenCalledTimes( 1 );
+		expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			updateBlockAttributes.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'leaves a lone field alone when it is already required', () => {
+		renderHook( () =>
+			useSingleInputFieldRequired( {
+				innerBlocks: [ field( 'jetpack/field-email', 'email-1', { required: true } ) ],
+			} )
+		);
+
+		expect( updateBlockAttributes ).not.toHaveBeenCalled();
+		expect( markNextChangeAsNotPersistent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing once a form has more than one field', () => {
+		renderHook( () =>
+			useSingleInputFieldRequired( {
+				innerBlocks: [
+					field( 'jetpack/field-name', 'name-1' ),
+					field( 'jetpack/field-email', 'email-1' ),
+				],
+			} )
+		);
+
+		expect( updateBlockAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing for a form with no fields', () => {
+		renderHook( () => useSingleInputFieldRequired( { innerBlocks: [] } ) );
+
+		expect( updateBlockAttributes ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-deprecated-thank-you-migration.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-deprecated-thank-you-migration.js
@@ -1,0 +1,45 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Carry the deprecated customThankyou attribute over to its replacements.
+ *
+ * Forms saved before `confirmationType` and `disableSummary` existed only carry
+ * `customThankyou`, so the two newer attributes have to be derived from it.
+ *
+ * @param {object}   params               - Hook parameters.
+ * @param {object}   params.attributes    - Block attributes.
+ * @param {Function} params.setAttributes - Setter for block attributes.
+ */
+export default function useDeprecatedThankYouMigration( { attributes, setAttributes } ) {
+	const { customThankyou, confirmationType, disableSummary } = attributes || {};
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		const migrated = {};
+
+		if ( customThankyou === 'redirect' && confirmationType !== 'redirect' ) {
+			migrated.confirmationType = 'redirect';
+		}
+
+		if ( [ 'noSummary', 'message' ].includes( customThankyou ) && ! disableSummary ) {
+			migrated.disableSummary = true;
+		}
+
+		if ( ! Object.keys( migrated ).length ) {
+			return;
+		}
+
+		// Migrating an old attribute is not a user edit, so it must not mark the
+		// post, template, or template part holding the form as having changes.
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( migrated );
+	}, [
+		confirmationType,
+		customThankyou,
+		disableSummary,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
+}

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
@@ -1,4 +1,5 @@
-import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { INTEGRATIONS_STORE } from '../../../../store/integrations/index.ts';
 
@@ -18,6 +19,7 @@ export default function useFormBlockDefaults( { attributes, setAttributes } ) {
 		return store.getIntegrations() || [];
 	}, [] );
 	const isLoading = useSelect( select => select( INTEGRATIONS_STORE ).isIntegrationsLoading(), [] );
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		if ( isLoading || ! Array.isArray( integrations ) ) {
@@ -30,33 +32,51 @@ export default function useFormBlockDefaults( { attributes, setAttributes } ) {
 		const mailpoet = find( 'mailpoet' );
 		const salesforce = find( 'salesforce' );
 
-		if ( typeof attributes?.jetpackCRM === 'undefined' && crm ) {
-			setAttributes( { jetpackCRM: !! crm.enabledByDefault } );
+		/*
+		 * Collect every missing flag into a single update. One update means one
+		 * block-editor action, which is what lets the
+		 * __unstableMarkNextChangeAsNotPersistent() call below cover all of them.
+		 */
+		const defaults = {};
+
+		if ( crm && typeof attributes?.jetpackCRM === 'undefined' ) {
+			defaults.jetpackCRM = !! crm.enabledByDefault;
 		}
 
-		if ( typeof attributes?.mailpoet?.enabledForForm === 'undefined' && mailpoet ) {
-			setAttributes( {
-				mailpoet: {
-					...attributes.mailpoet,
-					enabledForForm: !! mailpoet.enabledByDefault,
-				},
-			} );
+		if ( mailpoet && typeof attributes?.mailpoet?.enabledForForm === 'undefined' ) {
+			defaults.mailpoet = {
+				...attributes?.mailpoet,
+				enabledForForm: !! mailpoet.enabledByDefault,
+			};
 		}
 
-		if ( typeof attributes?.salesforceData?.sendToSalesforce === 'undefined' && salesforce ) {
-			setAttributes( {
-				salesforceData: {
-					...attributes.salesforceData,
-					sendToSalesforce: !! salesforce.enabledByDefault,
-				},
-			} );
+		if ( salesforce && typeof attributes?.salesforceData?.sendToSalesforce === 'undefined' ) {
+			defaults.salesforceData = {
+				...attributes?.salesforceData,
+				sendToSalesforce: !! salesforce.enabledByDefault,
+			};
 		}
+
+		if ( ! Object.keys( defaults ).length ) {
+			return;
+		}
+
+		/*
+		 * Seeding a default is not something the user did, so it must not register
+		 * as an edit. Form markup that ships in a theme file, a pattern, or any
+		 * post saved before these flags existed carries none of them, so without
+		 * this the block dirties its post, template, or template part the moment
+		 * the canvas mounts it and the editor offers to save changes nobody made.
+		 */
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( defaults );
 	}, [
 		isLoading,
 		integrations,
 		attributes?.jetpackCRM,
-		attributes.mailpoet,
-		attributes.salesforceData,
+		attributes?.mailpoet,
+		attributes?.salesforceData,
 		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 }

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-single-input-field-required.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-single-input-field-required.js
@@ -1,0 +1,40 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { getInputFields } from '../../util/get-input-fields.ts';
+
+/**
+ * Make a form's only input field required.
+ *
+ * A form with a single field has nothing to submit unless that field is filled
+ * in, so leaving it optional is never what the author meant.
+ *
+ * @param {object} params             - Hook parameters.
+ * @param {Array}  params.innerBlocks - The form's inner blocks.
+ */
+export default function useSingleInputFieldRequired( { innerBlocks } ) {
+	const { updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		const inputFields = getInputFields( innerBlocks );
+
+		if ( inputFields.length !== 1 ) {
+			return;
+		}
+
+		const singleField = inputFields[ 0 ];
+
+		if ( singleField.attributes?.required ) {
+			return;
+		}
+
+		/*
+		 * Nobody asked for this, so it must not count as an edit. Otherwise a
+		 * one-field form -- a footer newsletter signup, say -- opens its post,
+		 * template, or template part with unsaved changes on every load.
+		 */
+		__unstableMarkNextChangeAsNotPersistent();
+		updateBlockAttributes( singleField.clientId, { required: true } );
+	}, [ innerBlocks, updateBlockAttributes, __unstableMarkNextChangeAsNotPersistent ] );
+}

--- a/projects/packages/forms/src/blocks/contact-form/util/get-input-fields.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/get-input-fields.ts
@@ -1,0 +1,62 @@
+import { childBlocks } from '../child-blocks.js';
+
+type BlockLike = {
+	name?: string;
+	clientId?: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: BlockLike[];
+};
+
+/**
+ * Determine whether a block is an input the visitor can be asked to fill in.
+ *
+ * Hidden fields and implicit consent checkboxes carry a `required` attribute but
+ * are never something a visitor answers, so they don't count.
+ *
+ * @param {string} fullName - Fully qualified block name, e.g. `jetpack/field-email`.
+ * @return {boolean} True when the block is a visitor-facing input.
+ */
+export const isInputWithRequiredField = ( fullName?: string ): boolean => {
+	if ( ! fullName || ! fullName.startsWith( 'jetpack/' ) ) return false;
+	const baseName = fullName.slice( 'jetpack/'.length );
+	const field = childBlocks.find( block => block.name === baseName );
+	// @ts-expect-error: childBlocks are defined in JS without explicit types.
+	// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
+	const hasRequired = !! field && field?.settings?.attributes?.required !== undefined;
+	const isHidden = field?.name === 'field-hidden';
+	const isImplicitConsent =
+		field?.name === 'field-consent' &&
+		// @ts-expect-error: childBlocks are defined in JS without explicit types.
+		// TS is inferring the type wrong. Fix is to update childBlocks to TS with types.
+		field?.settings?.attributes?.consentType !== 'explicit';
+	return hasRequired && ! isHidden && ! isImplicitConsent;
+};
+
+/**
+ * Collect the visitor-facing input fields anywhere inside a form.
+ *
+ * Recurses, because a multi-step form keeps its fields inside step blocks rather
+ * than directly under the form.
+ *
+ * @param {Array} blocks - Blocks to search, typically a form's inner blocks.
+ * @return {Array} Every input block found, in document order.
+ */
+export const getInputFields = ( blocks: BlockLike[] = [] ): BlockLike[] => {
+	const inputFields: BlockLike[] = [];
+
+	const findInputFields = ( blockList: BlockLike[] ) => {
+		blockList.forEach( block => {
+			if ( isInputWithRequiredField( block.name ) ) {
+				inputFields.push( block );
+			}
+			if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+				findInputFields( block.innerBlocks );
+			}
+		} );
+	};
+
+	findInputFields( blocks );
+	return inputFields;
+};
+
+export default getInputFields;

--- a/projects/packages/forms/src/blocks/contact-form/util/test/get-input-fields.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/test/get-input-fields.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+// A stand-in registry covering the four shapes the predicate has to tell apart:
+// an ordinary input, a hidden field, implicit consent, explicit consent.
+await jest.unstable_mockModule( '../../child-blocks.js', () => ( {
+	childBlocks: [
+		{ name: 'field-email', settings: { attributes: { required: { type: 'boolean' } } } },
+		{ name: 'field-name', settings: { attributes: { required: { type: 'boolean' } } } },
+		{ name: 'field-hidden', settings: { attributes: { required: { type: 'boolean' } } } },
+		{
+			name: 'field-consent',
+			settings: { attributes: { required: { type: 'boolean' }, consentType: 'implicit' } },
+		},
+		{ name: 'label', settings: { attributes: {} } },
+	],
+} ) );
+
+const { getInputFields, isInputWithRequiredField } = await import( '../get-input-fields.ts' );
+
+const block = ( name, clientId, innerBlocks = [] ) => ( {
+	name,
+	clientId,
+	attributes: {},
+	innerBlocks,
+} );
+
+describe( 'isInputWithRequiredField', () => {
+	it( 'accepts a field the visitor fills in', () => {
+		expect( isInputWithRequiredField( 'jetpack/field-email' ) ).toBe( true );
+	} );
+
+	it( 'rejects a hidden field', () => {
+		expect( isInputWithRequiredField( 'jetpack/field-hidden' ) ).toBe( false );
+	} );
+
+	it( 'rejects implicit consent, which the visitor never answers', () => {
+		expect( isInputWithRequiredField( 'jetpack/field-consent' ) ).toBe( false );
+	} );
+
+	it( 'rejects a block with no required attribute', () => {
+		expect( isInputWithRequiredField( 'jetpack/label' ) ).toBe( false );
+	} );
+
+	it.each( [ [ 'core/paragraph' ], [ 'jetpack/not-a-field' ], [ '' ], [ undefined ] ] )(
+		'rejects %s',
+		name => {
+			expect( isInputWithRequiredField( name ) ).toBe( false );
+		}
+	);
+} );
+
+describe( 'getInputFields', () => {
+	it( 'returns the inputs in document order and skips everything else', () => {
+		const fields = getInputFields( [
+			block( 'core/heading', 'h' ),
+			block( 'jetpack/field-name', 'name-1' ),
+			block( 'jetpack/field-email', 'email-1' ),
+			block( 'jetpack/field-hidden', 'hidden-1' ),
+			block( 'core/button', 'btn' ),
+		] );
+
+		expect( fields.map( f => f.clientId ) ).toEqual( [ 'name-1', 'email-1' ] );
+	} );
+
+	it( 'finds fields nested inside step blocks in a multi-step form', () => {
+		const fields = getInputFields( [
+			block( 'jetpack/form-step', 'step-1', [ block( 'jetpack/field-name', 'name-1' ) ] ),
+			block( 'jetpack/form-step', 'step-2', [
+				block( 'core/group', 'grp', [ block( 'jetpack/field-email', 'email-1' ) ] ),
+			] ),
+		] );
+
+		expect( fields.map( f => f.clientId ) ).toEqual( [ 'name-1', 'email-1' ] );
+	} );
+
+	it( 'returns nothing for an empty or missing form', () => {
+		expect( getInputFields( [] ) ).toEqual( [] );
+		expect( getInputFields() ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/forms/src/blocks/field-name/edit.jsx
+++ b/projects/packages/forms/src/blocks/field-name/edit.jsx
@@ -1,17 +1,8 @@
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field.jsx';
 import useFormWrapper from '../shared/hooks/use-form-wrapper.js';
+import useFieldVariantDefault from './hooks/use-field-variant-default.js';
 import useNameFieldTransforms from './hooks/use-name-field-transforms.js';
-import {
-	isFirstNameVariationId,
-	isLastNameVariationId,
-	FIRST_NAME_ID,
-	LAST_NAME_ID,
-	NAME_ID,
-} from './variations.js';
 
 export default function NameFieldEdit( props ) {
 	const { clientId, attributes, setAttributes } = props;
@@ -19,26 +10,8 @@ export default function NameFieldEdit( props ) {
 
 	useFormWrapper( props );
 
-	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
-
 	// Initialize fieldVariant for backward compatibility with existing Name field blocks.
-	useEffect( () => {
-		if ( fieldVariant ) {
-			return;
-		}
-
-		let variant = NAME_ID;
-		if ( isFirstNameVariationId( id ) ) {
-			variant = FIRST_NAME_ID;
-		} else if ( isLastNameVariationId( id ) ) {
-			variant = LAST_NAME_ID;
-		}
-
-		// Backfilling an attribute the block did not have yet is not a user edit,
-		// so it must not mark the post or template holding the form as changed.
-		__unstableMarkNextChangeAsNotPersistent();
-		setAttributes( { fieldVariant: variant } );
-	}, [ fieldVariant, id, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
+	useFieldVariantDefault( { id, fieldVariant, setAttributes } );
 
 	// Update HTML IDs and labels when transforming between variations.
 	useNameFieldTransforms( { clientId, fieldVariant } );

--- a/projects/packages/forms/src/blocks/field-name/edit.jsx
+++ b/projects/packages/forms/src/blocks/field-name/edit.jsx
@@ -1,3 +1,5 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import JetpackField from '../shared/components/jetpack-field.jsx';
@@ -17,6 +19,8 @@ export default function NameFieldEdit( props ) {
 
 	useFormWrapper( props );
 
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+
 	// Initialize fieldVariant for backward compatibility with existing Name field blocks.
 	useEffect( () => {
 		if ( fieldVariant ) {
@@ -30,8 +34,11 @@ export default function NameFieldEdit( props ) {
 			variant = LAST_NAME_ID;
 		}
 
+		// Backfilling an attribute the block did not have yet is not a user edit,
+		// so it must not mark the post or template holding the form as changed.
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { fieldVariant: variant } );
-	}, [ fieldVariant, id, setAttributes ] );
+	}, [ fieldVariant, id, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
 
 	// Update HTML IDs and labels when transforming between variations.
 	useNameFieldTransforms( { clientId, fieldVariant } );

--- a/projects/packages/forms/src/blocks/field-name/hooks/test/use-field-variant-default.test.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/test/use-field-variant-default.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+const markNextChangeAsNotPersistent = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		__unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent,
+	} ),
+} ) );
+
+// variations.js pulls in an icon component and translations, neither of which
+// this hook's behavior depends on.
+await jest.unstable_mockModule( '../../variations.js', () => ( {
+	FIRST_NAME_ID: 'first-name',
+	LAST_NAME_ID: 'last-name',
+	NAME_ID: 'name',
+	isFirstNameVariationId: id => typeof id === 'string' && /^first-name(?:-\d+)?$/.test( id ),
+	isLastNameVariationId: id => typeof id === 'string' && /^last-name(?:-\d+)?$/.test( id ),
+} ) );
+
+const { default: useFieldVariantDefault } = await import( '../use-field-variant-default.js' );
+
+describe( 'useFieldVariantDefault', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it.each( [
+		[ 'first-name', 'first-name' ],
+		[ 'first-name-2', 'first-name' ],
+		[ 'last-name', 'last-name' ],
+		[ 'last-name-3', 'last-name' ],
+		[ 'name', 'name' ],
+		[ 'whatever-the-author-typed', 'name' ],
+		[ undefined, 'name' ],
+	] )( 'derives the variant %s from the stored id', ( id, expected ) => {
+		const setAttributes = jest.fn();
+
+		renderHook( () => useFieldVariantDefault( { id, fieldVariant: undefined, setAttributes } ) );
+
+		expect( setAttributes ).toHaveBeenCalledWith( { fieldVariant: expected } );
+	} );
+
+	it( 'marks the backfill as not persistent so the entity stays clean', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useFieldVariantDefault( { id: 'name', fieldVariant: undefined, setAttributes } )
+		);
+
+		expect( markNextChangeAsNotPersistent ).toHaveBeenCalledTimes( 1 );
+		expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			setAttributes.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'leaves a field that already has a variant alone', () => {
+		const setAttributes = jest.fn();
+
+		renderHook( () =>
+			useFieldVariantDefault( { id: 'first-name', fieldVariant: 'last-name', setAttributes } )
+		);
+
+		expect( setAttributes ).not.toHaveBeenCalled();
+		expect( markNextChangeAsNotPersistent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/forms/src/blocks/field-name/hooks/use-field-variant-default.js
+++ b/projects/packages/forms/src/blocks/field-name/hooks/use-field-variant-default.js
@@ -1,0 +1,43 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import {
+	isFirstNameVariationId,
+	isLastNameVariationId,
+	FIRST_NAME_ID,
+	LAST_NAME_ID,
+	NAME_ID,
+} from '../variations.js';
+
+/**
+ * Backfill fieldVariant on Name fields saved before the attribute existed.
+ *
+ * The stored HTML id is the only clue those blocks carry about which variation
+ * the author picked, so the variant is derived from it.
+ *
+ * @param {object}   params               - Hook parameters.
+ * @param {string}   params.id            - The field's HTML id.
+ * @param {string}   params.fieldVariant  - The field's current variant, if any.
+ * @param {Function} params.setAttributes - Setter for block attributes.
+ */
+export default function useFieldVariantDefault( { id, fieldVariant, setAttributes } ) {
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( fieldVariant ) {
+			return;
+		}
+
+		let variant = NAME_ID;
+		if ( isFirstNameVariationId( id ) ) {
+			variant = FIRST_NAME_ID;
+		} else if ( isLastNameVariationId( id ) ) {
+			variant = LAST_NAME_ID;
+		}
+
+		// Backfilling an attribute the block did not have yet is not a user edit,
+		// so it must not mark the post or template holding the form as changed.
+		__unstableMarkNextChangeAsNotPersistent();
+		setAttributes( { fieldVariant: variant } );
+	}, [ fieldVariant, id, setAttributes, __unstableMarkNextChangeAsNotPersistent ] );
+}

--- a/projects/plugins/jetpack/changelog/forms-block-dirties-templates
+++ b/projects/plugins/jetpack/changelog/forms-block-dirties-templates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: stop the form block from marking a post, template, or template part as having unsaved changes the moment it loads.


### PR DESCRIPTION
Fixes #51737

## Proposed changes

Opening a post, template, or template part that contains a form marked it as having unsaved changes before the user touched anything. In the Site Editor that shows up as "Review 1 change" naming a template part nobody edited; taking the offered save persists a DB customization that shadows the theme file, so later theme updates to that part silently stop applying.

Three mount effects seeded a default with `setAttributes()` and no `__unstableMarkNextChangeAsNotPersistent()`, so the block-editor entity store recorded each one as a `content` edit:

* `shared/hooks/use-form-block-defaults.js` wrote `jetpackCRM`, `mailpoet.enabledForForm`, and `salesforceData.sendToSalesforce` whenever they were absent. That is every form authored in a theme file, and every form built from one of Jetpack's own seven form patterns, none of which carry those keys. The three writes are now collected into one update so a single mark covers them.
* `contact-form/edit.tsx` marked the only input field `required: true` on mount, which fires on any one-field form such as a footer newsletter signup. Its migration of the deprecated `customThankyou` attribute had the same problem and is fixed the same way.
* `field-name/edit.jsx` backfilled `fieldVariant` on any Name field saved before that attribute existed.

Marking the change non-persistent routes it through the editor's `onInput` path, which writes only the transient `blocks` and `selection` entity edits instead of `content`. The seeded values still apply in the editor and still persist on the next real save; they just stop counting as a user edit. This is already the pattern in eight other places in the package, including `field-checkbox/edit.jsx`, `field-consent/edit.jsx`, and `shared/hooks/use-form-wrapper.js`.

Two of those effects lived inline in `edit.tsx` and `field-name/edit.jsx`, neither of which has any test coverage, so each is now its own hook next to `useFormBlockDefaults`: `use-deprecated-thank-you-migration.js`, `use-single-input-field-required.js`, and `field-name/hooks/use-field-variant-default.js`. The recursive field scan the auto-required effect relied on moves to `util/get-input-fields.ts` with the predicate it used, so a hook test can reach it without pulling in the whole child-block registry.

All four get Jest suites, covering the single-update shape, the mark-before-write ordering, `enabledByDefault` pass-through, and the no-write cases. 32 new tests; the package is at 1526 passing across 116 suites.

Writing the util test turned up one incidental thing: `isInputWithRequiredField` returned `undefined` rather than `false` for an unregistered `jetpack/*` block, despite declaring a `boolean` return. Every caller treated it as falsy so nothing behaved differently, but the type was wrong, and it is now honest.

**Not in scope, and worth their own issues.** Three more mount writes have the same shape but each needs a judgement call I did not want to make here: `field-slider/edit.jsx` (its comment says the write exists "so they serialize into post markup", so silencing it may need PHP defaults for min/max/step), `field-telephone/edit.jsx` (`showCountrySelector`/`default` may matter to the renderer), and `shared/hooks/use-sync-required-indicator.js` (it writes unconditionally, so a blanket mark would stop genuine user changes from saving; it needs a condition, not just a mark).

## Related product discussion/links

* FORMS-641 — https://linear.app/a8c/issue/FORMS-641
* FORMS-771 (closed as a duplicate of 641) — https://linear.app/a8c/issue/FORMS-771

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change is editor-side only, so a site with the Forms module active is all you need. There are three independent cases; the first is the one from the report.

**Case 1: a form in a block theme's template part.**

1. On a site running this branch, create a child theme of a block theme (Twenty Twenty-Four works) with a `parts/footer.html` containing a `jetpack/contact-form` block. The quickest faithful source for that markup is one of Jetpack's own patterns: in the editor console, `wp.data.select( 'core' ).getBlockPatterns().find( p => p.name === 'newsletter-form' ).content`. Activate the child theme.
2. Open the footer template part in the Site Editor: `/wp-admin/site-editor.php?postType=wp_template_part&postId=<stylesheet>%2F%2Ffooter&canvas=edit`.
3. Touch nothing. The Save button stays disabled, and in the console `wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords()` returns `[]`.
4. On trunk, the same steps light up Save, and that selector returns the footer template part. `wp.data.select( 'core' ).getEntityRecordNonTransientEdits( 'postType', 'wp_template_part', '<stylesheet>//footer' )` shows a `content` edit whose diff is exactly `{"jetpackCRM":false,"salesforceData":{...,"sendToSalesforce":false},"mailpoet":{...,"enabledForForm":false}}`.

**Case 2: a one-field form in a post.** Create a page via the REST API whose content is a `jetpack/contact-form` holding a single `jetpack/field-email` with no `required` attribute, then open it. On this branch `wp.data.select( 'core/editor' ).isEditedPostDirty()` is `false`; on trunk it is `true` and `required: true` has been injected.

**Case 3: a Name field with no `fieldVariant`.** Same, with a `jetpack/field-name` whose attributes omit `fieldVariant`. Clean here, dirty on trunk.

**Check the fix did not silence real edits.** With any of the above open, change something (a form title, a label). Save enables, `isEditedPostDirty()` is `true`, and saving writes the seeded integration attributes into the markup along with your edit. Insert a fresh form and confirm it still picks up the integration defaults.

**Automated:** `jetpack test js packages/forms` (1526 tests, 116 suites). The `useFormBlockDefaults` suite fails 3 of its 6 cases with the fix reverted, so it is a real guard rather than a description of current behavior.
