### PR TITLE
Issue templates: route WP Super Cache reports to its own repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Ask a support question
     url: http://jetpack.com/contact-support/
     about: This issue tracker is not for support. If you have questions about one of our plugins, you can contact us here.
+  - name: WP Super Cache bug reports and feature requests
+    url: https://github.com/Automattic/wp-super-cache/issues
+    about: WP Super Cache moved to its own repository - please file issues there.


### PR DESCRIPTION
## Proposed changes

* Add a contact link to the GitHub issue chooser (`.github/ISSUE_TEMPLATE/config.yml`) so WP Super Cache bug reports and feature requests route to the now-separate [Automattic/wp-super-cache](https://github.com/Automattic/wp-super-cache/issues) repository.

WP Super Cache was extracted from this monorepo in April 2026, but users still open Super Cache issues here (e.g. Automattic/wp-super-cache#1108), where they land in the wrong Linear triage. The new entry matches the existing `contact_links` schema, with a short `about` line explaining the move.

## Related product discussion/links

* BOOST-643 (Linear twin of Automattic/wp-super-cache#1108) — a Super Cache request that arrived in Boost triage, which prompted this change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to https://github.com/Automattic/jetpack/issues/new/choose on this branch's fork (or review `.github/ISSUE_TEMPLATE/config.yml` directly).
* Confirm a "WP Super Cache bug reports and feature requests" entry appears among the contact links and points to https://github.com/Automattic/wp-super-cache/issues.
* Confirm the existing issue templates and other contact links are unchanged.