### PR TITLE
SEO: don't resolve the plan catalog to decide whether the SEO menu exists

### DIFF
--- a/projects/packages/plans/changelog/seo-skip-billing-catalog
+++ b/projects/packages/plans/changelog/seo-skip-billing-catalog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow callers that only need a Simple site's active features to skip building the upgradeable list.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.4",
+		"automattic/jetpack-constants": "@dev",
 		"automattic/jetpack-connection": "@dev"
 	},
 	"require-dev": {

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -437,10 +437,20 @@ class Current_Plan {
 	 *
 	 * See Jetpack_Gutenberg::get_site_specific_features()
 	 *
+	 * @param bool $include_available Whether to include the features the site could
+	 *                                upgrade to, alongside the ones it has. Building
+	 *                                that list walks the plan catalog in the current
+	 *                                user's currency, which is by far the expensive
+	 *                                half of this call — pass false when only the
+	 *                                site's active features matter.
 	 * @return array
 	 */
-	public static function get_simple_site_specific_features() {
-		$is_simple_site = defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' );
+	public static function get_simple_site_specific_features( $include_available = true ) {
+		// Through Constants rather than `defined()`/`constant()` directly, matching
+		// `Host::is_wpcom_simple()` and the rest of this class. Identical in production
+		// — Constants falls through to the real constant — and it makes the branch
+		// reachable from a test.
+		$is_simple_site = Constants::is_true( 'IS_WPCOM' );
 
 		if ( ! $is_simple_site ) {
 			return array(
@@ -450,19 +460,24 @@ class Current_Plan {
 		}
 
 		$current_blog_id = get_current_blog_id();
+		$cache_key       = $include_available ? 'full' : 'active_only';
 
-		// Return the cached value if it exists.
-		if ( isset( self::$simple_site_specific_features[ $current_blog_id ] ) ) {
-			return self::$simple_site_specific_features[ $current_blog_id ];
+		// Return the cached value if it exists. A full result answers an active-only
+		// request too, so that one is reused rather than recomputed.
+		if ( isset( self::$simple_site_specific_features[ $current_blog_id ][ $cache_key ] ) ) {
+			return self::$simple_site_specific_features[ $current_blog_id ][ $cache_key ];
+		}
+		if ( ! $include_available && isset( self::$simple_site_specific_features[ $current_blog_id ]['full'] ) ) {
+			return self::$simple_site_specific_features[ $current_blog_id ]['full'];
 		}
 
 		if ( ! class_exists( '\Store_Product_List' ) ) {
 			require WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/store-product-list.php';
 		}
 
-		$simple_site_specific_features = \Store_Product_List::get_site_specific_features_data( $current_blog_id );
+		$simple_site_specific_features = \Store_Product_List::get_site_specific_features_data( $current_blog_id, $include_available );
 
-		self::$simple_site_specific_features[ $current_blog_id ] = $simple_site_specific_features;
+		self::$simple_site_specific_features[ $current_blog_id ][ $cache_key ] = $simple_site_specific_features;
 
 		return $simple_site_specific_features;
 	}

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -43,6 +43,71 @@ class Jetpack_Plan_Test extends TestCase {
 	}
 
 	/**
+	 * Empty the per-request memo of Simple-site features, so each assertion below
+	 * measures a fresh lookup rather than a cached one.
+	 */
+	private function reset_simple_features_cache() {
+		$property = new \ReflectionProperty( Jetpack_Plan::class, 'simple_site_specific_features' );
+		// Required to write a private static on PHP < 8.1 (a no-op from 8.1 on).
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, array() );
+		\Store_Product_List::$calls = array();
+	}
+
+	/**
+	 * Building the upgradeable-features list walks the plan catalog in the current
+	 * user's currency; the active list reads blog stickers and costs nothing like it.
+	 * A caller that only needs to know what the site *has* can skip the expensive half,
+	 * and this is what lets it.
+	 */
+	public function test_simple_site_features_can_skip_the_upgradeable_list() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$this->reset_simple_features_cache();
+		$full = Jetpack_Plan::get_simple_site_specific_features();
+		$this->assertSame( array( true ), \Store_Product_List::$calls, 'Precondition: the default asks for the upgradeable list.' );
+		$this->assertArrayHasKey( 'available', $full );
+
+		$this->reset_simple_features_cache();
+		$active_only = Jetpack_Plan::get_simple_site_specific_features( false );
+
+		$this->assertSame( array( false ), \Store_Product_List::$calls, 'The upgradeable list must not be requested.' );
+		$this->assertArrayHasKey( 'active', $active_only );
+		$this->assertArrayNotHasKey( 'available', $active_only );
+	}
+
+	/**
+	 * A full result already contains the active features, so an active-only request
+	 * after one reuses it rather than paying for a second lookup.
+	 */
+	public function test_an_active_only_request_reuses_a_full_result() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->reset_simple_features_cache();
+
+		Jetpack_Plan::get_simple_site_specific_features();
+		Jetpack_Plan::get_simple_site_specific_features( false );
+
+		$this->assertSame( array( true ), \Store_Product_List::$calls, 'The second call should be served from the first.' );
+	}
+
+	/**
+	 * ...but the reverse doesn't hold: an active-only result can't answer a request
+	 * for the upgradeable list, so that one still does its own lookup.
+	 */
+	public function test_a_full_request_is_not_answered_by_an_active_only_result() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->reset_simple_features_cache();
+
+		Jetpack_Plan::get_simple_site_specific_features( false );
+		$full = Jetpack_Plan::get_simple_site_specific_features();
+
+		$this->assertSame( array( false, true ), \Store_Product_List::$calls );
+		$this->assertArrayHasKey( 'available', $full );
+	}
+
+	/**
 	 * A refresh reads WordPress.com directly, so the shared site record cache can still hold an
 	 * older record. A cached read stores the plan again, so leaving that copy in place would
 	 * revert the plan this fetch just stored — the case a plan purchase hits.

--- a/projects/packages/plans/tests/php/bootstrap.php
+++ b/projects/packages/plans/tests/php/bootstrap.php
@@ -14,3 +14,5 @@ define( 'WP_DEBUG', true );
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
+
+require_once __DIR__ . '/stubs/class-store-product-list.php';

--- a/projects/packages/plans/tests/php/stubs/class-store-product-list.php
+++ b/projects/packages/plans/tests/php/stubs/class-store-product-list.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Stand-in for the wpcom billing class `Current_Plan::get_simple_site_specific_features()`
+ * reads Simple-site features from. Defined here so the real one is never required — it
+ * lives in the wpcom repo, not this one — and so a test can see which shape was asked for.
+ *
+ * @package automattic/jetpack-plans
+ */
+class Store_Product_List {
+
+	/**
+	 * One entry per call, recording the `$include_available` argument it was given.
+	 *
+	 * @var bool[]
+	 */
+	public static $calls = array();
+
+	/**
+	 * Record the call and answer in the requested shape.
+	 *
+	 * @param int  $blog_id           Blog ID (unused).
+	 * @param bool $include_available Whether the upgradeable list was asked for.
+	 * @return array
+	 */
+	public static function get_site_specific_features_data( $blog_id = 0, $include_available = true ) {
+		self::$calls[] = $include_available;
+
+		$data = array( 'active' => array( 'seo-admin-ui' ) );
+		if ( $include_available ) {
+			$data['available'] = array( 'some-upgrade' );
+		}
+
+		return $data;
+	}
+}

--- a/projects/packages/seo/changelog/seo-skip-billing-catalog
+++ b/projects/packages/seo/changelog/seo-skip-billing-catalog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop resolving the WordPress.com plan catalog on every request when checking whether the SEO surface is available.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -267,8 +267,12 @@ class Initializer {
 			return true;
 		}
 
+		// `false`: only the site's active features decide this. Asking for the
+		// upgradeable ones too would walk the plan catalog in the current user's
+		// currency on every request this runs on, including the front end, to answer
+		// a question about a menu item.
 		$features = ( new Host() )->is_wpcom_simple()
-			? Current_Plan::get_simple_site_specific_features()
+			? Current_Plan::get_simple_site_specific_features( false )
 			: Current_Plan::get()['features'];
 
 		return in_array( self::FEATURE_SLUG, $features['active'] ?? array(), true );

--- a/projects/plugins/backup/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/backup/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1480,10 +1480,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/boost/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/boost/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1397,10 +1397,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/jetpack/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/jetpack/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2741,10 +2741,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1711,10 +1711,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -678,10 +678,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/protect/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1459,10 +1459,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/search/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/search/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1337,10 +1337,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/social/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1460,10 +1460,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/starter-plugin/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/starter-plugin/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1261,10 +1261,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/stats/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/stats/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -1261,10 +1261,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/videopress/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/videopress/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1337,10 +1337,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "649c6960275b22fd20aa60ca647e6727d13054b4"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/wpcomsh/changelog/fix-seo-skip-billing-catalog-on-availability-check
+++ b/projects/plugins/wpcomsh/changelog/fix-seo-skip-billing-catalog-on-availability-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1827,10 +1827,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "558843aaf5371dd08a6a7cf26a3a8fa8b1da03a9"
+                "reference": "f90f66f893218c816b16467191a8f9d201d6b9eb"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {


### PR DESCRIPTION
Related to 234793-gh-Automattic/wpcom

## Proposed changes

`Initializer::is_available()` reads the site's **active** features. On WordPress.com Simple that goes through `Current_Plan::get_simple_site_specific_features()`, which asked `Store_Product_List` for the full payload — including the **"available for upgrade"** list.

That upgradeable list is the expensive half: it resolves the current user's currency and walks the plan catalog for it. The active half is blog stickers and cheap checks. **Nothing in the SEO package ever reads `available`.**

* `get_simple_site_specific_features()` takes an `$include_available` flag, defaulting to today's behavior so Publicize's script data — the only other caller — is untouched.
* Results are memoized per shape, and a full result answers an active-only request rather than recomputing.
* SEO's availability check passes `false`.

## Why this matters now

The wpcom Simple loader (234793-gh-Automattic/wpcom) calls `Initializer::init()` on **every** Simple request, front end included. Each one was pulling the billing catalog in to answer a question about whether an admin menu item should exist.

It also looks like what breaks the billing suites on that PR: **741 failures**, all in shoppingcart / marketplace / subscriptions / upgrades, nearly all `No latest sellable plan for Product:218, JPY year 1`. That is a currency-keyed plan lookup — exactly what this path resolves — and `get_available_features_for_blog()` caches its result under a key of `blog_id` + store table that **does not include the currency**. Resolving it early, under whatever user is current at `plugins_loaded`, is enough to poison it for everything after.

I have not reproduced that in isolation, so treat the causal claim as strong-but-unproven. The change stands on its own either way: this is not work a front-end request should be doing.

## The `IS_WPCOM` check

Also switches that method from `defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' )` to `Constants::is_true( 'IS_WPCOM' )`, matching `Host::is_wpcom_simple()` and the rest of the class. Identical in production — Constants falls through to the real constant — and it is what makes the branch reachable from a test; without it the new tests cannot enter the method at all.

`automattic/jetpack-constants` is now declared in `composer.json` rather than relied on transitively (per AGENTS.md), with dependent lock files regenerated by `tools/fixup-project-versions.sh`.

**Version skew note:** the new argument is optional, and PHP ignores extra arguments to a user-defined function, so a plugin bundling an older `jetpack-plans` degrades to today's behavior rather than fatalling.

## Testing instructions

* `jp test php packages/plans` — 16 tests. Three are new: the flag skips the upgradeable lookup, a full result is reused for an active-only request, and an active-only result is *not* reused for a full one.
* `jp test php packages/seo` and `jp test js packages/seo` — unchanged, 188 and 284 green.

**Tested:** the above, plus mutation-verification of the new behavior — ignoring the flag, and collapsing the two cache slots into one, each fail a test. PHPCS clean.

**Not tested:** the wpcom-side effect. Whether this actually clears the 741 billing failures can only be seen once it reaches wpcom and #234793 re-runs. That is the real confirmation, and it is still outstanding.

## Does this pull request change what data or activity we track or use?

No.

