### PR TITLE
Premium Analytics: keep the last day of the selected range in the WordAds chart

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2007-wordads-range
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2007-wordads-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ads: Include the last day of the selected range in the WordAds card.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -56,7 +56,7 @@ import type { StatsReportParams } from '../stats-query';
 jest.mock( '@wordpress/api-fetch' );
 
 // `localTZDate()` defaults to the site zone, so pin it rather than letting the
-// machine timezone decide the WordAds "yesterday" clamp.
+// machine timezone decide the WordAds "today" clamp.
 setSettings( {
 	...getSettings(),
 	timezone: { string: 'UTC', offset: 0, offsetFormatted: '0', abbr: 'UTC' },
@@ -1298,6 +1298,73 @@ describe( 'Stats query factories', () => {
 			);
 		} finally {
 			jest.useRealTimers();
+		}
+	} );
+
+	// Each unit counts buckets its own way, so pin every one of them on a day where
+	// clamping the end back to yesterday would drop the whole trailing bucket.
+	it.each( [
+		{ interval: 'week', now: '2026-06-01', from: '2026-05-11', quantity: 4 },
+		{ interval: 'month', now: '2026-06-01', from: '2026-01-01', quantity: 6 },
+		{ interval: 'year', now: '2026-01-01', from: '2024-01-01', quantity: 3 },
+	] )(
+		'keeps the trailing $interval bucket of a WordAds window ending today',
+		( { interval, now, from, quantity } ) => {
+			jest.useFakeTimers().setSystemTime( new Date( `${ now }T12:00:00Z` ) );
+
+			try {
+				expect(
+					statsWordAdsStatsQuery( { from, to: now, interval } as StatsReportParams ).queryKey
+				).toEqual(
+					expect.arrayContaining( [
+						expect.objectContaining( { unit: interval, date: now, quantity } ),
+					] )
+				);
+			} finally {
+				jest.useRealTimers();
+			}
+		}
+	);
+
+	it( 'falls back to a default WordAds bucket count without a range start', () => {
+		// Reachable: an end with no start still passes `enabled`, so the request goes out.
+		expect(
+			statsWordAdsStatsQuery( { to: '2026-06-10', interval: 'day' } as StatsReportParams ).queryKey
+		).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( { unit: 'day', date: '2026-06-10', quantity: 30 } ),
+			] )
+		);
+
+		expect(
+			statsWordAdsStatsQuery( { to: '2026-06-10', interval: 'year' } as StatsReportParams ).queryKey
+		).toEqual( expect.arrayContaining( [ expect.objectContaining( { quantity: 10 } ) ] ) );
+	} );
+
+	it( 'clamps the WordAds window end against the site timezone, not the machine clock', () => {
+		// 02:00 UTC on the 16th is still the 15th in Los Angeles, so the 16th is future.
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { string: 'America/Los_Angeles', offset: -7, offsetFormatted: '-7', abbr: 'PDT' },
+		} );
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-16T02:00:00Z' ) );
+
+		try {
+			expect(
+				statsWordAdsStatsQuery( {
+					from: '2026-06-09',
+					to: '2026-06-16',
+					interval: 'day',
+				} ).queryKey
+			).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( { unit: 'day', date: '2026-06-15', quantity: 7 } ),
+				] )
+			);
+		} finally {
+			jest.useRealTimers();
+			setSettings( settings );
 		}
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1192,9 +1192,9 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
-	it( 'clamps the WordAds window end to yesterday, keeping it anchored to the range start', () => {
-		// The window stays anchored to the range start: the unavailable trailing
-		// bucket is dropped rather than the whole window shifting earlier.
+	it( 'keeps every bucket of a WordAds window ending today', () => {
+		// The endpoint honors an end of today, so the range asks for the bucket count
+		// its header covers; today's bucket is empty until the nightly run lands.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
 
 		try {
@@ -1208,8 +1208,34 @@ describe( 'Stats query factories', () => {
 				expect.arrayContaining( [
 					expect.objectContaining( {
 						unit: 'day',
-						date: '2026-06-14',
-						quantity: 6,
+						date: '2026-06-15',
+						quantity: 7,
+					} ),
+				] )
+			);
+		} finally {
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'clamps a future WordAds window end to today, keeping it anchored to the range start', () => {
+		// The window stays anchored to the range start: the unavailable trailing
+		// buckets are dropped rather than the whole window shifting earlier.
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
+
+		try {
+			expect(
+				statsWordAdsStatsQuery( {
+					from: '2026-06-09',
+					to: '2026-06-20',
+					interval: 'day',
+				} ).queryKey
+			).toEqual(
+				expect.arrayContaining( [
+					expect.objectContaining( {
+						unit: 'day',
+						date: '2026-06-15',
+						quantity: 7,
 					} ),
 				] )
 			);
@@ -1248,36 +1274,10 @@ describe( 'Stats query factories', () => {
 		}
 	} );
 
-	it( 'leaves a WordAds window ending exactly yesterday unclamped', () => {
+	it( 'leaves an offset-bearing WordAds window ending today unclamped', () => {
 		// Why the clamp compares calendar days: the raw offset-bearing string sorts
-		// after the bare `yesterday` it starts with, so a range already ending on
-		// yesterday would clamp and silently lose a bucket.
-		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
-
-		try {
-			expect(
-				statsWordAdsStatsQuery( {
-					from: '2026-06-08T00:00:00.000-07:00',
-					to: '2026-06-14T23:59:59.999-07:00',
-					interval: 'day',
-				} ).queryKey
-			).toEqual(
-				expect.arrayContaining( [
-					expect.objectContaining( {
-						unit: 'day',
-						date: '2026-06-14T23:59:59.999-07:00',
-						quantity: 7,
-					} ),
-				] )
-			);
-		} finally {
-			jest.useRealTimers();
-		}
-	} );
-
-	it( 'clamps an offset-bearing WordAds window end to yesterday, keyed off its calendar day', () => {
-		// The clamp fires, so `date` becomes the locally built bare `yesterday`;
-		// both the comparison and the bucket count key off the calendar day.
+		// after the bare `today` it starts with, so a range already ending on today
+		// would clamp and silently lose a bucket.
 		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00Z' ) );
 
 		try {
@@ -1291,8 +1291,8 @@ describe( 'Stats query factories', () => {
 				expect.arrayContaining( [
 					expect.objectContaining( {
 						unit: 'day',
-						date: '2026-06-14',
-						quantity: 6,
+						date: '2026-06-15T23:59:59.000-07:00',
+						quantity: 7,
 					} ),
 				] )
 			);

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -35,9 +35,7 @@ export const statsWordAdsStatsQuery = (
 	const unit = String( apiParams.period ?? 'day' );
 	const { start_date: startDate } = statsParams;
 	const rangeEnd = typeof apiParams.date === 'string' ? apiParams.date : undefined;
-	// Clamp to today, not yesterday: the endpoint honors an end of today, and the
-	// bucket count below reads this same end, so clamping earlier loses a bucket.
-	// Today's own bucket stays empty until the nightly run lands.
+	// The endpoint honors an end of today; that bucket stays empty until the nightly run.
 	const today = format( localTZDate(), 'yyyy-MM-dd' );
 	// Compare date parts, not the raw strings: a datetime sorts after the bare day
 	// it starts with, so a window ending exactly on today would clamp too.

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-wordads-query.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDatePart } from '@jetpack-premium-analytics/datetime';
-import { format, subDays } from 'date-fns';
+import { format } from 'date-fns';
 /**
  * Internal dependencies
  */
@@ -35,15 +35,16 @@ export const statsWordAdsStatsQuery = (
 	const unit = String( apiParams.period ?? 'day' );
 	const { start_date: startDate } = statsParams;
 	const rangeEnd = typeof apiParams.date === 'string' ? apiParams.date : undefined;
-	// WordAds stats are computed nightly, so clamp later end dates to yesterday.
-	// Compare date parts, not the raw strings: a datetime sorts after the bare
-	// day it starts with, so a window ending exactly on yesterday would clamp too.
+	// Clamp to today, not yesterday: the endpoint honors an end of today, and the
+	// bucket count below reads this same end, so clamping earlier loses a bucket.
+	// Today's own bucket stays empty until the nightly run lands.
+	const today = format( localTZDate(), 'yyyy-MM-dd' );
+	// Compare date parts, not the raw strings: a datetime sorts after the bare day
+	// it starts with, so a window ending exactly on today would clamp too.
 	const rangeEndDay = getDatePart( rangeEnd );
-	const yesterday = format( subDays( localTZDate(), 1 ), 'yyyy-MM-dd' );
-	const clampToYesterday = rangeEndDay !== undefined && rangeEndDay > yesterday;
-	const date = clampToYesterday ? yesterday : rangeEnd;
-	// The endpoint takes a bucket count and end date, not a range: derive the count
-	// from the clamped end so dropping today's bucket does not shift the start.
+	const clampToToday = rangeEndDay !== undefined && rangeEndDay > today;
+	const date = clampToToday ? today : rangeEnd;
+	// The endpoint takes a bucket count and end date, not a range.
 	const defaultQuantity = unit === 'year' ? 10 : 30;
 	const quantity =
 		params.quantity ??

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1392,6 +1392,11 @@ function buildWordAdsStatsResponse( query: URLSearchParams ) {
 			period = bucket.toISOString().slice( 0, 10 );
 		}
 
+		// A day bucket for today has no figures until the nightly WordAds run lands.
+		if ( unit === 'day' && period >= new Date().toISOString().slice( 0, 10 ) ) {
+			return [ period, 0, 0, 0 ];
+		}
+
 		const absDay = Math.floor( bucket.getTime() / DAY_MS );
 		const trend = ( absDay - anchorDay ) * 3;
 		const wave = 200 * Math.sin( absDay / 9 ) + 80 * Math.cos( absDay / 13 );

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
@@ -43,7 +43,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"WordAds performance over the selected period as selectable metric tabs — Ads Served, Average CPM, and Revenue, matching the Calypso WordAds page's tabs — over a line chart. Ads Served is a count; CPM and revenue are currency (WordAds pays USD). The widget hosts its own date range and bucket-size controls in its header, saved onto the widget instance; which metric is plotted is the chart's own tab selection. WordAds stats are computed nightly, so a range ending today is clamped to end at yesterday. Data comes from the `useStatsWordAdsStats` hook (the `wordads` proxy prefix); in Storybook it is served by `registerReportMocks`. Requires WordAds to be active on the site for live data.",
+					"WordAds performance over the selected period as selectable metric tabs — Ads Served, Average CPM, and Revenue, matching the Calypso WordAds page's tabs — over a line chart. Ads Served is a count; CPM and revenue are currency (WordAds pays USD). The widget hosts its own date range and bucket-size controls in its header, saved onto the widget instance; which metric is plotted is the chart's own tab selection. WordAds stats are computed nightly, so the last bucket of a range ending today stays empty until that run lands; only a range ending in the future is clamped back to today. Data comes from the `useStatsWordAdsStats` hook (the `wordads` proxy prefix); in Storybook it is served by `registerReportMocks`. Requires WordAds to be active on the site for live data.",
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -25,8 +25,8 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 export type WordAdsChartTabsAttributes = Partial< ReportParamsFieldAttributes >;
 
 /**
- * WordAds is reported to us daily, so a sub-daily window collapses to one
- * bucket: no line, and yesterday's totals labelled as the last 24 hours.
+ * WordAds is reported to us daily, so a sub-daily window has no finer bucket to
+ * plot and its trailing day is empty until the nightly run lands.
  */
 const WORDADS_PRESETS = [ PRESET_LAST_7_DAYS, PRESET_LAST_30_DAYS, PRESET_LAST_12_MONTHS ] as const;
 

--- a/projects/plugins/jetpack/changelog/wooa7s-2007-wordads-range
+++ b/projects/plugins/jetpack/changelog/wooa7s-2007-wordads-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Include the last day of the selected range in the WordAds card.

--- a/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2007-wordads-range
+++ b/projects/plugins/mu-wpcom-plugin/changelog/wooa7s-2007-wordads-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Include the last day of the selected range in the WordAds card.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2007-wordads-range
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2007-wordads-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ads: Include the last day of the selected range in the WordAds card.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2007-wordads-range
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2007-wordads-range
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Include the last day of the selected range in the WordAds card.


### PR DESCRIPTION
## Proposed changes

* The WordAds chart clamped its window end back to yesterday, then derived the endpoint's bucket count from that clamped end, so a day-bucketed range asked for one bucket fewer than its header covers.
* Move the clamp to today instead of removing it: the endpoint honors an end of today and only rejects a future one, so the count now matches the header, and a deep-linked future end is still capped.
* Clamping only a future end also keeps the offset-bearing datetime on the normal path, rather than flattening it back to a bare `yyyy-MM-dd`.
* Today's own bucket stays empty until the nightly WordAds run lands. That matches what Calypso's Ads chart already draws, which requests `date=<today>` every day.
* Tests: cover a window ending today (all buckets kept), a future end (clamped, start still anchored), and an offset-bearing end on today (unclamped, so the calendar-day comparison stays guarded).

Relevant for the follow-up in WOOA7S-1937: once the rolling presets end today, every one of them hits this path. Today only a custom range ending today does.

## Related product discussion/links

* WOOA7S-2007
* STATS-424 covers the server-side guard this relies on. `resolve_window_end()` falls back only when the requested day is strictly after today.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard and go to the Ads section.
* On the WordAds chart card, open the date control and pick a custom range that ends today, for example the last 7 days including today.
* Watch the network request for `wordads/stats`. Before this change it sent `date=<yesterday>&quantity=6`; it should now send `date=<today>&quantity=7`.
* Confirm the chart's first bar matches the range start shown in the card header, and that the trailing bar for today is present and empty.
* The 7 days / 30 days / 12 months presets still end yesterday on trunk, so they are unchanged here. Worth a quick check that they still render as before.
