### PR TITLE
Tracking: add a server-side wpcom_admin_screen event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-admin-screen-server-side-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-admin-screen-server-side-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+wp-admin: Record a server-side page view event alongside the existing client-side one.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -178,9 +178,9 @@ function wpcom_admin_screen_watch_request( $screen ) {
 		return;
 	}
 
-	// Deferred to shutdown because a redirect is only knowable once the response headers have
-	// settled, and admin_init has by then populated the user types below. Named callback so the
-	// second set_current_screen() in admin-header.php cannot register it twice.
+	// Deferred to shutdown because what the response turned out to be is only knowable once its
+	// headers have settled, and admin_init has by then populated the user types below. Named
+	// callback so a request that resolves its screen more than once still records one event.
 	add_action( 'shutdown', __NAMESPACE__ . '\wpcom_admin_screen_record' );
 }
 add_action( 'current_screen', __NAMESPACE__ . '\wpcom_admin_screen_watch_request' );
@@ -204,8 +204,15 @@ function wpcom_admin_screen_is_countable( $screen ) {
 		return false;
 	}
 
-	// set_current_screen() also runs for a handful of admin-ajax actions, which render no page.
-	if ( wp_doing_ajax() ) {
+	// Not is_admin(): it defers to the screen we were just handed, which reports itself as being
+	// in the admin for every set_current_screen() caller, REST endpoints included.
+	if ( ! defined( 'WP_ADMIN' ) || ! WP_ADMIN ) {
+		return false;
+	}
+
+	// admin-ajax.php defines WP_ADMIN, and REST endpoints resolve a screen to simulate an admin
+	// context. Neither renders a page.
+	if ( wp_doing_ajax() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 		return false;
 	}
 
@@ -213,24 +220,50 @@ function wpcom_admin_screen_is_countable( $screen ) {
 		return false;
 	}
 
+	// The Customizer runs no admin_footer, so its client-side counterpart comes from
+	// wpcom_maybe_track_customizer(), which records nothing for a Calypso frame or a frontend link.
+	if ( 'customize' === $screen->id && ( isset( $_GET['calypso'] ) || isset( $_GET['url'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return false;
+	}
+
 	return ! do_not_track_a11ns();
 }
 
 /**
- * A redirecting request renders no screen; the one it points at records itself. Counting both
- * would inflate the denominator on every admin POST, since those all end in a redirect.
+ * Whether the response the request produced was actually an admin screen.
+ *
+ * A redirect renders nothing and the screen it points at records itself, so counting both would
+ * inflate the denominator on every admin POST. A download (export.php) or a bare fragment
+ * (async-upload.php) resolves a screen and then exits without an admin footer, so the client
+ * event never fires for it and counting it would depress the ratio the same way.
  *
  * @param string[] $headers Response headers, as returned by headers_list().
  * @return bool
  */
 function wpcom_admin_screen_rendered( array $headers ) {
+	$content_type = null;
+
 	foreach ( $headers as $header ) {
 		if ( 0 === stripos( $header, 'location:' ) ) {
 			return false;
 		}
+
+		if ( 0 === stripos( $header, 'content-disposition:' ) && false !== stripos( $header, 'attachment' ) ) {
+			return false;
+		}
+
+		if ( 0 === stripos( $header, 'content-type:' ) ) {
+			$content_type = strtolower( ltrim( substr( $header, strlen( 'content-type:' ) ) ) );
+		}
 	}
 
-	return true;
+	// A response that never got as far as a Content-Type is still countable: an early wp_die() or
+	// a fatal is precisely the traffic this event exists to measure.
+	if ( null === $content_type ) {
+		return true;
+	}
+
+	return 0 === strpos( $content_type, 'text/html' ) || 0 === strpos( $content_type, 'application/xhtml+xml' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -167,3 +167,108 @@ function get_account_age_in_days() {
 
 	return ( time() - strtotime( $current_user->user_registered ) ) / DAY_IN_SECONDS;
 }
+
+/**
+ * Watch a request that resolved an admin screen, so it can be counted once the response settles.
+ *
+ * @param \WP_Screen $screen The screen WordPress resolved for this request.
+ */
+function wpcom_admin_screen_watch_request( $screen ) {
+	if ( ! wpcom_admin_screen_is_countable( $screen ) ) {
+		return;
+	}
+
+	// Deferred to shutdown because a redirect is only knowable once the response headers have
+	// settled, and admin_init has by then populated the user types below. Named callback so the
+	// second set_current_screen() in admin-header.php cannot register it twice.
+	add_action( 'shutdown', __NAMESPACE__ . '\wpcom_admin_screen_record' );
+}
+add_action( 'current_screen', __NAMESPACE__ . '\wpcom_admin_screen_watch_request' );
+
+/**
+ * Whether wpcom_admin_page_view could also have reported this request. An exclusion on one side
+ * but not the other makes the coverage percentage a measure of the disagreement between the two
+ * events rather than of the tracking gap.
+ *
+ * @param \WP_Screen $screen The screen WordPress resolved for this request.
+ * @return bool
+ */
+function wpcom_admin_screen_is_countable( $screen ) {
+	// Atomic's only server-side delivery is a blocking 1s HTTP request per page view, which is
+	// too expensive to run on every admin screen.
+	if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		return false;
+	}
+
+	if ( ! $screen instanceof \WP_Screen ) {
+		return false;
+	}
+
+	// set_current_screen() also runs for a handful of admin-ajax actions, which render no page.
+	if ( wp_doing_ajax() ) {
+		return false;
+	}
+
+	if ( ! is_user_logged_in() ) {
+		return false;
+	}
+
+	return ! do_not_track_a11ns();
+}
+
+/**
+ * A redirecting request renders no screen; the one it points at records itself. Counting both
+ * would inflate the denominator on every admin POST, since those all end in a redirect.
+ *
+ * @param string[] $headers Response headers, as returned by headers_list().
+ * @return bool
+ */
+function wpcom_admin_screen_rendered( array $headers ) {
+	foreach ( $headers as $header ) {
+		if ( 0 === stripos( $header, 'location:' ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Record one Tracks event per rendered admin screen.
+ *
+ * @return void
+ */
+function wpcom_admin_screen_record() {
+	if ( ! wpcom_admin_screen_rendered( headers_list() ) ) {
+		return;
+	}
+
+	$screen = get_current_screen();
+	if ( ! $screen instanceof \WP_Screen ) {
+		return;
+	}
+
+	global $current_blog;
+	if ( ! $current_blog instanceof \WP_Site ) {
+		return;
+	}
+
+	// Called instead of wpcom_record_tracks_event() because that helper tests for
+	// tracks_record_event() before require_lib() has had a chance to define it, and so drops
+	// events whenever nothing else loaded the lib first.
+	require_lib( 'tracks/client' );
+
+	// Property names and value shapes are copied from wpcom_admin_page_view so that the two
+	// events join per screen without a translation step in the query.
+	tracks_record_event(
+		wp_get_current_user(),
+		'wpcom_admin_screen',
+		array(
+			'from_page'       => $screen->id,
+			'is_block_editor' => $screen->is_block_editor ? 'true' : 'false',
+			'source'          => 'wp-admin',
+			'blog_id'         => (string) $current_blog->blog_id,
+			'user_type'       => implode( ',', \WPCOM_User::get_types() ),
+		)
+	);
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -221,20 +221,32 @@ function wpcom_admin_screen_is_countable( $screen ) {
 /**
  * Whether wpcom_admin_page_view had any chance to run on this screen.
  *
- * Some screens never fire admin_footer, which the client event hangs off: media-upload.php renders
- * through wp_iframe(), press-this.php renders standalone, and the Customizer has its own footer
- * hook, which wpcom_maybe_track_customizer() answers only for a request that is neither a Calypso
- * frame nor a link in from the frontend. Counting a screen the client event cannot reach would
- * depress the ratio instead of measuring it.
+ * Some screens never fire admin_footer, which the client event hangs off: media-upload.php goes
+ * through wp_iframe(), async-upload.php and press-this.php render their own output and exit, the
+ * dashboard index-*stuff fragments answer background requests, and the Customizer has its own
+ * footer hook, which wpcom_maybe_track_customizer() answers only for a request that is neither a
+ * Calypso frame nor a link in from the frontend. Excluding these by route rather than by response
+ * headers matters because an error on one of them is re-sent as HTML by wp_die(). Counting a
+ * screen the client event cannot reach would depress the ratio instead of measuring it.
  *
  * @param string $screen_id The resolved screen id.
  * @param array  $query     Query parameters, as in $_GET.
  * @return bool
  */
 function wpcom_admin_screen_has_client_counterpart( $screen_id, array $query ) {
+	// admin.php skips admin-header.php for a noheader request, so nothing reaches admin_footer
+	// either. The importers poll in this shape.
+	if ( isset( $query['noheader'] ) ) {
+		return false;
+	}
+
 	// Not IFRAME_REQUEST: update.php and the install screens define that too, and do reach
 	// admin_footer through iframe_footer().
-	if ( in_array( $screen_id, array( 'media-upload', 'press-this' ), true ) ) {
+	if ( in_array(
+		$screen_id,
+		array( 'media-upload', 'async-upload', 'press-this', 'index-hotstuff', 'index-yourstuff' ),
+		true
+	) ) {
 		return false;
 	}
 
@@ -311,6 +323,14 @@ function wpcom_admin_screen_record() {
 	// tracks_record_event() before require_lib() has had a chance to define it, and so drops
 	// events whenever nothing else loaded the lib first.
 	require_lib( 'tracks/client' );
+
+	// tracks_record_event() falls back to a blocking one-second pixel request when the async spool
+	// or its daemon is missing, which is the same per-page-view cost that keeps this event off
+	// Atomic. Drop the event rather than let a Tracks outage slow every admin screen.
+	// @phan-suppress-next-line PhanUndeclaredClassMethod -- WPCOM_Tracks_Client is wpcom-only and not yet carried in .phan/stubs/wpcom-stubs.php.
+	if ( ! class_exists( 'WPCOM_Tracks_Client' ) || ! \WPCOM_Tracks_Client::can_do_async() ) {
+		return;
+	}
 
 	// Property names and value shapes are copied from wpcom_admin_page_view so that the two
 	// events join per screen without a translation step in the query.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -328,7 +328,7 @@ function wpcom_admin_screen_record() {
 	// or its daemon is missing, which is the same per-page-view cost that keeps this event off
 	// Atomic. Drop the event rather than let a Tracks outage slow every admin screen.
 	// @phan-suppress-next-line PhanUndeclaredClassMethod -- WPCOM_Tracks_Client is wpcom-only and not yet carried in .phan/stubs/wpcom-stubs.php.
-	if ( ! class_exists( 'WPCOM_Tracks_Client' ) || ! \WPCOM_Tracks_Client::can_do_async() ) {
+	if ( ! is_callable( array( 'WPCOM_Tracks_Client', 'can_do_async' ) ) || ! \WPCOM_Tracks_Client::can_do_async() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -168,29 +168,20 @@ function get_account_age_in_days() {
 	return ( time() - strtotime( $current_user->user_registered ) ) / DAY_IN_SECONDS;
 }
 
-/**
- * Watch a request that resolved an admin screen, so it can be counted once the response settles.
- *
- * @param \WP_Screen $screen The screen WordPress resolved for this request.
- */
-function wpcom_admin_screen_watch_request( $screen ) {
-	if ( ! wpcom_admin_screen_is_countable( $screen ) ) {
-		return;
-	}
-
-	// Deferred to shutdown because what the response turned out to be is only knowable once its
-	// headers have settled, and admin_init has by then populated the user types below. Named
-	// callback so a request that resolves its screen more than once still records one event.
+// Everything is decided at shutdown: what the response turned out to be is only knowable once its
+// headers have settled, and admin_init has by then populated the user types. Registered here
+// rather than from a current_screen callback because another callback on that hook can fatal at an
+// earlier priority, which would lose the failed request this event exists to count.
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM && defined( 'WP_ADMIN' ) && WP_ADMIN ) {
 	add_action( 'shutdown', __NAMESPACE__ . '\wpcom_admin_screen_record' );
 }
-add_action( 'current_screen', __NAMESPACE__ . '\wpcom_admin_screen_watch_request' );
 
 /**
  * Whether wpcom_admin_page_view could also have reported this request. An exclusion on one side
  * but not the other makes the coverage percentage a measure of the disagreement between the two
  * events rather than of the tracking gap.
  *
- * @param \WP_Screen $screen The screen WordPress resolved for this request.
+ * @param \WP_Screen|null $screen The screen WordPress resolved for this request, if any.
  * @return bool
  */
 function wpcom_admin_screen_is_countable( $screen ) {
@@ -230,8 +221,8 @@ function wpcom_admin_screen_is_countable( $screen ) {
 /**
  * Whether wpcom_admin_page_view had any chance to run on this screen.
  *
- * Neither of these screens fires admin_footer: media-upload.php renders through wp_iframe(),
- * which runs admin_print_footer_scripts and nothing else, and the Customizer has its own footer
+ * Some screens never fire admin_footer, which the client event hangs off: media-upload.php renders
+ * through wp_iframe(), press-this.php renders standalone, and the Customizer has its own footer
  * hook, which wpcom_maybe_track_customizer() answers only for a request that is neither a Calypso
  * frame nor a link in from the frontend. Counting a screen the client event cannot reach would
  * depress the ratio instead of measuring it.
@@ -241,7 +232,9 @@ function wpcom_admin_screen_is_countable( $screen ) {
  * @return bool
  */
 function wpcom_admin_screen_has_client_counterpart( $screen_id, array $query ) {
-	if ( 'media-upload' === $screen_id ) {
+	// Not IFRAME_REQUEST: update.php and the install screens define that too, and do reach
+	// admin_footer through iframe_footer().
+	if ( in_array( $screen_id, array( 'media-upload', 'press-this' ), true ) ) {
 		return false;
 	}
 
@@ -295,12 +288,17 @@ function wpcom_admin_screen_rendered( array $headers ) {
  * @return void
  */
 function wpcom_admin_screen_record() {
-	if ( ! wpcom_admin_screen_rendered( headers_list() ) ) {
+	// A request that fataled before the admin includes loaded has no screen to attribute anyway.
+	if ( ! function_exists( 'get_current_screen' ) ) {
 		return;
 	}
 
 	$screen = get_current_screen();
-	if ( ! $screen instanceof \WP_Screen ) {
+	if ( ! wpcom_admin_screen_is_countable( $screen ) ) {
+		return;
+	}
+
+	if ( ! wpcom_admin_screen_rendered( headers_list() ) ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -220,13 +220,36 @@ function wpcom_admin_screen_is_countable( $screen ) {
 		return false;
 	}
 
-	// The Customizer runs no admin_footer, so its client-side counterpart comes from
-	// wpcom_maybe_track_customizer(), which records nothing for a Calypso frame or a frontend link.
-	if ( 'customize' === $screen->id && ( isset( $_GET['calypso'] ) || isset( $_GET['url'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	if ( ! wpcom_admin_screen_has_client_counterpart( $screen->id, $_GET ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return false;
 	}
 
 	return ! do_not_track_a11ns();
+}
+
+/**
+ * Whether wpcom_admin_page_view had any chance to run on this screen.
+ *
+ * Neither of these screens fires admin_footer: media-upload.php renders through wp_iframe(),
+ * which runs admin_print_footer_scripts and nothing else, and the Customizer has its own footer
+ * hook, which wpcom_maybe_track_customizer() answers only for a request that is neither a Calypso
+ * frame nor a link in from the frontend. Counting a screen the client event cannot reach would
+ * depress the ratio instead of measuring it.
+ *
+ * @param string $screen_id The resolved screen id.
+ * @param array  $query     Query parameters, as in $_GET.
+ * @return bool
+ */
+function wpcom_admin_screen_has_client_counterpart( $screen_id, array $query ) {
+	if ( 'media-upload' === $screen_id ) {
+		return false;
+	}
+
+	if ( 'customize' === $screen_id ) {
+		return ! isset( $query['calypso'] ) && ! isset( $query['url'] );
+	}
+
+	return true;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
@@ -82,6 +82,38 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 	}
 
 	/**
+	 * Tests which screens the client-side event could have reported.
+	 *
+	 * @dataProvider wpcom_admin_screen_has_client_counterpart_provider
+	 *
+	 * @param string $screen_id The resolved screen id.
+	 * @param array  $query     Query parameters, as in $_GET.
+	 * @param bool   $expected  Whether the client event could have run on the screen.
+	 */
+	#[DataProvider( 'wpcom_admin_screen_has_client_counterpart_provider' )]
+	public function test_wpcom_admin_screen_has_client_counterpart( $screen_id, $query, $expected ) {
+		$this->assertSame( $expected, wpcom_admin_screen_has_client_counterpart( $screen_id, $query ) );
+	}
+
+	/**
+	 * Data provider for test_wpcom_admin_screen_has_client_counterpart.
+	 *
+	 * Counting a screen that never fires admin_footer would depress the coverage ratio the event
+	 * exists to measure, while excluding an ordinary screen would shrink the denominator itself.
+	 *
+	 * @return array
+	 */
+	public static function wpcom_admin_screen_has_client_counterpart_provider() {
+		return array(
+			'ordinary screen'        => array( 'edit', array(), true ),
+			'media upload iframe'    => array( 'media-upload', array(), false ),
+			'customizer'             => array( 'customize', array(), true ),
+			'customizer in calypso'  => array( 'customize', array( 'calypso' => '1' ), false ),
+			'customizer from a link' => array( 'customize', array( 'url' => 'https://example.com' ), false ),
+		);
+	}
+
+	/**
 	 * Tests that only a Location response header marks a request as having rendered no screen.
 	 *
 	 * @dataProvider wpcom_admin_screen_rendered_provider

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
@@ -107,6 +107,7 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 		return array(
 			'ordinary screen'        => array( 'edit', array(), true ),
 			'media upload iframe'    => array( 'media-upload', array(), false ),
+			'press this'             => array( 'press-this', array(), false ),
 			'customizer'             => array( 'customize', array(), true ),
 			'customizer in calypso'  => array( 'customize', array( 'calypso' => '1' ), false ),
 			'customizer from a link' => array( 'customize', array( 'url' => 'https://example.com' ), false ),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
@@ -108,6 +108,9 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 			'ordinary screen'        => array( 'edit', array(), true ),
 			'media upload iframe'    => array( 'media-upload', array(), false ),
 			'press this'             => array( 'press-this', array(), false ),
+			'async upload'           => array( 'async-upload', array(), false ),
+			'dashboard fragment'     => array( 'index-hotstuff', array(), false ),
+			'noheader poll'          => array( 'import', array( 'noheader' => 'true' ), false ),
 			'customizer'             => array( 'customize', array(), true ),
 			'customizer in calypso'  => array( 'customize', array( 'calypso' => '1' ), false ),
 			'customizer from a link' => array( 'customize', array( 'url' => 'https://example.com' ), false ),
@@ -134,8 +137,9 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 	 * wp_redirect(), while matching the header name anywhere in the string would treat
 	 * X-Content-Location as a redirect and drop real screens out of the denominator.
 	 *
-	 * The download and fragment cases each isolate one guard: export.php sends an attachment as
-	 * text/html would otherwise be accepted, and async-upload.php sends text/plain.
+	 * The download and fragment cases each isolate one guard: export.php sends an attachment that
+	 * would otherwise be accepted as text/html, and a non-HTML body is not a screen. Routes known
+	 * to render no footer are excluded before this runs, so these cover unpredictable responses.
 	 *
 	 * @return array
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
@@ -101,6 +101,9 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 	 * wp_redirect(), while matching the header name anywhere in the string would treat
 	 * X-Content-Location as a redirect and drop real screens out of the denominator.
 	 *
+	 * The download and fragment cases each isolate one guard: export.php sends an attachment as
+	 * text/html would otherwise be accepted, and async-upload.php sends text/plain.
+	 *
 	 * @return array
 	 */
 	public static function wpcom_admin_screen_rendered_provider() {
@@ -110,6 +113,8 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 			'wp_redirect'          => array( array( 'Content-Type: text/html; charset=UTF-8', 'Location: /wp-admin/edit.php' ), false ),
 			'lowercased by caller' => array( array( 'location: /wp-admin/' ), false ),
 			'location in a name'   => array( array( 'X-Content-Location: /wp-admin/' ), true ),
+			'attachment download'  => array( array( 'Content-Type: text/html; charset=UTF-8', 'Content-Disposition: attachment; filename=export.xml' ), false ),
+			'non-html fragment'    => array( array( 'Content-Type: text/plain; charset=UTF-8' ), false ),
 		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Page_View_Test.php
@@ -80,4 +80,36 @@ class WPCOM_WPAdmin_Page_View_Test extends TestCase {
 			array( false, null, null ),
 		);
 	}
+
+	/**
+	 * Tests that only a Location response header marks a request as having rendered no screen.
+	 *
+	 * @dataProvider wpcom_admin_screen_rendered_provider
+	 *
+	 * @param string[] $headers  Response headers, as returned by headers_list().
+	 * @param bool     $expected Whether the request should count as a rendered screen.
+	 */
+	#[DataProvider( 'wpcom_admin_screen_rendered_provider' )]
+	public function test_wpcom_admin_screen_rendered( $headers, $expected ) {
+		$this->assertSame( $expected, wpcom_admin_screen_rendered( $headers ) );
+	}
+
+	/**
+	 * Data provider for test_wpcom_admin_screen_rendered.
+	 *
+	 * PHP echoes the caller's casing back from header() and not every redirect goes through
+	 * wp_redirect(), while matching the header name anywhere in the string would treat
+	 * X-Content-Location as a redirect and drop real screens out of the denominator.
+	 *
+	 * @return array
+	 */
+	public static function wpcom_admin_screen_rendered_provider() {
+		return array(
+			'rendered screen'      => array( array( 'Content-Type: text/html; charset=UTF-8', 'X-Frame-Options: SAMEORIGIN' ), true ),
+			'headerless response'  => array( array(), true ),
+			'wp_redirect'          => array( array( 'Content-Type: text/html; charset=UTF-8', 'Location: /wp-admin/edit.php' ), false ),
+			'lowercased by caller' => array( array( 'location: /wp-admin/' ), false ),
+			'location in a name'   => array( array( 'X-Content-Location: /wp-admin/' ), true ),
+		);
+	}
 }


### PR DESCRIPTION
## Proposed changes

* `wpcom_admin_page_view` is pushed from the admin footer and delivered by the browser, so it cannot report a screen that redirected, hit `wp_die()`, fataled, or whose beacon never sent. Nothing counts the admin screens actually rendered, so the size of that loss is unknown.
* This adds `wpcom_admin_screen`, recorded server-side over the same requests under the same exclusions, so the ratio between the two events per screen is the coverage of the existing one. Requests that render no screen — redirects, admin-ajax — are excluded, since the screen a redirect points at records itself.
* Simple sites only for now. Atomic's one server-side delivery path issues a blocking outbound HTTP request per page view, which is too expensive to run on every admin screen; an Atomic denominator needs a non-blocking path first.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

Yes — please apply the **[Status] Needs Privacy Updates** label. It adds a Tracks event, `wpcom_admin_screen`, recorded once per rendered wp-admin screen on Simple sites. It carries the same properties as the existing `wpcom_admin_page_view` — screen id, block editor flag, source, blog id, user type — and records nothing that event does not already record, under the same Automattician exclusion.

## Testing instructions

* Run the package tests: `jp test php packages/jetpack-mu-wpcom`. The added cases cover the redirect detection that decides whether a request is counted.
* On a Simple site, load a few wp-admin screens as a non-Automattician and confirm one `wpcom_admin_screen` per screen, with properties matching the `wpcom_admin_page_view` recorded on the same page load.
* Submit a wp-admin form that ends in a redirect, and confirm the redirecting request records nothing — only the screen it lands on does.
