### PR TITLE
Jetpack AI: show the real period count on the Overview usage card

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -8,7 +8,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink, ProgressBar, Spinner, VisuallyHidden } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { sprintf, __, _n } from '@wordpress/i18n';
 import { connection, list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Stack, Text } from '@wordpress/ui';
 import NavRow from '../components/nav-row';
@@ -115,9 +115,8 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 	// authoritative for the tier, so an expired purchase cannot relabel Free.
 	const planLabel = ( ! usage.isFree && planName ) || usage.planLabel;
 	const hasNumbers = usage.requestsAvailable !== null && usage.requestsLimit > 0;
-	// The backend reports a legacy "unlimited" tier for every paid state while
-	// a fair-usage cap still applies (JETPACK-2384), so the card shows the
-	// period's real usage instead of claiming Unlimited over a full meter.
+	// A fair-usage cap applies on every plan, so the card shows the
+	// period's real usage on the uncapped tier.
 	const hasPeriodCount = usage.unlimited && usage.periodRequestsCount !== null;
 	// One translatable sentence for screen readers; the visible value/limit
 	// pair and the meter are its visual restatements.
@@ -125,7 +124,12 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 		? hasPeriodCount &&
 		  sprintf(
 				/* translators: %d: requests used in the current period. */
-				__( '%d requests used this period', 'jetpack' ),
+				_n(
+					'%d request used this period',
+					'%d requests used this period',
+					usage.periodRequestsCount,
+					'jetpack'
+				),
 				usage.periodRequestsCount
 		  )
 		: hasNumbers &&
@@ -135,9 +139,8 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 				usage.requestsAvailable,
 				usage.requestsLimit
 		  );
-	// No limit, no meter: with nothing to draw the bar against, a meter could
-	// only overstate. normalizeUsage floors availability at 0 and it can never
-	// exceed the limit, so the ratio needs no clamping here.
+	// normalizeUsage floors availability at 0 and it can never exceed the
+	// limit, so the ratio needs no clamping here.
 	const showMeter = ! usage.unlimited && hasNumbers;
 	const meterValue = ( usage.requestsAvailable / usage.requestsLimit ) * 100;
 

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -8,7 +8,7 @@ import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ExternalLink, ProgressBar, Spinner, VisuallyHidden } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf, __, _n } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { connection, list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Stack, Text } from '@wordpress/ui';
 import NavRow from '../components/nav-row';
@@ -115,22 +115,19 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 	// authoritative for the tier, so an expired purchase cannot relabel Free.
 	const planLabel = ( ! usage.isFree && planName ) || usage.planLabel;
 	const hasNumbers = usage.requestsAvailable !== null && usage.requestsLimit > 0;
-	// A fair-usage cap applies on every plan, so the card shows the
-	// period's real usage on the uncapped tier.
+	// A fair-usage cap applies on every plan, so the uncapped tier shows real
+	// usage — this period and all-time — matching the My Jetpack AI page.
 	const hasPeriodCount = usage.unlimited && usage.periodRequestsCount !== null;
 	// One translatable sentence for screen readers; the visible value/limit
 	// pair and the meter are its visual restatements.
 	const srSummary = usage.unlimited
 		? hasPeriodCount &&
+		  usage.allTimeRequestsCount !== null &&
 		  sprintf(
-				/* translators: %d: requests used in the current period. */
-				_n(
-					'%d request used this period',
-					'%d requests used this period',
-					usage.periodRequestsCount,
-					'jetpack'
-				),
-				usage.periodRequestsCount
+				/* translators: %1$d: requests used in the current period. %2$d: requests used all-time. */
+				__( 'Requests used: %1$d this period, %2$d all-time', 'jetpack' ),
+				usage.periodRequestsCount,
+				usage.allTimeRequestsCount
 		  )
 		: hasNumbers &&
 		  sprintf(
@@ -162,32 +159,75 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 				{ ! isLoading && ! error && (
 					<div className="jetpack-ai-overview__usage">
 						<div className="jetpack-ai-overview__usage-cell">
-							<Text render={ <p /> } variant="heading-sm" className="jetpack-ai-overview__eyebrow">
-								{ usage.unlimited
-									? __( 'Requests this period', 'jetpack' )
-									: __( 'Available requests', 'jetpack' ) }
-							</Text>
-							{ /* Its own paragraph, padded with spaces — clipped text glues
-						     onto the neighboring heading in some screen readers. */ }
-							{ srSummary && <VisuallyHidden as="p">{ ` ${ srSummary } ` }</VisuallyHidden> }
-							<Stack
-								direction="row"
-								justify="space-between"
-								align="baseline"
-								// With a hidden summary sentence in place, the loose value
-								// and limit nodes would only be read as fragments.
-								aria-hidden={ srSummary ? 'true' : undefined }
-							>
-								{ usage.unlimited ? (
+							{ usage.unlimited ? (
+								<>
+									{ /* Its own paragraph, padded with spaces — clipped text glues
+								     onto the neighboring heading in some screen readers. */ }
+									{ srSummary && <VisuallyHidden as="p">{ ` ${ srSummary } ` }</VisuallyHidden> }
+									<Stack
+										direction="row"
+										gap="xl"
+										className="jetpack-ai-overview__stats"
+										// With a hidden summary sentence in place, the loose
+										// stat nodes would only be read as fragments.
+										aria-hidden={ srSummary ? 'true' : undefined }
+									>
+										<div className="jetpack-ai-overview__stat">
+											<Text
+												render={ <p /> }
+												variant="heading-sm"
+												className="jetpack-ai-overview__eyebrow"
+											>
+												{ __( 'Requests this period', 'jetpack' ) }
+											</Text>
+											<Text
+												render={ <p /> }
+												variant="heading-xl"
+												className="jetpack-ai-overview__requests-value"
+											>
+												{ hasPeriodCount ? usage.periodRequestsCount : '—' }
+											</Text>
+										</div>
+										{ usage.allTimeRequestsCount !== null && (
+											<div className="jetpack-ai-overview__stat">
+												<Text
+													render={ <p /> }
+													variant="heading-sm"
+													className="jetpack-ai-overview__eyebrow"
+												>
+													{ __( 'All-time', 'jetpack' ) }
+												</Text>
+												<Text
+													render={ <p /> }
+													variant="heading-xl"
+													className="jetpack-ai-overview__requests-value"
+												>
+													{ usage.allTimeRequestsCount }
+												</Text>
+											</div>
+										) }
+									</Stack>
+								</>
+							) : (
+								<>
 									<Text
 										render={ <p /> }
-										variant="heading-xl"
-										className="jetpack-ai-overview__requests-value"
+										variant="heading-sm"
+										className="jetpack-ai-overview__eyebrow"
 									>
-										{ hasPeriodCount ? usage.periodRequestsCount : '—' }
+										{ __( 'Available requests', 'jetpack' ) }
 									</Text>
-								) : (
-									<>
+									{ /* Its own paragraph, padded with spaces — clipped text glues
+								     onto the neighboring heading in some screen readers. */ }
+									{ srSummary && <VisuallyHidden as="p">{ ` ${ srSummary } ` }</VisuallyHidden> }
+									<Stack
+										direction="row"
+										justify="space-between"
+										align="baseline"
+										// With a hidden summary sentence in place, the loose value
+										// and limit nodes would only be read as fragments.
+										aria-hidden={ srSummary ? 'true' : undefined }
+									>
 										<Text
 											render={ <p /> }
 											variant="heading-xl"
@@ -204,18 +244,18 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 												{ usage.requestsLimit }
 											</Text>
 										) }
-									</>
-								) }
-							</Stack>
-							{ showMeter && (
-								// The bar only restates the visible numbers, so it is
-								// decorative — screen readers get "8 of 20" from the text
-								// (VoiceOver reads a named bar's label and percent again).
-								<ProgressBar
-									aria-hidden="true"
-									className="jetpack-ai-overview__meter"
-									value={ meterValue }
-								/>
+									</Stack>
+									{ showMeter && (
+										// The bar only restates the visible numbers, so it is
+										// decorative — screen readers get "8 of 20" from the text
+										// (VoiceOver reads a named bar's label and percent again).
+										<ProgressBar
+											aria-hidden="true"
+											className="jetpack-ai-overview__meter"
+											value={ meterValue }
+										/>
+									) }
+								</>
 							) }
 						</div>
 

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -115,10 +115,19 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 	// authoritative for the tier, so an expired purchase cannot relabel Free.
 	const planLabel = ( ! usage.isFree && planName ) || usage.planLabel;
 	const hasNumbers = usage.requestsAvailable !== null && usage.requestsLimit > 0;
+	// The backend reports a legacy "unlimited" tier for every paid state while
+	// a fair-usage cap still applies (JETPACK-2384), so the card shows the
+	// period's real usage instead of claiming Unlimited over a full meter.
+	const hasPeriodCount = usage.unlimited && usage.periodRequestsCount !== null;
 	// One translatable sentence for screen readers; the visible value/limit
 	// pair and the meter are its visual restatements.
 	const srSummary = usage.unlimited
-		? __( 'Unlimited requests', 'jetpack' )
+		? hasPeriodCount &&
+		  sprintf(
+				/* translators: %d: requests used in the current period. */
+				__( '%d requests used this period', 'jetpack' ),
+				usage.periodRequestsCount
+		  )
 		: hasNumbers &&
 		  sprintf(
 				/* translators: %1$d: requests still available. %2$d: total requests in the plan. */
@@ -126,12 +135,11 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 				usage.requestsAvailable,
 				usage.requestsLimit
 		  );
-	// normalizeUsage floors availability at 0 and it can never exceed the
-	// limit, so the ratio needs no clamping here.
-	const showMeter = usage.unlimited || hasNumbers;
-	const meterValue = usage.unlimited
-		? 100
-		: ( usage.requestsAvailable / usage.requestsLimit ) * 100;
+	// No limit, no meter: with nothing to draw the bar against, a meter could
+	// only overstate. normalizeUsage floors availability at 0 and it can never
+	// exceed the limit, so the ratio needs no clamping here.
+	const showMeter = ! usage.unlimited && hasNumbers;
+	const meterValue = ( usage.requestsAvailable / usage.requestsLimit ) * 100;
 
 	return (
 		<Card.Root>
@@ -152,7 +160,9 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 					<div className="jetpack-ai-overview__usage">
 						<div className="jetpack-ai-overview__usage-cell">
 							<Text render={ <p /> } variant="heading-sm" className="jetpack-ai-overview__eyebrow">
-								{ __( 'Available requests', 'jetpack' ) }
+								{ usage.unlimited
+									? __( 'Requests this period', 'jetpack' )
+									: __( 'Available requests', 'jetpack' ) }
 							</Text>
 							{ /* Its own paragraph, padded with spaces — clipped text glues
 						     onto the neighboring heading in some screen readers. */ }
@@ -168,10 +178,10 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 								{ usage.unlimited ? (
 									<Text
 										render={ <p /> }
-										variant="body-md"
-										className="jetpack-ai-overview__muted jetpack-ai-overview__unlimited"
+										variant="heading-xl"
+										className="jetpack-ai-overview__requests-value"
 									>
-										{ __( 'Unlimited', 'jetpack' ) }
+										{ hasPeriodCount ? usage.periodRequestsCount : '—' }
 									</Text>
 								) : (
 									<>

--- a/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
@@ -156,13 +156,6 @@
 		color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 	}
 
-	// Two classes: the Text component's runtime-injected p reset (margin: 0)
-	// otherwise outranks the auto margin by order alone.
-	&__usage &__unlimited {
-		text-transform: uppercase;
-		margin-inline-start: auto;
-	}
-
 	// Doubled class beats the component's runtime-injected rules. ProgressBar
 	// derives its track from the foreground colour (accent at 10%); the frame
 	// wants a neutral track under a rounded brand-coloured fill.

--- a/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
@@ -156,6 +156,20 @@
 		color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 	}
 
+	// The stats row fills the cell so each column can push its number to
+	// the bottom edge — level with the plan name in the neighboring cell.
+	&__usage &__stats {
+		flex: 1;
+	}
+
+	&__stat {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		gap: var(--wpds-dimension-gap-sm, 8px);
+		min-inline-size: 0;
+	}
+
 	// Doubled class beats the component's runtime-injected rules. ProgressBar
 	// derives its track from the foreground colour (accent at 10%); the frame
 	// wants a neutral track under a rounded brand-coloured fill.

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.js
@@ -74,8 +74,9 @@ describe( 'normalizeUsage', () => {
 		expect( usage.requestsCount ).toBeNull();
 		expect( usage.requestsLimit ).toBeNull();
 		expect( usage.requestsAvailable ).toBeNull();
-		// The card falls back to the period's real usage on this tier.
+		// The card falls back to real usage on this tier.
 		expect( usage.periodRequestsCount ).toBe( 340 );
+		expect( usage.allTimeRequestsCount ).toBe( 950 );
 		// The plan name can only come from the purchase; "Unlimited" would
 		// just repeat the requests cell.
 		expect( usage.planLabel ).toBeNull();
@@ -117,6 +118,7 @@ describe( 'normalizeUsage', () => {
 			expect( usage.requestsLimit ).toBeNull();
 			expect( usage.requestsAvailable ).toBeNull();
 			expect( usage.periodRequestsCount ).toBeNull();
+			expect( usage.allTimeRequestsCount ).toBeNull();
 			expect( usage.unlimited ).toBe( false );
 			expect( usage.showUpgrade ).toBe( false );
 			expect( usage.planLabel ).toBeNull();

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.js
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.js
@@ -74,6 +74,8 @@ describe( 'normalizeUsage', () => {
 		expect( usage.requestsCount ).toBeNull();
 		expect( usage.requestsLimit ).toBeNull();
 		expect( usage.requestsAvailable ).toBeNull();
+		// The card falls back to the period's real usage on this tier.
+		expect( usage.periodRequestsCount ).toBe( 340 );
 		// The plan name can only come from the purchase; "Unlimited" would
 		// just repeat the requests cell.
 		expect( usage.planLabel ).toBeNull();
@@ -114,6 +116,7 @@ describe( 'normalizeUsage', () => {
 			expect( usage.requestsCount ).toBeNull();
 			expect( usage.requestsLimit ).toBeNull();
 			expect( usage.requestsAvailable ).toBeNull();
+			expect( usage.periodRequestsCount ).toBeNull();
 			expect( usage.unlimited ).toBe( false );
 			expect( usage.showUpgrade ).toBe( false );
 			expect( usage.planLabel ).toBeNull();

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -84,18 +84,41 @@ describe( 'AiOverview', () => {
 		expect( screen.getByRole( 'progressbar', { hidden: true } ) ).toBeInTheDocument();
 	} );
 
-	test( 'legacy unlimited: full meter, renewal date, no upgrade', async () => {
-		apiFetch.mockResolvedValueOnce( { ...tieredPayload(), 'current-tier': { value: 1 } } );
+	test( 'unlimited tier: shows the period count instead of an Unlimited claim', async () => {
+		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
 
 		render( <AiOverview { ...PROPS } /> );
 
-		// The i4 paid card shows UNLIMITED over a full meter — once — and no
-		// Upgrade. Without a purchase date there is no renewal line: the usage
-		// period's rollover is a different date and must not stand in for it.
-		await expect( screen.findAllByText( 'Unlimited' ) ).resolves.toHaveLength( 1 );
-		expect( screen.getByRole( 'progressbar', { hidden: true } ) ).toBeInTheDocument();
+		// The backend has no real "unlimited" — a fair-usage cap applies to every
+		// plan — so the card reports the period's actual usage instead of claiming
+		// (JETPACK-2384). No meter: there is no limit to draw it against. Without
+		// a purchase date there is still no renewal line, and no Upgrade.
+		await expect( screen.findByText( '340' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Requests this period' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Available requests' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'progressbar', { hidden: true } ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( /Renews on/ ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'unlimited a11y: one hidden sentence carries the period count', async () => {
+		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( '340' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( '340 requests used this period' ) ).toBeInTheDocument();
+	} );
+
+	test( 'unlimited tier: a payload without a period count renders a dash', async () => {
+		apiFetch.mockResolvedValueOnce( { ...unlimitedPayload(), 'usage-period': undefined } );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( '—' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'progressbar', { hidden: true } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'plan name: the purchase name labels a paid state', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -89,10 +89,8 @@ describe( 'AiOverview', () => {
 
 		render( <AiOverview { ...PROPS } /> );
 
-		// The backend has no real "unlimited" — a fair-usage cap applies to every
-		// plan — so the card reports the period's actual usage instead of claiming
-		// (JETPACK-2384). No meter: there is no limit to draw it against. Without
-		// a purchase date there is still no renewal line, and no Upgrade.
+		// The card reports the period's actual usage with no meter. Without a
+		// purchase date there is still no renewal line, and no Upgrade.
 		await expect( screen.findByText( '340' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Requests this period' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
@@ -111,6 +109,18 @@ describe( 'AiOverview', () => {
 		expect( screen.getByText( '340 requests used this period' ) ).toBeInTheDocument();
 	} );
 
+	test( 'unlimited a11y: a single request reads in the singular', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			...unlimitedPayload(),
+			'usage-period': { 'requests-count': 1, 'next-start': '2026-09-01' },
+		} );
+
+		render( <AiOverview { ...PROPS } /> );
+
+		await expect( screen.findByText( '1' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( '1 request used this period' ) ).toBeInTheDocument();
+	} );
+
 	test( 'unlimited tier: a payload without a period count renders a dash', async () => {
 		apiFetch.mockResolvedValueOnce( { ...unlimitedPayload(), 'usage-period': undefined } );
 
@@ -119,6 +129,8 @@ describe( 'AiOverview', () => {
 		await expect( screen.findByText( '—' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'progressbar', { hidden: true } ) ).not.toBeInTheDocument();
+		// With no count there is nothing to summarize: no stale hidden sentence.
+		expect( screen.queryByText( /requests? used this period/ ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'plan name: the purchase name labels a paid state', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -84,15 +84,18 @@ describe( 'AiOverview', () => {
 		expect( screen.getByRole( 'progressbar', { hidden: true } ) ).toBeInTheDocument();
 	} );
 
-	test( 'unlimited tier: shows the period count instead of an Unlimited claim', async () => {
+	test( 'unlimited tier: shows period and all-time counts instead of an Unlimited claim', async () => {
 		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
 
 		render( <AiOverview { ...PROPS } /> );
 
-		// The card reports the period's actual usage with no meter. Without a
-		// purchase date there is still no renewal line, and no Upgrade.
+		// The card reports actual usage — this period and all-time, like the
+		// My Jetpack AI page — with no meter. Without a purchase date there
+		// is still no renewal line, and no Upgrade.
 		await expect( screen.findByText( '340' ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Requests this period' ) ).toBeInTheDocument();
+		expect( screen.getByText( '950' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'All-time' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Available requests' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'progressbar', { hidden: true } ) ).not.toBeInTheDocument();
@@ -100,37 +103,28 @@ describe( 'AiOverview', () => {
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'unlimited a11y: one hidden sentence carries the period count', async () => {
+	test( 'unlimited a11y: one hidden sentence carries both counts', async () => {
 		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
 
 		render( <AiOverview { ...PROPS } /> );
 
 		await expect( screen.findByText( '340' ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( '340 requests used this period' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Requests used: 340 this period, 950 all-time' )
+		).toBeInTheDocument();
 	} );
 
-	test( 'unlimited a11y: a single request reads in the singular', async () => {
-		apiFetch.mockResolvedValueOnce( {
-			...unlimitedPayload(),
-			'usage-period': { 'requests-count': 1, 'next-start': '2026-09-01' },
-		} );
-
-		render( <AiOverview { ...PROPS } /> );
-
-		await expect( screen.findByText( '1' ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( '1 request used this period' ) ).toBeInTheDocument();
-	} );
-
-	test( 'unlimited tier: a payload without a period count renders a dash', async () => {
+	test( 'unlimited tier: a payload without a period count renders a dash, keeping all-time', async () => {
 		apiFetch.mockResolvedValueOnce( { ...unlimitedPayload(), 'usage-period': undefined } );
 
 		render( <AiOverview { ...PROPS } /> );
 
 		await expect( screen.findByText( '—' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( '950' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Unlimited' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'progressbar', { hidden: true } ) ).not.toBeInTheDocument();
-		// With no count there is nothing to summarize: no stale hidden sentence.
-		expect( screen.queryByText( /requests? used this period/ ) ).not.toBeInTheDocument();
+		// With no period count there is no summary sentence to go stale.
+		expect( screen.queryByText( /Requests used:/ ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'plan name: the purchase name labels a paid state', async () => {
@@ -376,7 +370,9 @@ describe( 'AiOverview', () => {
 
 		render( <AiOverview { ...PROPS } /> );
 
-		await expect( screen.findByText( 'Walkthrough videos' ) ).resolves.toBeInTheDocument();
+		// Settle the usage fetch first: its loading Spinner is also
+		// role="presentation" and would be caught by the query below.
+		await expect( screen.findByText( 'Available requests' ) ).resolves.toBeInTheDocument();
 
 		// The artwork is decorative — the card's title carries the meaning —
 		// so the images are alt-empty and queried by role="presentation".

--- a/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
@@ -42,7 +42,7 @@ export function anchorDateToUtc( value ) {
  * AVAILABLE (limit − used), so that is derived here.
  *
  * @param {object} data - Raw endpoint payload (dash-cased keys).
- * @return {object} { unlimited, isFree, requestsCount, requestsLimit, requestsAvailable, periodRequestsCount, planLabel, showUpgrade }
+ * @return {object} { unlimited, isFree, requestsCount, requestsLimit, requestsAvailable, periodRequestsCount, allTimeRequestsCount, planLabel, showUpgrade }
  */
 export function normalizeUsage( data ) {
 	const currentTier = data?.[ 'current-tier' ] ?? null;
@@ -70,9 +70,10 @@ export function normalizeUsage( data ) {
 			? Math.max( 0, requestsLimit - requestsCount )
 			: null;
 
-	// The uncapped tier's payload still carries the period's real usage;
-	// the card shows that.
+	// The uncapped tier's payload still carries real usage — this period and
+	// all-time — and the card shows those, like the My Jetpack AI page.
 	const periodRequestsCount = data?.[ 'usage-period' ]?.[ 'requests-count' ] ?? null;
+	const allTimeRequestsCount = data?.[ 'requests-count' ] ?? null;
 
 	// Free is upgradable by definition, whatever the payload says about tiers.
 	const showUpgrade =
@@ -91,6 +92,7 @@ export function normalizeUsage( data ) {
 		requestsLimit,
 		requestsAvailable,
 		periodRequestsCount,
+		allTimeRequestsCount,
 		planLabel,
 		showUpgrade,
 	};

--- a/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
@@ -42,7 +42,7 @@ export function anchorDateToUtc( value ) {
  * AVAILABLE (limit − used), so that is derived here.
  *
  * @param {object} data - Raw endpoint payload (dash-cased keys).
- * @return {object} { unlimited, isFree, requestsCount, requestsLimit, requestsAvailable, planLabel, showUpgrade }
+ * @return {object} { unlimited, isFree, requestsCount, requestsLimit, requestsAvailable, periodRequestsCount, planLabel, showUpgrade }
  */
 export function normalizeUsage( data ) {
 	const currentTier = data?.[ 'current-tier' ] ?? null;
@@ -70,6 +70,11 @@ export function normalizeUsage( data ) {
 			? Math.max( 0, requestsLimit - requestsCount )
 			: null;
 
+	// The "unlimited" tier has no limit to count against, but its payload still
+	// carries the period's real usage — the card shows that instead of claiming
+	// Unlimited, since a fair-usage cap applies to every plan (JETPACK-2384).
+	const periodRequestsCount = data?.[ 'usage-period' ]?.[ 'requests-count' ] ?? null;
+
 	// Free is upgradable by definition, whatever the payload says about tiers.
 	const showUpgrade =
 		! unlimited &&
@@ -86,6 +91,7 @@ export function normalizeUsage( data ) {
 		requestsCount,
 		requestsLimit,
 		requestsAvailable,
+		periodRequestsCount,
 		planLabel,
 		showUpgrade,
 	};

--- a/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/use-ai-usage.js
@@ -70,9 +70,8 @@ export function normalizeUsage( data ) {
 			? Math.max( 0, requestsLimit - requestsCount )
 			: null;
 
-	// The "unlimited" tier has no limit to count against, but its payload still
-	// carries the period's real usage — the card shows that instead of claiming
-	// Unlimited, since a fair-usage cap applies to every plan (JETPACK-2384).
+	// The uncapped tier's payload still carries the period's real usage;
+	// the card shows that.
 	const periodRequestsCount = data?.[ 'usage-period' ]?.[ 'requests-count' ] ?? null;
 
 	// Free is upgradable by definition, whatever the payload says about tiers.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-usage-card
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-usage-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI: Show the period's real request count on the Overview usage card instead of an Unlimited claim.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-usage-card
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-usage-card
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-AI: Show the period's real request count on the Overview usage card instead of an Unlimited claim.
+AI: Show real request usage on the Overview card instead of an Unlimited claim.


### PR DESCRIPTION
Fixes the "Unlimited" usage-card item from JETPACK-2384

## Proposed changes

* Replace "Unlimited" and the full meter on the Overview usage card with real usage: requests this period and all-time, shown level with the plan name.

| Before | After |
| --- | --- |
| ![The usage card claiming Unlimited over a full meter](https://github.com/Automattic/jetpack/blob/screenshots/update/jetpack-ai-overview-usage-card/before.png?raw=true) | ![The usage card showing requests this period and all-time counts](https://github.com/Automattic/jetpack/blob/screenshots/update/jetpack-ai-overview-usage-card/after.png?raw=true) |

## Related product discussion/links

* JETPACK-2384

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with a paid plan, open `/wp-admin/admin.php?page=jetpack-ai` → Overview (a11n-gated).
* The requests card shows "Requests this period" and "All-time" counts — no "Unlimited", no meter.
* Free sites are unchanged.
