### PR TITLE
SEO: don't let the indexing toggle publish a private or coming-soon site (JETPACK-2444)

### DIFF
--- a/projects/packages/seo/_inc/data/overview-types.ts
+++ b/projects/packages/seo/_inc/data/overview-types.ts
@@ -4,6 +4,8 @@
 
 export interface SiteVisibility {
 	search_engines_visible: boolean;
+	// See `SettingsResponse['site_is_private']`.
+	site_is_private: boolean;
 	sitemap_active: boolean;
 	seo_tools_active: boolean;
 }

--- a/projects/packages/seo/_inc/data/settings-types.ts
+++ b/projects/packages/seo/_inc/data/settings-types.ts
@@ -33,6 +33,10 @@ export interface SettingsResponse {
 		facebook: string;
 	};
 	search_engines_visible: boolean;
+	// WordPress.com records a private or coming-soon site as a negative `blog_public`.
+	// Indexing is off for such a site because it isn't published at all, which no SEO
+	// setting here can change — so the toggle is disabled rather than silently inert.
+	site_is_private: boolean;
 	sitemap_active: boolean;
 	// Read-only: the reachable sitemap URL, or '' until it's been generated and is
 	// serveable. Not editable, so it's never sent back in a save payload.

--- a/projects/packages/seo/_inc/data/test/build-payload.test.ts
+++ b/projects/packages/seo/_inc/data/test/build-payload.test.ts
@@ -13,6 +13,7 @@ const makeSettings = ( overrides: Partial< SettingsResponse > = {} ): SettingsRe
 	title_formats_editable: true,
 	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
+	site_is_private: false,
 	search_engines_visible: true,
 	sitemap_active: false,
 	sitemap_url: '',

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -32,6 +32,7 @@ export const SEEDED_SETTINGS: SettingsResponse = {
 	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
+	site_is_private: false,
 	sitemap_active: false,
 	sitemap_url: '',
 	canonical_active: false,

--- a/projects/packages/seo/_inc/data/test/use-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-settings.test.ts
@@ -21,6 +21,7 @@ const SEED: SettingsResponse = {
 	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
+	site_is_private: false,
 	sitemap_active: false,
 	sitemap_url: '',
 	canonical_active: false,

--- a/projects/packages/seo/_inc/screens/overview/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/index.test.tsx
@@ -35,6 +35,7 @@ const OFF_RAMP_TEXT = 'Using a different SEO solution?';
 const buildOverview = (): OverviewResponse => ( {
 	site_visibility: {
 		search_engines_visible: true,
+		site_is_private: false,
 		sitemap_active: true,
 		seo_tools_active: true,
 	},

--- a/projects/packages/seo/_inc/screens/overview/test/site-visibility-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/site-visibility-card.test.tsx
@@ -14,6 +14,7 @@ type Visibility = OverviewResponse[ 'site_visibility' ];
  */
 const buildVisibility = ( overrides: Partial< Visibility > = {} ): Visibility => ( {
 	search_engines_visible: true,
+	site_is_private: false,
 	sitemap_active: true,
 	seo_tools_active: true,
 	...overrides,

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -37,6 +37,16 @@ const sitemapBlockedHelp = __(
 	'Allow search engines to index this site to generate a sitemap.',
 	'jetpack-seo'
 );
+const indexingHelp = __(
+	'Turning this off asks search engines to stop indexing your site — Google and Bing honor it, others ignore it. Same setting as Settings → Reading.',
+	'jetpack-seo'
+);
+// Shown when the site is unpublished: on WordPress.com a private or coming-soon
+// site isn't hidden from search by a setting, so no SEO toggle can reveal it.
+const indexingPrivateHelp = __(
+	'Your site is private, so search engines cannot see it at all. Make it public in your site visibility settings to change this.',
+	'jetpack-seo'
+);
 const sitemapViewLabel = __( 'View sitemap', 'jetpack-seo' );
 // Figures are what search *displays*, not a limit we enforce — the field is
 // deliberately uncapped. Google measures a pixel width (920px desktop / 680px
@@ -225,17 +235,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						<Stack direction="column" gap="lg">
 							<ToggleControl
 								label={ __( 'Allow search engines to index this site', 'jetpack-seo' ) }
-								help={
-									local.site_is_private
-										? __(
-												'Your site is private, so search engines cannot see it at all. Make it public in your site visibility settings to change this.',
-												'jetpack-seo'
-										  )
-										: __(
-												'Turning this off asks search engines to stop indexing your site — Google and Bing honor it, others ignore it. Same setting as Settings → Reading.',
-												'jetpack-seo'
-										  )
-								}
+								help={ local.site_is_private ? indexingPrivateHelp : indexingHelp }
 								checked={ local.search_engines_visible }
 								onChange={ next => commit( { search_engines_visible: next } ) }
 								// A private site is unpublished, not de-indexed. Turning this on would

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -225,13 +225,22 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						<Stack direction="column" gap="lg">
 							<ToggleControl
 								label={ __( 'Allow search engines to index this site', 'jetpack-seo' ) }
-								help={ __(
-									'Turning this off asks search engines to stop indexing your site — Google and Bing honor it, others ignore it. Same setting as Settings → Reading.',
-									'jetpack-seo'
-								) }
+								help={
+									local.site_is_private
+										? __(
+												'Your site is private, so search engines cannot see it at all. Make it public in your site visibility settings to change this.',
+												'jetpack-seo'
+										  )
+										: __(
+												'Turning this off asks search engines to stop indexing your site — Google and Bing honor it, others ignore it. Same setting as Settings → Reading.',
+												'jetpack-seo'
+										  )
+								}
 								checked={ local.search_engines_visible }
 								onChange={ next => commit( { search_engines_visible: next } ) }
-								disabled={ isSaving }
+								// A private site is unpublished, not de-indexed. Turning this on would
+								// have to publish it, which is not this surface's decision to make.
+								disabled={ isSaving || local.site_is_private }
 								__nextHasNoMarginBottom
 							/>
 							<Stack direction="column" gap="xs">

--- a/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
@@ -59,6 +59,7 @@ const buildForm = ( hasLegacy: boolean ): SettingsForm => {
 		verification_tools_active: true,
 		verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 		search_engines_visible: true,
+		site_is_private: false,
 		sitemap_active: false,
 		sitemap_url: '',
 		canonical_active: false,

--- a/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
@@ -67,6 +67,7 @@ const buildForm = ( overrides: Partial< SettingsResponse > = {} ): SettingsForm 
 		verification_tools_active: true,
 		verification: { ...EMPTY_VERIFICATION },
 		search_engines_visible: false,
+		site_is_private: false,
 		sitemap_active: false,
 		sitemap_url: '',
 		canonical_active: false,
@@ -113,6 +114,29 @@ const statusFor = ( moduleTitle: string ): string | undefined => {
 	}
 	return undefined;
 };
+
+describe( 'Indexing toggle on an unpublished site', () => {
+	const indexingToggle = () =>
+		screen.getByRole( 'checkbox', { name: /Allow search engines to index this site/i } );
+
+	// WordPress.com stores a private or coming-soon site as a negative `blog_public`.
+	// Such a site isn't hidden from search by a setting, so no SEO toggle can reveal
+	// it — turning this on would have to publish the site, which isn't this surface's
+	// decision. Disabled and explained, rather than appearing to work.
+	it( 'is disabled and explains why when the site is private', () => {
+		render( <SettingsScreen form={ buildForm( { site_is_private: true } ) } /> );
+
+		expect( indexingToggle() ).toBeDisabled();
+		expect( screen.getByText( /Your site is private/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'is enabled with the usual help text on a public site', () => {
+		render( <SettingsScreen form={ buildForm( { site_is_private: false } ) } /> );
+
+		expect( indexingToggle() ).toBeEnabled();
+		expect( screen.queryByText( /Your site is private/i ) ).not.toBeInTheDocument();
+	} );
+} );
 
 describe( 'Settings module completion status', () => {
 	describe( 'Site visibility — counts its two toggles', () => {

--- a/projects/packages/seo/changelog/seo-private-site-publishing
+++ b/projects/packages/seo/changelog/seo-private-site-publishing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop the search-engine indexing toggle from publishing a private or coming-soon site.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -102,6 +102,55 @@ class Dashboard_Data {
 				'default'      => 1,
 			)
 		);
+
+		// Refuse an indexing write that would publish a private site. Scoped to core's
+		// settings route rather than attached as `blog_public`'s sanitizer, because a
+		// `register_setting()` sanitizer applies to every writer of the option for the
+		// rest of the request — including the site's own visibility control, which must
+		// stay able to change it.
+		add_filter( 'rest_pre_update_setting', array( __CLASS__, 'block_publishing_a_private_site' ), 10, 3 );
+	}
+
+	/**
+	 * Whether the site is private or still in coming-soon, which WordPress.com records
+	 * as a negative `blog_public`. Always false on self-hosted, where the option is a
+	 * plain 0/1.
+	 *
+	 * @return bool
+	 */
+	private static function is_site_private() {
+		return (int) get_option( 'blog_public', 1 ) < 0;
+	}
+
+	/**
+	 * Keep a WordPress.com site's private or coming-soon state out of reach of an SEO
+	 * toggle.
+	 *
+	 * `blog_public` is a plain 0/1 on self-hosted, but WordPress.com also stores `-1`
+	 * for a private site and `-2` for one still in coming-soon. This dashboard only
+	 * offers "allow search engines to index this site", which writes 1 or 0 — so
+	 * without this, the owner of an unfinished site who flipped that toggle on
+	 * published it. Publishing a site is not a search-engine setting and isn't a
+	 * decision this surface asks for, so a negative stored value is left alone.
+	 *
+	 * The site's own visibility control is what changes it — and still can, because
+	 * this hangs off core's settings route rather than the option's sanitizer.
+	 * {@see self::get_settings_data()} reports `site_is_private` so the toggle can say
+	 * why it's disabled rather than silently doing nothing.
+	 *
+	 * @param bool   $handled Whether another handler already wrote the setting.
+	 * @param string $name    Setting name.
+	 * @param mixed  $value   Submitted value.
+	 * @return bool True to report the write as handled, which skips it.
+	 */
+	public static function block_publishing_a_private_site( $handled, $name, $value ) {
+		if ( $handled || 'blog_public' !== $name ) {
+			return $handled;
+		}
+
+		// Leave a write that keeps the site unpublished alone; only a move to a public
+		// value is refused.
+		return self::is_site_private() && (int) $value >= 0;
 	}
 
 	/**
@@ -122,6 +171,7 @@ class Dashboard_Data {
 		return array(
 			'site_visibility'   => array(
 				'search_engines_visible' => (int) get_option( 'blog_public', 1 ) === 1,
+				'site_is_private'        => self::is_site_private(),
 				// Read the durable SEO option (seeded/synced from the `sitemaps` module
 				// by the Jetpack plugin) so the state survives the module's removal. The
 				// reachable sitemap URL + "View" link live on the Settings tab.
@@ -186,6 +236,9 @@ class Dashboard_Data {
 
 		return array(
 			'search_engines_visible'     => (int) get_option( 'blog_public', 1 ) === 1,
+			// A private or coming-soon WordPress.com site isn't hidden from search by an
+			// SEO setting and can't be unhidden by one — see {@see self::block_publishing_a_private_site()}.
+			'site_is_private'            => self::is_site_private(),
 			// Read the durable SEO option (seeded/synced from the `sitemaps` module
 			// by the Jetpack plugin) so the state survives the module's removal.
 			'sitemap_active'             => $sitemap_active,

--- a/projects/packages/seo/tests/php/DashboardPrivateSiteTest.php
+++ b/projects/packages/seo/tests/php/DashboardPrivateSiteTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Tests for the guard that keeps a WordPress.com site's private or coming-soon
+ * state out of reach of the SEO dashboard's indexing toggle.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\Dashboard_Data
+ */
+#[CoversClass( Dashboard_Data::class )]
+class DashboardPrivateSiteTest extends SeoTestCase {
+
+	/**
+	 * `blog_public` as the bootstrap left it, restored rather than deleted — it's a
+	 * core option other suites read, so clobbering it leaks state. Null when absent.
+	 *
+	 * @var mixed
+	 */
+	private $original_blog_public;
+
+	/**
+	 * Capture `blog_public` before a test moves it.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->original_blog_public = get_option( 'blog_public', null );
+	}
+
+	/**
+	 * Put `blog_public` back and unhook the guard, so no other suite inherits either.
+	 */
+	protected function tearDown(): void {
+		remove_filter( 'rest_pre_update_setting', array( Dashboard_Data::class, 'block_publishing_a_private_site' ), 10 );
+
+		if ( null === $this->original_blog_public ) {
+			delete_option( 'blog_public' );
+		} else {
+			update_option( 'blog_public', $this->original_blog_public );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Registering the settings also hooks the guard. Without this the callback below
+	 * could be correct and never consulted.
+	 */
+	public function test_registering_settings_hooks_the_guard() {
+		$this->assertFalse(
+			has_filter( 'rest_pre_update_setting', array( Dashboard_Data::class, 'block_publishing_a_private_site' ) ),
+			'Precondition: not hooked before registration.'
+		);
+
+		Dashboard_Data::register_rest_settings();
+
+		$this->assertNotFalse(
+			has_filter( 'rest_pre_update_setting', array( Dashboard_Data::class, 'block_publishing_a_private_site' ) )
+		);
+	}
+
+	/**
+	 * WordPress.com stores `-1` for a private site and `-2` for coming-soon. The
+	 * dashboard's only control writes 1 or 0, so before this guard an owner who
+	 * flipped "allow search engines to index this site" on an unfinished site
+	 * published it.
+	 *
+	 * Reporting the write as handled is what makes core's settings controller skip it.
+	 */
+	public function test_publishing_a_private_site_is_refused() {
+		foreach ( array( -1, -2 ) as $private ) {
+			update_option( 'blog_public', $private );
+
+			$this->assertTrue(
+				Dashboard_Data::block_publishing_a_private_site( false, 'blog_public', 1 ),
+				"A site stored as $private should refuse a write to 1."
+			);
+		}
+	}
+
+	/**
+	 * A write that keeps the site unpublished still goes through, so the guard can't
+	 * strand a site between its own visibility states.
+	 */
+	public function test_a_private_site_can_still_move_between_unpublished_states() {
+		update_option( 'blog_public', -1 );
+
+		$this->assertFalse( Dashboard_Data::block_publishing_a_private_site( false, 'blog_public', -2 ) );
+	}
+
+	/**
+	 * A public site's toggle is untouched in both directions.
+	 */
+	public function test_a_public_site_is_unaffected() {
+		update_option( 'blog_public', 1 );
+		$this->assertFalse( Dashboard_Data::block_publishing_a_private_site( false, 'blog_public', 0 ) );
+
+		update_option( 'blog_public', 0 );
+		$this->assertFalse( Dashboard_Data::block_publishing_a_private_site( false, 'blog_public', 1 ) );
+	}
+
+	/**
+	 * The guard owns one option and defers on everything else, including a write
+	 * another handler has already claimed.
+	 */
+	public function test_the_guard_defers_outside_its_own_option() {
+		update_option( 'blog_public', -1 );
+
+		$this->assertFalse( Dashboard_Data::block_publishing_a_private_site( false, 'blogname', 1 ) );
+		$this->assertTrue( Dashboard_Data::block_publishing_a_private_site( true, 'blogname', 1 ) );
+	}
+
+	/**
+	 * The dashboard reports the state, so the toggle can say why it's disabled rather
+	 * than appearing to work and silently doing nothing.
+	 */
+	public function test_the_dashboard_reports_a_private_site() {
+		update_option( 'blog_public', -1 );
+		$this->assertTrue( Dashboard_Data::get_settings_data()['site_is_private'] );
+		$this->assertTrue( Dashboard_Data::get_overview_data()['site_visibility']['site_is_private'] );
+
+		// Discouraging search engines is not the same as being unpublished.
+		update_option( 'blog_public', 0 );
+		$this->assertFalse( Dashboard_Data::get_settings_data()['site_is_private'] );
+		$this->assertFalse( Dashboard_Data::get_settings_data()['search_engines_visible'] );
+	}
+}

--- a/projects/plugins/jetpack/changelog/seo-private-site-publishing
+++ b/projects/plugins/jetpack/changelog/seo-private-site-publishing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: stop the search-engine indexing toggle from publishing a private or coming-soon site.


### PR DESCRIPTION
Fixes [JETPACK-2444](https://linear.app/a8c/issue/JETPACK-2444/seo-indexing-toggle-can-publish-a-private-or-coming-soon-site)

## Proposed changes

The SEO Settings tab's **"Allow search engines to index this site"** toggle writes a literal `1` or `0` to `blog_public`. On WordPress.com that option also carries **`-1` for a private site** and **`-2` for coming soon**.

The dashboard collapses everything that isn't `1` into one "not visible to search engines" state, so a private or coming-soon site renders with the toggle simply off. Turning it on writes `1` — **publishing the site**.

* Refuse a write that would move a negative `blog_public` to a public value.
* Report `site_is_private` on the Settings and Overview payloads, so the toggle is **disabled with copy explaining why** rather than appearing to work and silently doing nothing.
* Writes that keep the site unpublished still go through, so the guard can't strand a site between `-1` and `-2`.

**Why `rest_pre_update_setting` and not `blog_public`'s sanitizer.** A `register_setting()` sanitize callback is attached as a global `sanitize_option_{$option}` filter, so from `rest_api_init` onward it applies to *every* writer of that option for the rest of the request — including the site's own visibility control. Guarding there would have made a private site impossible to un-private. The first version of this fix did exactly that, and the tests caught it. Hanging off core's settings route confines the guard to writes through the exposure this package creates.

Publishing a site is not a search-engine setting, and it isn't a decision this surface asks the user to make.

## Why now

The Jetpack SEO dashboard is being rolled out to WordPress.com — Simple first, then Atomic. Private and coming-soon sites are a large share of both; they're disproportionately new and unfinished, which is exactly the population this hurts. Fixing it is a prerequisite for that rollout.

Found by the security lens of a pre-review battery on #51318.

## Testing instructions

Needs a WordPress.com site, Simple or Atomic — `blog_public` is a plain `0`/`1` on self-hosted, so the bug is not reproducible on Jurassic Ninja.

1. Set the site to **Private** (or **Coming soon**) in its visibility settings. Confirm `blog_public` is `-1` (or `-2`).
2. Go to **Jetpack → SEO → Settings**.
3. **"Allow search engines to index this site"** should be **off and disabled**, with help text saying the site is private and where to change it.
4. Before this change, that toggle was enabled — flipping it on set `blog_public` to `1` and published the site.
5. Set the site back to **Public**. The toggle should be enabled again and work in both directions.
6. While private, change visibility between **Private** and **Coming soon** in the site's own settings. Both should still work — the guard must not block those.

**Tested:** the guard, its wiring to `rest_pre_update_setting`, and both payloads, by unit test — 194 tests green. Mutation-verified in four directions: neutering the guard, widening it to block every write while private, making it defer unconditionally, and unhooking the filter each fail a test.

**Not tested:** the UI on a real private WordPress.com site. The disabled state and its copy have only been exercised in jsdom — that's the step worth a reviewer's or Angela's eyes.

## Does this pull request change what data or activity we track or use?

No.
