### PR TITLE
Jetpack AI: fix the MCP settings showing an upgrade prompt or raw error to not-connected admins

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -15,7 +15,7 @@ import { AdminPage, GlobalNotices, useGlobalNotices } from '@automattic/jetpack-
 import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
+import { Badge, Link, Notice, Stack, Tabs } from '@wordpress/ui';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
 import McpHub from './mcp/index';
@@ -149,8 +149,14 @@ export default function App() {
 	// auto-dismissing, no page-level styling needed.
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 	const mcpViewedRecorded = useRef( false );
+	// Strict false: older page data (undefined) must not read as unlinked.
+	const userUnlinked = isUserConnected === false;
+	// MCP settings ride the site's and the user's own WordPress.com connections,
+	// so with either one missing the MCP body gives way to a connection notice —
+	// and the settings fetch is skipped, since it could only fail.
+	const showConnectNotice = !! blogId && userUnlinked;
 	const { isLoading, savingToolIds, mcpAbilities, hasMcpAccess, error, updateMcpAbilities } =
-		useMcpSettings();
+		useMcpSettings( { skip: showConnectNotice || ! blogId } );
 	const {
 		isLoading: isAiSettingsLoading,
 		savingKeys: aiSavingKeys,
@@ -296,9 +302,9 @@ export default function App() {
 							</div>
 						) }
 
-						{ ! isLoading && error && <LoadErrorNotice message={ error } /> }
+						{ ! isLoading && error && ! showConnectNotice && <LoadErrorNotice message={ error } /> }
 
-						{ ! isLoading && ! error && ! blogId && (
+						{ ! blogId && (
 							<Notice.Root intent="warning">
 								<Notice.Description>
 									{ __(
@@ -309,9 +315,25 @@ export default function App() {
 							</Notice.Root>
 						) }
 
-						{ ! isLoading && ! error && !! blogId && ! hasMcpAccess && <McpUpsell /> }
+						{ showConnectNotice && (
+							<Notice.Root intent="warning">
+								<Notice.Title>
+									{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
+								</Notice.Title>
+								<Notice.Description>
+									{ __( 'Connect your account to manage MCP settings.', 'jetpack' ) }{ ' ' }
+									<Link href="admin.php?page=my-jetpack#/connection">
+										{ __( 'Connect account', 'jetpack' ) }
+									</Link>
+								</Notice.Description>
+							</Notice.Root>
+						) }
 
-						{ ! isLoading && ! error && !! blogId && hasMcpAccess && (
+						{ ! isLoading && ! error && !! blogId && ! userUnlinked && ! hasMcpAccess && (
+							<McpUpsell />
+						) }
+
+						{ ! isLoading && ! error && !! blogId && ! userUnlinked && hasMcpAccess && (
 							<Stack direction="column" gap="md">
 								{ view === 'mcp' && (
 									<McpHub

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/use-mcp-settings.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/use-mcp-settings.jsx
@@ -93,3 +93,38 @@ describe( 'useMcpSettings with the native WordPress.com API', () => {
 		expect( result.current.mcpAbilities ).toEqual( {} );
 	} );
 } );
+
+describe( 'useMcpSettings with skip', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	test( 'skip: exposes empty state and never fetches', () => {
+		const { result } = renderHook( () => useMcpSettings( { skip: true } ) );
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( result.current.mcpAbilities ).toBeNull();
+		expect( result.current.hasMcpAccess ).toBeNull();
+		expect( result.current.error ).toBeNull();
+		expect( result.current.savingToolIds.size ).toBe( 0 );
+	} );
+
+	test( 'un-skipping starts the fetch', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			has_mcp_access: true,
+			mcp_abilities: { account: { some_tool: {} }, sites: [] },
+		} );
+
+		const { result, rerender } = renderHook( ( { skip } ) => useMcpSettings( { skip } ), {
+			initialProps: { skip: true },
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+
+		rerender( { skip: false } );
+
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.hasMcpAccess ).toBe( true );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
@@ -84,19 +84,31 @@ export function prepareWpcomMcpUpdate( update ) {
 /**
  * Hook that loads and exposes MCP settings for the current site.
  *
+ * @param {object}  [options]      - Hook options.
+ * @param {boolean} [options.skip] - Skip the fetch and expose empty state (for callers
+ *                                 that know the request cannot succeed).
  * @return {{ isLoading: boolean, isSaving: boolean, mcpAbilities: Object|null, error: string|null, updateMcpAbilities: Function }} MCP settings state and updater.
  */
-export function useMcpSettings() {
+export function useMcpSettings( { skip = false } = {} ) {
 	const { blogId = 0, mcpSettingsApi = DEFAULT_API } = window?.jetpackAiSettings ?? {};
 	const endpoint = mcpSettingsApi.path ?? DEFAULT_API.path;
 	const usesWpcomApi = mcpSettingsApi.format === 'wpcom';
-	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isLoading, setIsLoading ] = useState( ! skip );
 	const [ savingToolIds, setSavingToolIds ] = useState( () => new Set() );
 	const [ mcpAbilities, setMcpAbilities ] = useState( null );
 	const [ hasMcpAccess, setHasMcpAccess ] = useState( null );
 	const [ error, setError ] = useState( null );
 
 	useEffect( () => {
+		if ( skip ) {
+			// Clear state so nothing from an earlier fetch lingers.
+			setIsLoading( false );
+			setSavingToolIds( new Set() );
+			setMcpAbilities( null );
+			setHasMcpAccess( null );
+			setError( null );
+			return;
+		}
 		let cancelled = false;
 		setIsLoading( true );
 		apiFetch( { path: endpoint } )
@@ -126,7 +138,7 @@ export function useMcpSettings() {
 		return () => {
 			cancelled = true;
 		};
-	}, [ blogId, endpoint, usesWpcomApi ] );
+	}, [ blogId, endpoint, usesWpcomApi, skip ] );
 
 	/**
 	 * Send a partial mcp_abilities update.

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/use-mcp-settings.js
@@ -87,7 +87,7 @@ export function prepareWpcomMcpUpdate( update ) {
  * @param {object}  [options]      - Hook options.
  * @param {boolean} [options.skip] - Skip the fetch and expose empty state (for callers
  *                                 that know the request cannot succeed).
- * @return {{ isLoading: boolean, isSaving: boolean, mcpAbilities: Object|null, error: string|null, updateMcpAbilities: Function }} MCP settings state and updater.
+ * @return {{ isLoading: boolean, savingToolIds: Set, mcpAbilities: Object|null, hasMcpAccess: boolean|null, error: string|null, updateMcpAbilities: Function }} MCP settings state and updater.
  */
 export function useMcpSettings( { skip = false } = {} ) {
 	const { blogId = 0, mcpSettingsApi = DEFAULT_API } = window?.jetpackAiSettings ?? {};

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -265,6 +265,9 @@ describe( 'AI admin page (main.jsx)', () => {
 	} );
 
 	test( 'MCP view tracking: fires once on the MCP tab, never on Features, and latches per mount', async () => {
+		// A successful settings payload implies a connected site, so the fixture
+		// carries the blogId (the fetch is skipped entirely without one).
+		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
 		mockApiFetch( {
 			mcpGet: { has_mcp_access: true, mcp_abilities: { account: { some_tool: {} }, sites: [] } },
 		} );
@@ -296,6 +299,121 @@ describe( 'AI admin page (main.jsx)', () => {
 		} );
 
 		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
+	} );
+
+	describe( 'MCP view: connection notices', () => {
+		const CONNECT_TITLE = 'Your WordPress.com account isn’t connected.';
+		const UPSELL_CTA = 'Upgrade plan';
+
+		beforeEach( () => {
+			window.location.hash = '#/mcp';
+		} );
+
+		test( 'site connected, no plan: shows the connect notice instead of the upsell', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
+			mockApiFetch( { mcpGet: { has_mcp_access: false, mcp_abilities: {} } } );
+
+			render( <App /> );
+
+			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Connect account' } ) ).toHaveAttribute(
+				'href',
+				'admin.php?page=my-jetpack#/connection'
+			);
+			expect( screen.queryByText( UPSELL_CTA ) ).not.toBeInTheDocument();
+			// The settings fetch is skipped: without a user token it can only fail.
+			expect( apiFetch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { path: expect.stringContaining( 'mcp-settings' ) } )
+			);
+		} );
+
+		test( 'site connected, has plan: shows the connect notice and not the hub', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
+			mockApiFetch( { mcpGet: connectedMcpGet() } );
+
+			render( <App /> );
+
+			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+			// The skipped fetch keeps hasMcpAccess null, so the hub cannot render.
+			expect(
+				screen.queryByText( 'External AI agent access', IGNORE_A11Y )
+			).not.toBeInTheDocument();
+			expect( screen.queryByLabelText( 'Enable MCP access' ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'unlinked user: no settings request escapes and no error notice appears', async () => {
+			// The fetch is skipped for unlinked users: the rejecting mock proves no request escapes.
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
+			apiFetch.mockImplementation( ( { path } = {} ) =>
+				path?.includes( 'mcp-settings' )
+					? Promise.reject( new Error( 'No token for user 2' ) )
+					: Promise.resolve( enabledSettings() )
+			);
+
+			render( <App /> );
+
+			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+			expect( screen.queryByText( 'No token for user 2', IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect( apiFetch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { path: expect.stringContaining( 'mcp-settings' ) } )
+			);
+		} );
+
+		test( 'linked user, settings request fails: the load error still shows', async () => {
+			// The error branch must stay live for everyone the connect notice does
+			// not cover.
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: true };
+			apiFetch.mockImplementation( ( { path } = {} ) =>
+				path?.includes( 'mcp-settings' )
+					? Promise.reject( new Error( 'Something went wrong.' ) )
+					: Promise.resolve( enabledSettings() )
+			);
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( 'Something went wrong.', IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'isUserConnected undefined: behaviour unchanged, the upsell still shows', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
+			mockApiFetch( { mcpGet: { has_mcp_access: false, mcp_abilities: {} } } );
+
+			render( <App /> );
+
+			await expect( screen.findByText( UPSELL_CTA ) ).resolves.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'site not connected: the site notice still comes first', async () => {
+			// On a disconnected site the settings request could only reject (the
+			// proxy has no site ID), so the fetch is skipped and the friendly
+			// notice must show instead of that raw error.
+			window.jetpackAiSettings = { showFeaturesView: true, isUserConnected: false };
+			apiFetch.mockImplementation( ( { path } = {} ) =>
+				path?.includes( 'mcp-settings' )
+					? Promise.reject( new Error( 'Sorry, something is wrong with your Jetpack connection.' ) )
+					: Promise.resolve( enabledSettings() )
+			);
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText(
+					'This site is not connected to WordPress.com. Please connect Jetpack to manage MCP settings.',
+					IGNORE_A11Y
+				)
+			).resolves.toBeInTheDocument();
+			expect(
+				screen.queryByText( 'Sorry, something is wrong with your Jetpack connection.', IGNORE_A11Y )
+			).not.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect( apiFetch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { path: expect.stringContaining( 'mcp-settings' ) } )
+			);
+		} );
 	} );
 
 	test( 'MCP sub-views: the breadcrumb root reads Jetpack AI', async () => {
@@ -455,6 +573,9 @@ describe( 'AI admin page (main.jsx)', () => {
 	} );
 
 	test( 'MCP view tracking: does not fire on the Features tab', async () => {
+		// blogId keeps the settings fetch live so hasMcpAccess resolves; the
+		// isMcpContext guard is then the only thing holding the event back.
+		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
 		mockApiFetch( {
 			mcpGet: { has_mcp_access: true, mcp_abilities: { account: { some_tool: {} }, sites: [] } },
 		} );
@@ -473,7 +594,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		// The audience properties are computed server-side and ride the
 		// jetpackAiSettings global; the event must send the strings
 		// 'true'/'false', not booleans (AIINT-576 encoding).
-		window.jetpackAiSettings = { showFeaturesView: true, isA11n: true, isTest: true };
+		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isA11n: true, isTest: true };
 		mockApiFetch( {
 			mcpGet: { has_mcp_access: true, mcp_abilities: { account: { some_tool: {} }, sites: [] } },
 		} );

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-connect-notice
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-connect-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Show connection notices instead of raw connection errors on the MCP settings page when the site or the current user is not connected to WordPress.com.


### PR DESCRIPTION
## Proposed changes

Fixes a regression on the MCP settings page before it ships in the next release.

* **The regression:** since #51116 (in the 16.2 test releases), an admin who has not connected their own WordPress.com account sees a raw error — "No token for user N". #51116 started reporting failures that were previously silent, and this page had no handling for that one.
* **What it replaced:** on the current stable release the same admin sees an **"Upgrade plan"** card — the silent failure is treated as "this site has no plan". This is also incorrect (upgrading doesn't help an admin who isn't connected), and it's what the original report describes.
* **With this fix** they see "Your WordPress.com account isn’t connected." with a **Connect account** link — the right message in both cases.

Also:
* When the site itself is not connected, show its connection notice instead of a raw error.
* Skip the request in these two cases, since it cannot succeed without a connection, so the notice shows immediately.

## Does this pull request change what data or activity we track or use?
No.

## Real-screen before / after

Taken on a live test site, logged in as an admin who never connected their own account.

| Before (16.2 test release) | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-mcp-connect-notice/before-mcp-unlinked.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-mcp-connect-notice/after-mcp-unlinked.png) |

On the stable release the same admin sees the "Upgrade plan" card instead.

## Testing instructions

You need a self-hosted site connected to Jetpack (a Jurassic Ninja site works).

1. Log in as an admin who has not connected their own WordPress.com account — either a second admin who never connected, or run `wp jetpack disconnect user` for your own.
2. Open `https://<your-site>/wp-admin/admin.php?page=jetpack-ai#/mcp`.
3. You see a notice: "Your WordPress.com account isn’t connected." with a **Connect account** link. It shows immediately — no upgrade button, no raw error. (Before this fix you saw the "Upgrade plan" card on stable, or a raw "No token for user N" error on the 16.2 test releases.)
4. Click **Connect account** and connect your account.
5. Go back to `https://<your-site>/wp-admin/admin.php?page=jetpack-ai#/mcp`. You see the page as it was before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
