### PR TITLE
Premium Analytics: shorten the Popular post title so it fits a narrow cell

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2013-popular-post-title-width
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2013-popular-post-title-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: Shorten the Popular post card title so it survives a narrow dashboard cell.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card-skeleton.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card-skeleton.test.tsx
@@ -12,7 +12,7 @@ describe( 'PostHighlightCardSkeleton', () => {
 		render( <PostHighlightCardSkeleton /> );
 
 		expect( screen.getAllByTestId( 'skeleton-title-line' ) ).toHaveLength( 2 );
-		// Latest post and Most popular post both render views, likes, and comments.
+		// Latest post and Popular post both render views, likes, and comments.
 		expect( screen.getAllByTestId( 'skeleton-stat' ) ).toHaveLength( 3 );
 	} );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/stories/post-highlight-card-skeleton.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/stories/post-highlight-card-skeleton.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta< typeof PostHighlightCardSkeleton > = {
 		docs: {
 			description: {
 				component:
-					"Loading shape for `PostHighlightCard`, passed through `WidgetState`'s `renderLoading` by the Latest post and Most popular post widgets.",
+					"Loading shape for `PostHighlightCard`, passed through `WidgetState`'s `renderLoading` by the Latest post and Popular post widgets.",
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/post-content.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/post-content.ts
@@ -7,7 +7,7 @@
  * the Latest post stories mock the unfiltered "newest post" form themselves.
  *
  * The IDs match the `stats/top-posts` fixture in `register-stats-mocks.ts`, so
- * the Most popular post widget resolves the winning row to real content.
+ * the Popular post widget resolves the winning row to real content.
  */
 
 // A neutral gradient stands in for a featured image, inline so Storybook needs

--- a/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/stories/popular-post-widget.stories.tsx
@@ -48,7 +48,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Most popular post in the last 12 months" widget shows the site\'s most-viewed post of the last 12 months, with its publish date and its all-time views, likes, and comments. The window is the widget\'s own — the dashboard date range does not change which post wins — and it only picks the winner: every tile comes from the all-time `stats/post` response, so the three cannot measure different periods. There is no `WithComparison` story: the card shows no period-over-period delta, so the dashboard story below carries the comparison report params instead.',
+					'The "Popular post (12 months)" widget shows the site\'s most-viewed post of the last 12 months, with its publish date and its all-time views, likes, and comments. The window is the widget\'s own — the dashboard date range does not change which post wins — and it only picks the winner: every tile comes from the all-time `stats/post` response, so the three cannot measure different periods. There is no `WithComparison` story: the card shows no period-over-period delta, so the dashboard story below carries the comparison report params instead.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/popular-post/widget.json
+++ b/projects/packages/premium-analytics/widgets/popular-post/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/popular-post",
-	"title": "Most popular post in the last 12 months",
+	"title": "Popular post (12 months)",
 	"description": "Your most-viewed post of the last 12 months, with its all-time stats.",
 	"help": {
 		"content": "Your most viewed post of the last 12 months, with its all-time views, likes, and comments."

--- a/projects/plugins/jetpack/changelog/wooa7s-2013-popular-post-title-width
+++ b/projects/plugins/jetpack/changelog/wooa7s-2013-popular-post-title-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Shorten the Popular post card title so it survives a narrow dashboard cell.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2013-popular-post-title-width
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2013-popular-post-title-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Shorten the Popular post card title so it survives a narrow dashboard cell.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2013-popular-post-title-width
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2013-popular-post-title-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: Shorten the Popular post card title so it survives a narrow dashboard cell.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2013-popular-post-title-width
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2013-popular-post-title-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Shorten the Popular post card title so it survives a narrow dashboard cell.


### PR DESCRIPTION
Follow up to #51649 (already merged).

## Proposed changes

* Retitle the card from "Most popular post in the last 12 months" to **"Popular post (12 months)"**.

That title needs 282px of header space, and a 1-wide dashboard cell gives it 140-240px depending on the viewport, so it truncated to "Most popular post in the l..." - and the phrase that got cut is exactly the one doing the work, since it's the only thing on the card explaining why it ignores the section's year filter. The default placement is 2-wide so it ships fine, this only bites after someone resizes it.

"Popular post (12 months)" is 181px and fits the 1-wide cell from 1366 up. Measured in the real header font on a docker env:

| title | px | 1600 (240px) | 1440 (200px) | 1366 (182px) | 1280 (160px) | 1200 (140px) |
| --- | --- | --- | --- | --- | --- | --- |
| Most popular post in the last 12 months | 282 | clips | clips | clips | clips | clips |
| Popular post (12 months) | 181 | fits | fits | fits | clips | clips |

**Known issue, and I'd rather be upfront about it: this doesn't fix 1280 and below.** The grid keeps 4 columns down to ~1200, where the header is left with 140-160px, and nothing that names the window fits in that - only dropping the window entirely ("Most popular post", 130px) would, which defeats the point. The proper fix for those widths is the header exposing its full text when it truncates - the `h2` carries no `title` attribute today, so a clipped title isn't recoverable on hover - but that's `@wordpress/widget-primitives` chrome, not ours, so it's out of scope here. Happy to raise it upstream if folks agree that's where it belongs.

Below ~1200 the grid drops to 2 columns and a "1-wide" cell gets wider again, so nothing clips there.

The prose references in the toolkit that #51649 changed to "Most popular post" are back to "Popular post" to match, and the ⓘ note, description and empty state still say "the last 12 months" - only the title changed.

## Related product discussion/links

* WOOA7S-2013

## Does this pull request change what data or activity we track or use?

No. Title copy only - same endpoints, same window, same request.

## Testing instructions

* Build and load the dashboard - `jp build plugins/premium-analytics --deps`, then Stats v2 → **Insights**.
* Ensure the card is titled "Popular post (12 months)" and the ⓘ note still reads "Your most viewed post of the last 12 months, with its all-time views, likes, and comments."
* Ensure the widget library (Customize → Add widget) lists it under the new title too.
* Resize the card to 1-wide, and at a 1366-or-wider window ensure the title shows in full rather than being cut off.
* Narrow the window to ~1200-1280 and ensure the title clips - that's the known gap above, not a regression.
* Ensure nothing else moved: the ranking request is still `max=20 … days=365` ending yesterday, and clicking the section year pills still doesn't re-rank the card.

### Before / after, 1-wide cell

At 1440 the title now fits:

| before | after |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d7d40892-3bed-4eee-a700-0e96301c8797" width="200"> | <img src="https://github.com/user-attachments/assets/1936a037-b9d1-4a88-8957-3888266b4bed" width="200"> |

At 1200 it's shorter but still clipped - the gap this PR doesn't close ("Comments" truncates there too, which is pre-existing):

| before | after |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/004c2a9f-e9e0-42a2-b4b7-0cb92375d5af" width="170"> | <img src="https://github.com/user-attachments/assets/d28858f5-6f5b-422f-9c13-c449dec518aa" width="170"> |
