### PR TITLE
Social previews: add WPDS token fallbacks at build time

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1603,6 +1603,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
+      '@wordpress/theme':
+        specifier: 2.1.1-next.v.202608281122.0
+        version: 2.1.1-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       babel-jest:
         specifier: 30.4.1
         version: 30.4.1(@babel/core@7.29.7)

--- a/projects/js-packages/social-previews/changelog/update-social-previews-wpds-token-fallbacks
+++ b/projects/js-packages/social-previews/changelog/update-social-previews-wpds-token-fallbacks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Emit DS token fallbacks via Lightning CSS/tsdown and drop hardcoded fallbacks from Social Previews styles.
+

--- a/projects/js-packages/social-previews/package.json
+++ b/projects/js-packages/social-previews/package.json
@@ -56,6 +56,7 @@
 		"@types/react": "18.3.31",
 		"@types/react-dom": "18.3.7",
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",
+		"@wordpress/theme": "2.1.1-next.v.202608281122.0",
 		"babel-jest": "30.4.1",
 		"jest": "30.4.2",
 		"react": "18.3.1",

--- a/projects/js-packages/social-previews/src/google-search-preview/style.scss
+++ b/projects/js-packages/social-previews/src/google-search-preview/style.scss
@@ -10,7 +10,7 @@
 */
 
 .search-preview__display {
-	border: 1px solid var(--wpds-color-stroke-surface-neutral, #dbdbdb);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
 	font-family: arial, sans-serif;
 	padding: 10px 20px;
 	overflow-wrap: break-word;

--- a/projects/js-packages/social-previews/tsdown.config.ts
+++ b/projects/js-packages/social-previews/tsdown.config.ts
@@ -1,3 +1,4 @@
+import lightningcssDsTokenFallbacks from '@wordpress/theme/lightningcss-plugins/lightningcss-ds-token-fallbacks';
 import { defineConfig } from 'tsdown';
 
 export default defineConfig( {
@@ -9,5 +10,9 @@ export default defineConfig( {
 	outDir: 'dist',
 	css: {
 		fileName: 'style.css',
+		// Lightning CSS injects official `--wpds-*` fallbacks into SCSS/CSS.
+		lightningcss: {
+			visitor: lightningcssDsTokenFallbacks,
+		},
 	},
 } );

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -90,7 +90,6 @@ const baseConfig = {
 			files: [
 				'projects/js-packages/base-styles/**/*.{css,scss,sass}',
 				'projects/js-packages/components/**/*.{css,scss,sass}',
-				'projects/js-packages/social-previews/**/*.{css,scss,sass}',
 				'projects/plugins/jetpack/**/*.{css,scss,sass}',
 			],
 			rules: {


### PR DESCRIPTION

Depends on https://github.com/Automattic/jetpack/pull/51701 and https://github.com/Automattic/jetpack/pull/51665

The same done for the Charts package https://github.com/Automattic/jetpack/pull/51722

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds WPDS token fallbacks during build time in the charts package using the [recently added](https://github.com/WordPress/gutenberg/pull/80401) LightningCSS wpds token fallback plugin from `@wordpress/theme` (hence `@next-` version usage for now)
    * The `@next` version here was released so close to the stable release; it basically [just includes](https://github.com/WordPress/gutenberg/blob/45b200e9b8a6a2c816ae0c06bb60ebfab46ded33/packages/theme/CHANGELOG.md#unreleased) the LightningCSS plugin, which is a build tool, so it doesn't matter at runtime even if `@wordpress/theme` is externalised. It's safe as long as https://github.com/Automattic/jetpack/pull/51701, which updates `@wordpress/theme` to the latest stable, is merged first.
* Lints the Charts package for;
    * incorrect wpds tokens, 
    * doesn't allow manually added wpds tokens fallbacks, 
    * doesn't allow overwriting core wpds tokens
* Removes currently added manual fallback

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* No difference in `dist` bundle
