### PR TITLE
Premium Analytics: keep Apply disabled when re-picking "No comparison"

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2039-no-comparison-apply-stuck
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2039-no-comparison-apply-stuck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date filters: Keep the custom range Apply button disabled when re-selecting "No comparison".

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -336,6 +336,25 @@ describe( 'report params field', () => {
 		);
 	} );
 
+	// Re-picking the item that already has the checkmark changes nothing, so the
+	// widget must not save and Apply must stay greyed out (WOOA7S-2039).
+	it( 'saves nothing when No comparison is re-picked with none applied', async () => {
+		const user = userEvent.setup();
+		const { saved } = renderField();
+
+		await user.click( screen.getByRole( 'button', { name: /compare/i } ) );
+		await user.click( await screen.findByRole( 'menuitemradio', { name: 'No comparison' } ) );
+
+		expect( saved ).toHaveLength( 0 );
+
+		await openCustomRange( user );
+
+		await expect( screen.findByRole( 'button', { name: 'Apply' } ) ).resolves.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
 	// Committing the comparison on its own would apply the range draft with it.
 	it( 'holds a comparison picked mid-draft until Apply', async () => {
 		const user = userEvent.setup();

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -62,7 +62,12 @@ describe( 'useReportDateFilters', () => {
 			}: {
 				search: ( prev: Record< string, unknown > ) => Record< string, unknown >;
 			} ) => {
-				mockSearch = search( mockSearch );
+				// The URL drops `undefined` on the way out, so a patch that only
+				// clears absent params must round-trip back unchanged — keeping the
+				// keys would realign the draft where the router would not.
+				mockSearch = Object.fromEntries(
+					Object.entries( search( mockSearch ) ).filter( ( [ , value ] ) => value !== undefined )
+				);
 			}
 		);
 	} );
@@ -200,6 +205,67 @@ describe( 'useReportDateFilters', () => {
 		} );
 
 		expect( result.current.appliedComparisonRange ).toBeUndefined();
+	} );
+
+	// Re-picking "No comparison" with none applied clears params the URL does
+	// not carry: the commit would write the same URL and leave Apply on for
+	// good, since only a changed committed value empties the buffer.
+	it( 'stages nothing when the comparison is cleared with none applied', () => {
+		const { result, rerender } = renderDateFilters( {
+			from: '2026-07-01T00:00:00.000Z',
+			to: '2026-07-30T23:59:59.999Z',
+			preset: 'last-30-days',
+			interval: 'day',
+		} );
+
+		act( () => result.current.onComparisonChange( undefined, undefined ) );
+		rerender();
+
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( result.current.canApply ).toBe( false );
+	} );
+
+	// The same no-op reached the long way: a comparison picked and dropped again
+	// inside one draft leaves the params back where the URL already has them.
+	it( 'stops reading as dirty when a staged comparison is dropped again', () => {
+		const { result, rerender } = renderDateFilters( {
+			from: '2026-07-01T00:00:00.000Z',
+			to: '2026-07-30T23:59:59.999Z',
+			preset: 'custom',
+			interval: 'day',
+		} );
+
+		act( () =>
+			result.current.onChange(
+				{
+					from: new Date( '2026-07-10T00:00:00.000Z' ),
+					to: new Date( '2026-07-30T23:59:59.999Z' ),
+				},
+				'custom'
+			)
+		);
+		act( () =>
+			result.current.onComparisonChange(
+				{
+					from: new Date( '2026-06-01T00:00:00.000Z' ),
+					to: new Date( '2026-06-30T23:59:59.999Z' ),
+				},
+				'previous-period'
+			)
+		);
+		act( () => result.current.onComparisonChange( undefined, undefined ) );
+		act( () =>
+			result.current.onChange(
+				{
+					from: new Date( '2026-07-01T00:00:00.000Z' ),
+					to: new Date( '2026-07-30T23:59:59.999Z' ),
+				},
+				'custom'
+			)
+		);
+		rerender();
+
+		expect( result.current.canApply ).toBe( false );
 	} );
 
 	it( 'commits an interval change on its own', () => {

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
@@ -30,8 +30,7 @@ function renderStagedValue( initial: Params = { preset: 'last-30-days' } ) {
 			const onCommit = useCallback( ( staged: Params, patch: Partial< Params > ) => {
 				commits.push( staged );
 				patches.push( patch );
-				// Dropping the `undefined` keys is what makes this a faithful store:
-				// the URL binding serializes them away, so a value staged as
+				// The URL binding serializes `undefined` away, so a value staged as
 				// `undefined` never round-trips back as a key.
 				setCommitted(
 					Object.fromEntries( Object.entries( staged ).filter( ( [ , v ] ) => v !== undefined ) )
@@ -169,6 +168,29 @@ describe( 'useStagedValue', () => {
 
 		expect( result.current.isDirty ).toBe( false );
 		expect( commits ).toHaveLength( 0 );
+	} );
+
+	// A patch it drops entirely must not publish a new draft: the identity
+	// travels into `effective` and re-renders every widget reading it.
+	it( 'leaves the draft alone when the whole patch is dropped', () => {
+		const { result } = renderStagedValue();
+		const before = result.current.staged;
+
+		act( () => result.current.stage( { interval: undefined } ) );
+
+		expect( result.current.staged ).toBe( before );
+	} );
+
+	// Clearing a key staged earlier in the same draft is the same no-op reached
+	// the long way round: the draft is back to the committed value, so Apply
+	// must go back to disabled rather than commit an unchanged URL.
+	it( 'stops reading as dirty once a staged key is cleared again', () => {
+		const { result } = renderStagedValue();
+
+		act( () => result.current.stage( { interval: 'week' } ) );
+		act( () => result.current.stage( { interval: undefined } ) );
+
+		expect( result.current.isDirty ).toBe( false );
 	} );
 
 	// The other half of the same rule: staging an explicit `undefined` is how a

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
@@ -30,7 +30,12 @@ function renderStagedValue( initial: Params = { preset: 'last-30-days' } ) {
 			const onCommit = useCallback( ( staged: Params, patch: Partial< Params > ) => {
 				commits.push( staged );
 				patches.push( patch );
-				setCommitted( staged );
+				// Dropping the `undefined` keys is what makes this a faithful store:
+				// the URL binding serializes them away, so a value staged as
+				// `undefined` never round-trips back as a key.
+				setCommitted(
+					Object.fromEntries( Object.entries( staged ).filter( ( [ , v ] ) => v !== undefined ) )
+				);
 			}, [] );
 
 			return { ...useStagedValue< Params >( committed, onCommit ), setCommitted };
@@ -149,5 +154,33 @@ describe( 'useStagedValue', () => {
 		act( () => result.current.stage( { preset: 'last-30-days' } ) );
 
 		expect( result.current.isDirty ).toBe( false );
+	} );
+
+	// Re-picking "No comparison" with comparison already off stages a patch of
+	// nothing. Left in the buffer it reads as dirty forever, and Apply never
+	// goes back to disabled (WOOA7S-2039).
+	it( 'ignores clearing a key the value does not carry', () => {
+		const { result, commits } = renderStagedValue();
+
+		act( () => {
+			result.current.stage( { interval: undefined } );
+			result.current.commit();
+		} );
+
+		expect( result.current.isDirty ).toBe( false );
+		expect( commits ).toHaveLength( 0 );
+	} );
+
+	// The other half of the same rule: staging an explicit `undefined` is how a
+	// caller drops a param it does hold, which the URL binding relies on.
+	it( 'still clears a key the value carries', () => {
+		const { result, patches } = renderStagedValue( { preset: 'last-30-days', interval: 'week' } );
+
+		act( () => {
+			result.current.stage( { interval: undefined } );
+			result.current.commit();
+		} );
+
+		expect( patches ).toStrictEqual( [ { interval: undefined } ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
@@ -44,13 +44,19 @@ function sameValue( a: unknown, b: unknown ) {
 	);
 }
 
+function definedKeys( o: AnyObject ) {
+	return Object.keys( o ).filter( k => o[ k ] !== undefined );
+}
+
+// A key held as `undefined` is counted out: the URL binding serializes it away,
+// so a draft that cleared one equals a store that never carried it (WOOA7S-2039).
 function sameValues( a: AnyObject, b: AnyObject ) {
 	if ( a === b ) {
 		return true;
 	}
 
-	const ak = Object.keys( a );
-	if ( ak.length !== Object.keys( b ).length ) {
+	const ak = definedKeys( a );
+	if ( ak.length !== definedKeys( b ).length ) {
 		return false;
 	}
 
@@ -95,9 +101,8 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 	}
 
 	/*
-	 * Dropping a key the draft does not carry changes nothing, but the entry
-	 * would keep the buffer non-empty and the draft dirty forever: the store
-	 * writes back the same value, so the realign never runs (WOOA7S-2039).
+	 * A patch that only clears keys the draft does not carry changes nothing, so
+	 * dropping it here keeps `commit` from pushing a history entry for a no-op.
 	 */
 	const stage = useCallback( ( patch: Partial< TValue > ) => {
 		const changes = Object.fromEntries(

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
@@ -94,9 +94,25 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 		setStaged( committed );
 	}
 
+	/*
+	 * Dropping a key the draft does not carry changes nothing, but the entry
+	 * would keep the buffer non-empty and the draft dirty forever: the store
+	 * writes back the same value, so the realign never runs (WOOA7S-2039).
+	 */
 	const stage = useCallback( ( patch: Partial< TValue > ) => {
-		stagedRef.current = { ...stagedRef.current, ...patch };
-		patchRef.current = { ...patchRef.current, ...patch };
+		const changes = Object.fromEntries(
+			Object.entries( patch ).filter(
+				( [ key, value ] ) =>
+					value !== undefined || ( stagedRef.current as AnyObject )[ key ] !== undefined
+			)
+		) as Partial< TValue >;
+
+		if ( Object.keys( changes ).length === 0 ) {
+			return;
+		}
+
+		stagedRef.current = { ...stagedRef.current, ...changes };
+		patchRef.current = { ...patchRef.current, ...changes };
 		setStaged( stagedRef.current );
 	}, [] );
 

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
@@ -69,4 +69,25 @@ describe( 'DateComparisonDropdown', () => {
 		await user.click( screen.getByRole( 'menuitemradio', { name: 'No comparison' } ) );
 		expect( onClear ).toHaveBeenCalled();
 	} );
+
+	// Clearing what is already clear stages a patch of nothing, which leaves the
+	// picker's Apply enabled and inert (WOOA7S-2039).
+	it( 'does not clear a comparison that is already off', async () => {
+		const onClear = jest.fn();
+		const user = userEvent.setup();
+
+		render(
+			<DateComparisonDropdown
+				presets={ presets }
+				enabled={ false }
+				onPresetChange={ jest.fn() }
+				onClear={ onClear }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Compare' } ) );
+		await user.click( screen.getByRole( 'menuitemradio', { name: 'No comparison' } ) );
+
+		expect( onClear ).not.toHaveBeenCalled();
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/__tests__/date-comparison-dropdown.test.tsx
@@ -70,9 +70,9 @@ describe( 'DateComparisonDropdown', () => {
 		expect( onClear ).toHaveBeenCalled();
 	} );
 
-	// Clearing what is already clear stages a patch of nothing, which leaves the
-	// picker's Apply enabled and inert (WOOA7S-2039).
-	it( 'does not clear a comparison that is already off', async () => {
+	// A URL can carry a comparison whose preset the trigger cannot name — the
+	// widgets still compare, so the menu has to stay the way out (WOOA7S-2039).
+	it( 'clears a comparison the trigger cannot name', async () => {
 		const onClear = jest.fn();
 		const user = userEvent.setup();
 
@@ -88,6 +88,6 @@ describe( 'DateComparisonDropdown', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Compare' } ) );
 		await user.click( screen.getByRole( 'menuitemradio', { name: 'No comparison' } ) );
 
-		expect( onClear ).not.toHaveBeenCalled();
+		expect( onClear ).toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
@@ -74,17 +74,13 @@ export function DateComparisonDropdown( {
 	const handleSelect = useCallback(
 		( value: string ) => {
 			if ( value === NO_COMPARISON_VALUE ) {
-				// Clearing a comparison that is already off stages a patch of nothing,
-				// which leaves the picker's Apply enabled and inert (WOOA7S-2039).
-				if ( enabled ) {
-					onClear();
-				}
+				onClear();
 				return;
 			}
 
 			onPresetChange( value as ComparisonPresetId );
 		},
-		[ enabled, onClear, onPresetChange ]
+		[ onClear, onPresetChange ]
 	);
 
 	/*

--- a/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-comparison-dropdown/date-comparison-dropdown.tsx
@@ -74,13 +74,17 @@ export function DateComparisonDropdown( {
 	const handleSelect = useCallback(
 		( value: string ) => {
 			if ( value === NO_COMPARISON_VALUE ) {
-				onClear();
+				// Clearing a comparison that is already off stages a patch of nothing,
+				// which leaves the picker's Apply enabled and inert (WOOA7S-2039).
+				if ( enabled ) {
+					onClear();
+				}
 				return;
 			}
 
 			onPresetChange( value as ComparisonPresetId );
 		},
-		[ onClear, onPresetChange ]
+		[ enabled, onClear, onPresetChange ]
 	);
 
 	/*

--- a/projects/plugins/jetpack/changelog/wooa7s-2039-no-comparison-apply-stuck
+++ b/projects/plugins/jetpack/changelog/wooa7s-2039-no-comparison-apply-stuck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Keep the custom range Apply button disabled when re-selecting "No comparison".

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2039-no-comparison-apply-stuck
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2039-no-comparison-apply-stuck
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date filters: Keep the custom range Apply button disabled when re-selecting "No comparison".


### PR DESCRIPTION
## Proposed changes

- With comparison already off, picking **No comparison** again left the custom-range popover's **Apply** button enabled forever, and clicking it did nothing.
- `sameValues()` now compares the draft and the store by their *defined* keys, so a param cleared to `undefined` stops reading as a difference.
- `stage()` still drops a patch that only clears keys the draft does not carry, which keeps a no-op click from pushing a history entry.
- Adds regression tests at three levels: the staging hook, the routing controller, and the widget settings DOM.

`onComparisonChange` stages four `undefined` keys the URL does not carry. `sameValues` counted them, so the key totals differed and `isDirty` read `true`. The commit then serialized to the same URL, and the realign that empties the buffer only runs on a changed committed value, so the draft stayed dirty. This predates #51644 — the same `isDirty` formula lived in `useStagedSearch`.

The routing test's `navigate` mock now drops `undefined` the way `qss` does. Without that it kept the cleared keys, realigned where the router would not, and hid this whole class of bug at the integration level.

## Related product discussion/links

- WOOA7S-2039

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard and turn comparison off (comparison dropdown → **No comparison**).
- Open the comparison dropdown and pick **No comparison** again — the item that already has the checkmark.
- Open the custom range popover without changing any date.
- **Apply** should be greyed out. Before this change it was enabled, and clicking it did nothing.
- Check the other direction still works: turn comparison on, pick **No comparison**, and confirm the comparison params leave the URL.
- Load a link carrying an applied comparison with no `compare_preset` (`&compare_from=…&compare_to=…&comp="1"`). The trigger reads **Compare**, but the widgets are comparing, and **No comparison** must still clear it.

Before


https://github.com/user-attachments/assets/bc368b86-129b-4801-91d5-266f2423cde8


After

https://github.com/user-attachments/assets/68656c0f-837d-4876-a0be-85d98b6ea405
