### PR TITLE
test-environment: Avoid sqlite database locking issues

### DIFF
--- a/projects/packages/test-environment/changelog/fix-test-sqlite-locking-issues
+++ b/projects/packages/test-environment/changelog/fix-test-sqlite-locking-issues
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Use separate sqlite databases for each test to avoid locking issues.

--- a/projects/packages/test-environment/src/class-test-environment.php
+++ b/projects/packages/test-environment/src/class-test-environment.php
@@ -71,9 +71,10 @@ class Test_Environment {
 	/**
 	 * Remove a directory, recursively.
 	 *
+	 * @private
 	 * @param string $dir Directory to remove.
 	 */
-	private static function rmrf( $dir ) {
+	public static function rmrf( $dir ) {
 		if ( ! file_exists( $dir ) ) {
 			return;
 		}

--- a/projects/packages/test-environment/src/class-test-environment.php
+++ b/projects/packages/test-environment/src/class-test-environment.php
@@ -48,6 +48,59 @@ class Test_Environment {
 	}
 
 	/**
+	 * Create a temporary directory.
+	 *
+	 * @param string $prefix Directory name prefix. The created directory will be under `sys_get_temp_dir()` with a random suffix added to this prefix.
+	 * @return string Created path.
+	 * @throws \RuntimeException On failure to create any directory.
+	 */
+	private static function make_temp_dir( $prefix ) {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rand_rand -- Not security sensitive, and `wp_rand` isn't loaded yet.
+		$mask = rand( 0, 0xffffff );
+		for ( $i = 0; $i < 0xffffff; $i++ ) {
+			$tmpdir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $prefix . sprintf( '%06x', $i ^ $mask );
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_mkdir -- WP isn't loaded yet, and we're handling errors here.
+			if ( @mkdir( $tmpdir, 0700 ) ) {
+				return $tmpdir;
+			}
+		}
+
+		throw new \RuntimeException( 'Failed to create temporary directory' );
+	}
+
+	/**
+	 * Remove a directory, recursively.
+	 *
+	 * @param string $dir Directory to remove.
+	 */
+	private static function rmrf( $dir ) {
+		if ( ! file_exists( $dir ) ) {
+			return;
+		}
+		if ( ! is_dir( $dir ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- WP isn't loaded yet.
+			unlink( $dir );
+			return;
+		}
+
+		$iter = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS ),
+			\RecursiveIteratorIterator::CHILD_FIRST
+		);
+		foreach ( $iter as $path ) {
+			if ( is_dir( $path ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- WP isn't loaded yet.
+				rmdir( $path );
+			} else {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- WP isn't loaded yet.
+				unlink( $path );
+			}
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- WP isn't loaded yet.
+		rmdir( $dir );
+	}
+
+	/**
 	 * Initialize the shared WordPress test environment.
 	 *
 	 * This ensures we only load WordPress once across all packages.
@@ -65,6 +118,8 @@ class Test_Environment {
 		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 		require_once self::find_autoloader();
 
+		$tmpdir = null;
+
 		try {
 			if ( ! class_exists( '\WorDBless\Load' ) ) {
 				throw new \RuntimeException( 'WorDBless not found. Please ensure automattic/wordbless is installed in tools/php-test-env/composer.json' );
@@ -75,8 +130,25 @@ class Test_Environment {
 				define( 'dbless_UPLOADS', 'uploads-' . $package_slug ); // phpcs:ignore Generic.NamingConventions.UpperCaseConstantName.ConstantNotUpperCase
 			}
 
-			\WorDBless\Load::load( $db_engine, true ); // persist the database across tests so with sqlite tests concurrency is possible without accidental deletions.
+			// If using sqlite, point FQDBDIR at a unique directory so concurrent runs don't interfere with each other (sqlite does poorly with multiple writers).
+			$persist = false;
+			if ( $db_engine === 'sqlite' ) {
+				$tmpdir = self::make_temp_dir( 'test-sqlite-' . ( $package_slug ?? 'null' ) . '-' );
+				define( 'FQDBDIR', "$tmpdir/" );
+				$persist = true;
+			}
+
+			\WorDBless\Load::load( $db_engine, $persist );
+
+			// WorDBless's normal cleanup won't handle cleanup when the above is redefined.
+			// Note this must be registered after `WorDBless\Load::load()` registers the exit handler for `shutdown_action_hook`.
+			if ( $db_engine === 'sqlite' ) {
+				register_shutdown_function( array( self::class, 'rmrf' ), $tmpdir );
+			}
 		} catch ( \Exception $e ) {
+			if ( $tmpdir ) {
+				self::rmrf( $tmpdir );
+			}
 			throw new \RuntimeException( 'Failed to initialize WordPress test environment: ' . $e->getMessage() );
 		}
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
sqlite isn't very good about multiple writing processes accessing the same database. Avoid the problem by defining `FQDBDIR` in our wrapper to point each test process at its own temporary directory.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1788199599144879/1788199542.299309-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* In separate console windows, try running `jetpack test -v php packages/seo` and `jetpack test -v php packages/cookie-consent` at the same time. Without this PR, likely one or both will fail with an error about the database being locked.