### PR TITLE
Boost: align the upgrade modal copy with Jetpack.com

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/upgrade-cta/interstitial-modal-cta.tsx
@@ -33,14 +33,14 @@ const InterstitialModalCTA = ( {
 			}
 			secondaryButtonHref={ learnMoreUrl }
 			description={ __(
-				'Unlock the full potential of Jetpack Boost with automated performance optimization tools and more.',
+				'Unlock the full potential of Jetpack Boost with automated performance improvements and advanced image optimization for a consistently fast site.',
 				'jetpack-boost'
 			) }
 			features={ [
-				__( 'Automated Critical CSS Generation', 'jetpack-boost' ),
-				__( 'In-depth Performance Insights', 'jetpack-boost' ),
-				__( 'Customizable Image Optimization', 'jetpack-boost' ),
-				__( 'Expert Support With Personal Assistance Available', 'jetpack-boost' ),
+				__( 'Automated critical CSS generation', 'jetpack-boost' ),
+				__( 'Image CDN and quality controls', 'jetpack-boost' ),
+				__( 'Image guide and performance history', 'jetpack-boost' ),
+				__( 'Priority support', 'jetpack-boost' ),
 			] }
 		/>
 	);

--- a/projects/plugins/boost/changelog/boost-162-update-the-upgrade-modal-copy-to-be-more-persuasive-benefit
+++ b/projects/plugins/boost/changelog/boost-162-update-the-upgrade-modal-copy-to-be-more-persuasive-benefit
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Upgrade modal: refresh the copy to match the plan comparison on Jetpack.com.


### PR DESCRIPTION
## Proposed changes

The Boost upgrade modal's copy had drifted: its description and four feature names matched neither Boost's own in-plugin pricing table nor the Boost card on [jetpack.com/boost](https://jetpack.com/boost/). This PR replaces the feature list with the paid card's "What's included" list from jetpack.com:

<img width="2434" height="1431" alt="image" src="https://github.com/user-attachments/assets/8e567de5-a111-49d0-96eb-43181c3bc038" />

Copy only — no behavior, markup or logic changes.

| Before | After |
|---|---|
|<img width="2442" height="1569" alt="image" src="https://github.com/user-attachments/assets/06b9f1a1-fa04-4523-bbd5-936c79d980d9" />|<img width="2442" height="1569" alt="image" src="https://github.com/user-attachments/assets/ae5e8c64-fae9-4d1c-bb10-c939e1212431" />|

## Related product discussion/links

* https://linear.app/a8c/issue/BOOST-162

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Install and activate Jetpack Boost on a site connected to WordPress.com, on the **free** tier.
* Go to **Jetpack → Boost**.
* Scroll to **Performance History**. It shows a locked graph with an **Upgrade now!** button — click it.
* The modal that opens should show the new description and the four new feature bullets, matching the "Jetpack Boost" card at https://jetpack.com/boost/ (minus its "Everything in Boost Free" line).
