### PR TITLE
Premium Analytics: stop sending the unsupported `days` param to Stats list endpoints

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -610,7 +610,7 @@ const report = primary.data as StatsNormalizedReport< StatsXxxItem > | undefined
 const items = report?.data?.[ 0 ]?.items ?? [];
 ```
 
-Date-range conversion (`from`/`to` → `period`/`end_date`/`days`) is handled inside
+Date-range conversion (`from`/`to` → `period`/`start_date`/`date`) is handled inside
 the query factory — do not do it in the widget or the view hook.
 
 **Row count**

--- a/projects/packages/premium-analytics/changelog/wooa7s-1574-omit-unsupported-days-param
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1574-omit-unsupported-days-param
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Stats: stop sending the unsupported `days` parameter on list-endpoint requests.
+Comment: Drop a parameter the list endpoints discard. The request changes; the response, and so everything a reader sees, does not.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1574-omit-unsupported-days-param
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1574-omit-unsupported-days-param
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: stop sending the unsupported `days` parameter on list-endpoint requests.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -592,9 +592,13 @@ describe( 'Stats query factories', () => {
 		} as StatsReportParams );
 
 		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
+		// `summarize` and `period` are derived from `days` before it is dropped, so
+		// they belong here: moving the omission any earlier would silently lose them.
 		expect( query.queryKey[ 5 ] ).toMatchObject( {
 			start_date: '2026-06-01',
 			date: '2026-06-07',
+			period: 'day',
+			summarize: 1,
 		} );
 	} );
 
@@ -718,11 +722,15 @@ describe( 'Stats query factories', () => {
 			interval: 'week',
 		} );
 
-		// A leaked `period=week` would make the endpoint count the range in weeks
-		// and stop returning one row per post.
+		// A leaked `period=week` would make the endpoint recount the window in weeks
+		// instead of the requested days.
 		expect( query.queryKey ).toEqual(
 			expect.arrayContaining( [
-				expect.objectContaining( { period: 'day', start_date: '2026-01-01' } ),
+				expect.objectContaining( {
+					period: 'day',
+					start_date: '2026-01-01',
+					date: '2026-06-07',
+				} ),
 			] )
 		);
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -19,6 +19,7 @@ import { statsArchivesQuery } from '../stats-archives-query';
 import { statsClicksQuery } from '../stats-clicks-query';
 import { statsCommentFollowersQuery } from '../stats-comment-followers-query';
 import { statsCommentsQuery } from '../stats-comments-query';
+import { statsCountryViewsQuery } from '../stats-country-views-query';
 import { statsDevicesQuery } from '../stats-devices-query';
 import {
 	statsEmailClicksBreakdownQuery,
@@ -46,8 +47,10 @@ import {
 	statsSubscribersReportQuery,
 } from '../stats-subscribers-query';
 import { statsTagsQuery } from '../stats-tags-query';
+import { statsTopAuthorsQuery } from '../stats-top-authors-query';
 import { statsTopPostsQuery } from '../stats-top-posts-query';
 import { statsUtmQuery } from '../stats-utm-query';
+import { statsVideoPlaysQuery } from '../stats-video-plays-query';
 import { statsVideoPlaysSummaryQuery } from '../stats-video-plays-summary-query';
 import { statsVisitsQuery } from '../stats-visits-query';
 import { statsWordAdsEarningsQuery, statsWordAdsStatsQuery } from '../stats-wordads-query';
@@ -383,7 +386,6 @@ describe( 'Stats query factories', () => {
 				expect.objectContaining( {
 					date: '2026-06-07',
 					start_date: '2026-06-01',
-					days: 7,
 					summarize: 1,
 				} ),
 			] )
@@ -404,7 +406,6 @@ describe( 'Stats query factories', () => {
 				expect.objectContaining( {
 					date: '2026-06-07T23:59:59.999-07:00',
 					start_date: '2026-06-01T00:00:00.000-07:00',
-					days: 7,
 				} ),
 			] )
 		);
@@ -570,6 +571,33 @@ describe( 'Stats query factories', () => {
 		);
 	} );
 
+	// None of the list endpoints declares `days`, so WPCOM drops it before the
+	// handler runs and the window comes from `start_date` + `date` instead.
+	it.each( [
+		[ 'top-posts', statsTopPostsQuery ],
+		[ 'archives', statsArchivesQuery ],
+		[ 'top-authors', statsTopAuthorsQuery ],
+		[ 'country-views', statsCountryViewsQuery ],
+		[ 'location-views', statsLocationsQuery ],
+		[ 'video-plays', statsVideoPlaysQuery ],
+		[ 'clicks', statsClicksQuery ],
+		[ 'referrers', statsReferrersQuery ],
+		[ 'search-terms', statsSearchTermsQuery ],
+		[ 'file-downloads', statsFileDownloadsQuery ],
+	] )( 'omits the unsupported days parameter from the %s range request', ( _name, factory ) => {
+		const query = factory( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'day',
+		} as StatsReportParams );
+
+		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
+		expect( query.queryKey[ 5 ] ).toMatchObject( {
+			start_date: '2026-06-01',
+			date: '2026-06-07',
+		} );
+	} );
+
 	it( 'builds tags query keys for the Calypso endpoint path', () => {
 		const query = statsTagsQuery( {} );
 
@@ -690,10 +718,12 @@ describe( 'Stats query factories', () => {
 			interval: 'week',
 		} );
 
-		// `days` counts calendar days, so a leaked `period=week` would cover
-		// `days` weeks instead of the requested range.
+		// A leaked `period=week` would make the endpoint count the range in weeks
+		// and stop returning one row per post.
 		expect( query.queryKey ).toEqual(
-			expect.arrayContaining( [ expect.objectContaining( { period: 'day', days: 158 } ) ] )
+			expect.arrayContaining( [
+				expect.objectContaining( { period: 'day', start_date: '2026-01-01' } ),
+			] )
 		);
 	} );
 
@@ -722,7 +752,6 @@ describe( 'Stats query factories', () => {
 			expect.arrayContaining( [
 				expect.objectContaining( {
 					date: '2026-06-07',
-					days: 7,
 					summarize: false,
 				} ),
 			] )

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-archives-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-archives-query.ts
@@ -8,6 +8,12 @@ import { statsReportQuery, type StatsReportParams } from './stats-query';
 // entry inside `stats/top-posts` (as "Homepage (Latest posts)") and drops it
 // from this report.
 export const statsArchivesQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'archives', 'stats/archives', params, 'archives', '1.1', {
-		skip_archives: 1,
-	} );
+	statsReportQuery(
+		'archives',
+		'stats/archives',
+		params,
+		'archives',
+		'1.1',
+		{ skip_archives: 1 },
+		{ omitParams: [ 'days' ] }
+	);

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
@@ -5,8 +5,5 @@ import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsClicksQuery = ( params: StatsReportParams ) =>
 	statsReportQuery( 'clicks', 'stats/clicks', params, 'clicks', '1.1', undefined, {
-		// The Clicks endpoint uses start_date + date to delimit custom ranges.
-		// Calypso omits the generic day count, and doing the same avoids sending
-		// a parameter this endpoint does not accept.
 		omitParams: [ 'days' ],
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-country-views-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-country-views-query.ts
@@ -4,4 +4,6 @@
 import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsCountryViewsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'country-views', 'stats/country-views', params, 'locations' );
+	statsReportQuery( 'country-views', 'stats/country-views', params, 'locations', '1.1', undefined, {
+		omitParams: [ 'days' ],
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-file-downloads-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-file-downloads-query.ts
@@ -18,9 +18,6 @@ export const statsFileDownloadsQuery = (
 		'1.1',
 		undefined,
 		{
-			// The endpoint derives the number of periods from `start_date` and `date`,
-			// so the generic `days` parameter is redundant and is not part of the
-			// legacy Calypso request.
 			omitParams: [ 'days' ],
 		}
 	);

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-locations-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-locations-query.ts
@@ -21,6 +21,7 @@ export const statsLocationsQuery = (
 		params,
 		'locations',
 		'1.1',
-		filter_by_country ? { filter_by_country } : undefined
+		filter_by_country ? { filter_by_country } : undefined,
+		{ omitParams: [ 'days' ] }
 	);
 };

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -58,9 +58,8 @@ type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQuer
 type StatsReportQuerySettings = {
 	/**
 	 * Query params derived from the shared report range that this endpoint does not accept.
-	 * WPCOM intersects the query string with the endpoint's declared parameters, so an
-	 * undeclared one is dropped before the handler runs — omitting it here only keeps the
-	 * request URL and the proxy cache key honest.
+	 * WPCOM drops params an endpoint does not declare, so this changes nothing server-side —
+	 * it only keeps the request URL and the proxy cache key honest.
 	 */
 	omitParams?: readonly ( keyof StatsQueryParamFields )[];
 };
@@ -186,9 +185,8 @@ export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const reportParams = {
 		...statsParams,
-		// The summarized window is `period` × `days`, so the dashboard's chart
-		// interval must not leak in as the period — `period=week` with `days=189`
-		// would cover 189 weeks.
+		// A leaked chart interval would make the endpoint recount the window in
+		// weeks or months instead of the requested days.
 		...( params.period === undefined ? { period: 'day' as const } : {} ),
 		...extraParams,
 		...( statsParams.summarize === undefined &&
@@ -199,6 +197,8 @@ export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 	};
 	const queryParams: StatsQueryParams = { ...reportParams };
 
+	// Runs after `summarize` is derived above: that derivation reads `days`, which
+	// the list endpoints omit.
 	for ( const param of settings?.omitParams ?? [] ) {
 		delete queryParams[ param ];
 	}

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -56,7 +56,12 @@ export type StatsReportParams = ReportParams & StatsQueryParamFields;
 type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQueryParams ) => TData;
 
 type StatsReportQuerySettings = {
-	/** Query params derived from the shared report range that this endpoint does not accept. */
+	/**
+	 * Query params derived from the shared report range that this endpoint does not accept.
+	 * WPCOM intersects the query string with the endpoint's declared parameters, so an
+	 * undeclared one is dropped before the handler runs — omitting it here only keeps the
+	 * request URL and the proxy cache key honest.
+	 */
 	omitParams?: readonly ( keyof StatsQueryParamFields )[];
 };
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-referrers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-referrers-query.ts
@@ -5,7 +5,5 @@ import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsReferrersQuery = ( params: StatsReportParams ) =>
 	statsReportQuery( 'referrers', 'stats/referrers', params, 'referrers', '1.1', undefined, {
-		// Calypso summarizes explicit ranges with start_date/date rather than the
-		// generic Stats `days` parameter. Keep the range query parameters aligned.
 		omitParams: [ 'days' ],
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-search-terms-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-search-terms-query.ts
@@ -11,8 +11,5 @@ export const statsSearchTermsQuery = (
 	params: StatsReportParams
 ): StatsReportQueryOptions< 'searchTerms' > =>
 	statsReportQuery( 'search-terms', 'stats/search-terms', params, 'searchTerms', '1.1', undefined, {
-		// The Search Terms endpoint derives the inclusive range from start_date
-		// and date, matching legacy Stats, rather than the generic report-layer
-		// `days` parameter.
 		omitParams: [ 'days' ],
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-top-authors-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-top-authors-query.ts
@@ -4,4 +4,6 @@
 import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsTopAuthorsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'top-authors', 'stats/top-authors', params, 'topAuthors' );
+	statsReportQuery( 'top-authors', 'stats/top-authors', params, 'topAuthors', '1.1', undefined, {
+		omitParams: [ 'days' ],
+	} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-top-posts-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-top-posts-query.ts
@@ -7,6 +7,12 @@ import { statsReportQuery, type StatsReportParams } from './stats-query';
 // post list, mirroring the Stats "Most viewed" card — archives are their own
 // report (`stats/archives`).
 export const statsTopPostsQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'top-posts', 'stats/top-posts', params, 'topPosts', '1.1', {
-		skip_archives: 1,
-	} );
+	statsReportQuery(
+		'top-posts',
+		'stats/top-posts',
+		params,
+		'topPosts',
+		'1.1',
+		{ skip_archives: 1 },
+		{ omitParams: [ 'days' ] }
+	);

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-video-plays-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-video-plays-query.ts
@@ -4,4 +4,6 @@
 import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsVideoPlaysQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'video-plays', 'stats/video-plays', params, 'videoPlays' );
+	statsReportQuery( 'video-plays', 'stats/video-plays', params, 'videoPlays', '1.1', undefined, {
+		omitParams: [ 'days' ],
+	} );

--- a/projects/packages/premium-analytics/widgets/popular-post/__tests__/use-popular-post.test.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-post/__tests__/use-popular-post.test.tsx
@@ -314,7 +314,7 @@ describe( 'usePopularPost', () => {
 			// of yesterday.
 			expect( ranking ).toContain( 'start_date=2025-08-27T00:00:00' );
 			expect( ranking ).toContain( 'date=2026-08-26T23:59:59' );
-			expect( ranking ).toContain( 'days=365' );
+			expect( ranking ).not.toContain( 'days=' );
 		} );
 
 		it( 'draws the window in the site zone, not at UTC midnight', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -137,10 +137,10 @@ describe( 'VideoPressWidget', () => {
 		const requestedPath = mockApiFetch.mock.calls[ 0 ]?.[ 0 ]?.path ?? '';
 		expect( requestedPath ).toContain( 'stats/video-plays' );
 		// The query factory derives the Stats date params from `reportParams`:
-		// `to` becomes the end `date` and the inclusive range length becomes `days`.
+		// `from` becomes `start_date` and `to` becomes the end `date`.
 		expect( requestedPath ).toContain( 'start_date=2026-03-01' );
 		expect( requestedPath ).toContain( 'date=2026-03-10' );
-		expect( requestedPath ).toContain( 'days=10' );
+		expect( requestedPath ).not.toContain( 'days=' );
 	} );
 
 	it( 'links to the Videos report', () => {


### PR DESCRIPTION
## Proposed changes

* Add `omitParams: [ 'days' ]` to the six Stats list queries that were still sending it: `top-posts`, `archives`, `top-authors`, `country-views`, `location-views`, `video-plays`.
* WPCOM intersects the query string with each endpoint's declared `query_parameters`, and none of the list endpoints declares `days` — it is dropped before the handler runs. The window comes from `start_date` + `date`, which override the endpoint's `num`.
* `clicks`, `referrers`, `search-terms` and `file-downloads` already did this; this finishes the set.
* `devices` and `utm` keep theirs: both endpoints do declare `days`, so every `statsReportQuery` caller now sends only what its endpoint accepts.
* No change on the wire beyond a shorter URL: the param never reached a handler. It does change the React Query keys and the proxy transient cache key, so caches repopulate once.
* Reframes WOOA7S-1574, which proposed stripping `start_date` instead. That premise turned out to be inverted: every list endpoint declares and honors `start_date`, and `days` is the one that goes nowhere.

## Related product discussion/links

* WOOA7S-1574

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm jetpack test js packages/premium-analytics`, or scoped: `TZ=UTC pnpm exec jest --config=tests/jest.config.cjs packages/data widgets/popular-post widgets/videopress` from `projects/packages/premium-analytics`.
* In the dashboard, open a report backed by one of the six endpoints (Posts & Pages, Locations, Authors, Videos, Archives) and pick a custom date range.
* In the Network tab, confirm the proxy request carries `start_date` + `date` and no `days`, and that the rows still match the selected range.
