### PR TITLE
Forms: add alt attributes to the success summary image thumbnails

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-772-success-summary-image-alt
+++ b/projects/packages/forms/changelog/fix-forms-772-success-summary-image-alt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Add an empty alt attribute to the image option thumbnails in the form success summary.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -2234,8 +2234,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 							<template data-wp-each--image="context.submission.images">
 								<div class="field-image-option" data-wp-class--is-empty="!context.image.src">
 									<figure class="field-image-option__image" data-wp-class--is-empty="!context.image.src">
-										<img data-wp-bind--src="context.image.src" data-wp-bind--hidden="!context.image.src" />
-										<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image.src" />
+										<img alt="" data-wp-bind--src="context.image.src" data-wp-bind--hidden="!context.image.src" />
+										<img alt="" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image.src" />
 									</figure>
 									<div class="field-image-option__label-wrapper">
 										<span class="field-image-option__label-code" data-wp-text="context.image.letterCode"></span>
@@ -2312,8 +2312,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 							$html .= '<div data-wp-each-child class="field-image-option ' . ( empty( $image_src ) ? 'is-empty' : '' ) . '" data-wp-class--is-empty="!context.image.src">';
 							$html .= '<figure class="field-image-option__image ' . ( empty( $image_src ) ? 'is-empty' : '' ) . '" data-wp-class--is-empty="!context.image.src">';
-							$html .= '<img data-wp-bind--src="context.image.src" src="' . esc_attr( $image_src ) . '" data-wp-bind--hidden="!context.image.src"' . ( empty( $image_src ) ? ' hidden' : '' ) . '/>';
-							$html .= '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image.src"' . ( empty( $image_src ) ? '' : ' hidden' ) . '/>';
+							$html .= '<img alt="" data-wp-bind--src="context.image.src" src="' . esc_attr( $image_src ) . '" data-wp-bind--hidden="!context.image.src"' . ( empty( $image_src ) ? ' hidden' : '' ) . '/>';
+							$html .= '<img alt="" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image.src"' . ( empty( $image_src ) ? '' : ' hidden' ) . '/>';
 							$html .= '</figure>';
 							$html .= '<div class="field-image-option__label-wrapper">';
 							$html .= '<span class="field-image-option__label-code" data-wp-text="context.image.letterCode">' . esc_html( $image_letter_code ) . '</span>';

--- a/projects/plugins/jetpack/changelog/fix-forms-772-success-summary-image-alt
+++ b/projects/plugins/jetpack/changelog/fix-forms-772-success-summary-image-alt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: add an empty alt attribute to the image option thumbnails in the form success summary.


### PR DESCRIPTION
Fixes FORMS-772

## Proposed changes

* Add `alt=""` to the two image option thumbnails rendered in a form's success summary.

A site owner reported that every page containing a Jetpack form ships two `img` tags with no `alt` attribute:

```html
<img data-wp-bind--src="context.image.src" data-wp-bind--hidden="!context.image.src" />
<img decoding="async" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" data-wp-bind--hidden="context.image.src" />
```

They sit inside the Interactivity API `<template>` for the success summary, so a screen reader never reaches them, but source-parsing SEO and accessibility scanners flag them on every form page.

Empty alt is the right value rather than binding the option's label: the label and its letter code are already rendered as visible text next to the thumbnail, and the second `img` is a 1x1 transparent placeholder GIF shown when an option has no image. This matches `class-contact-form-field.php`, which already uses `alt=""` on the same placeholder.

The tags appear twice in `class-contact-form.php` because the Interactivity API needs a `<template>` and a matching server-rendered hydration target. Both are updated so the two stay structurally identical.

## Related product discussion/links

* FORMS-772

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Forms module active, publish a page containing a form. View source and confirm the two `img` tags inside `jetpack_forms_contact-form-success-summary` now carry `alt=""`.
* Add an Image Select field with at least one image option, publish, then submit the form. The success summary should show the selected image exactly as before, and its `img` tags should also carry `alt=""`.
* `document.querySelectorAll('img:not([alt])').length` should be `0` on both the form page and the post-submission page.
