### PR TITLE
Premium Analytics: pin the sync checksum table config that WPCOM mirrors

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-checksum-config-pin-test
+++ b/projects/packages/premium-analytics/changelog/add-checksum-config-pin-test
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Test-only change: pin the sync checksum table config that WPCOM mirrors.
+
+

--- a/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
@@ -65,6 +65,11 @@ class Configuration_Test extends TestCase {
 	 *
 	 * If this test fails because you changed the config: the change must ship together
 	 * with the matching WPCOM change, then update the pin here.
+	 *
+	 * The `table` values pin the suffix but not where the prefix comes from: the
+	 * expectation is built from the same `$wpdb->prefix` as the code under test, and
+	 * single-site test environments cannot tell `prefix` from `base_prefix`, so a swap
+	 * to `base_prefix` would pass here and only surface on multisite.
 	 */
 	public function test_checksum_table_config_matches_the_wpcom_pin() {
 		$configuration = new class() extends Configuration {
@@ -84,37 +89,48 @@ class Configuration_Test extends TestCase {
 				"Table '{$name}' must gate on an is_table_enabled_callback."
 			);
 			unset( $tables[ $name ]['is_table_enabled_callback'] );
+			// Key order carries no meaning in these config maps; normalize it so a
+			// pure reorder does not read as drift.
+			ksort( $tables[ $name ] );
 		}
+		ksort( $tables );
 
 		global $wpdb;
-		$this->assertSame(
-			array(
-				'wc_order_stats'          => array(
-					'table'                => "{$wpdb->prefix}wc_order_stats",
-					'range_field'          => 'order_id',
-					'key_fields'           => array( 'order_id' ),
-					'checksum_fields'      => array( 'date_paid', 'date_completed', 'total_sales' ),
-					'checksum_text_fields' => array( 'status' ),
-				),
-				'wc_order_product_lookup' => array(
-					'table'           => "{$wpdb->prefix}wc_order_product_lookup",
-					'range_field'     => 'order_id',
-					'key_fields'      => array( 'order_id', 'order_item_id' ),
-					'checksum_fields' => array( 'product_id', 'variation_id', 'product_qty', 'product_net_revenue', 'date_created' ),
-				),
-				'wc_order_coupon_lookup'  => array(
-					'table'           => "{$wpdb->prefix}wc_order_coupon_lookup",
-					'range_field'     => 'order_id',
-					'key_fields'      => array( 'order_id', 'coupon_id' ),
-					'checksum_fields' => array( 'discount_amount', 'date_created' ),
-				),
-				'wc_order_tax_lookup'     => array(
-					'table'           => "{$wpdb->prefix}wc_order_tax_lookup",
-					'range_field'     => 'order_id',
-					'key_fields'      => array( 'order_id', 'tax_rate_id' ),
-					'checksum_fields' => array( 'order_tax', 'total_tax', 'shipping_tax', 'date_created' ),
-				),
+		$expected = array(
+			'wc_order_stats'          => array(
+				'table'                => "{$wpdb->prefix}wc_order_stats",
+				'range_field'          => 'order_id',
+				'key_fields'           => array( 'order_id' ),
+				'checksum_fields'      => array( 'date_paid', 'date_completed', 'total_sales' ),
+				'checksum_text_fields' => array( 'status' ),
 			),
+			'wc_order_product_lookup' => array(
+				'table'           => "{$wpdb->prefix}wc_order_product_lookup",
+				'range_field'     => 'order_id',
+				'key_fields'      => array( 'order_id', 'order_item_id' ),
+				'checksum_fields' => array( 'product_id', 'variation_id', 'product_qty', 'product_net_revenue', 'date_created' ),
+			),
+			'wc_order_coupon_lookup'  => array(
+				'table'           => "{$wpdb->prefix}wc_order_coupon_lookup",
+				'range_field'     => 'order_id',
+				'key_fields'      => array( 'order_id', 'coupon_id' ),
+				'checksum_fields' => array( 'discount_amount', 'date_created' ),
+			),
+			'wc_order_tax_lookup'     => array(
+				'table'           => "{$wpdb->prefix}wc_order_tax_lookup",
+				'range_field'     => 'order_id',
+				'key_fields'      => array( 'order_id', 'tax_rate_id' ),
+				'checksum_fields' => array( 'order_tax', 'total_tax', 'shipping_tax', 'date_created' ),
+			),
+		);
+		foreach ( $expected as &$config ) {
+			ksort( $config );
+		}
+		unset( $config );
+		ksort( $expected );
+
+		$this->assertSame(
+			$expected,
 			$tables,
 			'The checksum table config changed. WPCOM mirrors it field-for-field; ship the matching ' .
 			'WPCOM change first (jetpack_wpcom_sync_checksum_allowed_tables), then update this pin.'

--- a/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
@@ -59,7 +59,7 @@ class Configuration_Test extends TestCase {
 	 * WPCOM mirrors this checksum table config field-for-field in
 	 * `jetpack_wpcom_sync_checksum_allowed_tables()` (wpcom:
 	 * `wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-shadow-replicastore.php`),
-	 * and a parity test there compares the vendored copy of this file against it.
+	 * and pins its side against the same map in JetpackSyncChecksumTableParityTest.
 	 * The two sides hash the same rows over their own field lists, so any drift makes
 	 * the affected table permanently fail its checksum audit for every syncing store.
 	 *

--- a/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Sync/Configuration_Test.php
@@ -54,4 +54,70 @@ class Configuration_Test extends TestCase {
 		// WC_ANALYTICS_VERSION is the standalone plugin's constant; PA must not whitelist it.
 		$this->assertNotContains( 'WC_ANALYTICS_VERSION', $config['jetpack_sync_constants_whitelist'] );
 	}
+
+	/**
+	 * WPCOM mirrors this checksum table config field-for-field in
+	 * `jetpack_wpcom_sync_checksum_allowed_tables()` (wpcom:
+	 * `wp-content/mu-plugins/jetpack/sync/class.jetpack-sync-shadow-replicastore.php`),
+	 * and a parity test there compares the vendored copy of this file against it.
+	 * The two sides hash the same rows over their own field lists, so any drift makes
+	 * the affected table permanently fail its checksum audit for every syncing store.
+	 *
+	 * If this test fails because you changed the config: the change must ship together
+	 * with the matching WPCOM change, then update the pin here.
+	 */
+	public function test_checksum_table_config_matches_the_wpcom_pin() {
+		$configuration = new class() extends Configuration {
+			/**
+			 * The real guard needs WooCommerce runtime symbols unavailable in this suite.
+			 */
+			protected function can_site_sync_orders(): bool {
+				return true;
+			}
+		};
+
+		$tables = $configuration->add_order_stats_to_checksum( array() );
+
+		foreach ( $tables as $name => $config ) {
+			$this->assertIsCallable(
+				$config['is_table_enabled_callback'] ?? null,
+				"Table '{$name}' must gate on an is_table_enabled_callback."
+			);
+			unset( $tables[ $name ]['is_table_enabled_callback'] );
+		}
+
+		global $wpdb;
+		$this->assertSame(
+			array(
+				'wc_order_stats'          => array(
+					'table'                => "{$wpdb->prefix}wc_order_stats",
+					'range_field'          => 'order_id',
+					'key_fields'           => array( 'order_id' ),
+					'checksum_fields'      => array( 'date_paid', 'date_completed', 'total_sales' ),
+					'checksum_text_fields' => array( 'status' ),
+				),
+				'wc_order_product_lookup' => array(
+					'table'           => "{$wpdb->prefix}wc_order_product_lookup",
+					'range_field'     => 'order_id',
+					'key_fields'      => array( 'order_id', 'order_item_id' ),
+					'checksum_fields' => array( 'product_id', 'variation_id', 'product_qty', 'product_net_revenue', 'date_created' ),
+				),
+				'wc_order_coupon_lookup'  => array(
+					'table'           => "{$wpdb->prefix}wc_order_coupon_lookup",
+					'range_field'     => 'order_id',
+					'key_fields'      => array( 'order_id', 'coupon_id' ),
+					'checksum_fields' => array( 'discount_amount', 'date_created' ),
+				),
+				'wc_order_tax_lookup'     => array(
+					'table'           => "{$wpdb->prefix}wc_order_tax_lookup",
+					'range_field'     => 'order_id',
+					'key_fields'      => array( 'order_id', 'tax_rate_id' ),
+					'checksum_fields' => array( 'order_tax', 'total_tax', 'shipping_tax', 'date_created' ),
+				),
+			),
+			$tables,
+			'The checksum table config changed. WPCOM mirrors it field-for-field; ship the matching ' .
+			'WPCOM change first (jetpack_wpcom_sync_checksum_allowed_tables), then update this pin.'
+		);
+	}
 }


### PR DESCRIPTION
## Proposed changes

* Add a test that pins the table/field lists `Configuration::add_order_stats_to_checksum()` declares for the Jetpack Sync checksum feature.

WPCOM mirrors this config field-for-field in `jetpack_wpcom_sync_checksum_allowed_tables()`. Any drift between the two makes the affected table permanently fail its checksum audit, because the two sides hash different column sets. This is how `wc_order_tax_lookup` broke: WPCOM omitted `order_tax`.

A parity test on the WPCOM side compares the vendored copy of this file against the WPCOM config, but it only fails once the change reaches wpcom. This pin fails at authoring time, in the PR that changes the config, with a message pointing at the WPCOM mirror.

## Related product discussion/links

* WPCOM parity test and fix: Automattic/wpcom#237466 (internal)
* SYNC-385

## Does this pull request change what data or activity we track or use?

No. Test-only change.

## Testing instructions

* `jp test php packages/premium-analytics`
* Change any entry in `add_order_stats_to_checksum()` and confirm the test fails with a message pointing at the WPCOM mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hdWNWJhFcs5Mm1gR66JN9