### PR TITLE
Admin color: removes stale customizations for checkboxes

### DIFF
--- a/projects/packages/masterbar/changelog/fix-admin-color-schemes-checkbox-tick
+++ b/projects/packages/masterbar/changelog/fix-admin-color-schemes-checkbox-tick
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin color schemes: render the checked checkbox and radio marks in white, matching core.

--- a/projects/packages/masterbar/src/admin-color-schemes/colors/_admin.scss
+++ b/projects/packages/masterbar/src/admin-color-schemes/colors/_admin.scss
@@ -39,8 +39,6 @@ $link-focus: color.adjust($link, $lightness: 10%) !default;
 $button-color: $highlight-color !default;
 $button-text-color: $text-color !default;
 
-$form-checked: #7e8993 !default;
-
 // admin menu & admin-bar
 
 $menu-text: $text-color !default;
@@ -154,14 +152,6 @@ span.wp-media-buttons-icon::before {
 }
 
 /* Forms */
-
-input[type="checkbox"]:checked::before {
-	content: url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour($form-checked)}%27%2F%3E%3C%2Fsvg%3E");
-}
-
-input[type="radio"]:checked::before {
-	background: $form-checked;
-}
 
 .wp-core-ui input[type="reset"]:hover,
 .wp-core-ui input[type="reset"]:active {

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-admin-color-schemes-checkbox-tick
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-admin-color-schemes-checkbox-tick
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin color schemes: render the checked checkbox and radio marks in white, matching core.

--- a/projects/plugins/wpcomsh/changelog/fix-admin-color-schemes-checkbox-tick
+++ b/projects/plugins/wpcomsh/changelog/fix-admin-color-schemes-checkbox-tick
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin color schemes: render the checked checkbox and radio marks in white, matching core.


### PR DESCRIPTION
Fixes DOTSITE-141

## Proposed changes

Our custom admin color schemes (e.g. Classic Dark) implement the scheme by copying the `admin.css` from Core.

Since 7.0, Core updated its `admin.css` and updated the style for checkboxes via https://core.trac.wordpress.org/ticket/64547. This PR ports the update.

Note that there might be more places where the customizations no longer make sense, but to keep the scope small, this PR only touches form inputs (which include checkboxes).

Before

<img width="700" height="160" alt="image" src="https://github.com/user-attachments/assets/153f8c06-ece6-4570-9ebc-61da93e7ffc9" />


After 

<img width="698" height="172" alt="image" src="https://github.com/user-attachments/assets/43e5785e-e8b0-4f84-9a2f-0c1a2de41e99" />


## Related product discussion/links


## Does this pull request change what data or activity we track or use?

No

## Testing instructions

1. Patch this PR
1. Go to `wp-admin/profile.php`
2. Select a custom WP.com color scheme
3. Verify checkboxes (when ticked) now show white tick instead of filled with color as shown above.