### PR TITLE
FORNO-494: Jetpack: register jetpack-ai-jwt through the shared Connection controller

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication;
 use Automattic\Jetpack\Connection\REST_Connector;
+use Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT;
 use Automattic\Jetpack\Connection\SSO;
 use Automattic\Jetpack\Jetpack_CRM_Data;
 use Automattic\Jetpack\Plugins_Installer;
@@ -72,21 +73,8 @@ class Jetpack_Core_Json_Api_Endpoints {
 		$site_endpoint          = new Jetpack_Core_API_Site_Endpoint();
 		$widget_endpoint        = new Jetpack_Core_API_Widget_Endpoint();
 
-		/**
-		 * TODO: Move me somewhere that makes more sense.
-		 * Also give me permissions that aren't awful.
-		 */
-		register_rest_route(
-			'jetpack/v4',
-			'jetpack-ai-jwt',
-			array(
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => __CLASS__ . '::get_openai_jwt',
-				'permission_callback' => function () {
-					return ( new Connection_Manager( 'jetpack' ) )->is_user_connected() && current_user_can( 'edit_posts' );
-				},
-			)
-		);
+		// My Jetpack and Agents Manager register the same controller; its guard keeps the route registered once.
+		( new REST_Jetpack_AI_JWT() )->register_rest_route();
 
 		register_rest_route(
 			'jetpack/v4',
@@ -778,9 +766,15 @@ class Jetpack_Core_Json_Api_Endpoints {
 
 	/**
 	 * Ask WPCOM for a JWT token to use for OpenAI conversations.
-	 * TODO: Clean me up. This is ugly hack code.
+	 *
+	 * @deprecated since $$next-version$$
+	 * @see Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT::get_jwt()
+	 *
+	 * @return array|WP_Error The token and blog ID, or the error from WPCOM.
 	 */
 	public static function get_openai_jwt() {
+		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', '\Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT::get_jwt' );
+
 		$blog_id = \Jetpack_Options::get_option( 'id' );
 
 		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -775,33 +775,14 @@ class Jetpack_Core_Json_Api_Endpoints {
 	public static function get_openai_jwt() {
 		_deprecated_function( __METHOD__, 'jetpack-$$next-version$$', '\Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT::get_jwt' );
 
-		$blog_id = \Jetpack_Options::get_option( 'id' );
-
-		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_user(
-			"/sites/$blog_id/jetpack-openai-query/jwt",
-			'2',
-			array(
-				'method'  => 'POST',
-				'headers' => array( 'Content-Type' => 'application/json; charset=utf-8' ),
-			),
-			wp_json_encode( array(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
-			'wpcom'
-		);
+		$response = ( new REST_Jetpack_AI_JWT() )->get_jwt();
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
-		$json = json_decode( wp_remote_retrieve_body( $response ) );
-
-		if ( ! isset( $json->token ) ) {
-			return new WP_Error( 'no-token', 'No token returned from WPCOM' );
-		}
-
-		return array(
-			'token'   => $json->token,
-			'blog_id' => $blog_id,
-		);
+		// Pre-deprecation callers expect the raw array, not a WP_REST_Response.
+		return $response->get_data();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/forno-494-remove-duplicate-jetpack-ai-jwt-registration-from-jetpack
+++ b/projects/plugins/jetpack/changelog/forno-494-remove-duplicate-jetpack-ai-jwt-registration-from-jetpack
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Register the jetpack-ai-jwt REST route through the shared Connection controller so the route is only registered once.


### PR DESCRIPTION
Fixes FORNO-494

## Proposed changes

* The Jetpack plugin registers `jetpack/v4/jetpack-ai-jwt` inline in `class.core-rest-api-endpoints.php` with no duplicate guard, so registration order decides how many handlers the route gets: if My Jetpack or Agents Manager registers first, the plugin registers again on top of it. The plugin now registers the route through `Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT`, so all three registrars share the one controller and its guard, and the route is registered exactly once no matter who runs first.
* `Jetpack_Core_Json_Api_Endpoints::get_openai_jwt()` stays as a deprecated method — it is public and was the inline route's callback, so it follows the six-month deprecation rule. Its behavior is unchanged for anything still calling it directly.

Same permission callback (`is_user_connected()` + `edit_posts`) and same response shape as before; the controller is the verbatim move from #51629. On a Jetpack-plugin-only site in offline mode (where My Jetpack skips init), the plugin still registers the route itself — no 404 regression.

Built on #51629 (now merged), which moved the controller into the Connection package.

## Related product discussion/links

* FORNO-494
* #51629 — moved the route into the Connection package (merged)
* #49415 — moved the route from My Jetpack into Agents Manager

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Docker site with the Jetpack plugin built from this branch (`jp build plugins/jetpack --deps`) and a connected admin: `POST /wp-json/jetpack/v4/jetpack-ai-jwt` returns `200` with `token` and `blog_id`. Logged out returns `401`; a subscriber returns `403`.
* Confirm single registration: `wp eval 'var_dump( rest_get_server()->get_routes()["/jetpack/v4/jetpack-ai-jwt"] );'` shows one handler whose callback is `Automattic\Jetpack\Connection\REST_Jetpack_AI_JWT::get_jwt`.
* `jp test php packages/connection` covers the controller, including `test_register_rest_route_does_not_register_duplicate_route` — with every registrar using the same guarded controller, registration order no longer matters, which is what the "test registration order" item in FORNO-494 asks for.

I verified the route and permission behavior through the Connection package tests and static analysis; I have not exercised the live endpoint from this branch on a connected site.

