### PR TITLE
Premium Analytics: add forced-state Storybook stories for post detail widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1737-post-detail-forced-state-stories
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1737-post-detail-forced-state-stories
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Storybook-only: add forced loading/error/empty stories for the post detail widgets.
+
+

--- a/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
@@ -5,7 +5,10 @@ import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -25,6 +28,8 @@ registerReportMocks();
 
 const MOCK_POST_ID = 779;
 const POST_COMMENTS_RENDER_MODULE = 'storybook/post-comments';
+
+const COMMENTS_REQUEST_PATH = `posts/${ MOCK_POST_ID }/replies`;
 
 interface PostCommentsStoryControls {
 	hasPostScope: boolean;
@@ -79,6 +84,55 @@ export const NoPostScope: Story = {
 	render: renderPostComments,
 	args: { hasPostScope: false },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Loading — the first fetch is still in flight, so the widget shows its
+ * skeleton roster. The mock is forced to never resolve for this story.
+ */
+export const Loading: Story = {
+	render: renderPostComments,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( COMMENTS_REQUEST_PATH, 'loading' );
+		return () => setReportMockState( COMMENTS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Error — the fetch failed with a 403: the widget shows its error copy and a
+ * Retry action, which re-runs the query (still mocked as failing here).
+ */
+export const Error: Story = {
+	render: renderPostComments,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( COMMENTS_REQUEST_PATH, 'error' );
+		return () => setReportMockState( COMMENTS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Empty — a scoped post that resolved with no comments: "There are no comments
+ * yet." This is the scoped empty state, distinct from the scopeless copy in
+ * NoPostScope.
+ */
+export const Empty: Story = {
+	render: renderPostComments,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( COMMENTS_REQUEST_PATH, 'empty' );
+		return () => setReportMockState( COMMENTS_REQUEST_PATH, null );
+	},
 };
 
 interface PostCommentsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
@@ -18,7 +18,10 @@ import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -41,6 +44,8 @@ registerReportMocks();
 const MOCK_POST_ID = 779;
 
 const POST_DETAIL_HIGHLIGHTS_RENDER_MODULE = 'storybook/post-detail-highlights';
+
+const POST_STATS_REQUEST_PATH = `stats/post/${ MOCK_POST_ID }`;
 
 interface PostDetailHighlightsStoryControls {
 	withComparison: boolean;
@@ -127,6 +132,55 @@ export const NoPostScope: Story = {
 	render: renderPostDetailHighlights,
 	args: { withComparison: false, hasPostScope: false },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Loading — the first fetch is still in flight, so the tiles show their
+ * skeleton. The mock is forced to never resolve for this story.
+ */
+export const Loading: Story = {
+	render: renderPostDetailHighlights,
+	args: { withComparison: false, hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'loading' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Error — the fetch failed with a 403 and there is nothing cached to keep on
+ * screen, so the widget shows its error copy with a Retry action.
+ */
+export const Error: Story = {
+	render: renderPostDetailHighlights,
+	args: { withComparison: false, hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'error' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Empty — a scoped post with no recorded activity: every tile reads 0. The
+ * widget's empty state covers only a missing post scope (see NoPostScope), so
+ * this is what a data-free post actually looks like.
+ */
+export const Empty: Story = {
+	render: renderPostDetailHighlights,
+	args: { withComparison: false, hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'empty' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
 };
 
 interface PostDetailHighlightsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
@@ -16,7 +16,10 @@ import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -39,6 +42,8 @@ registerReportMocks();
 const MOCK_POST_ID = 779;
 
 const POST_LIKES_RENDER_MODULE = 'storybook/post-likes';
+
+const LIKES_REQUEST_PATH = `posts/${ MOCK_POST_ID }/likes`;
 
 interface PostLikesStoryControls {
 	hasPostScope: boolean;
@@ -101,6 +106,55 @@ export const NoPostScope: Story = {
 	render: renderPostLikes,
 	args: { hasPostScope: false },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Loading — the first fetch is still in flight, so the widget shows its
+ * skeleton roster. The mock is forced to never resolve for this story.
+ */
+export const Loading: Story = {
+	render: renderPostLikes,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( LIKES_REQUEST_PATH, 'loading' );
+		return () => setReportMockState( LIKES_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Error — the fetch failed with a 403: the widget shows its error copy and a
+ * Retry action, which re-runs the query (still mocked as failing here).
+ */
+export const Error: Story = {
+	render: renderPostLikes,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( LIKES_REQUEST_PATH, 'error' );
+		return () => setReportMockState( LIKES_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Empty — a scoped post that resolved with no likes: "There are no likes yet."
+ * This is the scoped empty state, distinct from the scopeless copy in
+ * NoPostScope.
+ */
+export const Empty: Story = {
+	render: renderPostLikes,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( LIKES_REQUEST_PATH, 'empty' );
+		return () => setReportMockState( LIKES_REQUEST_PATH, null );
+	},
 };
 
 interface PostLikesDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -18,7 +18,10 @@ import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -41,6 +44,8 @@ registerReportMocks();
 const MOCK_POST_ID = 779;
 
 const POST_TRAFFIC_ACTIVITY_RENDER_MODULE = 'storybook/post-traffic-activity';
+
+const POST_STATS_REQUEST_PATH = `stats/post/${ MOCK_POST_ID }`;
 
 interface PostTrafficActivityStoryControls {
 	hasPostScope: boolean;
@@ -122,6 +127,56 @@ export const NoPostScope: Story = {
 	render: renderPostTrafficActivity,
 	args: { hasPostScope: false, preset: 'last-30-days' },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Loading — the first fetch is still in flight, so the widget shows its
+ * heatmap skeleton. The mock is forced to never resolve for this story.
+ */
+export const Loading: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true, preset: 'last-30-days' },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'loading' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Error — the fetch failed with a 403: the widget shows its error copy and a
+ * Retry action, which re-runs the query (still mocked as failing here).
+ */
+export const Error: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true, preset: 'last-30-days' },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'error' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Empty — a scoped post with no views in the range: the grid stays complete
+ * and every cell is blank, per the sparse design. The widget's empty state
+ * covers only a missing post scope (see NoPostScope), so this is what a
+ * traffic-free post actually looks like.
+ */
+export const Empty: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true, preset: 'last-30-days' },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'empty' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
 };
 
 interface PostTrafficActivityDashboardStoryProps


### PR DESCRIPTION
## Proposed changes

* Add forced `Loading`, `Error`, and `Empty` stories to the four post detail Traffic widgets: Post highlights, Latest likes, Latest comments, Traffic activity.
* Use the shared `setReportMockState` helper from the report mocks, following the `search-terms` reference, so no widget specific mocks are added.
* Keep the new stories off autodocs (`tags: [ '!autodocs' ]`), since the override is keyed by request path.
* `NoPostScope` keeps covering the missing scope case only; the new `Empty` stories cover a scoped post that resolves with no data.
* Skip `ErrorRetryable`: these four pass a static error object with Retry rather than mapping through `describeError`, so there is no second variant to show.

Two of the widgets have no scoped empty state today. Post highlights and Traffic activity render the `WidgetState` empty only when `post_id` is missing, so their `Empty` story shows what a data free post actually looks like: zeroed tiles, and a complete but all blank heatmap. Traffic activity also has an `isEmpty` clause on `heatmapData.length === 0` that the range derived grid makes unreachable, and its empty copy would read as a scope prompt if it ever fired. Both look worth a follow up rather than a change here.

Not covered: `post-views`, which sits in the same tab and has the same gap, and is outside this issue's scope.

## Related product discussion/links

* WOOA7S-1737

## Does this pull request change what data or activity we track or use?

No. Storybook stories only, no shipped code changes.

## Testing instructions

* Build the package so Storybook resolves the built internal packages: `jetpack build --deps packages/premium-analytics`.
* Start Storybook: `pnpm run storybook` from `projects/packages/premium-analytics`.
* Open `Packages/Premium Analytics/Widgets/PostComments`, `PostLikes`, `PostDetailHighlights`, and `PostTrafficActivity`.
* On each, check the new `Loading`, `Error`, and `Empty` stories, then switch back to `Default` and confirm it still renders its fixture data (the forced state clears on cleanup).

Verified against a running Storybook, all twelve stories: skeletons on `Loading`; each widget's own error copy plus Retry on `Error`; "There are no comments yet." / "There are no likes yet." on the two rosters; three tiles reading 0 on Post highlights; and a complete grid of neutral blank cells on Traffic activity. Switching back to `Default` from a forced story restores the fixture data, so the cleanup clears correctly.

