### PR TITLE
Connection: build the owner notice script without HEREDOC syntax

### DIFF
--- a/projects/packages/connection/changelog/stats-343-connection-heredoc
+++ b/projects/packages/connection/changelog/stats-343-connection-heredoc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build the connection owner notice script without HEREDOC syntax.

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -209,12 +209,8 @@ class Connection_Notice {
 	 * @return string
 	 */
 	private function get_connection_owner_script() {
-		$rest_url        = wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-		$rest_nonce      = wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-		$success_message = wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-		$error_message   = wp_json_encode( esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-
-		return <<<JS
+		ob_start();
+		?>
 ( function() {
 	const switchOwnerButton = document.getElementById('jp-switch-connection-owner');
 	if ( ! switchOwnerButton ) {
@@ -235,15 +231,15 @@ class Connection_Notice {
 			submitBtn.disabled = false;
 
 			results.classList.add( 'error-message' );
-			results.innerHTML = message || {$error_message};
+			results.innerHTML = message || <?php echo wp_json_encode( esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 		}
 
 		fetch(
-			{$rest_url},
+			<?php echo wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
 			{
 				method: 'POST',
 				headers: {
-					'X-WP-Nonce': {$rest_nonce},
+					'X-WP-Nonce': <?php echo wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
 				},
 				body: new URLSearchParams( new FormData( this ) ),
 			}
@@ -252,7 +248,7 @@ class Connection_Notice {
 			.then( data => {
 				if ( data.hasOwnProperty( 'code' ) && data.code === 'success' ) {
 					// Owner successfully changed.
-					results.innerHTML = {$success_message};
+					results.innerHTML = <?php echo wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
 					setTimeout(function () {
 						document.getElementById( 'jetpack-notice-switch-connection-owner' ).style.display = 'none';
 					}, 1000);
@@ -265,6 +261,7 @@ class Connection_Notice {
 			.catch( () => handleAPIError() );
 	});
 } )();
-JS;
+		<?php
+		return ob_get_clean();
 	}
 }

--- a/projects/packages/connection/src/class-connection-notice.php
+++ b/projects/packages/connection/src/class-connection-notice.php
@@ -209,6 +209,8 @@ class Connection_Notice {
 	 * @return string
 	 */
 	private function get_connection_owner_script() {
+		$json_flags = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP;
+
 		ob_start();
 		?>
 ( function() {
@@ -231,15 +233,15 @@ class Connection_Notice {
 			submitBtn.disabled = false;
 
 			results.classList.add( 'error-message' );
-			results.innerHTML = message || <?php echo wp_json_encode( esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+			results.innerHTML = message || <?php echo wp_json_encode( esc_html__( 'Something went wrong. Please try again.', 'jetpack-connection' ), $json_flags ); ?>;
 		}
 
 		fetch(
-			<?php echo wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
+			<?php echo wp_json_encode( esc_url_raw( get_rest_url() . 'jetpack/v4/connection/owner' ), $json_flags ); ?>,
 			{
 				method: 'POST',
 				headers: {
-					'X-WP-Nonce': <?php echo wp_json_encode( wp_create_nonce( 'wp_rest' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>,
+					'X-WP-Nonce': <?php echo wp_json_encode( wp_create_nonce( 'wp_rest' ), $json_flags ); ?>,
 				},
 				body: new URLSearchParams( new FormData( this ) ),
 			}
@@ -248,7 +250,7 @@ class Connection_Notice {
 			.then( data => {
 				if ( data.hasOwnProperty( 'code' ) && data.code === 'success' ) {
 					// Owner successfully changed.
-					results.innerHTML = <?php echo wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP ); ?>;
+					results.innerHTML = <?php echo wp_json_encode( esc_html__( 'Success!', 'jetpack-connection' ), $json_flags ); ?>;
 					setTimeout(function () {
 						document.getElementById( 'jetpack-notice-switch-connection-owner' ).style.display = 'none';
 					}, 1000);


### PR DESCRIPTION
## Proposed changes
* Build the connection owner notice script with output buffering instead of HEREDOC syntax. The generated JavaScript is unchanged; only the way the PHP string is assembled changes.
* The WordPress.org plugin review for the standalone Jetpack Stats plugin flagged the HEREDOC block in `Connection_Notice::get_connection_owner_script()` and asked for standard string concatenation or output buffering.
* The dynamic values keep the same `wp_json_encode()` calls with the `JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP` flags, now echoed inline the way this file did before #51461 moved the script to `wp_add_inline_script()`.

## Related product discussion/links
* Internal reference: pejTkB-2AJ-p2#comment-1993
* Follows up on #51461.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Connect a site that has at least two admins connected to WordPress.com, then delete or disconnect the connection owner so the "connection owner" notice appears in wp-admin.
* Confirm the notice still lets you pick a new owner: submit the form, and check that the success message shows and the notice hides.
* Alternatively, diff the old and the new `get_connection_owner_script()` output — the script is unchanged apart from trailing whitespace.
* `jp test php packages/connection`, `jp phan packages/connection`, and PHPCS on the changed file all pass.