### PR TITLE
Premium Analytics: turn date comparison off by default

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-comparison-off-by-default
+++ b/projects/packages/premium-analytics/changelog/update-comparison-off-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Date controls: turn the period comparison off by default.

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/normalize-report-params.test.ts
@@ -65,7 +65,7 @@ beforeEach( () => {
 } );
 
 describe( 'normalizeReportParams', () => {
-	it( 'applies defaults with preset and comparison on fresh load', () => {
+	it( 'applies default preset without comparison on fresh load', () => {
 		const result = normalizeReportParams();
 
 		expect( result.preset ).toBe( 'last-30-days' );
@@ -74,10 +74,12 @@ describe( 'normalizeReportParams', () => {
 		expect( result.from ).toBe( FRESH_FROM );
 		expect( result.to ).toBe( FRESH_TO );
 
-		// `search` is undefined → `!search?.from` → the default-comparison branch.
-		expect( result.comp ).toBe( '1' );
-		expect( result.compare_from ).toBe( DEFAULTS_WITH_COMPARISON.compare_from );
-		expect( result.compare_to ).toBe( DEFAULTS_WITH_COMPARISON.compare_to );
+		// Comparison is off by default: even defaults carrying one must not
+		// leak into a fresh load — only the URL enables it.
+		expect( result.comp ).toBeUndefined();
+		expect( result.compare_from ).toBeUndefined();
+		expect( result.compare_to ).toBeUndefined();
+		expect( result.compare_preset ).toBeUndefined();
 	} );
 
 	it( 'returns same dates when preset range is still fresh', () => {
@@ -99,7 +101,7 @@ describe( 'normalizeReportParams', () => {
 		);
 		expect( result.interval ).toBe( 'day' );
 
-		// `search.from` is present, so the default-comparison branch is skipped.
+		// No comparison in the URL, so none is applied.
 		expect( result.comp ).toBeUndefined();
 	} );
 
@@ -225,7 +227,7 @@ describe( 'normalizeReportParams', () => {
 		expect( result.from ).toBe( FRESH_FROM );
 		expect( result.to ).toBe( FRESH_TO );
 
-		// `search.from` is present, so the default comparison is not applied.
+		// No comparison in the URL, so none is applied.
 		expect( result.comp ).toBeUndefined();
 		expect( result.compare_from ).toBeUndefined();
 		expect( result.compare_to ).toBeUndefined();

--- a/projects/packages/premium-analytics/packages/data/src/utils/search.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/search.ts
@@ -88,9 +88,7 @@ export function normalizeReportParams(
 	search?: NormalizeReportParamsArgType,
 	defaultPreset?: PresetType
 ): ReportParams {
-	const defaults = defaultPreset
-		? getDefaultQueryParams( true, defaultPreset )
-		: getDefaultQueryParams( true );
+	const defaults = getDefaultQueryParams( false, defaultPreset );
 
 	let preset: ReportPresetId | undefined;
 	if (
@@ -140,16 +138,12 @@ export function normalizeReportParams(
 		...( postId > 0 ? { post_id: postId } : {} ),
 	};
 
+	// Comparison only ever comes from the URL. A fresh load carries none: the
+	// dashboard compares nothing until the user picks a comparison.
 	if ( search && hasComparisonEnabled( search ) ) {
 		normalized.compare_from = search.compare_from;
 		normalized.compare_to = search.compare_to;
 		normalized.compare_preset = search.compare_preset;
-		normalized.comp = '1';
-	} else if ( ! search?.from && hasComparisonEnabled( defaults ) ) {
-		// Fresh load (missing primary params) - apply default comparison
-		normalized.compare_from = defaults.compare_from;
-		normalized.compare_to = defaults.compare_to;
-		normalized.compare_preset = defaults.compare_preset;
 		normalized.comp = '1';
 	}
 

--- a/projects/packages/premium-analytics/routes/dashboard/route.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.test.ts
@@ -13,6 +13,21 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 		to: '2026-06-16T23:59:59',
 		...search,
 	} ) ),
+	// Real semantics, without pulling the data barrel: the seed's comparison
+	// stripping is under test here.
+	hasComparisonEnabled: ( params: {
+		comp?: unknown;
+		compare_from?: string;
+		compare_to?: string;
+	} ) => String( params.comp ) === '1' && !! params.compare_from && !! params.compare_to,
+	withoutComparison: ( params: Record< string, unknown > ) => {
+		const next = { ...params };
+		delete next.comp;
+		delete next.compare_from;
+		delete next.compare_to;
+		delete next.compare_preset;
+		return next;
+	},
 } ) );
 
 jest.mock( '../site-readiness', () => ( {
@@ -78,6 +93,52 @@ describe( 'dashboard route.beforeLoad', () => {
 		( needsReportDateParamsSeed as jest.Mock ).mockReturnValueOnce( true );
 
 		await expect( beforeLoad( {} ) ).rejects.toMatchObject( { to: '/', replace: true } );
+	} );
+
+	/**
+	 * Run the seed for a search and return the search the redirect writes.
+	 *
+	 * @param search - The URL search params the route loads with.
+	 * @return The seeded search params.
+	 */
+	async function seededSearch( search: object ): Promise< Record< string, unknown > > {
+		( needsReportDateParamsSeed as jest.Mock ).mockReturnValueOnce( true );
+
+		const thrown = ( await beforeLoad( search ).then(
+			() => null,
+			( redirectResult: unknown ) => redirectResult
+		) ) as { search: Record< string, unknown > } | null;
+
+		if ( ! thrown ) {
+			throw new Error( 'expected the seed to redirect' );
+		}
+
+		return thrown.search;
+	}
+
+	// A hand-edited bare `comp=1` (no compare dates) must not ride through the
+	// seed into the URL it writes.
+	it( 'drops stray comparison params from the seed', async () => {
+		const search = await seededSearch( {
+			comp: '1',
+			compare_preset: 'previous-period',
+			section: 'store',
+		} );
+
+		expect( search ).toMatchObject( { section: 'store' } );
+		expect( search ).not.toHaveProperty( 'comp' );
+		expect( search ).not.toHaveProperty( 'compare_preset' );
+	} );
+
+	it( 'keeps a complete comparison through the seed', async () => {
+		const search = await seededSearch( {
+			comp: '1',
+			compare_from: '2026-05-01T00:00:00',
+			compare_to: '2026-05-16T23:59:59',
+			compare_preset: 'previous-period',
+		} );
+
+		expect( search ).toMatchObject( { comp: '1', compare_preset: 'previous-period' } );
 	} );
 
 	it( 'registers both dashboard entities on a fresh store', async () => {

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -3,8 +3,10 @@
  */
 import {
 	ensureCoreSettingsReady,
+	hasComparisonEnabled,
 	needsReportDateParamsSeed,
 	normalizeReportParams,
+	withoutComparison,
 } from '@jetpack-premium-analytics/data';
 import { redirect } from '@wordpress/route';
 /**
@@ -39,14 +41,20 @@ export const route = {
 				// Proceed with the default seed below.
 			}
 
+			const normalized = normalizeReportParams(
+				params as Parameters< typeof normalizeReportParams >[ 0 ]
+			);
+
 			/*
 			 * Overlay `normalizeReportParams` onto `params`, not replace it, so
-			 * passthrough params like `section` survive the seed.
+			 * passthrough params like `section` survive the seed. Comparison keys
+			 * only survive when normalize returned a complete comparison: a
+			 * hand-edited bare `comp=1` must not outlive the seed.
 			 */
-			const seeded: Record< string, unknown > = {
-				...params,
-				...normalizeReportParams( params as Parameters< typeof normalizeReportParams >[ 0 ] ),
-			};
+			const merged = { ...params, ...normalized };
+			const seeded: Record< string, unknown > = hasComparisonEnabled( normalized )
+				? merged
+				: withoutComparison( merged );
 
 			throw redirect( {
 				to: '/',

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -40,8 +40,8 @@ export const route = {
 			}
 
 			/*
-			 * Overlay `normalizeReportParams` onto `params`, not replace it — a raw
-			 * default would force `comp=1` onto a custom deep-link and drop `section`.
+			 * Overlay `normalizeReportParams` onto `params`, not replace it, so
+			 * passthrough params like `section` survive the seed.
 			 */
 			const seeded: Record< string, unknown > = {
 				...params,

--- a/projects/plugins/jetpack/changelog/update-comparison-off-by-default
+++ b/projects/plugins/jetpack/changelog/update-comparison-off-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: turn the dashboard period comparison off by default.

--- a/projects/plugins/premium-analytics/changelog/update-comparison-off-by-default
+++ b/projects/plugins/premium-analytics/changelog/update-comparison-off-by-default
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Date controls: turn the period comparison off by default.


### PR DESCRIPTION
## Proposed changes

* Stop applying the default previous-period comparison on fresh loads. `normalizeReportParams` no longer copies a comparison out of the defaults when the URL carries no primary params, and it now asks `getDefaultQueryParams` for comparison-free defaults, so the dashboard route seed stops writing `comp=1` + `compare_*` into the URL on first visit.
* Comparison state now only ever comes from the URL: picked through the Compare control, or carried by a deep link. Both keep working exactly as before.
* The widgets' delta badges no longer render on a fresh load; they appear once a comparison is picked. This is the intended product change (see the issue).

The `withComparison` flag on `getDefaultQueryParams` stays: Storybook stories use it to build comparison-mode params.

This is the first PR for the linked issue: it lands the off-by-default half. The dynamic comparison options (derived from the applied range) come in a follow-up.

## Related product discussion/links

* Linear: [WOOA7S-2028](https://linear.app/a8c/issue/WOOA7S-2028/date-controls-comparison-off-by-default-with-options-derived-from-the) (see the "Comparison options as a function of the range" comment for the full spec and the correction about off-by-default not existing yet)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the dashboard: `jetpack build --deps packages/premium-analytics`.
* Open the Premium Analytics dashboard fresh (no search params, or strip them from the URL and reload).

<img width="907" height="391" alt="image" src="https://github.com/user-attachments/assets/c13eca04-b16b-4eeb-b6c1-7d41dc097e77" />

* Check the seeded URL: it should carry `from`, `to`, `interval`, `preset`, but no `comp`, `compare_from`, `compare_to`, or `compare_preset`. Widgets show no delta badges, and the Compare control renders in its additive state.
```
http://localhost:8092/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin&p=%2F%3Ffrom%3D2026-08-01T00%253A00%253A00.000%252B00%253A00%26to%3D2026-08-30T23%253A59%253A59.999%252B00%253A00%26interval%3Dday%26preset%3Dlast-30-days%26date_type%3Dcreated
```

* Pick a comparison from the Compare control: deltas appear, the URL gains `comp=1` + `compare_*`, and a reload preserves it.
* Paste a deep link that carries `comp=1&compare_from=…&compare_to=…&compare_preset=previous-period`: the comparison is honored as before.
* With a comparison active, change the date range and switch sections: the comparison window keeps following the primary range.
