### PR TITLE
Jetpack AI: enqueue the Tracks sender for self-hosted  so events reach WordPress.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai-admin.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai-admin.jsx
@@ -6,10 +6,16 @@
 
 import apiFetch from '@wordpress/api-fetch';
 import * as WPElement from '@wordpress/element';
+import analytics from 'lib/analytics';
 import App from './ai/main';
 import './ai/style.scss';
 
-const { apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
+const { apiRoot, apiNonce, tracksUserData } = window?.jetpackAiSettings ?? {};
+
+// Identify the connected user so Tracks events aren't anonymous.
+if ( tracksUserData?.userid && tracksUserData?.username ) {
+	analytics.initialize( tracksUserData.userid, tracksUserData.username );
+}
 
 if ( apiRoot ) {
 	apiFetch.use( apiFetch.createRootURLMiddleware( apiRoot ) );

--- a/projects/plugins/jetpack/_inc/client/ai/test/ai-admin.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/ai-admin.jsx
@@ -1,4 +1,5 @@
 import * as WPElement from '@wordpress/element';
+import analytics from 'lib/analytics';
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	createNonceMiddleware: jest.fn(),
@@ -7,11 +8,32 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 jest.mock( '@wordpress/element', () => ( { createRoot: jest.fn() } ) );
 jest.mock( '../main', () => () => null );
+jest.mock( 'lib/analytics', () => ( { initialize: jest.fn() } ), { virtual: true } );
 
 describe( 'AI admin entry point', () => {
 	beforeEach( () => {
 		WPElement.createRoot.mockReset();
+		analytics.initialize.mockReset();
+		delete window.jetpackAiSettings;
 		document.body.innerHTML = '<div id="jetpack-ai-root"></div>';
+	} );
+
+	test( 'identifies the connected user for Tracks', () => {
+		WPElement.createRoot.mockReturnValue( { render: jest.fn() } );
+		window.jetpackAiSettings = { tracksUserData: { userid: 123, username: 'testuser' } };
+
+		jest.isolateModules( () => require( '../../ai-admin' ) );
+
+		expect( analytics.initialize ).toHaveBeenCalledWith( 123, 'testuser' );
+	} );
+
+	test( 'skips Tracks identification without a linked account', () => {
+		WPElement.createRoot.mockReturnValue( { render: jest.fn() } );
+		window.jetpackAiSettings = { tracksUserData: null };
+
+		jest.isolateModules( () => require( '../../ai-admin' ) );
+
+		expect( analytics.initialize ).not.toHaveBeenCalled();
 	} );
 
 	test( 'reuses the root attached to the AI Hub container', () => {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -16,6 +16,8 @@ use Automattic\Jetpack\Feature_Flags\Feature_Flags;
 use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
+use Automattic\Jetpack\Terms_Of_Service;
+use Automattic\Jetpack\Tracking;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
@@ -206,7 +208,8 @@ class Jetpack_AI_Page {
 		}
 
 		$blog_id     = Connection_Manager::get_site_id( true );
-		$site_suffix = ( new Status() )->get_site_suffix();
+		$status      = new Status();
+		$site_suffix = $status->get_site_suffix();
 		// Use the plain hostname for the Atomic activity log URL — get_site_suffix() can
 		// include '::' for subdirectory installs, which would break the URL. This matches
 		// the approach used by jetpack-mu-wpcom for the sidebar Activity Log link.
@@ -248,6 +251,14 @@ class Jetpack_AI_Page {
 		);
 
 		wp_set_script_translations( 'jetpack-ai-admin', 'jetpack' );
+
+		// The Tracks sender (w.js); without it, queued events never leave the
+		// browser. Consent-gated like the other surfaces that load it.
+		$can_send_tracks = ( new Tracking( 'jetpack', new Connection_Manager() ) )->should_enable_tracking( new Terms_Of_Service(), $status );
+		if ( $can_send_tracks ) {
+			Tracking::register_tracks_functions_scripts( true );
+		}
+
 		if ( $show_scheduled_tasks_view ) {
 			Connection_Initial_State::render_script( 'jetpack-ai-admin' );
 		}
@@ -317,6 +328,9 @@ class Jetpack_AI_Page {
 			// sends them as the strings 'true'/'false' (AIINT-576).
 			'isA11n'           => self::is_current_user_automattician(),
 			'isTest'           => $is_internal_test,
+			// Identity for Tracks; the lookup can call WordPress.com on a
+			// cache miss, so it shares the sender's guard.
+			'tracksUserData'   => $can_send_tracks ? self::get_tracks_user_data() : null,
 			'mcpSettingsApi'   => $config['mcpSettingsApi'],
 		);
 
@@ -350,6 +364,24 @@ class Jetpack_AI_Page {
 			plugins_url( '_inc/build/jetpack-ai-admin.css', JETPACK__PLUGIN_FILE ),
 			array( 'wp-components' ),
 			$script_version
+		);
+	}
+
+	/**
+	 * Connected-user identity for Tracks; null when no WordPress.com account is
+	 * linked. Two keys only, so email and locale stay out of the page HTML.
+	 *
+	 * @return array{userid:int, username:string}|null
+	 */
+	private static function get_tracks_user_data() {
+		$identity = \Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+		if ( ! is_array( $identity ) || ! isset( $identity['userid'] ) || ! isset( $identity['username'] ) ) {
+			return null;
+		}
+
+		return array(
+			'userid'   => (int) $identity['userid'],
+			'username' => (string) $identity['username'],
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-page-tracks-script
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-page-tracks-script
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Send usage events from Jetpack AI Hub on self-hosted sites.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -45,6 +45,9 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		remove_all_filters( 'jetpack_feature_flag_enabled_ai-hub-scheduled-tasks' );
 		remove_all_filters( 'jetpack_is_connection_ready' );
 		remove_all_filters( 'jetpack_offline_mode' );
+		Jetpack_Options::delete_option( 'tos_agreed' );
+		Jetpack_Options::delete_option( 'user_tokens' );
+		wp_set_current_user( 0 );
 		remove_all_actions( 'admin_print_scripts-jetpack_page_jetpack-ai' );
 		remove_all_actions( 'admin_print_styles-jetpack_page_jetpack-ai' );
 		remove_all_actions( 'load-jetpack_page_jetpack-ai' );
@@ -509,6 +512,113 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 		$inline = implode( "\n", array_filter( (array) wp_scripts()->get_data( 'jetpack-ai-admin', 'before' ) ) );
 		$this->assertStringNotContainsString( 'JP_CONNECTION_INITIAL_STATE', $inline );
+	}
+
+	/**
+	 * The Tracks sender is enqueued once tracking is consented to.
+	 */
+	public function test_tracks_script_is_enqueued_with_tracking_consent() {
+		delete_option( 'jetpack_offline_mode' );
+		Jetpack_Options::update_option( 'tos_agreed', true );
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+
+		( new Jetpack_AI_Page() )->page_admin_scripts();
+
+		$this->assertTrue( wp_script_is( 'jp-tracks', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
+	}
+
+	/**
+	 * The sender stays out without tracking consent.
+	 */
+	public function test_tracks_script_stays_out_without_tracking_consent() {
+		Jetpack_Options::update_option( 'tos_agreed', false );
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+
+		( new Jetpack_AI_Page() )->page_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'jp-tracks', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
+	}
+
+	/**
+	 * Offline mode never talks to WordPress.com, consented or not.
+	 */
+	public function test_tracks_script_is_not_enqueued_in_offline_mode() {
+		Jetpack_Options::update_option( 'tos_agreed', true );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		( new Jetpack_AI_Page() )->page_admin_scripts();
+
+		$this->assertFalse( wp_script_is( 'jp-tracks', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'jp-tracks-functions', 'enqueued' ) );
+	}
+
+	/**
+	 * The tracksUserData slot is null without a linked WordPress.com account,
+	 * even when consent lets the identity lookup actually run.
+	 */
+	public function test_tracks_user_data_is_null_without_a_linked_account() {
+		delete_option( 'jetpack_offline_mode' );
+		Jetpack_Options::update_option( 'tos_agreed', true );
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertArrayHasKey( 'tracksUserData', $settings );
+		$this->assertNull( $settings['tracksUserData'] );
+	}
+
+	/**
+	 * The tracksUserData slot is null in offline mode — the lookup could call WordPress.com.
+	 */
+	public function test_tracks_user_data_is_null_in_offline_mode() {
+		Jetpack_Options::update_option( 'tos_agreed', true );
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertNull( $settings['tracksUserData'] );
+	}
+
+	/**
+	 * The tracksUserData slot names the linked WordPress.com account.
+	 */
+	public function test_tracks_user_data_names_the_linked_account() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'tracks_identity_user',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		delete_option( 'jetpack_offline_mode' );
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+		Jetpack_Options::update_option( 'user_tokens', array( $user_id => "dummy.usertoken.$user_id" ) );
+		set_transient(
+			"jetpack_connected_user_data_$user_id",
+			array(
+				'ID'          => 777,
+				'login'       => 'wpcomuser',
+				'email'       => 'wpcomuser@example.com',
+				'user_locale' => 'en',
+			)
+		);
+
+		try {
+			$settings = $this->get_injected_settings();
+
+			$this->assertSame(
+				array(
+					'userid'   => 777,
+					'username' => 'wpcomuser',
+				),
+				$settings['tracksUserData']
+			);
+		} finally {
+			delete_transient( "jetpack_connected_user_data_$user_id" );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* Jetpack AI Hub never loads the Tracks sender (`stats.wp.com/w.js`), so its events are
  dropped in the browser on self-hosted sites. It now loads it through the shared
  `Tracking::register_tracks_functions_scripts()` helper — gated on tracking consent
  (ToS agreed or a linked user), like the other surfaces that load it — and identifies
  the connected user at boot so the events aren't anonymous.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No - no new events or properties. Existing events now arrive attributed to the connected
WordPress.com user instead of anonymous.

## Testing instructions

1. On a connected self-hosted site (JN), open `wp-admin/admin.php?page=jetpack-ai`.
2. In dev tools, confirm a `pixel.wp.com/t.gif` request with `_en=jetpack_ai_hub_viewed` fires on load (on trunk it doesn't).
3. In the request URL, `_ut`/`_ui` carry the wpcom user (not `_ut=anon`); in MC Tracks Live View the row's User column shows your account.
