### PR TITLE
Premium Analytics: drop the widget style anchors left over from the WidgetState loading overlay

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1942-widget-style-anchors
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1942-widget-style-anchors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Drop the widget stylesheet position anchors left over from WidgetLoadingOverlay; no user-facing change.
+
+

--- a/projects/packages/premium-analytics/changelog/wooa7s-1942-widget-style-anchors
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1942-widget-style-anchors
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Drop the widget stylesheet position anchors left over from WidgetLoadingOverlay; no user-facing change.
+Comment: Drop the widget stylesheet position anchors left over from the WidgetState loading overlay; no user-facing change.
 
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -75,6 +75,8 @@
 	min-block-size: 0;
 }
 
+// Not positioned: an absolutely positioned descendant resolves against its own
+// component's anchor, or against `WidgetRoot`'s containment.
 .root,
 .content {
 	block-size: 100%;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -68,7 +68,6 @@
 }
 
 .loading {
-	position: relative;
 	block-size: 100%;
 
 	// Same rationale as `.state`: no floor, so a short tile's loading box stays
@@ -78,7 +77,6 @@
 
 .root,
 .content {
-	position: relative;
 	block-size: 100%;
 }
 

--- a/projects/packages/premium-analytics/widgets/annual-highlights/style.module.scss
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/style.module.scss
@@ -8,7 +8,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/clicks/style.module.css
+++ b/projects/packages/premium-analytics/widgets/clicks/style.module.css
@@ -16,7 +16,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/devices/style.module.css
+++ b/projects/packages/premium-analytics/widgets/devices/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/email-time-series/style.module.css
+++ b/projects/packages/premium-analytics/widgets/email-time-series/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/projects/packages/premium-analytics/widgets/emails/style.module.css
+++ b/projects/packages/premium-analytics/widgets/emails/style.module.css
@@ -9,7 +9,6 @@
 }
 
 .body {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
+++ b/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -15,7 +15,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;
@@ -30,7 +29,6 @@
 }
 
 .stateArea {
-	position: relative;
 	flex: 1 1 0;
 	min-height: 0;
 }

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -8,7 +8,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/style.module.css
@@ -1,5 +1,4 @@
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/projects/packages/premium-analytics/widgets/popular-days/style.module.css
+++ b/projects/packages/premium-analytics/widgets/popular-days/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/popular-hours/style.module.css
+++ b/projects/packages/premium-analytics/widgets/popular-hours/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -15,7 +15,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/projects/packages/premium-analytics/widgets/post-views/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-views/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -16,7 +16,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/search-terms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/search-terms/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/shares/style.module.css
+++ b/projects/packages/premium-analytics/widgets/shares/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/tags/style.module.css
+++ b/projects/packages/premium-analytics/widgets/tags/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -8,7 +8,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/total-views/style.module.css
+++ b/projects/packages/premium-analytics/widgets/total-views/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/total-visitors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/total-visitors/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/utm-insights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/utm-insights/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/style.module.css
@@ -9,7 +9,6 @@
 /* Hosts the WidgetState (or the no-video prompt); its `.root` wrapper fills
    this box so the list can scroll within the widget frame. */
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/style.module.css
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/style.module.css
@@ -1,5 +1,4 @@
 .root {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	block-size: 100%;

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -7,7 +7,6 @@
 }
 
 .content {
-	position: relative;
 	display: flex;
 	flex-direction: column;
 	flex: 1 1 0;


### PR DESCRIPTION

## Proposed changes

- Drop `position: relative` from 29 widget content wrappers that no longer anchor anything.
- Drop the same two leftovers from `WidgetState`'s `.loading` and `.root, .content`.
- Keep the four that still do a job: `plan-usage`'s meter and label, the dashboard stage's pin marker, and the sections root's stacking context.

Widgets carried these so `WidgetLoadingOverlay` (`position: absolute; inset: 0`) resolved against the widget body. #51202 replaced that overlay with a skeleton and removed the comments explaining the anchors, but left the declarations, so what remains is an unexplained positioning rule a reader has no reason to trust or remove. Every absolutely positioned element left in the package is anchored by its own component's stylesheet (`.line-chart`, the leaderboard's `--fit` content, the donut and semi-circle chart boxes, the heatmap pager's `.host`, `report-performance-chart`'s `.chart`), or rendered through a `useTooltipInPortal` portal.

## Related product discussion/links

- WOOA7S-1942

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is no user-visible change, so this is a "nothing moved" check.

- Go to **Stats v2** (`wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`).
- On the **Traffic** tab, confirm every widget looks the same as on trunk. The ones worth a closer look: **Top locations** (map sits beside the leaderboard) and the leaderboard widgets (**Top pages**, **Top referrers**) whose row labels paint over their bars.
- On the **Insights** tab, hover the **Posting activity** heatmap and confirm the floating pager arrows still appear centered over the cells rather than somewhere else on the page.
- Resize the browser narrow enough that a leaderboard fits no rows, and confirm its "not enough room" message still covers the rows instead of escaping the tile.
- Confirm the console stays clean.

Verified locally on a WordPress install serving this branch: every `position: absolute` element inside the app still resolves its `offsetParent` to its own component's anchor (pin marker to the stage content, leaderboard overlay labels to their row, heatmap arrows to the pager host), and no console errors on load.
