### PR TITLE
Stats: tighten validation of the role settings

### DIFF
--- a/projects/plugins/jetpack/.phan/baseline.php
+++ b/projects/plugins/jetpack/.phan/baseline.php
@@ -94,7 +94,7 @@ return [
         '_inc/lib/class-jetpack-mapbox-helper.php' => ['PhanTypeMismatchArgumentNullable'],
         '_inc/lib/class-jetpack-podcast-feed-locator.php' => ['PhanDeprecatedFunctionInternal'],
         '_inc/lib/class-jetpack-podcast-helper.php' => ['PhanStaticCallToNonStatic', 'PhanTypeMismatchReturnProbablyReal', 'PhanTypeSuspiciousStringExpression'],
-        '_inc/lib/class.core-rest-api-endpoints.php' => ['PhanTypeMismatchArgumentInternal', 'PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
+        '_inc/lib/class.core-rest-api-endpoints.php' => ['PhanTypeMismatchArgumentProbablyReal', 'PhanTypeMismatchDefault', 'PhanTypeMismatchReturn', 'PhanTypeMismatchReturnProbablyReal', 'PhanUndeclaredMethod'],
         '_inc/lib/class.jetpack-password-checker.php' => ['PhanTypeMismatchArgument', 'PhanTypeMismatchDefault', 'PhanTypeMismatchProperty', 'PhanTypeMismatchPropertyDefault', 'PhanTypeMismatchPropertyProbablyReal'],
         '_inc/lib/class.media-extractor.php' => ['PhanTypeMismatchDefault', 'PhanTypePossiblyInvalidDimOffset'],
         '_inc/lib/class.media.php' => ['PhanTypePossiblyInvalidDimOffset'],

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3203,18 +3203,35 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|bool     $value Value to check.
+	 * @param mixed           $value Value to check.
 	 * @param WP_REST_Request $request The request sent to the WP REST API.
 	 * @param string          $param Name of the parameter passed to endpoint holding $value.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public static function validate_stats_roles( $value, $request, $param ) {
+		// An empty value clears the setting; sanitize_stats_allowed_roles() falls back to 'administrator'.
+		if ( empty( $value ) ) {
+			return true;
+		}
+
+		// Enforce the schema's list-of-strings contract before array_intersect() below sees the value.
+		if ( ! is_array( $value ) || count( array_filter( $value, 'is_string' ) ) !== count( $value ) ) {
+			return new WP_Error(
+				'invalid_param',
+				sprintf(
+					/* Translators: Placeholder is a parameter name. */
+					esc_html__( '%s must be an array of user roles.', 'jetpack' ),
+					$param
+				)
+			);
+		}
+
 		if ( ! function_exists( 'get_editable_roles' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/user.php';
 		}
 		$editable_roles = array_keys( get_editable_roles() );
-		if ( ! empty( $value ) && ! array_intersect( $editable_roles, $value ) ) {
+		if ( ! array_intersect( $editable_roles, $value ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3611,9 +3611,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 *
 	 * @since 4.3.0
 	 *
-	 * @param string|bool $value Value to check.
+	 * @param mixed $value Value to check.
 	 *
-	 * @return bool|array
+	 * @return mixed The value as submitted, or an array holding only 'administrator' when it is empty.
 	 */
 	public static function sanitize_stats_allowed_roles( $value ) {
 		if ( empty( $value ) ) {

--- a/projects/plugins/jetpack/changelog/stats-roles-validation
+++ b/projects/plugins/jetpack/changelog/stats-roles-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: Return a validation error when the role settings are submitted in the wrong format.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -8,6 +8,7 @@
 
 use Automattic\Jetpack\Connection\REST_Connector;
 use Automattic\Jetpack\Status\Cache as StatusCache;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 require_once __DIR__ . '/../../../../modules/widgets/milestone.php';
 
@@ -722,6 +723,63 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 
 		$response = $this->create_and_get_request( 'settings', array(), 'POST', array( 'show' => array( 'post', 'page' ) ) );
 		$this->assertResponseStatus( 200, $response );
+	}
+
+	/**
+	 * The Stats role settings reject values that are not a list of role slugs.
+	 *
+	 * A POST to /module/all is served by the /module/(?P<slug>[a-z\-]+) handler, whose args cover
+	 * every updateable setting, so both Stats role options are validated on that request. No user
+	 * is set because argument validation does not depend on the current user.
+	 *
+	 * @dataProvider provider_invalid_stats_roles
+	 *
+	 * @param string $param Name of the Stats role parameter.
+	 * @param mixed  $value Value to submit for that parameter.
+	 */
+	#[DataProvider( 'provider_invalid_stats_roles' )]
+	public function test_stats_roles_reject_values_that_are_not_a_list_of_roles( $param, $value ) {
+		wp_set_current_user( 0 );
+
+		$response = $this->create_and_get_request( 'module/all', array( $param => $value ), 'POST' );
+		$this->assertResponseStatus( 400, $response );
+
+		// Also reachable with a POST body that is not JSON encoded.
+		$response = $this->create_and_get_request( 'module/all', array(), 'POST', array( $param => $value ) );
+		$this->assertResponseStatus( 400, $response );
+	}
+
+	/**
+	 * Values the Stats role settings must refuse.
+	 *
+	 * @return array[]
+	 */
+	public static function provider_invalid_stats_roles() {
+		return array(
+			'string roles'            => array( 'roles', 'http://example.com/x.png' ),
+			'string count_roles'      => array( 'count_roles', 'administrator' ),
+			'integer roles'           => array( 'roles', 42 ),
+			'nested array in roles'   => array( 'roles', array( array( 'administrator' ) ) ),
+			'non-string item in list' => array( 'roles', array( 'administrator', 42 ) ),
+		);
+	}
+
+	/**
+	 * The Stats role validator still accepts what it accepted before the type guard.
+	 */
+	public function test_stats_roles_accept_a_list_of_roles() {
+		$this->load_rest_endpoints_direct();
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/settings' );
+
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::validate_stats_roles( array( 'administrator', 'editor' ), $request, 'roles' ) );
+
+		// An empty value is allowed; sanitize_stats_allowed_roles() turns it into 'administrator'.
+		$this->assertTrue( Jetpack_Core_Json_Api_Endpoints::validate_stats_roles( array(), $request, 'roles' ) );
+		$this->assertSame( array( 'administrator' ), Jetpack_Core_Json_Api_Endpoints::sanitize_stats_allowed_roles( array() ) );
+
+		// A list holding no editable role is still rejected.
+		$this->assertInstanceOf( 'WP_Error', Jetpack_Core_Json_Api_Endpoints::validate_stats_roles( array( 'not-a-role' ), $request, 'roles' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
* `validate_stats_roles()` now enforces the contract its own schema already declares: the Stats `roles` and `count_roles` options must be a list of role slugs. Anything else returns `rest_invalid_param` rather than tripping over itself further down and leaving noise in the error log.
* Adds regression coverage for both options.

## Related product discussion/links
* Noticed while clearing error log noise on a WordPress.org-hosted site.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Set up a site running this branch.
* As an admin, go to Jetpack > Settings > Traffic and change which roles can view stats. Saving should behave exactly as it does on trunk.
* Send a badly-typed value straight at the REST API. The option takes a list, so pass a bare string instead:

```
wp eval '$r = new WP_REST_Request( "POST", "/jetpack/v4/settings" );
         $r->set_param( "roles", "administrator" );
         var_dump( rest_do_request( $r )->get_status() );'
```

  On trunk that request errors out. On this branch you get `int(400)` and `roles must be an array of user roles.`
* Repeat with `count_roles`.
