### PR TITLE
Write: Add a one-question survey after a writer's first publish

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-first-publish-survey
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-first-publish-survey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Ask writers one question about their experience after their first post, with an optional comment.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-checklist.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-checklist.php
@@ -27,6 +27,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 const WPCOM_WRITE_PUBLISHED_MARKER = 'wpcom_write_published';
 
 /**
+ * Strip the post-publish query args from the author's address bar.
+ *
+ * The redirect tags the permalink so the post-publish surfaces know a publish
+ * just happened, but the author is left looking at their own live post with our
+ * bookkeeping attached — and would share that URL if they copied it. Cleaning up
+ * belongs here rather than in either card: both are conditional, and the writer
+ * who has already answered the survey sees no card at all, so nothing would run.
+ *
+ * Server-side state has already been read by the time this executes, so removing
+ * the args client-side changes nothing but the visible URL.
+ *
+ * @return void
+ */
+function wpcom_write_print_post_publish_url_cleanup() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Display-only marker; writes nothing.
+	if ( ! isset( $_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] ) || ! is_singular( 'post' ) ) {
+		return;
+	}
+
+	// `source` is only stripped alongside the marker, so a campaign link that
+	// carries its own `source` to a post is left alone.
+	// Hex-escaped so the encoded value can never break out of the inline script tag.
+	$args = wp_json_encode( array( WPCOM_WRITE_PUBLISHED_MARKER, 'source' ), JSON_HEX_TAG | JSON_HEX_AMP );
+
+	wp_print_inline_script_tag(
+		'( function () {
+			try {
+				var url = new URL( window.location.href );
+				' . $args . '.forEach( function ( arg ) { url.searchParams.delete( arg ); } );
+				window.history.replaceState( null, "", url.href );
+			} catch ( e ) {}
+		} )();'
+	);
+}
+add_action( 'wp_footer', 'wpcom_write_print_post_publish_url_cleanup', 5 );
+
+/**
  * Whether the post-publish checklist overlay should render on the current request.
  *
  * All of the following must hold:

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.css
@@ -73,23 +73,22 @@
 	background: #f0f0f0;
 }
 
+/* Context for the question, not the headline.
+   Padded clear of the close button. */
 .wpcom-write-pps__heading {
-	margin: 0 0 4px;
-	font-size: 14px;
-	font-weight: 600;
-	color: #1e1e1e;
-}
-
-.wpcom-write-pps__intro {
+	margin: 0 0 10px;
+	padding-inline-end: 36px;
+	font-size: 13px;
 	font-weight: 400;
+	line-height: 1.4;
 	color: #6d6d6d;
 }
 
 .wpcom-write-pps__question {
-	margin: 0 0 16px;
-	font-size: 17px;
+	margin: 0 0 20px;
+	font-size: 20px;
 	font-weight: 600;
-	line-height: 1.4;
+	line-height: 1.35;
 	color: #1e1e1e;
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.css
@@ -1,0 +1,227 @@
+/**
+ * Write — one-question post-publish survey card.
+ *
+ * A card overlaying the published post, shown to the author once after their
+ * first Write publish. Self-contained styles (scoped under .wpcom-write-pps) so
+ * it renders consistently over any theme. Most Write publishers are on a phone,
+ * so the layout is sized for a small screen first and only widens past 480px.
+ */
+
+.wpcom-write-pps {
+	position: fixed;
+	inset: 0;
+	z-index: 100000;
+	display: flex;
+	align-items: flex-end;
+	justify-content: center;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+/* Match the Write editor's typography rather than inheriting the site theme's
+   fonts. Set explicitly on text elements (not just the container) so theme
+   rules targeting h2/p/button by element don't override via the cascade. */
+.wpcom-write-pps,
+.wpcom-write-pps h2,
+.wpcom-write-pps p,
+.wpcom-write-pps span,
+.wpcom-write-pps label,
+.wpcom-write-pps textarea,
+.wpcom-write-pps button {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
+}
+
+.wpcom-write-pps[hidden] {
+	display: none;
+}
+
+.wpcom-write-pps__backdrop {
+	position: absolute;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.45);
+}
+
+/* A sheet on a phone, a centered card once there's room for one. */
+.wpcom-write-pps__card {
+	position: relative;
+	inline-size: 100%;
+	max-inline-size: 480px;
+	background: #fff;
+	border-start-start-radius: 12px;
+	border-start-end-radius: 12px;
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.2);
+	padding: 24px 20px 20px;
+	box-sizing: border-box;
+}
+
+.wpcom-write-pps__close {
+	position: absolute;
+	inset-block-start: 8px;
+	inset-inline-end: 8px;
+	inline-size: 36px;
+	block-size: 36px;
+	border: 0;
+	background: transparent;
+	color: #6d6d6d;
+	font-size: 24px;
+	line-height: 1;
+	cursor: pointer;
+	border-radius: 4px;
+}
+
+.wpcom-write-pps__close:hover {
+	background: #f0f0f0;
+}
+
+.wpcom-write-pps__heading {
+	margin: 0 0 4px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1e1e1e;
+}
+
+.wpcom-write-pps__intro {
+	font-weight: 400;
+	color: #6d6d6d;
+}
+
+.wpcom-write-pps__question {
+	margin: 0 0 16px;
+	font-size: 17px;
+	font-weight: 600;
+	line-height: 1.4;
+	color: #1e1e1e;
+}
+
+.wpcom-write-pps__answers {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-block-end: 16px;
+}
+
+/* Tap targets stay comfortably above 44px tall on a phone. */
+.wpcom-write-pps__answer {
+	flex: 1 1 auto;
+	min-block-size: 44px;
+	padding: 10px 16px;
+	border: 1px solid #d8d8d8;
+	border-radius: 22px;
+	background: #fff;
+	color: #1e1e1e;
+	font-size: 15px;
+	line-height: 1.2;
+	cursor: pointer;
+}
+
+.wpcom-write-pps__answer:hover {
+	border-color: #3858e9;
+	color: #3858e9;
+}
+
+.wpcom-write-pps__answer.is-selected {
+	border-color: #3858e9;
+	background: #3858e9;
+	color: #fff;
+}
+
+.wpcom-write-pps__comment[hidden] {
+	display: none;
+}
+
+.wpcom-write-pps__comment-label {
+	display: block;
+	margin-block-end: 6px;
+	font-size: 14px;
+	font-weight: 600;
+	color: #1e1e1e;
+}
+
+.wpcom-write-pps__comment-hint {
+	margin-inline-start: 6px;
+	font-weight: 400;
+	color: #6d6d6d;
+}
+
+.wpcom-write-pps__comment-input {
+	display: block;
+	inline-size: 100%;
+	padding: 10px 12px;
+	border: 1px solid #d8d8d8;
+	border-radius: 4px;
+	background: #fff;
+	color: #1e1e1e;
+
+	/* 16px keeps iOS Safari from zooming the viewport on focus. */
+	font-size: 16px;
+	line-height: 1.4;
+	box-sizing: border-box;
+	resize: vertical;
+}
+
+.wpcom-write-pps__comment-input:focus {
+	border-color: #3858e9;
+	outline: 2px solid transparent;
+	outline-offset: 0;
+	box-shadow: 0 0 0 1px #3858e9;
+}
+
+.wpcom-write-pps__send {
+	display: block;
+	inline-size: 100%;
+	margin-block-start: 12px;
+	min-block-size: 44px;
+	padding: 12px 16px;
+	border: 0;
+	border-radius: 4px;
+	background: #3858e9;
+	color: #fff;
+	font-size: 15px;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.wpcom-write-pps__send:hover {
+	background: #2e49d9;
+}
+
+.wpcom-write-pps__skip {
+	display: block;
+	inline-size: 100%;
+	margin-block-start: 8px;
+	min-block-size: 44px;
+	padding: 10px 16px;
+	border: 0;
+	border-radius: 4px;
+	background: transparent;
+	color: #6d6d6d;
+	font-size: 14px;
+	cursor: pointer;
+}
+
+.wpcom-write-pps__skip:hover {
+	background: #f0f0f0;
+}
+
+.wpcom-write-pps__thanks[hidden] {
+	display: none;
+}
+
+.wpcom-write-pps__thanks {
+	margin: 12px 0 0;
+	font-size: 15px;
+	color: #1e1e1e;
+}
+
+@media (min-width: 480px) {
+
+	.wpcom-write-pps {
+		align-items: center;
+		padding: 20px;
+	}
+
+	.wpcom-write-pps__card {
+		border-radius: 8px;
+		padding: 28px 28px 24px;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -230,9 +230,13 @@
 		const send = overlay.querySelector( '[data-wpcom-write-pps-send]' );
 		if ( send ) {
 			send.addEventListener( 'click', function () {
-				recordEvent( 'wpcom_write_first_publish_survey_comment_sent', {
-					response_id: config.responseId || '',
-				} );
+				// Send is reachable with an empty box, and an empty comment is not
+				// stored — so firing this unconditionally would over-count prose.
+				if ( commentInput && commentInput.value.trim() ) {
+					recordEvent( 'wpcom_write_first_publish_survey_comment_sent', {
+						response_id: config.responseId || '',
+					} );
+				}
 				submitResponse();
 				if ( thanks ) {
 					thanks.removeAttribute( 'hidden' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -20,8 +20,13 @@
 	 * @param {object} [props] - Optional event properties.
 	 */
 	function recordEvent( event, props ) {
+		const payload = Object.assign( {}, props );
+		// Atomic front-end events carry no blogid column, so pass it as a property.
+		if ( config.blogId ) {
+			payload.blog_id = config.blogId;
+		}
 		window._tkq = window._tkq || [];
-		window._tkq.push( [ 'recordEvent', event, props || {} ] );
+		window._tkq.push( [ 'recordEvent', event, payload ] );
 	}
 
 	/**
@@ -125,24 +130,15 @@
 				return;
 			}
 
-			// The card still thanks the writer either way — a store we lost is not
-			// their problem. But a silently dropped response would otherwise be
-			// invisible, and the dataset's completeness depends on knowing the rate.
-			request
-				.then( function ( response ) {
-					if ( ! response.ok ) {
-						recordEvent( 'wpcom_write_first_publish_survey_store_failed', {
-							reason: String( response.status ),
-							response_id: config.responseId || '',
-						} );
-					}
-				} )
-				.catch( function () {
-					recordEvent( 'wpcom_write_first_publish_survey_store_failed', {
-						reason: 'network',
-						response_id: config.responseId || '',
-					} );
+			// Only the browser can see a request that never arrived; a request that
+			// arrived and failed to store is recorded server-side, which does not
+			// depend on this page still being open when the response lands.
+			request.catch( function () {
+				recordEvent( 'wpcom_write_first_publish_survey_store_failed', {
+					reason: 'network',
+					response_id: config.responseId || '',
 				} );
+			} );
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -87,25 +87,14 @@
 		let submitted = false;
 
 		/**
-		 * POST the response to admin-ajax. Fire-and-forget: a failed write costs one
-		 * survey answer and must never block the card.
+		 * POST to admin-ajax. Fire-and-forget: a failed write costs one survey
+		 * answer and must never block the card.
 		 *
-		 * @param {boolean} [duringUnload] - Use keepalive, for a submit made on the way out.
+		 * @param {URLSearchParams} body           - Form body; the nonce is added here.
+		 * @param {boolean}         [duringUnload] - Use keepalive, for a send on the way out.
 		 */
-		function submitResponse( duringUnload ) {
-			if ( submitted || ! selectedAnswer ) {
-				return;
-			}
-			submitted = true;
-
-			const body = new URLSearchParams();
-			body.set( 'action', 'wpcom_write_submit_survey' );
+		function post( body, duringUnload ) {
 			body.set( 'nonce', config.nonce || '' );
-			body.set( 'answer', selectedAnswer );
-			body.set( 'comment', commentInput ? commentInput.value : '' );
-			body.set( 'response_id', config.responseId || '' );
-			body.set( 'source', config.source || '' );
-
 			try {
 				fetch( config.ajaxUrl, {
 					method: 'POST',
@@ -119,6 +108,36 @@
 			} catch {
 				// Same.
 			}
+		}
+
+		/**
+		 * Close the once-per-user gate, now that the card is on screen.
+		 */
+		function markShown() {
+			const body = new URLSearchParams();
+			body.set( 'action', 'wpcom_write_survey_shown' );
+			post( body );
+		}
+
+		/**
+		 * Store the chosen answer and any free text, at most once.
+		 *
+		 * @param {boolean} [duringUnload] - Use keepalive, for a send on the way out.
+		 */
+		function submitResponse( duringUnload ) {
+			if ( submitted || ! selectedAnswer ) {
+				return;
+			}
+			submitted = true;
+
+			const body = new URLSearchParams();
+			body.set( 'action', 'wpcom_write_submit_survey' );
+			body.set( 'answer', selectedAnswer );
+			body.set( 'comment', commentInput ? commentInput.value : '' );
+			body.set( 'response_id', config.responseId || '' );
+			body.set( 'source', config.source || '' );
+
+			post( body, duringUnload );
 		}
 
 		/**
@@ -257,6 +276,7 @@
 
 		whenChecklistDismissed( function () {
 			overlay.removeAttribute( 'hidden' );
+			markShown();
 			recordEvent( 'wpcom_write_first_publish_survey_shown', {
 				variant: config.variant || '',
 				entry_point: config.source || '',

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -72,21 +72,20 @@
 		 *
 		 * @param {URLSearchParams} body           - Form body; the nonce is added here.
 		 * @param {boolean}         [duringUnload] - Use keepalive, for a send on the way out.
+		 * @return {Promise<Response>|null} The in-flight request, or null if it couldn't start.
 		 */
 		function post( body, duringUnload ) {
 			body.set( 'nonce', config.nonce || '' );
 			try {
-				fetch( config.ajaxUrl, {
+				return fetch( config.ajaxUrl, {
 					method: 'POST',
 					credentials: 'same-origin',
 					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 					body: body.toString(),
 					keepalive: !! duringUnload,
-				} ).catch( function () {
-					// The answer is already in Tracks; nothing useful to do here.
 				} );
 			} catch {
-				// Same.
+				return null;
 			}
 		}
 
@@ -96,7 +95,11 @@
 		function markShown() {
 			const body = new URLSearchParams();
 			body.set( 'action', 'wpcom_write_survey_shown' );
-			post( body );
+			const request = post( body );
+			if ( request ) {
+				// Losing this costs one repeat showing, which the submit guard absorbs.
+				request.catch( function () {} );
+			}
 		}
 
 		/**
@@ -117,7 +120,29 @@
 			body.set( 'response_id', config.responseId || '' );
 			body.set( 'source', config.source || '' );
 
-			post( body, duringUnload );
+			const request = post( body, duringUnload );
+			if ( ! request ) {
+				return;
+			}
+
+			// The card still thanks the writer either way — a store we lost is not
+			// their problem. But a silently dropped response would otherwise be
+			// invisible, and the dataset's completeness depends on knowing the rate.
+			request
+				.then( function ( response ) {
+					if ( ! response.ok ) {
+						recordEvent( 'wpcom_write_first_publish_survey_store_failed', {
+							reason: String( response.status ),
+							response_id: config.responseId || '',
+						} );
+					}
+				} )
+				.catch( function () {
+					recordEvent( 'wpcom_write_first_publish_survey_store_failed', {
+						reason: 'network',
+						response_id: config.responseId || '',
+					} );
+				} );
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -25,26 +25,6 @@
 	}
 
 	/**
-	 * Remove the post-publish marker from the URL without reloading, so the card
-	 * doesn't reappear on refresh or back-navigation.
-	 */
-	function cleanMarkerFromUrl() {
-		if ( ! config.marker || ! window.history || ! window.history.replaceState ) {
-			return;
-		}
-		try {
-			const url = new URL( window.location.href );
-			if ( ! url.searchParams.has( config.marker ) ) {
-				return;
-			}
-			url.searchParams.delete( config.marker );
-			window.history.replaceState( null, '', url.href );
-		} catch {
-			// Leave the URL as-is if it can't be parsed.
-		}
-	}
-
-	/**
 	 * Run a callback once the post-publish checklist is off the screen.
 	 *
 	 * The checklist removes its overlay on dismiss, so watching for that removal is
@@ -149,7 +129,6 @@
 			if ( overlay.parentNode ) {
 				overlay.parentNode.removeChild( overlay );
 			}
-			cleanMarkerFromUrl();
 			if (
 				previouslyFocused &&
 				typeof previouslyFocused.focus === 'function' &&

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.js
@@ -1,0 +1,282 @@
+/**
+ * Write — one-question post-publish survey (front-end wiring).
+ *
+ * Gated server-side; see post-publish-survey.php. Choosing an answer records it to
+ * Tracks at once and opens an optional free-text box; the stored response is
+ * written once, on send or on the way out, so an answer is never lost to a writer
+ * who types nothing and closes the card.
+ *
+ * On a Coming Soon site the post-publish checklist owns this screen first, so the
+ * survey waits for that card to go away rather than stacking on top of it.
+ */
+( function () {
+	const config = window.wpcomWritePostPublishSurvey || {};
+	const CHECKLIST_SELECTOR = '.wpcom-write-ppc';
+
+	/**
+	 * Record a Tracks event using the same global queue the Write editor uses.
+	 *
+	 * @param {string} event   - Event name.
+	 * @param {object} [props] - Optional event properties.
+	 */
+	function recordEvent( event, props ) {
+		window._tkq = window._tkq || [];
+		window._tkq.push( [ 'recordEvent', event, props || {} ] );
+	}
+
+	/**
+	 * Remove the post-publish marker from the URL without reloading, so the card
+	 * doesn't reappear on refresh or back-navigation.
+	 */
+	function cleanMarkerFromUrl() {
+		if ( ! config.marker || ! window.history || ! window.history.replaceState ) {
+			return;
+		}
+		try {
+			const url = new URL( window.location.href );
+			if ( ! url.searchParams.has( config.marker ) ) {
+				return;
+			}
+			url.searchParams.delete( config.marker );
+			window.history.replaceState( null, '', url.href );
+		} catch {
+			// Leave the URL as-is if it can't be parsed.
+		}
+	}
+
+	/**
+	 * Run a callback once the post-publish checklist is off the screen.
+	 *
+	 * The checklist removes its overlay on dismiss, so watching for that removal is
+	 * enough.
+	 *
+	 * @param {Function} callback - Invoked when the screen is free.
+	 */
+	function whenChecklistDismissed( callback ) {
+		const checklist = document.querySelector( CHECKLIST_SELECTOR );
+		if ( ! checklist || typeof MutationObserver === 'undefined' ) {
+			callback();
+			return;
+		}
+
+		const observer = new MutationObserver( function () {
+			if ( ! document.querySelector( CHECKLIST_SELECTOR ) ) {
+				observer.disconnect();
+				callback();
+			}
+		} );
+		observer.observe( document.body, { childList: true, subtree: true } );
+	}
+
+	/**
+	 * Find the card, wire its controls, and reveal it at the right moment.
+	 */
+	function init() {
+		const overlay = document.querySelector( '.wpcom-write-pps' );
+		if ( ! overlay ) {
+			return;
+		}
+
+		const card = overlay.querySelector( '.wpcom-write-pps__card' );
+		const commentWrap = overlay.querySelector( '.wpcom-write-pps__comment' );
+		const commentInput = overlay.querySelector( '.wpcom-write-pps__comment-input' );
+		const thanks = overlay.querySelector( '.wpcom-write-pps__thanks' );
+		const previouslyFocused = overlay.ownerDocument.activeElement;
+
+		let selectedAnswer = '';
+		let submitted = false;
+
+		/**
+		 * POST the response to admin-ajax. Fire-and-forget: a failed write costs one
+		 * survey answer and must never block the card.
+		 *
+		 * @param {boolean} [duringUnload] - Use keepalive, for a submit made on the way out.
+		 */
+		function submitResponse( duringUnload ) {
+			if ( submitted || ! selectedAnswer ) {
+				return;
+			}
+			submitted = true;
+
+			const body = new URLSearchParams();
+			body.set( 'action', 'wpcom_write_submit_survey' );
+			body.set( 'nonce', config.nonce || '' );
+			body.set( 'answer', selectedAnswer );
+			body.set( 'comment', commentInput ? commentInput.value : '' );
+			body.set( 'response_id', config.responseId || '' );
+			body.set( 'source', config.source || '' );
+
+			try {
+				fetch( config.ajaxUrl, {
+					method: 'POST',
+					credentials: 'same-origin',
+					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+					body: body.toString(),
+					keepalive: !! duringUnload,
+				} ).catch( function () {
+					// The answer is already in Tracks; nothing useful to do here.
+				} );
+			} catch {
+				// Same.
+			}
+		}
+
+		/**
+		 * Remove the card, tidy the URL, drop listeners, and restore focus.
+		 */
+		function dismiss() {
+			document.removeEventListener( 'keydown', onKeydown );
+			window.removeEventListener( 'pagehide', onPageHide );
+			if ( overlay.parentNode ) {
+				overlay.parentNode.removeChild( overlay );
+			}
+			cleanMarkerFromUrl();
+			if (
+				previouslyFocused &&
+				typeof previouslyFocused.focus === 'function' &&
+				document.contains( previouslyFocused )
+			) {
+				previouslyFocused.focus();
+			}
+		}
+
+		/**
+		 * Flush any chosen answer before the card goes away.
+		 */
+		function submitAndDismiss() {
+			submitResponse();
+			dismiss();
+		}
+
+		/**
+		 * Catch an answer chosen but never sent, when the writer navigates away.
+		 */
+		function onPageHide() {
+			submitResponse( true );
+		}
+
+		/**
+		 * The card's focusable controls, in DOM order.
+		 *
+		 * @return {HTMLElement[]} Enabled buttons and inputs within the card.
+		 */
+		function focusable() {
+			return Array.prototype.slice
+				.call( overlay.querySelectorAll( 'button:not([disabled]), textarea:not([disabled])' ) )
+				.filter( function ( el ) {
+					return el.offsetParent !== null;
+				} );
+		}
+
+		/**
+		 * Close on Escape and keep Tab focus trapped within the dialog.
+		 *
+		 * @param {KeyboardEvent} event - The keydown event.
+		 */
+		function onKeydown( event ) {
+			if ( event.key === 'Escape' ) {
+				recordEvent( 'wpcom_write_first_publish_survey_dismissed', {
+					answered: selectedAnswer ? '1' : '0',
+				} );
+				submitAndDismiss();
+				return;
+			}
+			if ( event.key !== 'Tab' ) {
+				return;
+			}
+			const items = focusable();
+			if ( ! items.length ) {
+				return;
+			}
+			const first = items[ 0 ];
+			const last = items[ items.length - 1 ];
+			const active = overlay.ownerDocument.activeElement;
+			if ( event.shiftKey ) {
+				if ( active === first || ! overlay.contains( active ) ) {
+					last.focus();
+					event.preventDefault();
+				}
+			} else if ( active === last || ! overlay.contains( active ) ) {
+				first.focus();
+				event.preventDefault();
+			}
+		}
+
+		overlay.querySelectorAll( '[data-wpcom-write-pps-answer]' ).forEach( function ( button ) {
+			button.addEventListener( 'click', function () {
+				selectedAnswer = button.getAttribute( 'data-wpcom-write-pps-answer' ) || '';
+
+				overlay.querySelectorAll( '[data-wpcom-write-pps-answer]' ).forEach( function ( other ) {
+					other.classList.toggle( 'is-selected', other === button );
+					other.setAttribute( 'aria-pressed', other === button ? 'true' : 'false' );
+				} );
+
+				// Recorded the moment it's made: this half segments against the
+				// wpcom_write_editor_* funnel and can't wait on the writer typing.
+				recordEvent( 'wpcom_write_first_publish_survey_response', {
+					answer: selectedAnswer,
+					variant: config.variant || '',
+					entry_point: config.source || '',
+					response_id: config.responseId || '',
+				} );
+
+				if ( commentWrap ) {
+					commentWrap.removeAttribute( 'hidden' );
+				}
+				if ( commentInput ) {
+					commentInput.focus();
+				}
+			} );
+		} );
+
+		const send = overlay.querySelector( '[data-wpcom-write-pps-send]' );
+		if ( send ) {
+			send.addEventListener( 'click', function () {
+				recordEvent( 'wpcom_write_first_publish_survey_comment_sent', {
+					response_id: config.responseId || '',
+				} );
+				submitResponse();
+				if ( thanks ) {
+					thanks.removeAttribute( 'hidden' );
+				}
+				if ( commentWrap ) {
+					commentWrap.setAttribute( 'hidden', '' );
+				}
+				window.setTimeout( dismiss, 1200 );
+			} );
+		}
+
+		overlay.querySelectorAll( '[data-wpcom-write-pps-dismiss]' ).forEach( function ( el ) {
+			el.addEventListener( 'click', function () {
+				recordEvent( 'wpcom_write_first_publish_survey_dismissed', {
+					answered: selectedAnswer ? '1' : '0',
+				} );
+				submitAndDismiss();
+			} );
+		} );
+
+		whenChecklistDismissed( function () {
+			overlay.removeAttribute( 'hidden' );
+			recordEvent( 'wpcom_write_first_publish_survey_shown', {
+				variant: config.variant || '',
+				entry_point: config.source || '',
+				response_id: config.responseId || '',
+			} );
+
+			// Focus the card rather than an answer button, so Enter doesn't arm a choice.
+			if ( card ) {
+				card.setAttribute( 'tabindex', '-1' );
+				card.focus();
+			}
+
+			document.addEventListener( 'keydown', onKeydown );
+			window.addEventListener( 'pagehide', onPageHide );
+		} );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )();

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -305,7 +305,6 @@ function wpcom_write_store_survey_response( $responses ) {
 		require_lib( 'marketing/survey' );
 
 		if ( class_exists( 'Marketing_Survey' ) ) {
-			// @phan-suppress-next-line PhanUndeclaredClassMethod -- wpcom-only lib loaded via require_lib(); stub to follow, see AGENTS.md.
 			$result = \Marketing_Survey::submit_survey( $blog_id, $user_id, WPCOM_WRITE_SURVEY_ID, $responses );
 
 			return ! empty( $result['success'] );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -354,6 +354,30 @@ function wpcom_write_ajax_mark_survey_shown() {
 add_action( 'wp_ajax_wpcom_write_survey_shown', 'wpcom_write_ajax_mark_survey_shown' );
 
 /**
+ * Neutralize a leading spreadsheet-formula character in free text.
+ *
+ * The stored responses are exported to CSV downstream, where a cell beginning
+ * `=`, `+`, `-`, `@`, tab or CR is evaluated as a formula by spreadsheet apps.
+ * Prefixing with an apostrophe is the standard defence and is reversible — a
+ * consumer that doesn't need it can strip the leading quote.
+ *
+ * Byte-wise on purpose: a multi-byte leading character starts with a byte above
+ * 0x7F and can never collide with these ASCII triggers.
+ *
+ * @param string $text Sanitized free text.
+ * @return string Text safe to place in a CSV cell.
+ */
+function wpcom_write_neutralize_csv_formula( $text ) {
+	if ( '' === $text ) {
+		return $text;
+	}
+
+	$triggers = array( '=', '+', '-', '@', "\t", "\r" );
+
+	return in_array( $text[0], $triggers, true ) ? "'" . $text : $text;
+}
+
+/**
  * Build the response payload stored against the survey.
  *
  * Answers are stored as a preset slug, or array( 'text' => … ) for prose — the
@@ -383,7 +407,8 @@ function wpcom_write_build_survey_response( $answer, $comment, $response_id, $so
 	$comment = mb_substr( $comment, 0, WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH );
 
 	if ( '' !== $comment ) {
-		$responses['comment'] = array( 'text' => $comment );
+		// Capped first, so the escape prefix is never what gets truncated away.
+		$responses['comment'] = array( 'text' => wpcom_write_neutralize_csv_formula( $comment ) );
 	}
 
 	return $responses;

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -30,6 +30,10 @@ const WPCOM_WRITE_SURVEY_ID = 'write-first-publish';
 
 /**
  * User meta recording that the survey has been shown, so it appears only once.
+ *
+ * Written when the card is actually revealed, not when it renders: on a Coming
+ * Soon site the checklist owns the screen first, and its launch CTA navigates
+ * away without dismissing, so a render is no evidence the writer saw anything.
  */
 const WPCOM_WRITE_SURVEY_SHOWN_META = '_wpcom_write_first_publish_survey_shown';
 
@@ -227,9 +231,6 @@ function wpcom_write_render_post_publish_survey() {
 	$strings        = wpcom_write_get_survey_strings( $is_write_first );
 	$answers        = wpcom_write_get_survey_answers( $is_write_first );
 
-	// Marked on render, not on submit: a writer who navigates away without
-	// answering has still had their turn.
-	update_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SHOWN_META, time() );
 	?>
 	<div class="wpcom-write-pps" role="dialog" aria-modal="true" aria-labelledby="wpcom-write-pps-question" hidden>
 		<div class="wpcom-write-pps__backdrop" data-wpcom-write-pps-dismiss></div>
@@ -306,6 +307,28 @@ function wpcom_write_store_survey_response( $responses ) {
 
 	return ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response );
 }
+
+/**
+ * Record that the survey card was revealed to this user.
+ *
+ * Fired by the card on reveal so the once-per-user gate closes on a card the
+ * writer actually saw. Best-effort: a dropped request costs one repeat showing,
+ * which is the better failure.
+ *
+ * @return void
+ */
+function wpcom_write_ajax_mark_survey_shown() {
+	check_ajax_referer( WPCOM_WRITE_SURVEY_NONCE, 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'reason' => 'forbidden' ), 403, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	}
+
+	update_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SHOWN_META, time() );
+
+	wp_send_json_success( null, 200, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+}
+add_action( 'wp_ajax_wpcom_write_survey_shown', 'wpcom_write_ajax_mark_survey_shown' );
 
 /**
  * Build the response payload stored against the survey.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -200,7 +200,6 @@ function wpcom_write_enqueue_post_publish_survey_assets() {
 		'wpcom-write-post-publish-survey',
 		'wpcomWritePostPublishSurvey',
 		array(
-			'marker'     => WPCOM_WRITE_PUBLISHED_MARKER,
 			// admin-ajax because a Simple site serves no REST API at its own hostname.
 			'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
 			'nonce'      => wp_create_nonce( WPCOM_WRITE_SURVEY_NONCE ),
@@ -208,7 +207,6 @@ function wpcom_write_enqueue_post_publish_survey_assets() {
 			'responseId' => wp_generate_uuid4(),
 			'variant'    => $is_write_first ? 'write_first' : 'returning',
 			'source'     => wpcom_write_survey_source(),
-			'maxLength'  => WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH,
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -151,7 +151,6 @@ function wpcom_write_get_survey_strings( $is_write_first ) {
 		'heading'      => $is_coming_soon
 			? __( 'Your post is saved.', 'jetpack-mu-wpcom' )
 			: __( 'Your post is live.', 'jetpack-mu-wpcom' ),
-		'intro'        => __( 'One quick question?', 'jetpack-mu-wpcom' ),
 		'question'     => $is_write_first
 			? __( 'How was it?', 'jetpack-mu-wpcom' )
 			: __( "How did writing this compare to the WordPress.com editor you've used before?", 'jetpack-mu-wpcom' ),
@@ -236,7 +235,7 @@ function wpcom_write_render_post_publish_survey() {
 		<div class="wpcom-write-pps__backdrop" data-wpcom-write-pps-dismiss></div>
 		<div class="wpcom-write-pps__card">
 			<button type="button" class="wpcom-write-pps__close" data-wpcom-write-pps-dismiss aria-label="<?php echo esc_attr( $strings['close'] ); ?>">&times;</button>
-			<p class="wpcom-write-pps__heading"><?php echo esc_html( $strings['heading'] ); ?> <span class="wpcom-write-pps__intro"><?php echo esc_html( $strings['intro'] ); ?></span></p>
+			<p class="wpcom-write-pps__heading"><?php echo esc_html( $strings['heading'] ); ?></p>
 			<h2 id="wpcom-write-pps-question" class="wpcom-write-pps__question"><?php echo esc_html( $strings['question'] ); ?></h2>
 			<div class="wpcom-write-pps__answers">
 				<?php foreach ( $answers as $slug => $label ) : ?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -38,6 +38,15 @@ const WPCOM_WRITE_SURVEY_ID = 'write-first-publish';
 const WPCOM_WRITE_SURVEY_SHOWN_META = '_wpcom_write_first_publish_survey_shown';
 
 /**
+ * User meta recording that a response has been stored.
+ *
+ * The authoritative record of "asked and answered". The shown meta above is a
+ * best-effort ping that can be lost to a dropped request, which would otherwise
+ * let the same writer be surveyed — and stored — twice.
+ */
+const WPCOM_WRITE_SURVEY_SUBMITTED_META = '_wpcom_write_first_publish_survey_submitted';
+
+/**
  * Nonce action guarding the survey submission.
  */
 const WPCOM_WRITE_SURVEY_NONCE = 'wpcom_write_survey';
@@ -96,7 +105,15 @@ function wpcom_write_should_show_post_publish_survey() {
 		return false;
 	}
 
-	if ( get_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SHOWN_META, true ) ) {
+	$user_id = get_current_user_id();
+
+	if ( get_user_meta( $user_id, WPCOM_WRITE_SURVEY_SHOWN_META, true ) ) {
+		return false;
+	}
+
+	// Also honoured here, so a lost shown-ping doesn't re-offer a card whose
+	// submission would then be rejected with nothing to show for it.
+	if ( get_user_meta( $user_id, WPCOM_WRITE_SURVEY_SUBMITTED_META, true ) ) {
 		return false;
 	}
 
@@ -399,11 +416,19 @@ function wpcom_write_ajax_submit_survey() {
 	$response_id = isset( $_POST['response_id'] ) ? sanitize_text_field( wp_unslash( $_POST['response_id'] ) ) : '';
 	$source      = isset( $_POST['source'] ) ? sanitize_key( wp_unslash( $_POST['source'] ) ) : '';
 
+	// Once per user is enforced here, not only on the render path: nonces replay
+	// for their full lifetime, and a lost shown-ping can re-offer the card.
+	if ( get_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SUBMITTED_META, true ) ) {
+		wp_send_json_error( array( 'reason' => 'already_submitted' ), 409, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	}
+
 	$responses = wpcom_write_build_survey_response( $answer, $comment, $response_id, $source, $is_write_first );
 
 	if ( ! wpcom_write_store_survey_response( $responses ) ) {
 		wp_send_json_error( array( 'reason' => 'store_failed' ), 500, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 	}
+
+	update_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SUBMITTED_META, time() );
 
 	wp_send_json_success( null, 200, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -401,11 +401,11 @@ function wpcom_write_neutralize_csv_formula( $text ) {
  */
 function wpcom_write_build_survey_response( $answer, $comment, $response_id, $source, $is_write_first ) {
 	$responses = array(
-		'experience' => $answer,
-		'variant'    => $is_write_first ? 'write_first' : 'returning',
-		'entryPoint' => substr( $source, 0, WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH ),
+		'experience'  => $answer,
+		'variant'     => $is_write_first ? 'write_first' : 'returning',
+		'entry_point' => substr( $source, 0, WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH ),
 		// Only ever a uuid4 we generated; anything else is discarded rather than stored.
-		'responseId' => wp_is_uuid( $response_id ) ? $response_id : '',
+		'response_id' => wp_is_uuid( $response_id ) ? $response_id : '',
 	);
 
 	$comment = mb_substr( $comment, 0, WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -51,6 +51,14 @@ const WPCOM_WRITE_SURVEY_NONCE = 'wpcom_write_survey';
 const WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH = 2000;
 
 /**
+ * Maximum length of the stored entry-point token.
+ *
+ * `sanitize_key()` bounds the character set but not the length, and the value
+ * round-trips through the client, so it needs a cap of its own.
+ */
+const WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH = 50;
+
+/**
  * Whether the current user arrived through the write-first signup flow.
  *
  * `site_creation_flow` is set to the flow name at site creation, so a site born
@@ -238,7 +246,7 @@ function wpcom_write_render_post_publish_survey() {
 			<h2 id="wpcom-write-pps-question" class="wpcom-write-pps__question"><?php echo esc_html( $strings['question'] ); ?></h2>
 			<div class="wpcom-write-pps__answers">
 				<?php foreach ( $answers as $slug => $label ) : ?>
-					<button type="button" class="wpcom-write-pps__answer" data-wpcom-write-pps-answer="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></button>
+					<button type="button" class="wpcom-write-pps__answer" aria-pressed="false" data-wpcom-write-pps-answer="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></button>
 				<?php endforeach; ?>
 			</div>
 			<div class="wpcom-write-pps__comment" hidden>
@@ -335,6 +343,10 @@ add_action( 'wp_ajax_wpcom_write_survey_shown', 'wpcom_write_ajax_mark_survey_sh
  * shape wpcom's response formatter reads. The trailing keys are metadata, stored
  * alongside the answers the way calypso-remove-purchase stores its own.
  *
+ * Every field is bounded here, because neither storage path passes through the
+ * endpoint that enforces wpcom's response-size cap. All of them arrive from the
+ * client, including the ID we minted and handed out at render.
+ *
  * @param string $answer         Validated answer slug.
  * @param string $comment        Optional free-text answer, already sanitized.
  * @param string $response_id    Shared ID linking this row to its Tracks event.
@@ -346,8 +358,9 @@ function wpcom_write_build_survey_response( $answer, $comment, $response_id, $so
 	$responses = array(
 		'experience' => $answer,
 		'variant'    => $is_write_first ? 'write_first' : 'returning',
-		'entryPoint' => $source,
-		'responseId' => $response_id,
+		'entryPoint' => substr( $source, 0, WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH ),
+		// Only ever a uuid4 we generated; anything else is discarded rather than stored.
+		'responseId' => wp_is_uuid( $response_id ) ? $response_id : '',
 	);
 
 	$comment = mb_substr( $comment, 0, WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -15,6 +15,7 @@
  */
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -298,20 +299,24 @@ add_action( 'wp_footer', 'wpcom_write_render_post_publish_survey' );
  * @return bool True when the response was handed to the store.
  */
 function wpcom_write_store_survey_response( $responses ) {
-	$blog_id = get_current_blog_id();
-	$user_id = get_current_user_id();
-
 	if ( function_exists( 'require_lib' ) ) {
 		require_lib( 'marketing/survey' );
 
 		if ( class_exists( 'Marketing_Survey' ) ) {
-			$result = \Marketing_Survey::submit_survey( $blog_id, $user_id, WPCOM_WRITE_SURVEY_ID, $responses );
+			$result = \Marketing_Survey::submit_survey( get_current_blog_id(), get_current_user_id(), WPCOM_WRITE_SURVEY_ID, $responses );
 
 			return ! empty( $result['success'] );
 		}
 	}
 
-	if ( ! class_exists( Client::class ) ) {
+	if ( ! class_exists( Client::class ) || ! class_exists( Connection_Manager::class ) ) {
+		return false;
+	}
+
+	// The endpoint keys both its capability check and the stored row off `site_id`,
+	// and Atomic's local blog ID is 1 — it has to be the wpcom one.
+	$blog_id = Connection_Manager::get_site_id( true );
+	if ( ! $blog_id ) {
 		return false;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -16,6 +16,7 @@
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -233,6 +234,7 @@ function wpcom_write_enqueue_post_publish_survey_assets() {
 			'responseId' => wp_generate_uuid4(),
 			'variant'    => $is_write_first ? 'write_first' : 'returning',
 			'source'     => wpcom_write_survey_source(),
+			'blogId'     => wpcom_write_survey_blog_id(),
 		)
 	);
 }
@@ -289,6 +291,19 @@ function wpcom_write_render_post_publish_survey() {
 add_action( 'wp_footer', 'wpcom_write_render_post_publish_survey' );
 
 /**
+ * The wpcom blog ID, which Atomic's local `get_current_blog_id()` is not.
+ *
+ * @return int Blog ID, or 0 when the site has no wpcom identity.
+ */
+function wpcom_write_survey_blog_id() {
+	if ( ! class_exists( Connection_Manager::class ) ) {
+		return 0;
+	}
+
+	return (int) Connection_Manager::get_site_id( true );
+}
+
+/**
  * Store a survey response in wpcom's central `marketing_survey_responses` table.
  *
  * Host-dependent transport, mirroring Common\wpcom_record_tracks_event(): Simple
@@ -309,14 +324,11 @@ function wpcom_write_store_survey_response( $responses ) {
 		}
 	}
 
-	if ( ! class_exists( Client::class ) || ! class_exists( Connection_Manager::class ) ) {
-		return false;
-	}
-
 	// The endpoint keys both its capability check and the stored row off `site_id`,
 	// and Atomic's local blog ID is 1 — it has to be the wpcom one.
-	$blog_id = Connection_Manager::get_site_id( true );
-	if ( ! $blog_id ) {
+	$blog_id = wpcom_write_survey_blog_id();
+
+	if ( ! class_exists( Client::class ) || ! $blog_id ) {
 		return false;
 	}
 
@@ -454,6 +466,21 @@ function wpcom_write_ajax_submit_survey() {
 	$responses = wpcom_write_build_survey_response( $answer, $comment, $response_id, $source, $is_write_first );
 
 	if ( ! wpcom_write_store_survey_response( $responses ) ) {
+		// Recorded here rather than from the card: the browser learns of the failure
+		// only once the request resolves, by which point the writer may well be gone.
+		if ( function_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_record_tracks_event' ) ) {
+			Common\wpcom_record_tracks_event(
+				'wpcom_write_first_publish_survey_store_failed',
+				array(
+					'reason'      => 'store',
+					'response_id' => $responses['response_id'],
+					'entry_point' => $responses['entry_point'],
+					'variant'     => $responses['variant'],
+					'blog_id'     => wpcom_write_survey_blog_id(),
+				)
+			);
+		}
+
 		wp_send_json_error( array( 'reason' => 'store_failed' ), 500, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/post-publish-survey.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Write — one-question survey after a writer's first Write publish.
+ *
+ * Shown once per user on the published post the editor redirects to, tagged with
+ * WPCOM_WRITE_PUBLISHED_MARKER. Writers who arrived through the write-first signup
+ * flow have no earlier WordPress.com editor to compare against, so they get a
+ * plain "how was it" instead of the comparison. See CM-892.
+ *
+ * The choice goes to Tracks so responses segment against the wpcom_write_editor_*
+ * funnel; the choice and any free text go to `marketing_survey_responses`, both
+ * carrying one response ID so the halves can be rejoined.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Connection\Client;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Survey ID under which responses are stored in `marketing_survey_responses`.
+ *
+ * Must be registered in wpcom's Survey_Helper: an unregistered ID stores fine
+ * but analyses as nothing.
+ */
+const WPCOM_WRITE_SURVEY_ID = 'write-first-publish';
+
+/**
+ * User meta recording that the survey has been shown, so it appears only once.
+ */
+const WPCOM_WRITE_SURVEY_SHOWN_META = '_wpcom_write_first_publish_survey_shown';
+
+/**
+ * Nonce action guarding the survey submission.
+ */
+const WPCOM_WRITE_SURVEY_NONCE = 'wpcom_write_survey';
+
+/**
+ * Maximum length of the optional free-text answer, in characters.
+ *
+ * Ours to enforce: wpcom's 50,000-character cap lives on the unauthenticated
+ * feedback-survey endpoint, which neither storage path goes through.
+ */
+const WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH = 2000;
+
+/**
+ * Whether the current user arrived through the write-first signup flow.
+ *
+ * `site_creation_flow` is set to the flow name at site creation, so a site born
+ * from `/setup/write-on` carries `write-on` for good.
+ *
+ * @return bool True when this site was created by the write-first flow.
+ */
+function wpcom_write_is_write_first_site() {
+	return 'write-on' === get_option( 'site_creation_flow' );
+}
+
+/**
+ * Whether the survey should render on the current request.
+ *
+ * All of the following must hold:
+ *  - the request carries the Write editor's post-publish marker;
+ *  - we're on a single post's front-end view;
+ *  - the viewer has `manage_options`, which the wpcom survey endpoint requires
+ *    of the submitter anyway;
+ *  - the user has not already been shown the survey.
+ *
+ * @return bool True when the survey should be shown.
+ */
+function wpcom_write_should_show_post_publish_survey() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Display-only marker; mirrors the post-publish checklist's read.
+	if ( ! isset( $_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] ) ) {
+		return false;
+	}
+
+	if ( ! is_singular( 'post' ) ) {
+		return false;
+	}
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return false;
+	}
+
+	if ( get_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SHOWN_META, true ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * The entry point the writer came from, as tagged onto the post-publish redirect.
+ *
+ * Mirrors the `source` on `wpcom_write_editor_open` so responses segment the same
+ * way the funnel does.
+ *
+ * @return string Sanitized source token, or '' when absent.
+ */
+function wpcom_write_survey_source() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only attribution parameter, no state change.
+	if ( empty( $_GET['source'] ) || ! is_scalar( $_GET['source'] ) ) {
+		return '';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	return sanitize_key( wp_unslash( $_GET['source'] ) );
+}
+
+/**
+ * The answer options for a variant, as slug => label.
+ *
+ * Slugs are stored verbatim as the preset answer key, so they must stay stable
+ * once responses exist.
+ *
+ * @param bool $is_write_first Whether to return the write-first variant.
+ * @return array<string, string> Map of answer slug to translated label.
+ */
+function wpcom_write_get_survey_answers( $is_write_first ) {
+	if ( $is_write_first ) {
+		return array(
+			'easy'        => __( 'Easy', 'jetpack-mu-wpcom' ),
+			'fine'        => __( 'Fine', 'jetpack-mu-wpcom' ),
+			'frustrating' => __( 'Frustrating', 'jetpack-mu-wpcom' ),
+		);
+	}
+
+	return array(
+		'easier'     => __( 'Easier', 'jetpack-mu-wpcom' ),
+		'about_same' => __( 'About the same', 'jetpack-mu-wpcom' ),
+		'harder'     => __( 'Harder', 'jetpack-mu-wpcom' ),
+		'first_post' => __( 'This was my first post', 'jetpack-mu-wpcom' ),
+	);
+}
+
+/**
+ * Translated strings for the survey card.
+ *
+ * On a Coming Soon site publishing lands a private post, so the heading says
+ * "saved" rather than the untrue "live" — as the post-publish checklist does.
+ *
+ * @param bool $is_write_first Whether to return the write-first variant.
+ * @return array<string, string> Map of key -> translated string.
+ */
+function wpcom_write_get_survey_strings( $is_write_first ) {
+	$is_coming_soon = 1 === (int) get_option( 'wpcom_public_coming_soon' );
+
+	return array(
+		'heading'      => $is_coming_soon
+			? __( 'Your post is saved.', 'jetpack-mu-wpcom' )
+			: __( 'Your post is live.', 'jetpack-mu-wpcom' ),
+		'intro'        => __( 'One quick question?', 'jetpack-mu-wpcom' ),
+		'question'     => $is_write_first
+			? __( 'How was it?', 'jetpack-mu-wpcom' )
+			: __( "How did writing this compare to the WordPress.com editor you've used before?", 'jetpack-mu-wpcom' ),
+		'commentLabel' => $is_write_first
+			? __( 'What almost stopped you?', 'jetpack-mu-wpcom' )
+			: __( 'What worked, and what got in your way?', 'jetpack-mu-wpcom' ),
+		'commentHint'  => __( 'Optional', 'jetpack-mu-wpcom' ),
+		'send'         => __( 'Send', 'jetpack-mu-wpcom' ),
+		'skip'         => __( 'No thanks', 'jetpack-mu-wpcom' ),
+		'close'        => __( 'Close', 'jetpack-mu-wpcom' ),
+		'thanks'       => __( 'Thank you — this helps.', 'jetpack-mu-wpcom' ),
+	);
+}
+
+/**
+ * Enqueue the survey assets when it should render.
+ *
+ * @return void
+ */
+function wpcom_write_enqueue_post_publish_survey_assets() {
+	if ( ! wpcom_write_should_show_post_publish_survey() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'wpcom-write-post-publish-survey',
+		wpcom_write_asset_url( 'post-publish-survey.css' ),
+		array(),
+		WPCOM_WRITE_VERSION
+	);
+
+	wp_enqueue_script(
+		'wpcom-write-post-publish-survey',
+		wpcom_write_asset_url( 'post-publish-survey.js' ),
+		array(),
+		WPCOM_WRITE_VERSION,
+		true
+	);
+
+	$is_write_first = wpcom_write_is_write_first_site();
+
+	wp_localize_script(
+		'wpcom-write-post-publish-survey',
+		'wpcomWritePostPublishSurvey',
+		array(
+			'marker'     => WPCOM_WRITE_PUBLISHED_MARKER,
+			// admin-ajax because a Simple site serves no REST API at its own hostname.
+			'ajaxUrl'    => admin_url( 'admin-ajax.php' ),
+			'nonce'      => wp_create_nonce( WPCOM_WRITE_SURVEY_NONCE ),
+			// Shared with the stored response so the two halves can be rejoined.
+			'responseId' => wp_generate_uuid4(),
+			'variant'    => $is_write_first ? 'write_first' : 'returning',
+			'source'     => wpcom_write_survey_source(),
+			'maxLength'  => WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH,
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'wpcom_write_enqueue_post_publish_survey_assets' );
+
+/**
+ * Output the survey card markup in the footer.
+ *
+ * Plain markup wired up by post-publish-survey.js — no Interactivity API, since
+ * this renders on an arbitrary theme front-end, not the Write editor surface.
+ *
+ * @return void
+ */
+function wpcom_write_render_post_publish_survey() {
+	if ( ! wpcom_write_should_show_post_publish_survey() ) {
+		return;
+	}
+
+	$is_write_first = wpcom_write_is_write_first_site();
+	$strings        = wpcom_write_get_survey_strings( $is_write_first );
+	$answers        = wpcom_write_get_survey_answers( $is_write_first );
+
+	// Marked on render, not on submit: a writer who navigates away without
+	// answering has still had their turn.
+	update_user_meta( get_current_user_id(), WPCOM_WRITE_SURVEY_SHOWN_META, time() );
+	?>
+	<div class="wpcom-write-pps" role="dialog" aria-modal="true" aria-labelledby="wpcom-write-pps-question" hidden>
+		<div class="wpcom-write-pps__backdrop" data-wpcom-write-pps-dismiss></div>
+		<div class="wpcom-write-pps__card">
+			<button type="button" class="wpcom-write-pps__close" data-wpcom-write-pps-dismiss aria-label="<?php echo esc_attr( $strings['close'] ); ?>">&times;</button>
+			<p class="wpcom-write-pps__heading"><?php echo esc_html( $strings['heading'] ); ?> <span class="wpcom-write-pps__intro"><?php echo esc_html( $strings['intro'] ); ?></span></p>
+			<h2 id="wpcom-write-pps-question" class="wpcom-write-pps__question"><?php echo esc_html( $strings['question'] ); ?></h2>
+			<div class="wpcom-write-pps__answers">
+				<?php foreach ( $answers as $slug => $label ) : ?>
+					<button type="button" class="wpcom-write-pps__answer" data-wpcom-write-pps-answer="<?php echo esc_attr( $slug ); ?>"><?php echo esc_html( $label ); ?></button>
+				<?php endforeach; ?>
+			</div>
+			<div class="wpcom-write-pps__comment" hidden>
+				<label class="wpcom-write-pps__comment-label" for="wpcom-write-pps-comment">
+					<?php echo esc_html( $strings['commentLabel'] ); ?>
+					<span class="wpcom-write-pps__comment-hint"><?php echo esc_html( $strings['commentHint'] ); ?></span>
+				</label>
+				<textarea
+					id="wpcom-write-pps-comment"
+					class="wpcom-write-pps__comment-input"
+					rows="3"
+					maxlength="<?php echo esc_attr( (string) WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH ); ?>"
+				></textarea>
+				<button type="button" class="wpcom-write-pps__send" data-wpcom-write-pps-send><?php echo esc_html( $strings['send'] ); ?></button>
+			</div>
+			<button type="button" class="wpcom-write-pps__skip" data-wpcom-write-pps-dismiss><?php echo esc_html( $strings['skip'] ); ?></button>
+			<p class="wpcom-write-pps__thanks" role="status" aria-live="polite" hidden><?php echo esc_html( $strings['thanks'] ); ?></p>
+		</div>
+	</div>
+	<?php
+}
+add_action( 'wp_footer', 'wpcom_write_render_post_publish_survey' );
+
+/**
+ * Store a survey response in wpcom's central `marketing_survey_responses` table.
+ *
+ * Host-dependent transport, mirroring Common\wpcom_record_tracks_event(): Simple
+ * loads the lib in-process, Atomic has no `require_lib()` and goes out through the
+ * connection client. The endpoint is not site-specific, hence the `site_id` param.
+ *
+ * @param array $responses Map of question key to answer (preset slug or array with 'text').
+ * @return bool True when the response was handed to the store.
+ */
+function wpcom_write_store_survey_response( $responses ) {
+	$blog_id = get_current_blog_id();
+	$user_id = get_current_user_id();
+
+	if ( function_exists( 'require_lib' ) ) {
+		require_lib( 'marketing/survey' );
+
+		if ( class_exists( 'Marketing_Survey' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- wpcom-only lib loaded via require_lib(); stub to follow, see AGENTS.md.
+			$result = \Marketing_Survey::submit_survey( $blog_id, $user_id, WPCOM_WRITE_SURVEY_ID, $responses );
+
+			return ! empty( $result['success'] );
+		}
+	}
+
+	if ( ! class_exists( Client::class ) ) {
+		return false;
+	}
+
+	$response = Client::wpcom_json_api_request_as_user(
+		'/marketing/survey',
+		'v2',
+		array( 'method' => 'POST' ),
+		array(
+			'site_id'          => $blog_id,
+			'survey_id'        => WPCOM_WRITE_SURVEY_ID,
+			'survey_responses' => $responses,
+		),
+		'wpcom'
+	);
+
+	return ! is_wp_error( $response ) && 200 === wp_remote_retrieve_response_code( $response );
+}
+
+/**
+ * Build the response payload stored against the survey.
+ *
+ * Answers are stored as a preset slug, or array( 'text' => … ) for prose — the
+ * shape wpcom's response formatter reads. The trailing keys are metadata, stored
+ * alongside the answers the way calypso-remove-purchase stores its own.
+ *
+ * @param string $answer         Validated answer slug.
+ * @param string $comment        Optional free-text answer, already sanitized.
+ * @param string $response_id    Shared ID linking this row to its Tracks event.
+ * @param string $source         Entry point the writer came from.
+ * @param bool   $is_write_first Whether this is the write-first variant.
+ * @return array<string, mixed> Payload for Marketing_Survey::submit_survey().
+ */
+function wpcom_write_build_survey_response( $answer, $comment, $response_id, $source, $is_write_first ) {
+	$responses = array(
+		'experience' => $answer,
+		'variant'    => $is_write_first ? 'write_first' : 'returning',
+		'entryPoint' => $source,
+		'responseId' => $response_id,
+	);
+
+	$comment = mb_substr( $comment, 0, WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH );
+
+	if ( '' !== $comment ) {
+		$responses['comment'] = array( 'text' => $comment );
+	}
+
+	return $responses;
+}
+
+/**
+ * Handle a survey submission from the card.
+ *
+ * Logged-in only (`wp_ajax_`, not `wp_ajax_nopriv_`): the card only ever renders
+ * to an authenticated author.
+ *
+ * @return void
+ */
+function wpcom_write_ajax_submit_survey() {
+	check_ajax_referer( WPCOM_WRITE_SURVEY_NONCE, 'nonce' );
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		wp_send_json_error( array( 'reason' => 'forbidden' ), 403, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	}
+
+	$is_write_first = wpcom_write_is_write_first_site();
+	$valid_answers  = array_keys( wpcom_write_get_survey_answers( $is_write_first ) );
+	$answer         = isset( $_POST['answer'] ) ? sanitize_key( wp_unslash( $_POST['answer'] ) ) : '';
+
+	if ( ! in_array( $answer, $valid_answers, true ) ) {
+		wp_send_json_error( array( 'reason' => 'invalid_answer' ), 400, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	}
+
+	$comment     = isset( $_POST['comment'] ) ? sanitize_textarea_field( wp_unslash( $_POST['comment'] ) ) : '';
+	$response_id = isset( $_POST['response_id'] ) ? sanitize_text_field( wp_unslash( $_POST['response_id'] ) ) : '';
+	$source      = isset( $_POST['source'] ) ? sanitize_key( wp_unslash( $_POST['source'] ) ) : '';
+
+	$responses = wpcom_write_build_survey_response( $answer, $comment, $response_id, $source, $is_write_first );
+
+	if ( ! wpcom_write_store_survey_response( $responses ) ) {
+		wp_send_json_error( array( 'reason' => 'store_failed' ), 500, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	}
+
+	wp_send_json_success( null, 200, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+}
+add_action( 'wp_ajax_wpcom_write_submit_survey', 'wpcom_write_ajax_submit_survey' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6478,19 +6478,22 @@ async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 				// the user later presses Back.
 				document.documentElement.style.visibility = 'hidden';
 
-				// On a Coming Soon site the published post is still private. Tag
-				// the redirect so the post-publish next-steps checklist (launch +
-				// share) surfaces on the post the author lands on. Public sites
-				// redirect to the bare permalink, unchanged.
+				// Tag the redirect so the post-publish surfaces know the author has
+				// just published from Write: the next-steps checklist (launch +
+				// share) on a Coming Soon site, and the one-question survey on any
+				// site. Both gate themselves server-side on top of this marker.
+				// `source` rides along so survey responses can be segmented by the
+				// same entry point the funnel records at editor open.
 				let destination = post.link;
-				if ( state.isComingSoon ) {
-					try {
-						const url = new URL( post.link );
-						url.searchParams.set( state.publishedMarker || 'wpcom_write_published', '1' );
-						destination = url.href;
-					} catch {
-						// Fall back to the bare permalink if it can't be parsed.
+				try {
+					const url = new URL( post.link );
+					url.searchParams.set( state.publishedMarker || 'wpcom_write_published', '1' );
+					if ( state.source ) {
+						url.searchParams.set( 'source', state.source );
 					}
+					destination = url.href;
+				} catch {
+					// Fall back to the bare permalink if it can't be parsed.
 				}
 				window.location.href = destination;
 			}, 800 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	// Use file modification time to bust CDN caches when files change.
-	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ), filemtime( __DIR__ . '/undo-history.js' ), filemtime( __DIR__ . '/image-format.js' ), filemtime( __DIR__ . '/text-helpers.js' ), filemtime( __DIR__ . '/post-publish-checklist.js' ), filemtime( __DIR__ . '/post-publish-checklist.css' ) ) );
+	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ), filemtime( __DIR__ . '/undo-history.js' ), filemtime( __DIR__ . '/image-format.js' ), filemtime( __DIR__ . '/text-helpers.js' ), filemtime( __DIR__ . '/post-publish-checklist.js' ), filemtime( __DIR__ . '/post-publish-checklist.css' ), filemtime( __DIR__ . '/post-publish-survey.js' ), filemtime( __DIR__ . '/post-publish-survey.css' ) ) );
 }
 
 // Inline SVG icons used by the top bar and the formatting toolbar.
@@ -29,6 +29,9 @@ require_once __DIR__ . '/post-publish-checklist.php';
 
 // Email-verification launch gate backing the checklist's inline confirm-email step.
 require_once __DIR__ . '/email-verification.php';
+
+// One-question survey shown on the published post after a writer's first Write publish.
+require_once __DIR__ . '/post-publish-survey.php';
 
 /**
  * Get the URL for a Write feature asset file.
@@ -918,14 +921,14 @@ function wpcom_write_render_admin_page() {
 			'editPostId'             => $edit_post_id,
 			'postStatus'             => $post_status,
 			'isPublishedPost'        => 'publish' === $post_status,
-			// When the site is still Coming Soon (private by default), publishing
-			// lands a private post. The publish redirect tags the post URL so the
-			// post-publish next-steps checklist can surface there.
-			'isComingSoon'           => 1 === (int) get_option( 'wpcom_public_coming_soon' ),
 			// The query arg the redirect tags onto the post URL, kept in sync with
 			// the server-side gate by sharing WPCOM_WRITE_PUBLISHED_MARKER (defined
 			// in post-publish-checklist.php) rather than hardcoding it in view.js.
 			'publishedMarker'        => WPCOM_WRITE_PUBLISHED_MARKER,
+			// The entry point this editor session was opened from, forwarded onto
+			// the post-publish redirect so survey responses segment by the same
+			// `source` the funnel's wpcom_write_editor_open event records.
+			'source'                 => $source,
 			'title'                  => $edit_title,
 			'isSaving'               => false,
 			'isPublished'            => false,

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Checklist_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Checklist_Test.php
@@ -95,6 +95,58 @@ class Write_Post_Publish_Checklist_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Capture the footer output of the post-publish URL cleanup.
+	 *
+	 * @return string Printed markup.
+	 */
+	private function render_url_cleanup() {
+		ob_start();
+		wpcom_write_print_post_publish_url_cleanup();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * The publish marker and its `source` companion are stripped from the address
+	 * bar on load, so the author isn't left holding a URL they'd share as-is.
+	 */
+	public function test_url_cleanup_strips_both_publish_args() {
+		$this->go_to_singular_post();
+		$_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] = '1';
+
+		$markup = $this->render_url_cleanup();
+
+		$this->assertStringContainsString( WPCOM_WRITE_PUBLISHED_MARKER, $markup );
+		$this->assertStringContainsString( 'source', $markup );
+		$this->assertStringContainsString( 'replaceState', $markup );
+	}
+
+	/**
+	 * Cleanup must not depend on either card rendering. A writer who has already
+	 * answered the survey on a launched site sees no card at all, and that is
+	 * exactly the case where the args used to be left behind for good.
+	 */
+	public function test_url_cleanup_runs_when_no_card_will_render() {
+		wp_set_current_user( $this->subscriber_id );
+		update_option( 'wpcom_public_coming_soon', 0 );
+		$this->go_to_singular_post();
+		$_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] = '1';
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_checklist() );
+		$this->assertNotEmpty( $this->render_url_cleanup() );
+	}
+
+	/**
+	 * Without the marker nothing is printed, so a campaign link carrying its own
+	 * `source` to a post is left alone.
+	 */
+	public function test_url_cleanup_is_silent_without_the_marker() {
+		$this->go_to_singular_post();
+		$_GET['source'] = 'newsletter';
+
+		$this->assertSame( '', $this->render_url_cleanup() );
+	}
+
+	/**
 	 * The post-publish checklist should not show without the publish marker.
 	 */
 	public function test_post_publish_checklist_hidden_without_marker() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -389,6 +389,24 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	 * Every stored field is bounded, not just the free text: neither storage path
 	 * passes through the endpoint that enforces wpcom's response-size cap.
 	 */
+	/**
+	 * The stored row and the endpoint's capability check both key off `site_id`,
+	 * and Atomic's local blog ID is 1 — returning it would target the wrong blog.
+	 */
+	public function test_survey_blog_id_is_never_the_local_blog_id() {
+		$this->assertSame( 1, get_current_blog_id(), 'Fixture expects the local blog ID to be 1.' );
+		$this->assertSame( 0, wpcom_write_survey_blog_id() );
+	}
+
+	/**
+	 * Without a wpcom blog ID there is nothing safe to submit against, so the
+	 * response is dropped rather than filed under whatever ID happens to be handy.
+	 */
+	public function test_store_is_refused_without_a_wpcom_blog_id() {
+		$this->assertSame( 0, wpcom_write_survey_blog_id() );
+		$this->assertFalse( wpcom_write_store_survey_response( array( 'experience' => 'easier' ) ) );
+	}
+
 	public function test_response_payload_caps_the_entry_point() {
 		$payload = wpcom_write_build_survey_response( 'easier', '', '', str_repeat( 'a', 500 ), false );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -285,6 +285,48 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Free text is exported to CSV downstream, where a leading =, +, -, @, tab or
+	 * CR is evaluated as a formula. Each is neutralized before storage.
+	 */
+	public function test_response_payload_neutralizes_csv_formulas() {
+		foreach ( array( '=', '+', '-', '@', "\t", "\r" ) as $trigger ) {
+			$payload = wpcom_write_build_survey_response(
+				'easier',
+				$trigger . 'HYPERLINK("https://example.invalid")',
+				wp_generate_uuid4(),
+				'',
+				false
+			);
+
+			$this->assertSame(
+				"'" . $trigger . 'HYPERLINK("https://example.invalid")',
+				$payload['comment']['text'],
+				"Leading '{$trigger}' should be escaped."
+			);
+		}
+	}
+
+	/**
+	 * Ordinary prose is stored untouched — the escape must not tax every response.
+	 */
+	public function test_response_payload_leaves_ordinary_prose_alone() {
+		$prose   = 'The toolbar covered my text on mobile.';
+		$payload = wpcom_write_build_survey_response( 'harder', $prose, wp_generate_uuid4(), '', false );
+
+		$this->assertSame( $prose, $payload['comment']['text'] );
+	}
+
+	/**
+	 * A multi-byte opening character cannot collide with the ASCII triggers.
+	 */
+	public function test_response_payload_leaves_multibyte_prose_alone() {
+		$prose   = '— it was harder than the block editor';
+		$payload = wpcom_write_build_survey_response( 'harder', $prose, wp_generate_uuid4(), '', false );
+
+		$this->assertSame( $prose, $payload['comment']['text'] );
+	}
+
+	/**
 	 * An empty comment is omitted rather than stored as an empty answer.
 	 */
 	public function test_response_payload_omits_an_empty_comment() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Tests for the Write feature's post-publish one-question survey.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+// write.php provides the survey's helpers (wpcom_write_asset_url(),
+// WPCOM_WRITE_VERSION) and require_once's post-publish-survey.php, which is the
+// code under test here.
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/write/write.php';
+
+/**
+ * Exercises the post-publish survey: its visibility gate, question variants,
+ * rendered markup, stored response payload, and submission endpoint.
+ */
+class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user ID (cannot submit the survey).
+	 *
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->admin_id = wp_insert_user(
+			array(
+				'user_login' => 'pps_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'pps_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'pps_subscriber',
+				'user_pass'  => 'password',
+				'user_email' => 'pps_subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		delete_option( 'site_creation_flow' );
+		delete_option( 'wpcom_public_coming_soon' );
+		unset( $_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] );
+		unset( $_GET['source'] );
+		$_POST    = array();
+		$_REQUEST = array();
+		parent::tear_down();
+	}
+
+	/**
+	 * Simulate a front-end single-post request so is_singular( 'post' ) is true.
+	 *
+	 * @param string $post_type Post type to query for ('post' or 'page').
+	 * @return int The created post ID.
+	 */
+	private function go_to_singular_post( $post_type = 'post' ) {
+		global $wp_query, $post;
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test post',
+				'post_status' => 'publish',
+				'post_type'   => $post_type,
+			)
+		);
+
+		$post                        = get_post( $post_id );
+		$wp_query->is_singular       = true;
+		$wp_query->is_single         = 'post' === $post_type;
+		$wp_query->is_page           = 'page' === $post_type;
+		$wp_query->queried_object    = $post;
+		$wp_query->queried_object_id = $post_id;
+
+		return $post_id;
+	}
+
+	/**
+	 * Put the request into the state where the survey is eligible to render.
+	 */
+	private function make_survey_eligible() {
+		wp_set_current_user( $this->admin_id );
+		$this->go_to_singular_post();
+		$_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] = '1';
+	}
+
+	/**
+	 * The survey should not show without the publish marker.
+	 */
+	public function test_survey_hidden_without_marker() {
+		wp_set_current_user( $this->admin_id );
+		$this->go_to_singular_post();
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * The survey should not show to a user who could not submit it.
+	 */
+	public function test_survey_hidden_without_manage_options() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->go_to_singular_post();
+		$_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] = '1';
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * The survey should not show outside a single post view.
+	 */
+	public function test_survey_hidden_when_not_singular_post() {
+		wp_set_current_user( $this->admin_id );
+		$this->go_to_singular_post( 'page' );
+		$_GET[ WPCOM_WRITE_PUBLISHED_MARKER ] = '1';
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * The survey is once per user: a recorded impression closes the gate.
+	 */
+	public function test_survey_hidden_after_it_has_been_shown() {
+		$this->make_survey_eligible();
+		update_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SHOWN_META, time() );
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * The survey shows when marker + single post + capability all hold, on a
+	 * launched site as well as a Coming Soon one.
+	 */
+	public function test_survey_shown_when_eligible() {
+		$this->make_survey_eligible();
+		update_option( 'wpcom_public_coming_soon', 0 );
+
+		$this->assertTrue( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * Rendering records the impression, so the next publish doesn't ask again.
+	 */
+	public function test_render_marks_the_survey_as_shown() {
+		$this->make_survey_eligible();
+
+		ob_start();
+		wpcom_write_render_post_publish_survey();
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'wpcom-write-pps', $markup );
+		$this->assertNotEmpty( get_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SHOWN_META, true ) );
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * A site created by the write-first flow is detected from its creation flow.
+	 */
+	public function test_write_first_site_detected_from_site_creation_flow() {
+		update_option( 'site_creation_flow', 'write-on' );
+		$this->assertTrue( wpcom_write_is_write_first_site() );
+
+		update_option( 'site_creation_flow', 'onboarding' );
+		$this->assertFalse( wpcom_write_is_write_first_site() );
+	}
+
+	/**
+	 * Write-first writers get the "how was it" scale; everyone else gets the
+	 * comparison scale, which includes an escape hatch for a first-ever post.
+	 */
+	public function test_answer_options_differ_by_variant() {
+		$write_first = array_keys( wpcom_write_get_survey_answers( true ) );
+		$returning   = array_keys( wpcom_write_get_survey_answers( false ) );
+
+		$this->assertSame( array( 'easy', 'fine', 'frustrating' ), $write_first );
+		$this->assertSame( array( 'easier', 'about_same', 'harder', 'first_post' ), $returning );
+	}
+
+	/**
+	 * "Live" would be untrue on a Coming Soon site, where the post stays private.
+	 */
+	public function test_heading_does_not_claim_the_post_is_live_when_coming_soon() {
+		update_option( 'wpcom_public_coming_soon', 1 );
+		$coming_soon = wpcom_write_get_survey_strings( false );
+
+		update_option( 'wpcom_public_coming_soon', 0 );
+		$launched = wpcom_write_get_survey_strings( false );
+
+		$this->assertSame( 'Your post is saved.', $coming_soon['heading'] );
+		$this->assertSame( 'Your post is live.', $launched['heading'] );
+	}
+
+	/**
+	 * The rendered card offers exactly the current variant's answers.
+	 */
+	public function test_rendered_markup_offers_the_write_first_answers() {
+		$this->make_survey_eligible();
+		update_option( 'site_creation_flow', 'write-on' );
+
+		ob_start();
+		wpcom_write_render_post_publish_survey();
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-wpcom-write-pps-answer="easy"', $markup );
+		$this->assertStringContainsString( 'data-wpcom-write-pps-answer="frustrating"', $markup );
+		$this->assertStringNotContainsString( 'data-wpcom-write-pps-answer="about_same"', $markup );
+	}
+
+	/**
+	 * The entry point is read from the redirect and sanitized.
+	 */
+	public function test_survey_source_is_read_and_sanitized() {
+		$this->assertSame( '', wpcom_write_survey_source() );
+
+		$_GET['source'] = 'Posts_List!';
+		$this->assertSame( 'posts_list', wpcom_write_survey_source() );
+	}
+
+	/**
+	 * Prose is stored under 'text' so wpcom's formatter reads it as free text
+	 * rather than as a preset answer key, alongside the segmenting metadata.
+	 */
+	public function test_response_payload_stores_prose_under_text() {
+		$payload = wpcom_write_build_survey_response( 'harder', 'The toolbar hid my text.', 'abc-123', 'dashboard', false );
+
+		$this->assertSame( 'harder', $payload['experience'] );
+		$this->assertSame( array( 'text' => 'The toolbar hid my text.' ), $payload['comment'] );
+		$this->assertSame( 'returning', $payload['variant'] );
+		$this->assertSame( 'dashboard', $payload['entryPoint'] );
+		$this->assertSame( 'abc-123', $payload['responseId'] );
+	}
+
+	/**
+	 * An empty comment is omitted rather than stored as an empty answer.
+	 */
+	public function test_response_payload_omits_an_empty_comment() {
+		$payload = wpcom_write_build_survey_response( 'easy', '', 'abc-123', '', true );
+
+		$this->assertArrayNotHasKey( 'comment', $payload );
+		$this->assertSame( 'write_first', $payload['variant'] );
+	}
+
+	/**
+	 * We cap the free text ourselves: neither storage path passes through the
+	 * endpoint that would otherwise enforce a limit.
+	 */
+	public function test_response_payload_caps_long_free_text() {
+		$long    = str_repeat( 'a', WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH + 500 );
+		$payload = wpcom_write_build_survey_response( 'easier', $long, 'abc-123', '', false );
+
+		$this->assertSame(
+			WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH,
+			strlen( $payload['comment']['text'] )
+		);
+	}
+
+	/**
+	 * An answer outside the current variant's scale is rejected, so a stray or
+	 * forged submission can't write a slug nothing knows how to read.
+	 */
+	public function test_submission_rejects_an_answer_from_the_other_variant() {
+		$this->make_survey_eligible();
+		$this->set_valid_nonce();
+		$_POST['answer'] = 'frustrating'; // Write-first slug on a non-write-first site.
+
+		$response = $this->capture_ajax_json( 'wpcom_write_ajax_submit_survey' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'invalid_answer', $response['data']['reason'] );
+	}
+
+	/**
+	 * A valid answer passes validation and reaches the store. No wpcom survey
+	 * library exists under test, so the store reports failure — which is what
+	 * distinguishes "validated and attempted" from "rejected at the door".
+	 */
+	public function test_submission_accepts_a_valid_answer_and_reaches_the_store() {
+		$this->make_survey_eligible();
+		$this->set_valid_nonce();
+		$_POST['answer'] = 'easier';
+
+		$response = $this->capture_ajax_json( 'wpcom_write_ajax_submit_survey' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'store_failed', $response['data']['reason'] );
+	}
+
+	/**
+	 * Prime a valid nonce for the survey submission.
+	 *
+	 * Note that check_ajax_referer() reads $_REQUEST, which PHP does not
+	 * repopulate from a test's $_POST writes, so both have to be set.
+	 */
+	private function set_valid_nonce() {
+		$nonce             = wp_create_nonce( WPCOM_WRITE_SURVEY_NONCE );
+		$_REQUEST['nonce'] = $nonce;
+		$_POST['nonce']    = $nonce;
+	}
+
+	/**
+	 * Invoke an ajax handler and return its JSON envelope as an array.
+	 *
+	 * WordPress's wp_send_json_* echoes the response then calls wp_die(); force the
+	 * ajax path and throw from the die handler so we can capture the buffered JSON
+	 * without ending the test process.
+	 *
+	 * @param callable $handler Ajax handler to invoke.
+	 * @return array<string, mixed> Decoded response.
+	 */
+	private function capture_ajax_json( $handler ) {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter(
+			'wp_die_ajax_handler',
+			function () {
+				// Throw so wp_send_json_*'s wp_die() unwinds back to the test rather
+				// than ending the process. A `never` return type would break PHP <8.1.
+				// @phan-suppress-next-line PhanPluginNeverReturnFunction
+				return function () {
+					throw new \Exception( 'wp_die' );
+				};
+			}
+		);
+
+		ob_start();
+		try {
+			$handler();
+		} catch ( \Exception $e ) {
+			unset( $e ); // wp_die() from wp_send_json_*; expected.
+		}
+		$output = ob_get_clean();
+
+		remove_all_filters( 'wp_doing_ajax' );
+		remove_all_filters( 'wp_die_ajax_handler' );
+
+		return json_decode( $output, true );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -351,6 +351,26 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The cap counts characters, not bytes.
+	 *
+	 * An ASCII fixture cannot tell the two apart, so it would not notice the cap
+	 * becoming byte-based. That failure is silent and nasty: substr() can cut a
+	 * character in half, and wp_json_encode() returns false on the resulting
+	 * invalid UTF-8 — so the Atomic storage path would send an empty body and
+	 * drop the response with nothing logged.
+	 */
+	public function test_response_payload_caps_multibyte_free_text_by_character() {
+		$long    = str_repeat( 'é', WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH + 100 );
+		$payload = wpcom_write_build_survey_response( 'easier', $long, wp_generate_uuid4(), '', false );
+
+		$this->assertSame(
+			WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH,
+			mb_strlen( $payload['comment']['text'] )
+		);
+		$this->assertTrue( mb_check_encoding( $payload['comment']['text'], 'UTF-8' ) );
+	}
+
+	/**
 	 * A forged response ID is discarded rather than stored. It is only ever a
 	 * uuid4 we minted at render, and it round-trips through the client.
 	 */

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -161,9 +161,12 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Rendering records the impression, so the next publish doesn't ask again.
+	 * Rendering must NOT record the impression. On a Coming Soon site the card
+	 * renders behind the post-publish checklist, whose launch CTA navigates away
+	 * without dismissing — so those writers would burn their one showing on a
+	 * card they never saw.
 	 */
-	public function test_render_marks_the_survey_as_shown() {
+	public function test_render_does_not_mark_the_survey_as_shown() {
 		$this->make_survey_eligible();
 
 		ob_start();
@@ -171,8 +174,36 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 		$markup = ob_get_clean();
 
 		$this->assertStringContainsString( 'wpcom-write-pps', $markup );
+		$this->assertEmpty( get_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SHOWN_META, true ) );
+		$this->assertTrue( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * Revealing the card is what closes the gate, so it appears exactly once.
+	 */
+	public function test_reveal_marks_the_survey_as_shown() {
+		$this->make_survey_eligible();
+		$this->set_valid_nonce();
+
+		$response = $this->capture_ajax_json( 'wpcom_write_ajax_mark_survey_shown' );
+
+		$this->assertTrue( $response['success'] );
 		$this->assertNotEmpty( get_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SHOWN_META, true ) );
 		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * A viewer who could not submit the survey cannot close their gate either.
+	 */
+	public function test_reveal_mark_rejects_a_user_without_manage_options() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->set_valid_nonce();
+
+		$response = $this->capture_ajax_json( 'wpcom_write_ajax_mark_survey_shown' );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'forbidden', $response['data']['reason'] );
+		$this->assertEmpty( get_user_meta( $this->subscriber_id, WPCOM_WRITE_SURVEY_SHOWN_META, true ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -280,8 +280,8 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'harder', $payload['experience'] );
 		$this->assertSame( array( 'text' => 'The toolbar hid my text.' ), $payload['comment'] );
 		$this->assertSame( 'returning', $payload['variant'] );
-		$this->assertSame( 'dashboard', $payload['entryPoint'] );
-		$this->assertSame( $uuid, $payload['responseId'] );
+		$this->assertSame( 'dashboard', $payload['entry_point'] );
+		$this->assertSame( $uuid, $payload['response_id'] );
 	}
 
 	/**
@@ -377,12 +377,12 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	public function test_response_payload_discards_a_non_uuid_response_id() {
 		$payload = wpcom_write_build_survey_response( 'easier', '', 'not-a-uuid', '', false );
 
-		$this->assertSame( '', $payload['responseId'] );
+		$this->assertSame( '', $payload['response_id'] );
 
 		$uuid    = wp_generate_uuid4();
 		$payload = wpcom_write_build_survey_response( 'easier', '', $uuid, '', false );
 
-		$this->assertSame( $uuid, $payload['responseId'] );
+		$this->assertSame( $uuid, $payload['response_id'] );
 	}
 
 	/**
@@ -394,7 +394,7 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertSame(
 			WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH,
-			strlen( $payload['entryPoint'] )
+			strlen( $payload['entry_point'] )
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -397,6 +397,41 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * A stored response closes the gate even if the shown-ping never landed.
+	 * That ping is fire-and-forget, so it is not the authoritative record.
+	 */
+	public function test_survey_hidden_after_a_response_was_stored() {
+		$this->make_survey_eligible();
+		update_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SUBMITTED_META, time() );
+
+		$this->assertFalse( wpcom_write_should_show_post_publish_survey() );
+	}
+
+	/**
+	 * A replayed submission is refused before it reaches the store. Nonces are
+	 * valid for their full lifetime and are not single-use, so the once-per-user
+	 * rule has to bind on the write path, not only on the render path.
+	 *
+	 * The 409-vs-500 distinction is the assertion: 500 is the store being
+	 * unavailable under test, which proves the request got that far, while 409
+	 * proves it short-circuited first.
+	 */
+	public function test_submission_is_refused_once_a_response_is_stored() {
+		$this->make_survey_eligible();
+		$this->set_valid_nonce();
+		$_POST['answer'] = 'easier';
+
+		$first = $this->capture_ajax_json( 'wpcom_write_ajax_submit_survey' );
+		$this->assertSame( 'store_failed', $first['data']['reason'] );
+
+		update_user_meta( $this->admin_id, WPCOM_WRITE_SURVEY_SUBMITTED_META, time() );
+
+		$second = $this->capture_ajax_json( 'wpcom_write_ajax_submit_survey' );
+		$this->assertFalse( $second['success'] );
+		$this->assertSame( 'already_submitted', $second['data']['reason'] );
+	}
+
+	/**
 	 * Invoke an ajax handler and return its JSON envelope as an array.
 	 *
 	 * WordPress's wp_send_json_* echoes the response then calls wp_die(); force the

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Post_Publish_Survey_Test.php
@@ -274,20 +274,21 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	 * rather than as a preset answer key, alongside the segmenting metadata.
 	 */
 	public function test_response_payload_stores_prose_under_text() {
-		$payload = wpcom_write_build_survey_response( 'harder', 'The toolbar hid my text.', 'abc-123', 'dashboard', false );
+		$uuid    = wp_generate_uuid4();
+		$payload = wpcom_write_build_survey_response( 'harder', 'The toolbar hid my text.', $uuid, 'dashboard', false );
 
 		$this->assertSame( 'harder', $payload['experience'] );
 		$this->assertSame( array( 'text' => 'The toolbar hid my text.' ), $payload['comment'] );
 		$this->assertSame( 'returning', $payload['variant'] );
 		$this->assertSame( 'dashboard', $payload['entryPoint'] );
-		$this->assertSame( 'abc-123', $payload['responseId'] );
+		$this->assertSame( $uuid, $payload['responseId'] );
 	}
 
 	/**
 	 * An empty comment is omitted rather than stored as an empty answer.
 	 */
 	public function test_response_payload_omits_an_empty_comment() {
-		$payload = wpcom_write_build_survey_response( 'easy', '', 'abc-123', '', true );
+		$payload = wpcom_write_build_survey_response( 'easy', '', wp_generate_uuid4(), '', true );
 
 		$this->assertArrayNotHasKey( 'comment', $payload );
 		$this->assertSame( 'write_first', $payload['variant'] );
@@ -299,11 +300,56 @@ class Write_Post_Publish_Survey_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_response_payload_caps_long_free_text() {
 		$long    = str_repeat( 'a', WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH + 500 );
-		$payload = wpcom_write_build_survey_response( 'easier', $long, 'abc-123', '', false );
+		$payload = wpcom_write_build_survey_response( 'easier', $long, wp_generate_uuid4(), '', false );
 
 		$this->assertSame(
 			WPCOM_WRITE_SURVEY_MAX_COMMENT_LENGTH,
 			strlen( $payload['comment']['text'] )
+		);
+	}
+
+	/**
+	 * A forged response ID is discarded rather than stored. It is only ever a
+	 * uuid4 we minted at render, and it round-trips through the client.
+	 */
+	public function test_response_payload_discards_a_non_uuid_response_id() {
+		$payload = wpcom_write_build_survey_response( 'easier', '', 'not-a-uuid', '', false );
+
+		$this->assertSame( '', $payload['responseId'] );
+
+		$uuid    = wp_generate_uuid4();
+		$payload = wpcom_write_build_survey_response( 'easier', '', $uuid, '', false );
+
+		$this->assertSame( $uuid, $payload['responseId'] );
+	}
+
+	/**
+	 * Every stored field is bounded, not just the free text: neither storage path
+	 * passes through the endpoint that enforces wpcom's response-size cap.
+	 */
+	public function test_response_payload_caps_the_entry_point() {
+		$payload = wpcom_write_build_survey_response( 'easier', '', '', str_repeat( 'a', 500 ), false );
+
+		$this->assertSame(
+			WPCOM_WRITE_SURVEY_MAX_SOURCE_LENGTH,
+			strlen( $payload['entryPoint'] )
+		);
+	}
+
+	/**
+	 * The single-select state is exposed from first render, not only after a
+	 * choice — otherwise the buttons change role mid-interaction.
+	 */
+	public function test_answer_buttons_expose_their_pressed_state_initially() {
+		$this->make_survey_eligible();
+
+		ob_start();
+		wpcom_write_render_post_publish_survey();
+		$markup = ob_get_clean();
+
+		$this->assertSame(
+			count( wpcom_write_get_survey_answers( false ) ),
+			substr_count( $markup, 'aria-pressed="false"' )
 		);
 	}
 

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-write-first-publish-survey
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-write-first-publish-survey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Ask writers one question about their experience after their first post, with an optional comment.

--- a/projects/plugins/wpcomsh/changelog/add-write-first-publish-survey
+++ b/projects/plugins/wpcomsh/changelog/add-write-first-publish-survey
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write: Ask writers one question about their experience after their first post, with an optional comment.


### PR DESCRIPTION
Fixes CM-892

## Proposed changes

* Add a one-question survey to the Write editor's post-publish flow. It renders on the published post the editor redirects to, once per user, and is skippable. Choosing an answer records it immediately — there is no submit button — and opens an optional free-text box.
* Two question variants. Writers whose site was created by the write-first signup flow (`site_creation_flow` is `write-on`) have no earlier WordPress.com editor to compare against, so they are asked "How was it?" rather than for a comparison.
* The heading follows the post's actual visibility: on a Coming Soon site publishing lands a private post, so it says "Your post is saved." rather than the untrue "live", matching what the existing post-publish checklist does.
* On a Coming Soon site the post-publish checklist owns that screen first. The survey waits for it to be dismissed rather than stacking on top of it. On a launched site there is no checklist and the card appears straight away.
* The publish redirect now always tags the permalink with `wpcom_write_published` (previously Coming Soon only, for the checklist) and carries the editor's `source` along, so responses can be segmented by the entry point the writer came from.
* Storage is host-dependent, mirroring `Common\wpcom_record_tracks_event()`: `require_lib( 'marketing/survey' )` in-process on Simple, and the `wpcom/v2/marketing/survey` endpoint via the connection client on Atomic. Free text is capped and sanitized at our own call site, since neither path passes through the endpoint that would otherwise cap it.

Mobile-first: most Write publishers are on a phone, so the card is a bottom sheet below 480px with 44px tap targets, and the comment box uses a 16px font so iOS doesn't zoom the viewport on focus.

<img width="390" height="844" alt="writeon-mobile-answered" src="https://github.com/user-attachments/assets/7e202094-6dd9-454f-a170-6e3535333c53" />
<img width="756" height="544" alt="Screenshot 2026-08-31 at 2 24 14 PM" src="https://github.com/user-attachments/assets/818e940a-3fb1-4b9a-91e5-690260ba5d0f" />


## Related product discussion/links

* CM-892

## Does this pull request change what data or activity we track or use?

**Yes — please treat this as needing a privacy review.**

New Tracks events on the published post. All are fired client-side except `…_store_failed`, which the ajax handler records server-side — the browser only learns of a failed store once its request resolves, by which point the writer has often already left, so a client-side event under-reports exactly the case it exists to measure.

| Event | Properties |
| --- | --- |
| `wpcom_write_first_publish_survey_shown` | `variant`, `entry_point`, `response_id`, `blog_id` |
| `wpcom_write_first_publish_survey_response` | `answer`, `variant`, `entry_point`, `response_id`, `blog_id` |
| `wpcom_write_first_publish_survey_comment_sent` | `response_id`, `blog_id` |
| `wpcom_write_first_publish_survey_dismissed` | `answered`, `blog_id` |
| `wpcom_write_first_publish_survey_store_failed` | `reason`, `response_id`, `blog_id`, plus `entry_point` and `variant` on the server-side path |

`blog_id` is the site's WordPress.com blog ID. It travels as an event property because Tracks
populates no `blogid` column for Atomic front-end events — the same gap the existing
`wpcom_write_post_publish_checklist_*` events have. It identifies the site, not the writer, and is
already present on the stored survey row.

**No free text is sent to Tracks.** Only the chosen option travels there. The optional comment goes solely to the central `marketing_survey_responses` store under the new survey ID `write-first-publish`, alongside the choice and the same `response_id` so the two can be rejoined. That table is where existing cancellation and feedback survey prose already lives.

The free-text field is user-authored, so it can contain anything the writer types. It is capped at 2000 characters and passed through `sanitize_textarea_field()` before storage. Text opening with `=`, `+`, `-`, `@`, tab or CR is additionally apostrophe-prefixed, because the stored responses are exported to CSV downstream and those characters are evaluated as formulas by spreadsheet apps — so a stored comment can differ from what was typed by that one leading character. Ordinary prose is untouched. Two new user meta keys hold timestamps so the card is offered and accepted only once: `_wpcom_write_first_publish_survey_shown` when it is displayed, and `_wpcom_write_first_publish_survey_submitted` when a response is stored.

Two admin-ajax actions back the card, both logged-in only (`wp_ajax_`, no `nopriv_`), nonce-guarded, and requiring `manage_options` — which the wpcom survey endpoint requires of the submitter regardless. `wpcom_write_submit_survey` stores the response; `wpcom_write_survey_shown` only sets the user meta above, and collects nothing.

## Testing instructions

Requires a Simple or Atomic site to exercise storage end to end.

* Make sure the Write editor is available, then go to `/wp-admin/admin.php?page=write&source=dashboard`.
* Write a post and publish it.
* Confirm the redirect lands on the post with both `wpcom_write_published=1` and `source=dashboard` on the URL.
* **Coming Soon site** (`wp option update wpcom_public_coming_soon 1`): the next-steps checklist appears first and the survey stays hidden behind it. Dismiss the checklist — the survey should then appear, with focus moving to the card, and the heading should read "Your post is saved."
* **Launched site** (`wp option update wpcom_public_coming_soon 0`): no checklist, the survey appears immediately, and the heading reads "Your post is live."
* **Write-first variant** (`wp option update site_creation_flow write-on`): the question becomes "How was it?" with Easy / Fine / Frustrating, and the comment prompt becomes "What almost stopped you?"
* Choose an answer: it should highlight, the optional comment box should open, and focus should move into it.
* Reload the same URL with the marker still on it — the card should not come back, and its assets should not be enqueued. To test again: `wp user meta delete <id> _wpcom_write_first_publish_survey_shown`.
* On a Coming Soon site, click "Launch your site" on the checklist instead of dismissing it. That navigates away without ever revealing the survey, so the impression must be preserved: come back to the post with the marker and the card should still be offered. The showing is only spent once the card is actually revealed.
* Check keyboard behaviour: Tab should stay trapped in the dialog, and Escape should close it (flushing any chosen answer first).

You do not need to publish repeatedly to iterate on the card — appending `?wpcom_write_published=1&source=dashboard` to any of your own published posts re-triggers it, provided the user meta above is cleared.

### Follow-up (not in this PR)

The survey card re-implements the post-publish checklist's focus trap, dismiss, and event helpers rather than sharing them, so the two overlays now carry near-identical copies of the same a11y code. Worth extracting into a small shared script both enqueues depend on — deliberately left out here to keep this diff off working checklist code. Deferring it is also why the query-arg cleanup moved to the footer in this PR: that logic was duplicated across both cards and wrong in both.




