### PR TITLE
Premium Analytics: divide a widget's metrics with lines instead of boxes

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Highlights widgets: Separate metrics with lines instead of boxes.
+Divide a widget's metrics with lines instead of boxing each one.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Highlights widgets: Separate metrics with lines instead of boxes.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
@@ -36,9 +36,11 @@ $tile-value-inline-size: 70%;
 }
 
 /* Narrow: one full-width row per metric, as the loaded grid's single column.
- * The loaded grid runs flush and spaces its rows with each tile's block
- * padding, so the stand-ins do the same rather than with a gap of their own -
- * otherwise the rows shift when the data lands. */
+ * The loaded grid runs flush and gives a row its height with the tile's own
+ * block padding, so the stand-ins do the same rather than carrying a gap
+ * instead. That matches a row's height, not its position: the loaded grid
+ * stretches its rows over the whole body and this stays a centred block, so in
+ * a cell with slack the two still sit at different heights. */
 .tiles {
 	display: flex;
 	flex: 1 1 auto;
@@ -79,7 +81,6 @@ $tile-value-inline-size: 70%;
 	.tiles {
 		flex-flow: row wrap;
 		align-content: safe center;
-		gap: 0;
 	}
 
 	/* Same swap as the narrow rows: the loaded tiles sit flush and hold each

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
@@ -1,7 +1,7 @@
 @use "../../styles/widget-container" as *;
 
 /* Placeholder treatment from the design prototype's highlights skeleton: flat
- * label and value stand-ins, without the loaded tile's border or type scale.
+ * label and value stand-ins, without the loaded tile's dividers or type scale.
  *
  * The prototype only draws the wide arrangement. The narrow one below mirrors
  * `metric-tile-grid.module.scss` instead, which stacks full-width rows until

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid-skeleton.module.scss
@@ -35,13 +35,16 @@ $tile-value-inline-size: 70%;
 	min-block-size: 0;
 }
 
-/* Narrow: one full-width row per metric, as the loaded grid's single column. */
+/* Narrow: one full-width row per metric, as the loaded grid's single column.
+ * The loaded grid runs flush and spaces its rows with each tile's block
+ * padding, so the stand-ins do the same rather than with a gap of their own -
+ * otherwise the rows shift when the data lands. */
 .tiles {
 	display: flex;
 	flex: 1 1 auto;
 	flex-direction: column;
 	justify-content: safe center;
-	gap: var(--wpds-dimension-gap-sm);
+	gap: 0;
 	min-block-size: 0;
 	overflow: hidden;
 }
@@ -52,6 +55,7 @@ $tile-value-inline-size: 70%;
 	align-items: center;
 	justify-content: space-between;
 	gap: var(--wpds-dimension-gap-md);
+	padding-block: var(--wpds-dimension-padding-sm);
 }
 
 .label {
@@ -75,15 +79,20 @@ $tile-value-inline-size: 70%;
 	.tiles {
 		flex-flow: row wrap;
 		align-content: safe center;
-		gap: var(--wpds-dimension-gap-xl);
+		gap: 0;
 	}
 
+	/* Same swap as the narrow rows: the loaded tiles sit flush and hold each
+	 * other off with inline padding, so a stand-in column lines up with the
+	 * column it replaces. */
 	.tile {
 		flex: 1 1 0;
 		flex-direction: column;
 		justify-content: unset;
 		gap: 0;
 		min-inline-size: $tile-min-inline-size;
+		padding-block: var(--wpds-dimension-padding-md);
+		padding-inline: var(--wpds-dimension-padding-md);
 	}
 
 	.label {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -205,7 +205,12 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	 * shares an edge with, so position decides. Column two is always an even
 	 * child, and the first row is always the first two. Each pair covers every
 	 * tile, so this block states both edges outright rather than patching over
-	 * what the one-row query left behind. */
+	 * what the one-row query left behind.
+	 *
+	 * Counting children only holds while every tile is rendered and laid out in
+	 * order, which the grid guarantees today - it maps `tiles` straight into
+	 * `.grid` and puts nothing else there. A consumer that hid a tile through
+	 * the public `className` prop would move the rules onto the wrong edges. */
 	.tile:nth-child(odd) {
 		border-inline-start: 0;
 	}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -7,6 +7,11 @@ $metric-tile-grid-row-value-font-size-max: 40px;
 // The design spec pins highlight-tile values at 32px.
 $metric-tile-grid-tile-value-font-size: 32px;
 $metric-tile-grid-prominent-value-font-size-max: 44px;
+// Metrics are separated by a hairline rather than boxed, so the tiles run flush
+// and each draws the rule on the edge it shares with the one before it. The
+// grid's outer edges stay open, which is what tells the two apart. Same weak
+// stroke as WidgetFooter's rule, which sits inches away in the same card.
+$metric-tile-grid-divider: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-height-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-gap-lg));
 
 /* Size containment removes the container from auto sizing, so it must get its
@@ -23,7 +28,7 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	display: grid;
 	grid-auto-rows: minmax(var(--wpds-typography-line-height-2xl), 1fr);
 	grid-template-columns: 1fr;
-	gap: var(--wpds-dimension-gap-sm);
+	gap: 0;
 	block-size: 100%;
 	min-block-size: 0;
 }
@@ -36,9 +41,11 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	min-inline-size: 0;
 	min-block-size: 0;
 	padding-block: var(--wpds-dimension-padding-sm);
-	padding-inline: var(--wpds-dimension-padding-lg);
-	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
-	border-radius: var(--wpds-border-radius-lg);
+}
+
+/* Narrow: one column, so the shared edge is the row above. */
+.tile + .tile {
+	border-block-start: $metric-tile-grid-divider;
 }
 
 .header {
@@ -124,6 +131,12 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 		text-align: center;
 	}
 
+	/* One row, so the shared edge is the tile to the left. */
+	.tile + .tile {
+		border-block-start: 0;
+		border-inline-start: $metric-tile-grid-divider;
+	}
+
 	.header {
 		flex: 0 1 auto;
 		justify-content: center;
@@ -171,6 +184,21 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	.tile {
 		padding-block: var(--wpds-dimension-padding-2xl);
 		padding-inline: var(--wpds-dimension-padding-lg);
+	}
+
+	/* Two columns: a tile's neighbour in document order is no longer the one it
+	 * shares an edge with, so position decides. Every second tile starts a
+	 * column edge, everything past the first row starts a row edge. */
+	.tile + .tile {
+		border-inline-start: 0;
+	}
+
+	.tile:nth-child(even) {
+		border-inline-start: $metric-tile-grid-divider;
+	}
+
+	.tile:nth-child(n + 3) {
+		border-block-start: $metric-tile-grid-divider;
 	}
 
 	.tile .value,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -8,9 +8,11 @@ $metric-tile-grid-row-value-font-size-max: 40px;
 $metric-tile-grid-tile-value-font-size: 32px;
 $metric-tile-grid-prominent-value-font-size-max: 44px;
 // Metrics are separated by a hairline rather than boxed, so the tiles run flush
-// and each draws the rule on the edge it shares with the one before it. The
-// grid's outer edges stay open, which is what tells the two apart. Same weak
-// stroke as WidgetFooter's rule, which sits inches away in the same card.
+// and each draws the rule on the edge it shares with its neighbour - the tile
+// before it in the one-dimensional layouts, whichever tile that turns out to be
+// in the two-column one. The grid's outer edges stay open, which is what tells
+// a divider from a box. Same weak stroke as WidgetFooter's rule, which sits
+// inches away in the same card.
 $metric-tile-grid-divider: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-height-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-gap-lg));
 
@@ -40,6 +42,10 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	gap: var(--wpds-dimension-gap-md);
 	min-inline-size: 0;
 	min-block-size: 0;
+
+	/* No inline padding: it existed to sit inside the border, and without one it
+	 * only pushes the label and value out of line with the widget's own header.
+	 * The wider layouts set their own, to hold the content off the rules. */
 	padding-block: var(--wpds-dimension-padding-sm);
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -131,8 +131,7 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 		text-align: center;
 	}
 
-	/* One row, so the shared edge moves to the tile's leading side. The
-	 * block-start reset is undone again by the two-column query below. */
+	/* One row, so the shared edge moves to the tile's leading side. */
 	.tile + .tile {
 		border-block-start: 0;
 		border-inline-start: $metric-tile-grid-divider;
@@ -170,8 +169,9 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	}
 }
 
-/* Wide and tall: a balanced two-column grid of large centered tiles. Resets the
- * one-row flow set above so tiles wrap into rows again. */
+/* Wide and tall: a balanced two-column grid of large centered tiles, the last
+ * one taking the whole row when the count is odd. Resets the one-row flow set
+ * above so tiles wrap into rows again. */
 @container (min-inline-size: #{$widget-wide-min-inline-size}) and (min-block-size: #{$metric-tile-grid-grid-min-block-size}) {
 
 	.grid {
@@ -196,19 +196,20 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	}
 
 	/* Two columns: a tile's neighbour in document order is no longer the one it
-	 * shares an edge with, so position decides. Every second tile starts a
-	 * column edge, everything past the first row starts a row edge.
-	 *
-	 * Order-dependent: `.tile + .tile` and `.tile:nth-child(n + 3)` have equal
-	 * specificity, so the row rules below win over the wide block's
-	 * `border-block-start: 0` only because this query comes later in the file.
-	 * Moving the two @container blocks past each other drops every row rule. */
-	.tile + .tile {
+	 * shares an edge with, so position decides. Column two is always an even
+	 * child, and the first row is always the first two. Each pair covers every
+	 * tile, so this block states both edges outright rather than patching over
+	 * what the one-row query left behind. */
+	.tile:nth-child(odd) {
 		border-inline-start: 0;
 	}
 
 	.tile:nth-child(even) {
 		border-inline-start: $metric-tile-grid-divider;
+	}
+
+	.tile:nth-child(-n + 2) {
+		border-block-start: 0;
 	}
 
 	.tile:nth-child(n + 3) {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -131,7 +131,8 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 		text-align: center;
 	}
 
-	/* One row, so the shared edge is the tile to the left. */
+	/* One row, so the shared edge moves to the tile's leading side. The
+	 * block-start reset is undone again by the two-column query below. */
 	.tile + .tile {
 		border-block-start: 0;
 		border-inline-start: $metric-tile-grid-divider;
@@ -186,9 +187,22 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 		padding-inline: var(--wpds-dimension-padding-lg);
 	}
 
+	/* An odd count leaves the last row half empty. A box needed no neighbour to
+	 * look finished, but a rule does: the row's divider would stop dead at the
+	 * midpoint. Give the trailing tile the whole row instead, which also spares
+	 * a lone tile from rendering at half the width it has. */
+	.tile:last-child:nth-child(odd) {
+		grid-column: 1 / -1;
+	}
+
 	/* Two columns: a tile's neighbour in document order is no longer the one it
 	 * shares an edge with, so position decides. Every second tile starts a
-	 * column edge, everything past the first row starts a row edge. */
+	 * column edge, everything past the first row starts a row edge.
+	 *
+	 * Order-dependent: `.tile + .tile` and `.tile:nth-child(n + 3)` have equal
+	 * specificity, so the row rules below win over the wide block's
+	 * `border-block-start: 0` only because this query comes later in the file.
+	 * Moving the two @container blocks past each other drops every row rule. */
 	.tile + .tile {
 		border-inline-start: 0;
 	}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
@@ -139,7 +139,8 @@ function MetricTileValue( {
  *
  * - narrow: a single column of compact rows (icon and label left, value right);
  * - wide but short: a single row of centered tiles (columns follow tile count);
- * - wide and tall: a balanced two-column grid of large centered tiles.
+ * - wide and tall: a balanced two-column grid of large centered tiles, the last
+ *   one taking the whole row when the tile count is odd.
  *
  * The grid is a size container, so it takes no height of its own: render it
  * inside a definite-height flex column (or a `height: 100%` chain) or it

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -53,7 +53,8 @@ const meta = {
 					'own layout — no column count needed. A narrow cell renders compact rows (icon ' +
 					'and label on the left, value on the right); a wide but short cell spreads the ' +
 					'tiles across a single row; a wide and tall cell uses a balanced two-column grid ' +
-					'of large centered tiles.',
+					'of large centered tiles, the last one taking the whole row when the tile count ' +
+					'is odd.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -99,8 +99,9 @@ export const WideShortRoomy: Story = {
 };
 
 /**
- * Three tiles: the layout still balances without an awkward orphan row — one row
- * when short, and a filled two-column grid when tall.
+ * Three tiles: the layout still balances without an awkward orphan — one row when
+ * short, and when tall a two-column grid whose trailing tile takes the last row
+ * rather than leaving half of it empty.
  */
 export const ThreeTiles: Story = {
 	args: { tiles: TILES.slice( 0, 3 ), dataFormat: COUNT_FORMAT },

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/stories/metric-tile-grid.stories.tsx
@@ -100,9 +100,8 @@ export const WideShortRoomy: Story = {
 };
 
 /**
- * Three tiles: the layout still balances without an awkward orphan — one row when
- * short, and when tall a two-column grid whose trailing tile takes the last row
- * rather than leaving half of it empty.
+ * Three tiles in a tall cell: an odd count still balances, because the trailing
+ * tile takes the last row rather than leaving half of it empty.
  */
 export const ThreeTiles: Story = {
 	args: { tiles: TILES.slice( 0, 3 ), dataFormat: COUNT_FORMAT },

--- a/projects/plugins/jetpack/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/jetpack/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.
+Premium Analytics: Divide a widget's metrics with lines instead of boxing each one.

--- a/projects/plugins/jetpack/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/jetpack/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Divide a widget's metrics with lines instead of boxing each one.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Highlights widgets: Separate metrics with lines instead of boxes.
+Divide a widget's metrics with lines instead of boxing each one.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Highlights widgets: Separate metrics with lines instead of boxes.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.
+Premium Analytics: Divide a widget's metrics with lines instead of boxing each one.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2034-highlights-metric-dividers
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2034-highlights-metric-dividers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Separate the metrics in the highlights widgets with lines instead of boxes.


### PR DESCRIPTION
Fixes WOOA7S-2034

## Why

On the Insights page every highlight metric used to sit in its own little rounded box, so a card with four numbers read as four cards inside a card. Now the numbers are just separated by a thin line. Site owners get the same information with a lot less to look at - same intent as dropping the page descriptions, applied inside the widget.

## Proposed changes

* The highlights widgets divide their metrics with a hairline instead of boxing each one. The box lived in one shared place, `MetricTileGrid`, so this is a single rule change and every highlight-style widget follows it: Year in review, All-time stats, Site overview, Subscriber highlights, WordAds highlights, Email highlights and Post highlights.
* The tiles run flush and each draws the rule on the edge it shares with the one before it, so the lines land between metrics and the grid's outer edges stay open - that's what makes it read as a divider rather than a box. The two-column layout can't use document adjacency for that, because a tile's DOM neighbour isn't the one it shares an edge with, so there the rules follow position.
* In the two-column layout a trailing tile now takes the whole row when the metric count is odd. A box needed no neighbour to look finished, but a rule does - without this the row divider stopped dead at the midpoint. Three metrics isn't hypothetical: All-time stats, WordAds highlights and Post highlights all ship exactly three. It also spares a lone tile from rendering at half the width it has, which it did before this change too.
* The row layout loses its inline padding along with the box. It was only there to sit inside the border, and without one it just pushed the label and value out of line with the widget's own header.
* The line uses the weak stroke, matching the `WidgetFooter` rule that sits inches away in the same card. The stronger stroke was picked back when it had to hold up a whole outline.

## Related product discussion/links

* Design spec: Eder's 26 August recap on the Unified Analytics P2, "Insights page" section - "Small adjustment to the highlights widgets to use lines to divide the metrics instead of boxes. It reduces noise."
* WOOA7S-2034

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

Before / after on Stats v2 -> Insights, captured from a local docker WP env at 1440x900.

![Insights: metrics boxed before, divided by lines after](https://github.com/user-attachments/assets/56bf9f22-f611-4134-9171-726a2470773c)

## Testing instructions

* Go to **Jetpack → Stats v2 → Insights**.
* Ensure **Year in review** and **All-time stats** divide their metrics with a thin line and no metric has a box around it.
* Ensure the lines sit *between* the metrics only - no line runs along the outside edge of the group.
* Narrow the browser until the widgets stack their metrics into rows. Ensure the divider becomes a horizontal line between rows, and that the metric labels line up with the widget's own title rather than being indented.
* Hit **Customize** and drag a highlights widget taller until the metrics rearrange into two columns. Ensure you get a clean cross of lines, and that with an odd number of metrics (**All-time stats** ships three) the last one takes the whole row instead of leaving half a row empty with a line ending in mid-air.
* Open **Customize → Add widget** and search for `highlights`. Ensure Subscriber highlights, WordAds highlights, Email highlights and Post highlights all get the same treatment.
* Ensure nothing changed for **Site overview** other than the boxes going away - the period-over-period deltas should still render.
