### PR TITLE
Premium Analytics: treat an empty referrer results list as a leaf row

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1575-empty-referrer-group
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1575-empty-referrer-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Referrers: treat a group with an empty results list as an external-link row.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers.test.ts
@@ -242,4 +242,38 @@ describe( 'Stats referrers normalizer', () => {
 			} ),
 		] );
 	} );
+
+	it( 'treats a referrer group with an empty results array as a leaf row', () => {
+		const result = sanitizeStatsReferrersResponse(
+			{
+				date: '2026-06-22',
+				period: 'day',
+				summary: {
+					groups: [
+						{
+							name: 'example.com',
+							group: 'example.com',
+							total: 3,
+							url: 'https://example.com/source',
+							results: [],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-16',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( result.data[ 0 ].items ).toEqual( [
+			expect.objectContaining( {
+				label: 'example.com',
+				labelIcon: 'external',
+				children: null,
+			} ),
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
@@ -103,6 +103,9 @@ export function sanitizeStatsReferrersResponse(
 	const parse = ( item: StatsRecord, parentName?: string ): StatsReferrersItem => {
 		const name = typeof item.name === 'string' ? item.name : undefined;
 		const label = name ?? item.group ?? '';
+		// Both fields below must agree on whether this row is a group, so read the
+		// nested rows once: an empty `results: []` is a leaf, not a childless group.
+		const nested = coerceStatsArray( item.results ?? item.children );
 
 		return {
 			label:
@@ -110,10 +113,8 @@ export function sanitizeStatsReferrersResponse(
 			views: safeParseFloat( item.views ?? item.total ),
 			link: typeof item.url === 'string' ? item.url : null,
 			icon: typeof item.icon === 'string' ? item.icon : null,
-			labelIcon: item.results || item.children ? null : 'external',
-			children: mapNestedItems( coerceStatsArray( item.results ?? item.children ), child =>
-				parse( child, name )
-			),
+			labelIcon: nested.length ? null : 'external',
+			children: mapNestedItems( nested, child => parse( child, name ) ),
 		};
 	};
 


### PR DESCRIPTION

## Proposed changes
* Read the nested referrer rows once, so `labelIcon` and `children` can no longer disagree about whether a row is a group.
* A group with an empty `results: []` now normalizes to `labelIcon: 'external'` instead of `null`, matching the `children: null` the same row already gets.
* Brings the referrers normalizer in line with `clicks.ts`, which already tests the array's length rather than its truthiness.
* Adds a normalizer test covering the empty-results group.

Edge-case hardening only. Real Stats groups always carry at least one result, and the referrers UI decides its leaf/group treatment from `children`, not from `labelIcon`, so no rendered output changes today.

## Related product discussion/links
* WOOA7S-1575

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack test js packages/premium-analytics` passes, or scope it to the normalizer:
  `cd projects/packages/premium-analytics && TZ=UTC pnpm exec jest --config=tests/jest.config.cjs packages/data/src/processing/stats/__tests__/referrers`
* Revert the `labelIcon` line to `item.results || item.children ? null : 'external'` and the new test fails with `labelIcon: null`, confirming it covers the fix.
* The Referrers widget and report page render unchanged, since neither reads `labelIcon`.
