### PR TITLE
Omnibar: fix misaligned items on <480px width due to specificity loss

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/wpcom-admin-bar-480-bug
+++ b/projects/packages/jetpack-mu-wpcom/changelog/wpcom-admin-bar-480-bug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Omnibar: fix misaligned items on <480px width due to specificity loss

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -53,7 +53,7 @@
 /**
  * WP logo menu
  */
-#wpadminbar #wp-admin-bar-wp-logo > .ab-item {
+#wpadminbar .quicklinks #wp-admin-bar-wp-logo > .ab-item {
 	padding: 0 10px;
 
 	@media (max-width: 782px) {
@@ -61,15 +61,11 @@
 	}
 }
 
-#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
+#wpadminbar .quicklinks #wp-admin-bar-wp-logo > .ab-item .ab-icon {
 	margin-right: 0 !important;
-
-	@media (max-width: 480px) {
-		width: 44px;
-	}
 }
 
-#wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon::before {
+#wpadminbar .quicklinks #wp-admin-bar-wp-logo > .ab-item .ab-icon::before {
 	display: flex;
 	content: "";
 	width: 20px;
@@ -91,17 +87,21 @@
 
 }
 
-#wpadminbar #wp-admin-bar-wp-logo:not(:first-child) {
+#wpadminbar .quicklinks #wp-admin-bar-wp-logo:not(:first-child) {
 	// Site admin on mobile viewport (the first child is the hamburger menu)
 	@media (max-width: 480px) {
 
+		>.ab-item .ab-icon {
+			width: 44px;
+		}
+
 		>.ab-item .ab-icon::before {
-			margin: 0 7px 0 5px;
+			margin: 0 7px;
 		}
 	}
 }
 
-#wpadminbar #wp-admin-bar-site-name {
+#wpadminbar .quicklinks #wp-admin-bar-site-name {
 
 	&:not(.has-site-icon) > .ab-item::before {
 
@@ -116,6 +116,10 @@
 		> a.ab-item,
 		> a.ab-item::before {
 			width: 46px;
+		}
+
+		> a.ab-item .site-icon {
+			left: 9.5px;
 		}
 	}
 }


### PR DESCRIPTION
Part of DOTCOM-18357

## Proposed changes

Before

<img width="960" height="92" alt="image" src="https://github.com/user-attachments/assets/4a87a320-0819-47f6-a3ce-5e231b1bd933" />

After

<img width="960" height="92" alt="image" src="https://github.com/user-attachments/assets/bc7a1f42-f865-4f1b-b0ef-1ecd537362bd" />

Before

<img width="960" height="92" alt="image" src="https://github.com/user-attachments/assets/7f355e56-56fa-4cd7-bb07-231cab49ae5e" />

After

<img width="960" height="92" alt="image" src="https://github.com/user-attachments/assets/47cbfedb-c58a-4f82-8ffd-a0f38113ac66" />



## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions

Patch this PR, go to wp-admin on 480px, verify the site-name node as shown above.
