### PR TITLE
e2e: Clean up obsolete `.ci.targets` from `**/tests/e2e/package.json`

### DIFF
--- a/projects/plugins/automattic-for-agencies-client/changelog/fix-cleanup-e2e-package-json-targets
+++ b/projects/plugins/automattic-for-agencies-client/changelog/fix-cleanup-e2e-package-json-targets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove `.ci.targets` from `tests/e2e/package.json`, apparently obsolete since #28913
+
+

--- a/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
+++ b/projects/plugins/automattic-for-agencies-client/tests/e2e/package.json
@@ -24,10 +24,6 @@
 		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
-		"targets": [
-			"plugins/automattic-for-agencies-client",
-			"tools/e2e-commons"
-		],
 		"pluginSlug": "automattic-for-agencies-client",
 		"mirrorName": "jetpack-automattic-for-agencies-client"
 	}

--- a/projects/plugins/classic-theme-helper-plugin/changelog/fix-cleanup-e2e-package-json-targets
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/fix-cleanup-e2e-package-json-targets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove `.ci.targets` from `tests/e2e/package.json`, apparently obsolete since #28913
+
+

--- a/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
+++ b/projects/plugins/classic-theme-helper-plugin/tests/e2e/package.json
@@ -27,10 +27,6 @@
 		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
-		"targets": [
-			"plugins/classic-theme-helper-plugin",
-			"tools/e2e-commons"
-		],
 		"pluginSlug": "classic-theme-helper-plugin",
 		"mirrorName": "classic-theme-helper-plugin"
 	}

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-cleanup-e2e-package-json-targets
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-cleanup-e2e-package-json-targets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove `.ci.targets` from `tests/e2e/package.json`, apparently obsolete since #28913
+
+

--- a/projects/plugins/paypal-payment-buttons/tests/e2e/package.json
+++ b/projects/plugins/paypal-payment-buttons/tests/e2e/package.json
@@ -24,10 +24,6 @@
 		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
-		"targets": [
-			"plugins/paypal-payment-buttons",
-			"tools/e2e-commons"
-		],
 		"pluginSlug": "paypal-payment-buttons",
 		"mirrorName": "paypal-payment-buttons"
 	}

--- a/projects/plugins/protect/changelog/fix-cleanup-e2e-package-json-targets
+++ b/projects/plugins/protect/changelog/fix-cleanup-e2e-package-json-targets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove `.ci.targets` from `tests/e2e/package.json`, apparently obsolete since #28913
+
+

--- a/projects/plugins/protect/tests/e2e/package.json
+++ b/projects/plugins/protect/tests/e2e/package.json
@@ -28,10 +28,6 @@
 		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
-		"targets": [
-			"plugins/protect",
-			"tools/e2e-commons"
-		],
 		"pluginSlug": "jetpack-protect",
 		"mirrorName": "jetpack-protect-plugin"
 	}

--- a/projects/plugins/starter-plugin/changelog/fix-cleanup-e2e-package-json-targets
+++ b/projects/plugins/starter-plugin/changelog/fix-cleanup-e2e-package-json-targets
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove `.ci.targets` from `tests/e2e/package.json`, apparently obsolete since #28913
+
+

--- a/projects/plugins/starter-plugin/tests/e2e/package.json
+++ b/projects/plugins/starter-plugin/tests/e2e/package.json
@@ -28,10 +28,6 @@
 		"playwright-ctrf-json-reporter": "^0.0.26"
 	},
 	"ci": {
-		"targets": [
-			"plugins/starter-plugin",
-			"tools/e2e-commons"
-		],
 		"pluginSlug": "jetpack-starter-plugin",
 		"mirrorName": "jetpack-starter-plugin"
 	}


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It appears these were moved to `.github/files/e2e-tests/e2e-matrix.js` in #28913, but plugins/starter-plugin was missed. Later-created plugins then inherited it from there. 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
#28913 I guess

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* E2Es still happy? 🤷