### PR TITLE
Newsletter: Disable unsupported date filtering

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-data-views.tsx
@@ -206,6 +206,7 @@ export default function SubscribersDataViews( {
 				type: 'date',
 				label: __( 'Date subscribed', 'jetpack-newsletter' ),
 				getValue: ( { item }: { item: Subscriber } ) => getSubscribedAt( item ) ?? '',
+				filterBy: false,
 				enableSorting: true,
 				enableHiding: false,
 			},

--- a/projects/packages/newsletter/changelog/fix-newsletter-date-filter
+++ b/projects/packages/newsletter/changelog/fix-newsletter-date-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent unsupported date filtering on the Subscribers page.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-date-filter
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-date-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Prevent unsupported date filtering on the Subscribers page.


### PR DESCRIPTION
Closes NL-882

## Proposed changes

* Disable the **Date subscribed** filter on the Newsletter Subscribers page.

### Why 
Date filtering was implicitly enabled when the Subscribers DataViews page was ported in #48581: the field was declared as `type: 'date'` without opting out of filtering. The Subscribers API does not support filtering by subscription date, so the filter cannot return the expected results. Sorting by **Date subscribed** remains available.


> **Note:** This is not the exact error described in NL-882. However, the reported problem only occurs when using the unsupported **Date subscribed** filter, so removing that filter also prevents the issue.

## Related product discussion/links

* Linear: NL-882

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch and build `packages/newsletter`, or create a Jurassic Ninja site using this branch.
* Go to **Jetpack → Newsletter → Subscribers**.
* Open the table's filter controls and confirm that **Date subscribed** is not available.
* Confirm that sorting by **Date subscribed** still works.
