### PR TITLE
Jetpack AI: Overview tab redirects in checkout page and My Jetpack AI card

### DIFF
--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-hub-manage-url
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-hub-manage-url
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: land the card's View link, post-checkout, and post-activation on the Jetpack AI Hub.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -519,9 +519,20 @@ class Jetpack_Ai extends Module_Product {
 	/**
 	 * Get the URL where the user manages the product
 	 *
+	 * Pre-release gate: the Jetpack AI Hub's gated views are limited to
+	 * internal testing environments, so only they land there — everyone else
+	 * keeps the My Jetpack product page. Drop the gate when the views go public.
+	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
+		if (
+			function_exists( 'jetpack_is_internal_testing_environment' ) &&
+			jetpack_is_internal_testing_environment()
+		) {
+			return admin_url( 'admin.php?page=jetpack-ai' );
+		}
+
 		return admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' );
 	}
 

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -5,6 +5,8 @@ namespace Automattic\Jetpack\My_Jetpack;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
 use Jetpack_Options;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -168,5 +170,85 @@ class Jetpack_Ai_Product_Test extends TestCase {
 
 		$this->assertTrue( Jetpack_Ai::is_module_active() );
 		$this->assertNotSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
+	}
+
+	/**
+	 * In internal testing environments the manage URL points at the Jetpack AI
+	 * Hub, whose Overview tab is visible behind the same gate.
+	 */
+	public function test_manage_url_points_at_the_jetpack_ai_hub_in_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+
+		$manage_url = Jetpack_Ai::get_manage_url();
+
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), $manage_url );
+		$this->assertStringNotContainsString( 'page=my-jetpack', (string) $manage_url );
+	}
+
+	/**
+	 * Outside internal testing the Jetpack AI Hub shows only MCP Settings, so
+	 * the manage URL must keep landing on the My Jetpack product page.
+	 */
+	public function test_manage_url_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * Post-checkout landing in internal testing environments is the Jetpack AI Hub.
+	 */
+	public function test_post_checkout_lands_on_the_jetpack_ai_hub_in_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
+	}
+
+	/**
+	 * Post-checkout landing outside internal testing stays on the My Jetpack product page.
+	 */
+	public function test_post_checkout_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
+	}
+
+	/**
+	 * Post-activation landing in internal testing environments is the Jetpack AI Hub.
+	 */
+	public function test_post_activation_lands_on_the_jetpack_ai_hub_in_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
+	}
+
+	/**
+	 * Post-activation landing outside internal testing stays on the My Jetpack product page.
+	 */
+	public function test_post_activation_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
+	}
+
+	/**
+	 * Standalone plugins ship My Jetpack without the Jetpack plugin, so the gate
+	 * helper never exists and the manage URL must fall back to My Jetpack. Separate
+	 * process so no earlier activate_plugins() call has defined the helper.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_manage_url_stays_on_the_my_jetpack_product_page_without_the_jetpack_plugin() {
+		$this->assertFalse( function_exists( 'jetpack_is_internal_testing_environment' ) );
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
 	}
 }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
@@ -2,7 +2,7 @@
  * MCP upsell card — shown when the current site does not have an MCP-capable plan.
  *
  * The CTA destination is read from `jetpackAiSettings.upgradeUrl`, which is
- * built server-side via `Redirect::get_url( 'jetpack-ai-upgrade-url-for-jetpack-sites' )`
+ * built server-side via `Redirect::get_url( 'jetpack-ai-hub-upgrade' )`
  * so the target can be changed via the Jetpack redirect service without
  * shipping a code change. The previous implementation hardcoded
  * `wordpress.com/plans/<host>`, which 403'd for non-.com sites (AIINT-404).

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -223,9 +223,9 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			Connection_Initial_State::render_script( 'jetpack-ai-admin' );
 		}
 
-		// Pre-release gate for the Overview and Features views. Everything the
-		// gated views need hangs off this one flag, so opening them up to
-		// everyone is a single change here.
+		// Pre-release gate for the Overview and Features views. When opening
+		// them to everyone, also drop the matching gate in My Jetpack's
+		// Jetpack_Ai::get_manage_url() so its links land here too.
 		$show_gated_views = $is_internal_test;
 
 		$plan_info = $show_gated_views ? self::get_ai_plan_info() : array(
@@ -245,10 +245,10 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 					'apiRoot'          => esc_url_raw( rest_url() ),
 					'apiNonce'         => wp_create_nonce( 'wp_rest' ),
 					'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
-					// Route through the Jetpack redirect service so the upgrade
-					// destination for the MCP upsell can be retargeted without
-					// shipping a code change.
-					'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-upgrade-url-for-jetpack-sites', array( 'path' => 'jetpack_ai_yearly' ) ),
+					// The redirect entry bakes in the jetpack_ai_yearly product and
+					// a post-checkout return to this page, so both can be
+					// retargeted without shipping a code change.
+					'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
 					// The purchase granting AI, for the Overview usage card — the
 					// usage endpoint cannot name it. Only looked up when a gated
 					// view can render it.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-manage-url
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-manage-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: return to the Jetpack AI Hub after upgrading from it, and point My Jetpack's AI links at the Hub.


### PR DESCRIPTION
Fixes FORNO-503

## Proposed changes

* My Jetpack: the Jetpack AI card's View link and the post-checkout/post-activation url now point at the Jetpack AI Hub/Overview tab.  Internal testing environments only. 
* Jetpack AI Hub: upgrading from the Hub now returns to the Jetpack AI Hub (Overview tab) after checkout, via the new `jetpack-ai-hub-upgrade` redirect entry. The old entry and its editor consumers are untouched.

## Related product discussion/links

* FORNO-503

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a JN site running this branch (or any internal testing environment):

* Go to wp-admin → Jetpack → **My Jetpack**, find the Jetpack AI card, and click **View**. You should land on the Jetpack AI Hub's Overview (`admin.php?page=jetpack-ai`).
* On the Hub's Overview, click **Upgrade** on the usage card. On the checkout page, check the address bar: the path should contain `/checkout/<your-site>/jetpack_ai_yearly` and the query should contain `redirect_to=admin.php%3Fpage%3Djetpack-ai`. Completing the purchase returns you to the Hub.
* Non-gated behavior is unchanged and pinned by unit tests (`projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php`): outside internal testing environments — including standalone plugins that ship My Jetpack without the Jetpack plugin — every link keeps its current destination.
