### PR TITLE
Expiry notices: complete the rollout and remove the gate

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/rollout-expiry-notices-100
+++ b/projects/packages/jetpack-mu-wpcom/changelog/rollout-expiry-notices-100
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Expiry notices: show the plan-expiry notices to all sites, in every language.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -50,13 +50,16 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param bool $enabled Whether the site is on the new expiry notices.
+	 * @param bool $enabled    Whether the site is on the new expiry notices.
+	 * @param int  $percentage Share of sites the rollout targets. Always 100 now
+	 *                         that it is complete; passed so that callbacks
+	 *                         declaring both parameters keep working.
 	 */
-	return (bool) apply_filters( 'wpcom_expiry_notices_enabled', true );
+	return (bool) apply_filters( 'wpcom_expiry_notices_enabled', true, 100 );
 }
 
 /**
- * Load the wp-admin banner for sites in the rollout.
+ * Load the wp-admin banner, unless something has held this site back.
  *
  * On `init` rather than at file load. This file is required on `plugins_loaded`,
  * and both of the banner's own hooks fire later still, so waiting keeps the

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'wpcom_expiry_get_purchases' ) ) {
  * two halves drift and a site ends up with both notices or neither.
  */
 function wpcom_expiry_notices_rollout_percentage(): int {
-	return 20;
+	return 100;
 }
 
 /**
@@ -109,9 +109,6 @@ function wpcom_expiry_notices_rollout_override(): ?bool {
 /**
  * Whether this site is in the share of sites running the new expiry notices.
  *
- * Also narrows on the reader's locale, so despite the name this is not answered
- * from the site alone.
- *
  * Buckets on the blog ID modulo 100 rather than modulo the share itself, so
  * raising the percentage only ever adds sites. Modulo-the-share does not hold
  * that property — going from 10% as `id % 10 === 0` to 33% as `id % 3 === 0`
@@ -138,13 +135,6 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 		$enabled = $blog_id > 0 && ( $blog_id % 100 ) < $percentage;
 	}
 
-	// Narrow the ramp again to readers in an English locale, while the
-	// translations catch up.
-	if ( $enabled ) {
-		$locale  = get_user_locale();
-		$enabled = 'en' === $locale || 0 === strpos( $locale, 'en_' );
-	}
-
 	/**
 	 * Filters whether the new expiry notices are enabled for this site.
 	 *
@@ -164,9 +154,9 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 /**
  * Load the wp-admin banner for sites in the rollout.
  *
- * On `init` because the gate reads the user's locale, and the current user is
- * not settled when this file is required on `plugins_loaded`. The banner's own
- * hooks fire later still, so nothing is lost by waiting.
+ * On `init` rather than at file load. This file is required on `plugins_loaded`,
+ * and both of the banner's own hooks fire later still, so waiting keeps the
+ * require off the bootstrap at no cost.
  */
 function wpcom_expiry_notices_maybe_load_admin_banner() {
 	if ( is_admin() && wpcom_expiry_notices_is_enabled_for_site() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -31,124 +31,28 @@ if ( ! function_exists( 'wpcom_expiry_get_purchases' ) ) {
 // @codeCoverageIgnoreEnd
 
 /**
- * Share of sites the new expiry notices are switched on for, as a percentage.
+ * Whether the new expiry notices are switched on for this site.
  *
- * The notices replace older per-host banners, so this number governs both
- * sides of the swap: a site inside the share gets the new notices and must
- * have the old ones suppressed, a site outside keeps the old ones and must not
- * see the new. Every surface making that decision has to call
- * `wpcom_expiry_notices_is_enabled_for_site()` rather than re-derive it, or the
- * two halves drift and a site ends up with both notices or neither.
- */
-function wpcom_expiry_notices_rollout_percentage(): int {
-	return 100;
-}
-
-/**
- * The WP.com blog ID, or 0 when it can't be established.
- *
- * Deliberately not `get_wpcom_blog_id()`: that falls back to the *local* blog
- * ID on Atomic when `jetpack_options['id']` isn't readable, which is 1 on a
- * single-site install. A wrong-but-plausible ID is worse than none here — 1
- * lands inside every bucket, so each site with an unreadable option would
- * quietly join the rollout. Returning 0 keeps them out instead.
- */
-function wpcom_expiry_notices_wpcom_blog_id(): int {
-	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
-		return (int) get_current_blog_id();
-	}
-
-	$jetpack_options = get_option( 'jetpack_options' );
-	if ( is_array( $jetpack_options ) && ! empty( $jetpack_options['id'] ) ) {
-		return (int) $jetpack_options['id'];
-	}
-
-	return 0;
-}
-
-/**
- * Per-site override for the rollout, or null when the site hasn't got one.
- *
- * Set on individual sites to pull one into the rollout early, or hold one out,
- * regardless of the bucket its blog ID falls in. Three-state on purpose:
- * absent means "follow the share", which is not the same as "stay out", so
- * clearing the option returns a site to the normal rule rather than pinning it
- * off forever.
- *
- * Reading a missing option is served from the `notoptions` cache, so sites
- * without one pay nothing for this.
- */
-function wpcom_expiry_notices_rollout_override(): ?bool {
-	$override = get_option( 'wpcom_expiry_notices_enabled', null );
-	if ( null === $override ) {
-		return null;
-	}
-
-	if ( is_string( $override ) ) {
-		$override = strtolower( trim( $override ) );
-	}
-
-	/*
-	 * Parsed against known values rather than through wp_validate_boolean(),
-	 * which reads every non-empty string as true -- "no" and "off" included.
-	 * This option is typed by hand on individual sites, so a value meant to
-	 * hold a site out that quietly opts it in is the wrong way to be wrong.
-	 */
-	if ( in_array( $override, array( true, 1, '1', 'true', 'yes', 'on' ), true ) ) {
-		return true;
-	}
-	if ( in_array( $override, array( false, 0, '0', 'false', 'no', 'off' ), true ) ) {
-		return false;
-	}
-
-	// An empty or unrecognised value is a mistake, not an instruction. Leave
-	// the site on the normal rule rather than guessing which way it meant.
-	return null;
-}
-
-/**
- * Whether this site is in the share of sites running the new expiry notices.
- *
- * Buckets on the blog ID modulo 100 rather than modulo the share itself, so
- * raising the percentage only ever adds sites. Modulo-the-share does not hold
- * that property — going from 10% as `id % 10 === 0` to 33% as `id % 3 === 0`
- * drops blog 10 — and a site that gained the new notices only to lose them
- * again would flip back to the old ones mid-rollout.
+ * The rollout that gated this is finished, so the answer is yes unless something
+ * says otherwise. Kept as a function rather than inlined because it is the one
+ * predicate both halves of the swap read: the notices themselves, and the
+ * suppression of the ones they replace -- wpcomsh's Atomic banner here, and the
+ * legacy plan-renew prompt on the WordPress.com side. They must never disagree,
+ * or a site ends up showing both notices or neither.
  */
 function wpcom_expiry_notices_is_enabled_for_site(): bool {
-	$percentage = wpcom_expiry_notices_rollout_percentage();
-	$override   = wpcom_expiry_notices_rollout_override();
-
-	if ( null !== $override ) {
-		// Hand-picked, either way. Checked first so a site can be pulled in
-		// ahead of its bucket or held out of one it already falls in.
-		$enabled = $override;
-	} elseif ( $percentage >= 100 ) {
-		// Fully rolled out. Answered before resolving an ID so that a site
-		// whose blog ID can't be read still gets the notices at the end of the
-		// ramp, rather than being stranded outside it forever.
-		$enabled = true;
-	} elseif ( $percentage <= 0 ) {
-		$enabled = false;
-	} else {
-		$blog_id = wpcom_expiry_notices_wpcom_blog_id();
-		$enabled = $blog_id > 0 && ( $blog_id % 100 ) < $percentage;
-	}
-
 	/**
 	 * Filters whether the new expiry notices are enabled for this site.
 	 *
 	 * Both the new notices and the suppression of the ones they replace read
-	 * this, so an override moves the whole swap together. Shares its name with
-	 * the per-site option and runs after it, so code can still override a site
-	 * that has one set.
+	 * this, so overriding it moves the whole swap together. Left in place after
+	 * the rollout as the way to hold a single site back.
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param bool $enabled Whether the site is in the rollout.
-	 * @param int  $percentage Share of sites the rollout currently targets.
+	 * @param bool $enabled Whether the site is on the new expiry notices.
 	 */
-	return (bool) apply_filters( 'wpcom_expiry_notices_enabled', $enabled, $percentage );
+	return (bool) apply_filters( 'wpcom_expiry_notices_enabled', true );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
@@ -20,10 +20,6 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		parent::tear_down();
 	}
 
-	/**
-	 * Blog 5 is inside the share and blog 55 outside it for any share from 6% to
-	 * 55%. Revisit these fixtures if the rollout is ever widened past that.
-	 */
 	private function set_blog_id( int $blog_id ): void {
 		update_option( 'jetpack_options', array( 'id' => $blog_id ) );
 	}
@@ -46,9 +42,9 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		);
 	}
 
-	public function test_ships_at_the_intended_share(): void {
-		// Pinned so widening the rollout is a deliberate edit, not a drift.
-		$this->assertSame( 20, wpcom_expiry_notices_rollout_percentage() );
+	public function test_ships_fully_rolled_out(): void {
+		// Pinned so a change to the share is a deliberate edit, not a drift.
+		$this->assertSame( 100, wpcom_expiry_notices_rollout_percentage() );
 	}
 
 	public function test_enables_exactly_the_configured_share(): void {
@@ -98,15 +94,15 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
-	public function test_an_unknown_blog_id_stays_out_of_the_rollout(): void {
-		// No jetpack_options at all: get_wpcom_blog_id() would fall back to the
-		// local blog ID of 1, which would land inside every bucket.
+	public function test_an_unknown_blog_id_still_resolves_to_zero(): void {
+		// Not a rollout question any more -- at 100% every site is in, unknown ID
+		// or not. Kept because the helper still must not fall back to the local
+		// blog ID of 1, which would matter again at any partial share.
 		delete_option( 'jetpack_options' );
 		$this->assertSame( 0, wpcom_expiry_notices_wpcom_blog_id() );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 
 		update_option( 'jetpack_options', array( 'id' => 0 ) );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+		$this->assertSame( 0, wpcom_expiry_notices_wpcom_blog_id() );
 	}
 
 	public function test_an_unknown_blog_id_is_included_once_fully_rolled_out(): void {
@@ -123,16 +119,13 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
-	public function test_the_option_pulls_a_site_into_the_rollout_early(): void {
-		$this->set_blog_id( 55 ); // 55 % 100 = 55, outside the share.
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-
+	public function test_a_truthy_option_leaves_a_site_in(): void {
+		// Redundant at 100%, but sites carrying the option from the ramp must not
+		// be treated any differently now that everyone is in.
+		$this->set_blog_id( 55 );
 		foreach ( array( '1', 1, 'true', 'yes', 'on', 'YES', ' 1 ' ) as $truthy ) {
 			update_option( 'wpcom_expiry_notices_enabled', $truthy );
-			$this->assertTrue(
-				wpcom_expiry_notices_is_enabled_for_site(),
-				sprintf( 'option value %s should read as opted in', var_export( $truthy, true ) )
-			);
+			$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 		}
 	}
 
@@ -163,18 +156,12 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 
 	public function test_an_unrecognised_option_value_changes_nothing(): void {
 		// A typo must not flip a site either way -- it leaves the normal rule in
-		// place, so a fat-fingered rollout command is inert rather than wrong.
-		$this->set_blog_id( 5 ); // Inside the share.
+		// place, which at 100% means the site stays in.
+		$this->set_blog_id( 5 );
 		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
 			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
 			$this->assertNull( wpcom_expiry_notices_rollout_override(), "'{$nonsense}' should not be read as an instruction" );
 			$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		}
-
-		$this->set_blog_id( 55 ); // Outside the share.
-		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
-			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
-			$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
 		}
 	}
 
@@ -188,16 +175,18 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function test_the_filter_can_force_a_site_in_or_out(): void {
-		$this->set_blog_id( 55 ); // 55 % 100 = 55, outside the share.
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-
-		add_filter( 'wpcom_expiry_notices_enabled', '__return_true' );
+		// At 100% the interesting direction is forcing a site out.
+		$this->set_blog_id( 5 );
 		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		remove_all_filters( 'wpcom_expiry_notices_enabled' );
 
-		$this->set_blog_id( 5 ); // 5 % 100 = 5, inside the share.
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 		add_filter( 'wpcom_expiry_notices_enabled', '__return_false' );
 		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+		remove_all_filters( 'wpcom_expiry_notices_enabled' );
+
+		// And back in, over a site opted out by the option.
+		update_option( 'wpcom_expiry_notices_enabled', '0' );
+		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
+		add_filter( 'wpcom_expiry_notices_enabled', '__return_true' );
+		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Rollout gate tests.
+ * Tests for the predicate both halves of the expiry-notice swap read.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -15,178 +15,43 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 
 	public function tear_down() {
 		remove_all_filters( 'wpcom_expiry_notices_enabled' );
-		delete_option( 'jetpack_options' );
-		delete_option( 'wpcom_expiry_notices_enabled' );
 		parent::tear_down();
 	}
 
-	private function set_blog_id( int $blog_id ): void {
-		update_option( 'jetpack_options', array( 'id' => $blog_id ) );
-	}
-
-	private function at_percentage( int $percentage ): void {
-		add_filter(
-			'wpcom_expiry_notices_enabled',
-			static function ( $enabled, $actual ) use ( $percentage ) {
-				// Re-derive at the percentage under test; the shipped number is
-				// a constant, so this is how the curve gets exercised.
-				unset( $enabled, $actual );
-				$blog_id = wpcom_expiry_notices_wpcom_blog_id();
-				if ( $percentage >= 100 ) {
-					return true;
-				}
-				return $percentage > 0 && $blog_id > 0 && ( $blog_id % 100 ) < $percentage;
-			},
-			10,
-			2
-		);
-	}
-
-	public function test_ships_fully_rolled_out(): void {
-		// Pinned so a change to the share is a deliberate edit, not a drift.
-		$this->assertSame( 100, wpcom_expiry_notices_rollout_percentage() );
-	}
-
-	public function test_enables_exactly_the_configured_share(): void {
-		$enabled = 0;
-		for ( $blog_id = 1; $blog_id <= 1000; $blog_id++ ) {
-			$this->set_blog_id( $blog_id );
-			if ( wpcom_expiry_notices_is_enabled_for_site() ) {
-				++$enabled;
-			}
-		}
-		// Derived from the shipped share, so widening the rollout does not need
-		// this number edited too.
-		$this->assertSame(
-			wpcom_expiry_notices_rollout_percentage() * 10,
-			$enabled,
-			'the rollout should cover exactly its share of 1000 sites'
-		);
-	}
-
-	public function test_the_same_site_always_lands_the_same_way(): void {
-		$this->set_blog_id( 12345 );
-		$first = wpcom_expiry_notices_is_enabled_for_site();
-		for ( $i = 0; $i < 5; $i++ ) {
-			$this->assertSame( $first, wpcom_expiry_notices_is_enabled_for_site() );
-		}
-	}
-
-	public function test_raising_the_percentage_only_ever_adds_sites(): void {
-		$previous = array();
-		foreach ( array( 1, 5, 10, 25, 33, 50, 99, 100 ) as $percentage ) {
-			$this->at_percentage( $percentage );
-			$current = array();
-			for ( $blog_id = 1; $blog_id <= 300; $blog_id++ ) {
-				$this->set_blog_id( $blog_id );
-				if ( wpcom_expiry_notices_is_enabled_for_site() ) {
-					$current[] = $blog_id;
-				}
-			}
-			$dropped = array_diff( $previous, $current );
-			$this->assertSame(
-				array(),
-				$dropped,
-				"raising the rollout to {$percentage}% dropped sites that were already in it"
-			);
-			$previous = $current;
-			remove_all_filters( 'wpcom_expiry_notices_enabled' );
-		}
-	}
-
-	public function test_an_unknown_blog_id_still_resolves_to_zero(): void {
-		// Not a rollout question any more -- at 100% every site is in, unknown ID
-		// or not. Kept because the helper still must not fall back to the local
-		// blog ID of 1, which would matter again at any partial share.
-		delete_option( 'jetpack_options' );
-		$this->assertSame( 0, wpcom_expiry_notices_wpcom_blog_id() );
-
-		update_option( 'jetpack_options', array( 'id' => 0 ) );
-		$this->assertSame( 0, wpcom_expiry_notices_wpcom_blog_id() );
-	}
-
-	public function test_an_unknown_blog_id_is_included_once_fully_rolled_out(): void {
-		delete_option( 'jetpack_options' );
-		$this->at_percentage( 100 );
+	public function test_every_site_is_on_the_new_notices(): void {
+		// The rollout is finished: no share, no bucket, no per-site option.
 		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 
-	public function test_zero_percent_disables_every_site(): void {
-		$this->at_percentage( 0 );
-		foreach ( array( 1, 50, 100, 12345 ) as $blog_id ) {
-			$this->set_blog_id( $blog_id );
-			$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-		}
-	}
-
-	public function test_a_truthy_option_leaves_a_site_in(): void {
-		// Redundant at 100%, but sites carrying the option from the ramp must not
-		// be treated any differently now that everyone is in.
-		$this->set_blog_id( 55 );
-		foreach ( array( '1', 1, 'true', 'yes', 'on', 'YES', ' 1 ' ) as $truthy ) {
-			update_option( 'wpcom_expiry_notices_enabled', $truthy );
+	public function test_the_answer_does_not_depend_on_the_site(): void {
+		// Nothing site-specific is read any more, so every site answers alike.
+		// Worth pinning: the swap only stays coherent while both halves get the
+		// same answer for the same request.
+		foreach ( array( 1, 5, 55, 100, 12345 ) as $blog_id ) {
+			update_option( 'jetpack_options', array( 'id' => $blog_id ) );
 			$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 		}
+		delete_option( 'jetpack_options' );
 	}
 
-	public function test_the_option_holds_a_site_out_of_a_bucket_it_falls_in(): void {
-		$this->set_blog_id( 5 ); // 5 % 100 = 5, inside the share.
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-
-		foreach ( array( '0', 0, 'false', 'no', 'off', 'NO', ' 0 ' ) as $falsy ) {
-			update_option( 'wpcom_expiry_notices_enabled', $falsy );
-			$this->assertFalse(
+	public function test_the_retired_rollout_option_no_longer_holds_a_site_out(): void {
+		// Sites still carry `wpcom_expiry_notices_enabled` from the ramp. It is
+		// no longer read, so a stale value cannot strand a site on the old
+		// notices. Use the filter instead.
+		foreach ( array( '0', 'false', 'no', 'off', '1' ) as $stale ) {
+			update_option( 'wpcom_expiry_notices_enabled', $stale );
+			$this->assertTrue(
 				wpcom_expiry_notices_is_enabled_for_site(),
-				sprintf( 'option value %s should read as opted out', var_export( $falsy, true ) )
+				sprintf( 'a leftover option value of %s should be inert', var_export( $stale, true ) )
 			);
 		}
-	}
-
-	public function test_clearing_the_option_returns_the_site_to_the_share(): void {
-		$this->set_blog_id( 5 ); // Inside the share.
-		update_option( 'wpcom_expiry_notices_enabled', '0' );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-
-		// Clearing must not read as "stay out" -- the site goes back under the
-		// normal rule, which for blog 5 means back in.
 		delete_option( 'wpcom_expiry_notices_enabled' );
-		$this->assertNull( wpcom_expiry_notices_rollout_override() );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 
-	public function test_an_unrecognised_option_value_changes_nothing(): void {
-		// A typo must not flip a site either way -- it leaves the normal rule in
-		// place, which at 100% means the site stays in.
-		$this->set_blog_id( 5 );
-		foreach ( array( 'ture', 'enabled', 'maybe', '' ) as $nonsense ) {
-			update_option( 'wpcom_expiry_notices_enabled', $nonsense );
-			$this->assertNull( wpcom_expiry_notices_rollout_override(), "'{$nonsense}' should not be read as an instruction" );
-			$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-		}
-	}
-
-	public function test_the_option_beats_a_zero_percent_rollout(): void {
-		// Useful before the share is opened at all: pick a site, see the notices.
-		$this->at_percentage( 0 );
-		$this->set_blog_id( 55 );
-		remove_all_filters( 'wpcom_expiry_notices_enabled' );
-		update_option( 'wpcom_expiry_notices_enabled', '1' );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-	}
-
-	public function test_the_filter_can_force_a_site_in_or_out(): void {
-		// At 100% the interesting direction is forcing a site out.
-		$this->set_blog_id( 5 );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
-
+	public function test_the_filter_can_still_hold_a_site_back(): void {
+		// The one remaining lever, and the one the legacy notices rely on: if
+		// this says a site is out, they must take over again.
 		add_filter( 'wpcom_expiry_notices_enabled', '__return_false' );
 		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-		remove_all_filters( 'wpcom_expiry_notices_enabled' );
-
-		// And back in, over a site opted out by the option.
-		update_option( 'wpcom_expiry_notices_enabled', '0' );
-		$this->assertFalse( wpcom_expiry_notices_is_enabled_for_site() );
-		add_filter( 'wpcom_expiry_notices_enabled', '__return_true' );
-		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Rollout_Test.php
@@ -48,6 +48,25 @@ class Rollout_Test extends \WorDBless\BaseTestCase {
 		delete_option( 'wpcom_expiry_notices_enabled' );
 	}
 
+	public function test_the_filter_still_passes_both_arguments(): void {
+		// WordPress passes a callback only as many arguments as the hook supplies,
+		// so dropping the second one would fatal any callback that declares it as
+		// required. The rollout is over but the signature outlives it.
+		$received = array();
+		add_filter(
+			'wpcom_expiry_notices_enabled',
+			static function ( $enabled, $percentage ) use ( &$received ) {
+				$received = array( $enabled, $percentage );
+				return $enabled;
+			},
+			10,
+			2
+		);
+
+		$this->assertTrue( wpcom_expiry_notices_is_enabled_for_site() );
+		$this->assertSame( array( true, 100 ), $received );
+	}
+
 	public function test_the_filter_can_still_hold_a_site_back(): void {
 		// The one remaining lever, and the one the legacy notices rely on: if
 		// this says a site is out, they must take over again.


### PR DESCRIPTION
Fixes DOTCOM-16615

The end of the ramp: **every site, every language** — and then the gate that got us here.

Based on current trunk (20%), so it supersedes #51477 rather than stacking on it. Two commits, reviewable separately:

1. **Complete the rollout** — share to 100%, English-only narrowing removed.
2. **Remove the finished rollout gate** — the machinery that no longer decides anything.

## Proposed changes

**Commit 1.** `wpcom_expiry_notices_rollout_percentage()` returns `100`, and the locale narrowing is deleted rather than widened — it was a hold for the translations, so there's no longer a set of allowed languages to express.

**Commit 2.** Removes the percentage, the `blog_id % 100` bucketing, the helper that resolved the blog ID, the per-site option reader, and the branch that chose between them. `expiry-notices.php` goes from 194 lines to 85.

## What deliberately stays, and why

`wpcom_expiry_notices_is_enabled_for_site()` remains, now a filterable `true`.

It is **not** safe to delete. It's the single predicate both halves of the swap read — the new notices, and the suppression of the ones they replace: `wpcomsh/notices/plan-notices.php` here and `admin-plugins/plan-renew-prompt.php` on the WordPress.com side. Both guard with:

```php
if ( function_exists( 'wpcom_expiry_notices_is_enabled_for_site' )
	&& wpcom_expiry_notices_is_enabled_for_site() ) {
	return;
}
```

Remove the function and `function_exists()` goes false, the guard short-circuits, and **every site renders the legacy notice alongside the new one**. That's the precise failure the shared predicate was built to prevent, and it would land on Simple and Atomic at once.

So the `wpcom_expiry_notices_enabled` filter stays too, and is now the only way to hold a site back.

## One behaviour change worth noticing

The retired `wpcom_expiry_notices_enabled` **option** is no longer read. Sites still carrying it from the ramp are unaffected either way — which is the point: a stale `0` can't strand a site on the old notices. There's a test for it.

## Related product discussion/links

* Linear: DOTCOM-16615
* Feature: #49304
* Supersedes: #51477
* Prepared stop: #51475 — ⚠️ **this PR invalidates it.** That branch stops the rollout by setting the share to `0`, and after this there is no share. If you want a stop after this lands, it becomes `add_filter( 'wpcom_expiry_notices_enabled', '__return_false' )`, which is what the WordPress.com-side stop already does.

## Does this pull request change what data or activity we track or use?

No new data. Existing Tracks events and the `wpcom-site-purchase` MC stats cover every site rather than a share.

## Testing instructions

1. Any site with a plan inside its notice window shows the new banner, and the legacy notice is gone. Exactly one notice — never two, never none.
2. `wp user meta update <id> locale it_IT` — that admin now sees the new notice too. Before this they'd have got the legacy one.
3. `wp option update wpcom_expiry_notices_enabled 0` — no longer holds a site out. Confirm the site still gets the new notice.
4. `add_filter( 'wpcom_expiry_notices_enabled', '__return_false' )` — the site drops back to the legacy notice. This is the remaining lever, so it's the one worth checking properly.

## ⚠️ Before merging

**This is the largest step change in `wpcom-site-purchase/billing-lookup` of the whole ramp** — from 20% of sites, English readers only, to every site in every language. Expect the MC alert to fire; consider raising the floor beforehand rather than acknowledging a page you already knew was coming.

**Confirm the translations have actually landed.** The narrowing exists because they hadn't; nothing here verifies they have.

**Consider splitting the two ramps.** Landing the locale removal on its own first, then the share, is both more measurable and the safer order — it widens the audience without widening the site count. Happy to reshape it that way.

## Follow-up

Once this is settled, both legacy notice files and the predicate itself can go. That must be sequenced across repos — the WordPress.com-side banner first, then the predicate here — or Simple sites get two notices during the window. Its own PR, not this one.
