### PR TITLE
Premium Analytics: restore the Annual insights CTA and finish the report

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-avg-words
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-avg-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Annual insights: print the words-per-post average whole, as the old Stats report does.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Annual insights: keep the Year in review report link reachable, and print the words-per-post average whole.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Annual insights: keep the Year in review report link reachable, and print the words-per-post average whole.
+Annual insights: keep the Year in review report link reachable.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-image-counts
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2016-annual-insights-image-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Annual insights: add total and per-post image counts to the report.

--- a/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
@@ -17,9 +17,9 @@ function formatNumber( value: number ): string {
 }
 
 /**
- * Format a per-post average for display. Comments, likes and images average
- * below one on most sites, so the decimal carries the whole signal and a whole
- * number keeps its trailing `.0`.
+ * Format a per-post average for display. Legacy's `formatTableValue` allowlists
+ * `avg_comments` and `avg_likes` for one decimal; images follow them by
+ * analogy, legacy having never rendered that column.
  *
  * @param value - The average to format.
  * @return The formatted average.

--- a/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
@@ -17,8 +17,9 @@ function formatNumber( value: number ): string {
 }
 
 /**
- * Format a per-post average for display. Legacy renders averages with one
- * decimal ("0.5", "4.0"), so a whole number keeps its trailing `.0`.
+ * Format a per-post average for display. Comments, likes and images average
+ * below one on most sites, so the decimal carries the whole signal and a whole
+ * number keeps its trailing `.0`.
  *
  * @param value - The average to format.
  * @return The formatted average.
@@ -29,9 +30,11 @@ function formatAverage( value: number ): string {
 
 /**
  * DataViews field config for the Annual insights records table. Columns and
- * order mirror the legacy "All-time annual insights" table (wp-calypso
+ * order follow the legacy "All-time annual insights" table (wp-calypso
  * `annual-site-stats`): Year, Total posts, Total comments, Avg comments per
- * post, Total likes, Avg likes per post, Total words, Avg words per post.
+ * post, Total likes, Avg likes per post, Total words, Avg words per post —
+ * then the image counts, which the endpoint has always returned but legacy
+ * never rendered.
  *
  * @return The field config.
  */
@@ -84,7 +87,20 @@ export function getAnnualInsightsFields(): Field< StatsInsightsYear >[] {
 			id: 'avg_words',
 			label: __( 'Avg words per post', 'jetpack-premium-analytics-pkg' ),
 			getValue: ( { item } ) => item.avg_words,
-			render: ( { item } ) => <>{ formatAverage( item.avg_words ) }</>,
+			// Legacy renders this one average whole, unlike comments and likes.
+			render: ( { item } ) => <>{ formatNumber( item.avg_words ) }</>,
+		},
+		{
+			id: 'total_images',
+			label: __( 'Total images', 'jetpack-premium-analytics-pkg' ),
+			getValue: ( { item } ) => item.total_images,
+			render: ( { item } ) => <>{ formatNumber( item.total_images ) }</>,
+		},
+		{
+			id: 'avg_images',
+			label: __( 'Avg images per post', 'jetpack-premium-analytics-pkg' ),
+			getValue: ( { item } ) => item.avg_images,
+			render: ( { item } ) => <>{ formatAverage( item.avg_images ) }</>,
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/annual-insights/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/annual-insights/page.tsx
@@ -33,6 +33,8 @@ const RECORDS_VIEW = {
 			avg_likes: { align: 'end' as const },
 			total_words: { align: 'end' as const },
 			avg_words: { align: 'end' as const },
+			total_images: { align: 'end' as const },
+			avg_images: { align: 'end' as const },
 		},
 	},
 };
@@ -88,6 +90,14 @@ function AnnualInsightsReport(): JSX.Element {
 			{
 				label: __( 'Avg words per post', 'jetpack-premium-analytics-pkg' ),
 				getValue: row => row.avg_words,
+			},
+			{
+				label: __( 'Total images', 'jetpack-premium-analytics-pkg' ),
+				getValue: row => row.total_images,
+			},
+			{
+				label: __( 'Avg images per post', 'jetpack-premium-analytics-pkg' ),
+				getValue: row => row.avg_images,
 			},
 		],
 		[]

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -106,4 +106,16 @@ describe( 'report table count fields', () => {
 
 		expect( screen.getByText( '4.0' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the Annual insights image average to one decimal', () => {
+		renderCountField( getAnnualInsightsFields(), 'avg_images', { avg_images: 4 } as never );
+
+		expect( screen.getByText( '4.0' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the Annual insights words-per-post average whole, as legacy does', () => {
+		renderCountField( getAnnualInsightsFields(), 'avg_words', { avg_words: 1234.4 } as never );
+
+		expect( screen.getByText( '1,234' ) ).toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -324,7 +324,7 @@ describe( 'report CSV exports', () => {
 			AnnualInsightsReportPage,
 			'annual-insights',
 			[ rows[ 1 ], rows[ 0 ] ],
-			[ '2026', 12, 24, 2, 36, 3, 1200, 100 ]
+			[ '2026', 12, 24, 2, 36, 3, 1200, 100, 5, 1 ]
 		);
 	} );
 

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -288,6 +288,9 @@ describe( 'report CSV exports', () => {
 		} );
 	} );
 
+	// `avg_words` is fractional on purpose: the table renders it whole while the
+	// export stays raw, as every other average column does. A whole fixture
+	// would pass either way.
 	it( 'configures the Annual insights export', () => {
 		const rows = [
 			{
@@ -298,7 +301,7 @@ describe( 'report CSV exports', () => {
 				total_likes: 30,
 				avg_likes: 3,
 				total_words: 1000,
-				avg_words: 100,
+				avg_words: 100.4,
 				total_images: 4,
 				avg_images: 1,
 			},
@@ -310,7 +313,7 @@ describe( 'report CSV exports', () => {
 				total_likes: 36,
 				avg_likes: 3,
 				total_words: 1200,
-				avg_words: 100,
+				avg_words: 120.6,
 				total_images: 5,
 				avg_images: 1,
 			},
@@ -324,7 +327,7 @@ describe( 'report CSV exports', () => {
 			AnnualInsightsReportPage,
 			'annual-insights',
 			[ rows[ 1 ], rows[ 0 ] ],
-			[ '2026', 12, 24, 2, 36, 3, 1200, 100, 5, 1 ]
+			[ '2026', 12, 24, 2, 36, 3, 1200, 120.6, 5, 1 ]
 		);
 	} );
 

--- a/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
@@ -147,6 +147,29 @@ describe( 'AnnualHighlightsWidget', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
+	it( 'links to the Annual insights report', async () => {
+		renderWidget();
+
+		await expect( screen.findByText( 'Posts' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the report link in the empty state', async () => {
+		// The footer sits outside `WidgetState`, so a year with no row must still
+		// offer the only route to the full report.
+		mockApiFetch.mockResolvedValue( {
+			...INSIGHTS_PAYLOAD,
+			years: [ INSIGHTS_PAYLOAD.years[ 0 ] ],
+		} );
+
+		renderWidget();
+
+		await expect(
+			screen.findByText( 'No highlights for this year.' )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toBeInTheDocument();
+	} );
+
 	it( 'survives a payload the sanitizer rejects', async () => {
 		// The insights sanitizer returns a bare object for a shape it does not
 		// recognize, so `years` is absent entirely.

--- a/projects/packages/premium-analytics/widgets/annual-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/render.tsx
@@ -113,7 +113,7 @@ function AnnualHighlightsReport( { year }: { year?: YearPresetId } ) {
 					</Stack>
 				) }
 			</WidgetState>
-			<WidgetFooter className={ styles.footer }>
+			<WidgetFooter>
 				<ReportLink report="annual-insights" />
 			</WidgetFooter>
 		</div>

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -132,7 +132,9 @@ export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetContr
 	render: args => <AnnualHighlightsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		widgetWidth: 1,
+		// The placement the dashboard seeds this widget at, where the tiles sit in
+		// one row above the report link.
+		widgetWidth: 4,
 		widgetHeight: 1,
 	},
 	argTypes: {

--- a/projects/packages/premium-analytics/widgets/annual-highlights/style.module.scss
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/style.module.scss
@@ -1,5 +1,3 @@
-@use "../../packages/widgets-toolkit/src/styles/widget-container" as *;
-
 /* No outer padding: the host frames the widget and owns the padding. */
 .root {
 	height: 100%;
@@ -13,17 +11,4 @@
 	flex-direction: column;
 	height: 100%;
 	min-height: 0;
-
-	/* Size container for the short-height query at the end of this file. */
-	container-type: size;
-}
-
-/* Wide and at the minimum widget height: the tiles lay out in one row and need
- * the whole body, so drop the report link. Narrower cells keep it — there the
- * tiles stack and scroll whether or not the link is in the way. */
-@container (min-inline-size: #{$widget-wide-min-inline-size}) and (max-block-size: #{$widget-short-max-block-size}) {
-
-	.content .footer {
-		display: none;
-	}
 }

--- a/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-avg-words
+++ b/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-avg-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: print the Annual insights words-per-post average whole, as the old Stats report does.

--- a/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.

--- a/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.
+Premium Analytics: keep the Year in review report link reachable.

--- a/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-image-counts
+++ b/projects/plugins/jetpack/changelog/wooa7s-2016-annual-insights-image-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: add total and per-post image counts to the Annual insights report.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-avg-words
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-avg-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: print the Annual insights words-per-post average whole, as the old Stats report does.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.
+Premium Analytics: keep the Year in review report link reachable.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-image-counts
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2016-annual-insights-image-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: add total and per-post image counts to the Annual insights report.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-avg-words
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-avg-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Annual insights: print the words-per-post average whole, as the old Stats report does.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Annual insights: keep the Year in review report link reachable, and print the words-per-post average whole.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Annual insights: keep the Year in review report link reachable, and print the words-per-post average whole.
+Annual insights: keep the Year in review report link reachable.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-image-counts
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2016-annual-insights-image-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Annual insights: add total and per-post image counts to the report.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-avg-words
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-avg-words
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: print the Annual insights words-per-post average whole, as the old Stats report does.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-cta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.
+Premium Analytics: keep the Year in review report link reachable.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-cta
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-cta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the Year in review report link reachable, and print the Annual insights words-per-post average whole.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-image-counts
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2016-annual-insights-image-counts
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: add total and per-post image counts to the Annual insights report.


### PR DESCRIPTION
Fixes WOOA7S-2016

## Why

WOOA7S-2016 asked to verify the Annual insights report against the report the old "View all annual insights" CTA opened, and to confirm that CTA survived the Year in review widget gaining its year dropdown.

The columns were already right. The CTA was not — and neither was one number.

**The CTA was unreachable at the placement the dashboard ships.** A container query in the widget stylesheet dropped the footer whenever the widget is wide *and* short, which is exactly the seeded placement (`width 4, height 1` — `src/dashboard-layout.php`). The link rendered with `display: none`, so it was out of the accessibility tree as well as off screen. Its stated premise — that the tiles need the whole body — does not survive measurement: with the footer shown the tile grid takes 73px of the 110px body, and tile content sits **4.5px inside** the tile border at every width in the wide branch (measured at 666 / 866 / 1166px). Nothing overflows, nothing overlaps the link.

The cost is 37px of grid row height, and nothing else. The tile keeps its `padding-block: sm` in both states — `metric-tile-grid.module.scss`'s wide-and-short branch fires at or below 140px, and the grid is 110px on `trunk` and 73px here, so both sides are already inside it. The value numerals are a flat 32px in the wide branch regardless of container height, so they are identical either way. What changes is that the tile's fixed ~64px of content (24px label row + 8px gap + 32px value) goes from sitting inside a 92px padding box with room to spare, to overflowing a 55px padding box by ~4.5px a side while staying inside the border.

**`Avg words per post` printed a decimal legacy never showed.** Legacy's `formatTableValue` restricts one-decimal formatting to an allowlist of `avg_comments` and `avg_likes`; everything else falls through to `formatNumber`, whose default is zero decimals. The report page sent all three averages down the one-decimal path, so a 426-word average read "426.4". Comments and likes keep their decimal — they sit below one on most sites, where it is the whole signal.

**One note on the issue's framing:** the description lists images among the metrics the old report shows. It doesn't — legacy's `getStrings()` has no image keys. But `stats/insights` has always returned `total_images` and `avg_images` (confirmed against the endpoint source), and the sanitizer, the type, and the test fixtures all carry them, so the data was reaching the browser and going nowhere. They're now the last two columns, which makes the report a deliberate superset of legacy rather than a match.

## Proposed changes

* Drop the container query that hid the Year in review footer at wide-and-short placements, so the "View all" link is reachable at the placement the dashboard seeds. Removes the now-unused `container-type: size` and its `@use`.
* Print `Avg words per post` whole, matching legacy; comments, likes and images keep one decimal.
* Add `Total images` and `Avg images per post` to the report table and the CSV export.
* Move the dashboard story to the seeded `4x1` placement, where the widget actually ships and where this bug lived.

## Related product discussion/links

* WOOA7S-2016
* Report parity checked against `client/my-sites/stats/annual-site-stats/index.jsx` in wp-calypso (the `annualstats` route).

## Does this pull request change what data or activity we track or use?

No. `total_images` and `avg_images` already arrived in the existing `stats/insights` response and were already parsed into `StatsInsightsYear`; this only renders them. No new request, parameter, or field.

## Testing instructions

The report is at **Stats v2 → Insights**, and the report page itself at `?page=jetpack-premium-analytics-wp-admin&p=/reports/annual-insights`. A Jetpack-connected site with a few years of posts is needed for real rows.

**The CTA (the actual fix)**

* Go to **Stats v2 → Insights** with the Year in review widget at its default full-width, one-row placement.
* Confirm a **View all** link now sits under the metric tiles, and that the tiles are still fully inside their bordered boxes — nothing clipped or overlapping.
* Click it: it opens the Annual insights report.
* On `trunk` the same link is in the DOM but `display: none`, so there is no way to reach the report from the widget.
* Switch the widget's year to one with no posts. The empty state ("No highlights for this year.") must still show **View all** — the footer sits outside the widget's state box.
* Resize the widget to `1x1` and `4x2` and confirm both are unchanged from `trunk`.

**Column parity**

* On the report, confirm the columns read: Year, Total posts, Total comments, Avg comments per post, Total likes, Avg likes per post, Total words, Avg words per post, Total images, Avg images per post.
* **Avg words per post** must be whole (`426`, not `426.4`). **Avg comments / likes / images per post** keep one decimal (`0.3`, `7.5`, `4.0`).
* Sort by **Total images** and confirm it orders numerically.
* Hit **Download** and confirm the CSV header and rows carry both image columns.

<details>
<summary>Raw <code>stats/insights</code> response, cross-checked against every rendered row</summary>

```json
[
  { "year": "2009", "total_posts": 6,  "total_words": 212,  "avg_words": 35.3,  "total_likes": 0, "avg_likes": 0, "total_comments": 1,  "avg_comments": 0.2, "total_images": 0,  "avg_images": 0 },
  { "year": "2010", "total_posts": 14, "total_words": 1565, "avg_words": 111.8, "total_likes": 0, "avg_likes": 0, "total_comments": 0,  "avg_comments": 0,   "total_images": 32, "avg_images": 6.4 },
  { "year": "2011", "total_posts": 1,  "total_words": 12,   "avg_words": 12,    "total_likes": 0, "avg_likes": 0, "total_comments": 0,  "avg_comments": 0,   "total_images": 0,  "avg_images": 0 },
  { "year": "2012", "total_posts": 11, "total_words": 487,  "avg_words": 44.3,  "total_likes": 0, "avg_likes": 0, "total_comments": 26, "avg_comments": 2.4, "total_images": 2,  "avg_images": 1 },
  { "year": "2013", "total_posts": 5,  "total_words": 2132, "avg_words": 426.4, "total_likes": 0, "avg_likes": 0, "total_comments": 0,  "avg_comments": 0,   "total_images": 6,  "avg_images": 6 },
  { "year": "2018", "total_posts": 12, "total_words": 3780, "avg_words": 315,   "total_likes": 0, "avg_likes": 0, "total_comments": 0,  "avg_comments": 0,   "total_images": 82, "avg_images": 13.7 },
  { "year": "2023", "total_posts": 7,  "total_words": 689,  "avg_words": 98.4,  "total_likes": 0, "avg_likes": 0, "total_comments": 1,  "avg_comments": 0.1, "total_images": 15, "avg_images": 7.5 }
]
```

Rendered: `avg_words` shows 35 / 112 / 12 / 44 / 426 / 315 / 98 — whole, as legacy prints them. Every other cell matches the payload exactly.

The endpoint returns years **ascending** and omits years with no published posts (`min_doc_count => 1`); the table sorts descending by default, which is a deliberate divergence from legacy's raw payload order and is user-sortable.

</details>

<details>
<summary>CSV export, captured from the built bundle</summary>

```
"Year","Total posts","Total comments","Avg comments per post","Total likes","Avg likes per post","Total words","Avg words per post","Total images","Avg images per post"
"2026","3","1","0.3","0","0","0","0","0","0"
"2025","2","0","0","0","0","0","0","0","0"
"2024","2","0","0","0","0","2","1","0","0"
```

</details>

Full package suite passes (2822 tests), typecheck clean.

