### PR TITLE
VideoPress: welcome modal's Upload button opens the file picker

### DIFF
--- a/projects/packages/videopress/changelog/vidp-378-make-upload-video-button-open-file-selector
+++ b/projects/packages/videopress/changelog/vidp-378-make-upload-video-button-open-file-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Open the file picker directly from the welcome modal's Upload a video button, then land on the Library to follow the upload's progress.

--- a/projects/packages/videopress/changelog/vidp-378-welcome-param-vs-dismissal
+++ b/projects/packages/videopress/changelog/vidp-378-welcome-param-vs-dismissal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Make the welcome=1 review parameter reopen the welcome modal after it has been dismissed.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -24,9 +24,8 @@ import { usePersistedView } from '../../src/dashboard/hooks/use-persisted-view';
 import { useSetPrivacy } from '../../src/dashboard/hooks/use-set-privacy';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
-import { useVideoPressUpgrade } from '../../src/dashboard/hooks/use-videopress-upgrade';
+import { useUploadIntake } from '../../src/dashboard/hooks/use-upload-intake';
 import { createPromoteLocal } from './promote-local';
-import { planVideoDrop } from './upload-drop';
 import { classifyUploadFailure } from './upload-failure';
 import './style.scss';
 import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
@@ -108,7 +107,7 @@ const StageInner = () => {
 		error: libraryError,
 		refetch,
 	} = useLibrary( view );
-	const { uploadQueue, startUpload, retryUpload } = useUpload();
+	const { uploadQueue, retryUpload } = useUpload();
 	// Read the store's existing errors so a failed row can name the cause; the
 	// notice this dashboard already renders carries the diagnosis and the
 	// reconnect button, so the row only has to point at it.
@@ -117,8 +116,7 @@ const StageInner = () => {
 	const { mutateAsync: deleteVideo } = useDeleteVideo();
 	const { mutateAsync: setPrivacyAsync } = useSetPrivacy();
 	const { mutateAsync: uploadFromLibrary } = useUploadFromLibrary();
-	const { isAtLimit, isFree, isUnlimited, videoCount, limit } = useFreeTier();
-	const runUpgrade = useVideoPressUpgrade();
+	const { isAtLimit, isFree, isUnlimited } = useFreeTier();
 
 	const onChangeView = useCallback(
 		( next: View ) => {
@@ -156,49 +154,11 @@ const StageInner = () => {
 
 	const { createSuccessNotice, createErrorNotice, createInfoNotice } = useGlobalNotices();
 
-	// Shared multi-file entry point for both the DropZone and the header
-	// "Upload video" file picker. Enforces the free-tier cap up front so
-	// neither path can sneak past the limit the picker button guards.
-	const handleFilesSelected = useCallback(
-		( files: File[] ) => {
-			const decision = planVideoDrop( files, {
-				isFree,
-				isUnlimited,
-				limit,
-				videoCount,
-			} );
-
-			if ( decision.kind === 'no-videos' ) {
-				createErrorNotice( __( 'Only video files can be uploaded.', 'jetpack-videopress-pkg' ) );
-				return;
-			}
-
-			if ( decision.kind === 'at-limit' ) {
-				createErrorNotice( FREE_TIER_AT_LIMIT_MESSAGE, {
-					actions: [ { label: __( 'Upgrade', 'jetpack-videopress-pkg' ), onClick: runUpgrade } ],
-				} );
-				return;
-			}
-
-			decision.toUpload.forEach( file => startUpload( file ) );
-
-			if ( decision.skipped > 0 ) {
-				createErrorNotice(
-					sprintf(
-						/* translators: %d: number of videos that could not be uploaded because the plan limit was reached. */
-						_n(
-							'%d video wasn’t uploaded because it exceeds your plan’s limit.',
-							'%d videos weren’t uploaded because they exceed your plan’s limit.',
-							decision.skipped,
-							'jetpack-videopress-pkg'
-						),
-						decision.skipped
-					)
-				);
-			}
-		},
-		[ isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice, runUpgrade ]
-	);
+	// Shared multi-file entry point for the DropZone, the header "Upload
+	// video" file picker, and (via the same hook) the welcome modal's CTA.
+	// Enforces the free-tier cap up front so no path can sneak past the limit
+	// the picker button guards.
+	const handleFilesSelected = useUploadIntake();
 
 	const onFilePicked = useCallback(
 		( event: ChangeEvent< HTMLInputElement > ) => {

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
@@ -12,11 +12,14 @@ import {
 	hasSeenOnboarding,
 	saveDismissal,
 } from '../../hooks/use-first-run-state';
+import { useFreeTier } from '../../hooks/use-free-tier';
 import { useOnboardingCounts } from '../../hooks/use-onboarding-counts';
 import { useUpload } from '../../hooks/use-upload';
+import { useUploadIntake } from '../../hooks/use-upload-intake';
+import { videoFileAccept } from '../upload-dropzone/video-files';
 import IntroVideo, { INTRO_VIDEO_ASPECT, getAssetUrl } from './intro-video';
 import './style.scss';
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { ChangeEvent, CSSProperties, ReactElement, ReactNode } from 'react';
 
 const LEARN_MORE_URL = 'https://jetpack.com/videopress/';
 
@@ -230,9 +233,12 @@ export default function OnboardingModal(): ReactElement | null {
 	// Observer instance, like `useFreeTier`'s: the queue lives in a shared
 	// window-scoped store, so reading it here starts nothing and owns nothing.
 	const { uploadQueue } = useUpload();
+	const intakeFiles = useUploadIntake();
+	const { isFree, isUnlimited } = useFreeTier();
 	const navigate = useNavigate();
 	const search = useSearch( { strict: false } ) as Record< string, unknown >;
 	const popupRef = useRef< HTMLDivElement >( null );
+	const filePickerRef = useRef< HTMLInputElement >( null );
 	// Resolved per render, like the film's own URL: the boot payload is a
 	// global, so reading it at module scope would bake in whatever existed when
 	// this bundle was imported.
@@ -305,19 +311,37 @@ export default function OnboardingModal(): ReactElement | null {
 		setIsDismissed( true );
 	}, [] );
 
-	// The primary CTA lands on the Library, whose empty state is the upload
-	// flow: on a true first run this is a no-op hop to the dropzone already
-	// showing. On a site whose media library holds only local videos the
-	// Library lists them instead, with its header Upload button and page-wide
-	// dropzone one gesture away.
-	const goToUpload = useCallback( () => {
-		dismiss();
-		navigate( { href: '/' } );
-	}, [ dismiss, navigate ] );
+	// The primary CTA opens the OS file picker directly — the same gesture as
+	// the Library header's "Upload video" button — rather than parking the
+	// user in front of another upload affordance. The modal stays up until a
+	// selection is actually made, so cancelling the picker costs nothing.
+	const openFilePicker = useCallback( () => {
+		filePickerRef.current?.click();
+	}, [] );
+
+	// A selection ends the first run either way: the files go through the
+	// same intake pipeline as the Library's own picker and DropZone (plan
+	// gating, notices, queueing), and the user lands on the Library, where
+	// the queued rows carry the live upload progress. A refused selection
+	// lands there too — the refusal notice must be read over the Library,
+	// not under this modal.
+	const onFilesPicked = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			const files = Array.from( event.target.files ?? [] );
+			event.target.value = '';
+			if ( files.length === 0 ) {
+				return;
+			}
+			intakeFiles( files );
+			dismiss();
+			navigate( { href: '/' } );
+		},
+		[ intakeFiles, dismiss, navigate ]
+	);
 
 	// Lands on the Library pre-filtered to local videos, where the existing
 	// bulk "Upload to VideoPress" action does the actual moving. The user
-	// picks what migrates — the modal never starts uploads on its own, and it
+	// picks what migrates — this path never starts uploads on its own, and it
 	// stays out of plan-limit logic (the library actions own that).
 	const goToLocalLibrary = useCallback( () => {
 		dismiss();
@@ -461,7 +485,18 @@ export default function OnboardingModal(): ReactElement | null {
 					 * default for a primary action is brand tone, so this
 					 * divergence is deliberate and owned by the spec.
 					 */ }
-					<Button variant="solid" tone="neutral" onClick={ goToUpload }>
+					<input
+						ref={ filePickerRef }
+						type="file"
+						accept={ videoFileAccept() }
+						// The capped free tier can only ever host `limit` videos, so
+						// multi-select there would only produce skipped-file notices;
+						// paid and grandfathered-unlimited plans get bulk selection.
+						multiple={ ! isFree || isUnlimited }
+						style={ { display: 'none' } }
+						onChange={ onFilesPicked }
+					/>
+					<Button variant="solid" tone="neutral" onClick={ openFilePicker }>
 						{ __( 'Upload a video', 'jetpack-videopress-pkg' ) }
 					</Button>
 				</Dialog.Footer>

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
@@ -130,6 +130,15 @@ function consumeWelcomeParam( inRouterSearch: boolean ): boolean {
 	scope[ WELCOME_CONSUMED_FLAG ] = true;
 	scope[ WELCOME_ACTIVE_FLAG ] = true;
 
+	// The stored dismissal is forgotten HERE, synchronously with consumption,
+	// not in the consuming mount's effect. The replaceState below wakes the
+	// router mid-render, and when the resulting transition discards the
+	// consuming mount, its effects never run — so an effect-based clear was
+	// skipped on exactly the load that needed it most: a reviewer who had
+	// dismissed the modal before got `consumed` without the clear, and
+	// welcome=1 opened nothing.
+	clearDismissal();
+
 	if ( params.has( 'welcome' ) ) {
 		params.delete( 'welcome' );
 		const query = params.toString();
@@ -255,9 +264,11 @@ export default function OnboardingModal(): ReactElement | null {
 	const [ isPreview ] = useState( () => consumeWelcomeParam( search?.welcome === '1' ) );
 	const [ isWelcomeSession ] = useState( isWelcomeLoad );
 
+	// The stored flag was already cleared at consume time (see
+	// consumeWelcomeParam); this only fixes up the in-memory copy, which the
+	// initializer above read before consumption ran.
 	useEffect( () => {
 		if ( isPreview ) {
-			clearDismissal();
 			setIsDismissed( false );
 		}
 	}, [ isPreview ] );

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/index.test.tsx
@@ -283,6 +283,41 @@ describe( 'OnboardingModal', () => {
 		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 	} );
 
+	it( 'clears the stored dismissal even when the consuming mount is discarded', () => {
+		// consumeWelcomeParam's replaceState wakes the router during the very
+		// render that consumes the param, and the resulting transition can
+		// discard that mount before its effects run. A throwing sibling AFTER
+		// the modal reproduces the discard: the modal's initializers run
+		// (consuming the param), the commit never happens, no effect fires.
+		// The remount must still find the dismissal cleared — an effect-based
+		// clear was skipped here, and welcome=1 opened nothing for exactly the
+		// reviewer who had dismissed the modal before.
+		mockCounts( { videoPressCount: 4, localCount: 0, isSettled: true } );
+		window.localStorage.setItem( 'jetpack-videopress-onboarding-seen-123-7', '1' );
+		window.history.replaceState( {}, '', '/wp-admin/admin.php?page=jetpack-videopress&welcome=1' );
+
+		const Discarded = () => {
+			throw new Error( 'discard the consuming render' );
+		};
+		// React reports the deliberate render error via console.error; keep
+		// the test output clean.
+		const errorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		expect( () =>
+			render(
+				<>
+					<OnboardingModal />
+					<Discarded />
+				</>
+			)
+		).toThrow( 'discard the consuming render' );
+		errorSpy.mockRestore();
+
+		render( <OnboardingModal /> );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( window.localStorage.getItem( 'jetpack-videopress-onboarding-seen-123-7' ) ).toBeNull();
+	} );
+
 	it( 'strips welcome=1 from the URL so a manual reload behaves normally', () => {
 		mockCounts( { videoPressCount: 4, localCount: 0, isSettled: true } );
 		window.history.replaceState( {}, '', '/wp-admin/admin.php?page=jetpack-videopress&welcome=1' );

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/index.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { markFirstPublish } from '../../../hooks/use-first-run-state';
 import { useOnboardingCounts } from '../../../hooks/use-onboarding-counts';
@@ -6,6 +6,26 @@ import OnboardingModal from '../index';
 
 jest.mock( '../../../hooks/use-onboarding-counts', () => ( {
 	useOnboardingCounts: jest.fn(),
+} ) );
+
+// The intake pipeline is the Library's own and tested with its hook; the
+// modal only feeds it files. The real hook would stand up a resumable
+// uploader and free-tier queries nothing here needs.
+const mockIntakeFiles = jest.fn( (): number => 1 );
+jest.mock( '../../../hooks/use-upload-intake', () => ( {
+	useUploadIntake: () => mockIntakeFiles,
+} ) );
+
+// Free-tier facts only size the picker's `multiple` here — the intake hook
+// above owns the actual plan enforcement.
+jest.mock( '../../../hooks/use-free-tier', () => ( {
+	useFreeTier: () => ( {
+		isFree: true,
+		isUnlimited: false,
+		isAtLimit: false,
+		videoCount: 0,
+		limit: 1,
+	} ),
 } ) );
 
 // The modal only OBSERVES the shared queue (the `useFreeTier` pattern); the
@@ -58,6 +78,21 @@ const mockCounts = ( counts: {
 	( useOnboardingCounts as jest.Mock ).mockReturnValue( counts );
 };
 
+/**
+ * The hidden file input behind the primary CTA. It is presentation-free
+ * plumbing with no role or accessible name, rendered through the dialog's
+ * portal, so it is looked up in the document.
+ *
+ * @return The file input element.
+ */
+function getFilePicker(): HTMLInputElement {
+	// eslint-disable-next-line testing-library/no-node-access -- the picker is a hidden input with no role or accessible name; no query reaches it.
+	const input = document.querySelector< HTMLInputElement >( 'input[type="file"]' );
+	expect( input ).not.toBeNull();
+
+	return input as HTMLInputElement;
+}
+
 const WELCOME_FLAG = '__jetpackVideoPressWelcomeConsumed';
 const WELCOME_ACTIVE_FLAG = '__jetpackVideoPressWelcomeActive';
 const UPLOAD_STARTED_FLAG = '__jetpackVideoPressUploadStarted';
@@ -72,6 +107,7 @@ describe( 'OnboardingModal', () => {
 	beforeEach( () => {
 		window.localStorage.clear();
 		mockNavigate.mockClear();
+		mockIntakeFiles.mockClear();
 		mockUploadQueue = [];
 		mockSearch = {};
 		// Every latch here is window-scoped (they have to outlive the per-route
@@ -120,17 +156,66 @@ describe( 'OnboardingModal', () => {
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'sends the primary CTA to the Library, whose empty state is the upload flow', async () => {
-		// With the widened gate the modal can open over Library or Home, so
-		// the primary must navigate rather than merely reveal what's beneath.
+	it( 'opens the file picker from the primary CTA without closing the modal', async () => {
+		// The CTA is the Library header button's gesture, not a navigation:
+		// nothing moves or closes until the picker actually yields files, so
+		// cancelling the OS dialog costs the user nothing.
 		mockCounts( { videoPressCount: 0, localCount: 3, isSettled: true } );
 		const user = userEvent.setup();
 
 		render( <OnboardingModal /> );
+		const pickerClick = jest.spyOn( getFilePicker(), 'click' );
 		await user.click( screen.getByRole( 'button', { name: 'Upload a video' } ) );
+
+		expect( pickerClick ).toHaveBeenCalled();
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+	} );
+
+	it( 'queues a picked file through the shared intake and lands on the Library', async () => {
+		mockCounts( { videoPressCount: 0, localCount: 0, isSettled: true } );
+		const user = userEvent.setup();
+
+		render( <OnboardingModal /> );
+		const file = new File( [ 'x' ], 'clip.mp4', { type: 'video/mp4' } );
+		await user.upload( getFilePicker(), file );
+
+		expect( mockIntakeFiles ).toHaveBeenCalledWith( [ file ] );
+		expect( mockNavigate ).toHaveBeenCalledWith( { href: '/' } );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still dismisses and navigates when the intake refuses the selection', async () => {
+		// The refusal notice renders over the Library, and reading it there
+		// beats leaving it hidden underneath this modal.
+		mockCounts( { videoPressCount: 0, localCount: 0, isSettled: true } );
+		mockIntakeFiles.mockReturnValueOnce( 0 );
+		// `applyAccept: false`: the picker's `accept` intentionally excludes
+		// this file — reaching the intake anyway is what a misbehaving OS
+		// dialog does, and what this case is about.
+		const user = userEvent.setup( { applyAccept: false } );
+
+		render( <OnboardingModal /> );
+		const file = new File( [ 'x' ], 'not-a-video.pdf', { type: 'application/pdf' } );
+		await user.upload( getFilePicker(), file );
 
 		expect( mockNavigate ).toHaveBeenCalledWith( { href: '/' } );
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stays open when the picker yields no files', () => {
+		// A cancelled OS dialog fires no change at all in most browsers, but
+		// an empty `change` is cheap to survive — `userEvent.upload` cannot
+		// deliver one, so the raw event is dispatched here.
+		mockCounts( { videoPressCount: 0, localCount: 0, isSettled: true } );
+
+		render( <OnboardingModal /> );
+		// eslint-disable-next-line testing-library/prefer-user-event -- userEvent.upload cannot simulate an empty selection.
+		fireEvent.change( getFilePicker(), { target: { files: [] } } );
+
+		expect( mockIntakeFiles ).not.toHaveBeenCalled();
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
 	} );
 
 	it( 'stays closed once any VideoPress video exists', () => {

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/missing-theme-provider.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/missing-theme-provider.test.tsx
@@ -21,6 +21,22 @@ jest.mock( '../../../hooks/use-upload', () => ( {
 	useUpload: () => ( { uploadQueue: [] } ),
 } ) );
 
+// The primary CTA's upload intake and picker sizing stand on react-query
+// hooks; this render provides no QueryClient, and none of that is under test.
+jest.mock( '../../../hooks/use-upload-intake', () => ( {
+	useUploadIntake: () => jest.fn( () => 0 ),
+} ) );
+
+jest.mock( '../../../hooks/use-free-tier', () => ( {
+	useFreeTier: () => ( {
+		isFree: true,
+		isUnlimited: false,
+		isAtLimit: false,
+		videoCount: 0,
+		limit: 1,
+	} ),
+} ) );
+
 jest.mock( '@wordpress/route', () => ( {
 	useNavigate: () => jest.fn(),
 	useSearch: () => ( {} ),

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-intake.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-intake.test.ts
@@ -1,0 +1,92 @@
+import { renderHook } from '@testing-library/react';
+import { FREE_TIER_AT_LIMIT_MESSAGE } from '../../components/free-tier-notice';
+import {
+	INVALID_FILE_NOTICE_ID,
+	NOT_A_VIDEO_MESSAGE,
+} from '../../components/upload-dropzone/video-files';
+import { useUploadIntake } from '../use-upload-intake';
+import type { FreeTierState } from '../use-free-tier';
+
+const mockStartUpload = jest.fn();
+jest.mock( '../use-upload', () => ( {
+	useUpload: () => ( { uploadQueue: [], startUpload: mockStartUpload } ),
+} ) );
+
+let mockFreeTier: FreeTierState;
+jest.mock( '../use-free-tier', () => ( {
+	useFreeTier: () => mockFreeTier,
+} ) );
+
+const mockRunUpgrade = jest.fn();
+jest.mock( '../use-videopress-upgrade', () => ( {
+	useVideoPressUpgrade: () => mockRunUpgrade,
+} ) );
+
+const mockCreateErrorNotice = jest.fn();
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( { createErrorNotice: mockCreateErrorNotice } ),
+} ) );
+
+const video = ( name: string ): File => new File( [ 'x' ], name, { type: 'video/mp4' } );
+
+const intake = () => renderHook( () => useUploadIntake() ).result.current;
+
+describe( 'useUploadIntake', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockFreeTier = {
+			isFree: false,
+			isAtomic: false,
+			isUnlimited: false,
+			videoCount: 0,
+			limit: 1,
+			isAtLimit: false,
+		};
+	} );
+
+	it( 'starts an upload per accepted file and reports the count', () => {
+		const files = [ video( 'a.mp4' ), video( 'b.mp4' ) ];
+
+		expect( intake()( files ) ).toBe( 2 );
+
+		expect( mockStartUpload ).toHaveBeenCalledTimes( 2 );
+		expect( mockStartUpload ).toHaveBeenNthCalledWith( 1, files[ 0 ] );
+		expect( mockStartUpload ).toHaveBeenNthCalledWith( 2, files[ 1 ] );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'refuses a selection with no videos in it', () => {
+		const files = [ new File( [ 'x' ], 'doc.pdf', { type: 'application/pdf' } ) ];
+
+		expect( intake()( files ) ).toBe( 0 );
+
+		expect( mockStartUpload ).not.toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith( NOT_A_VIDEO_MESSAGE, {
+			id: INVALID_FILE_NOTICE_ID,
+		} );
+	} );
+
+	it( 'refuses everything at the free-tier limit, offering the upgrade', () => {
+		mockFreeTier = { ...mockFreeTier, isFree: true, videoCount: 1, isAtLimit: true };
+
+		expect( intake()( [ video( 'a.mp4' ) ] ) ).toBe( 0 );
+
+		expect( mockStartUpload ).not.toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith( FREE_TIER_AT_LIMIT_MESSAGE, {
+			actions: [ { label: 'Upgrade', onClick: mockRunUpgrade } ],
+		} );
+	} );
+
+	it( 'uploads up to the free-tier allowance and surfaces the skipped rest', () => {
+		mockFreeTier = { ...mockFreeTier, isFree: true };
+		const files = [ video( 'a.mp4' ), video( 'b.mp4' ), video( 'c.mp4' ) ];
+
+		expect( intake()( files ) ).toBe( 1 );
+
+		expect( mockStartUpload ).toHaveBeenCalledTimes( 1 );
+		expect( mockStartUpload ).toHaveBeenCalledWith( files[ 0 ] );
+		expect( mockCreateErrorNotice ).toHaveBeenCalledWith(
+			'2 videos weren’t uploaded because they exceed your plan’s limit.'
+		);
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-intake.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-intake.ts
@@ -1,0 +1,73 @@
+import { useGlobalNotices } from '@automattic/jetpack-components/global-notices';
+import { useCallback } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { FREE_TIER_AT_LIMIT_MESSAGE } from '../components/free-tier-notice';
+import {
+	INVALID_FILE_NOTICE_ID,
+	NOT_A_VIDEO_MESSAGE,
+} from '../components/upload-dropzone/video-files';
+import { planVideoDrop } from '../utils/upload-drop';
+import { useFreeTier } from './use-free-tier';
+import { useUpload } from './use-upload';
+import { useVideoPressUpgrade } from './use-videopress-upgrade';
+
+/**
+ * The shared multi-file upload entry point behind every "give me your files"
+ * surface — the Library's DropZone, its header "Upload video" picker, and the
+ * welcome modal's primary CTA. Enforces the free-tier cap up front so no
+ * surface can sneak past the limit, and raises the same notices from all of
+ * them.
+ *
+ * @return A callback that plans and starts uploads for a picked or dropped
+ * file set, returning how many uploads it actually started — 0 when the whole
+ * selection was refused (with the refusal already surfaced as a notice).
+ */
+export function useUploadIntake(): ( files: File[] ) => number {
+	const { isFree, isUnlimited, limit, videoCount } = useFreeTier();
+	const { startUpload } = useUpload();
+	const { createErrorNotice } = useGlobalNotices();
+	const runUpgrade = useVideoPressUpgrade();
+
+	return useCallback(
+		( files: File[] ): number => {
+			const decision = planVideoDrop( files, {
+				isFree,
+				isUnlimited,
+				limit,
+				videoCount,
+			} );
+
+			if ( decision.kind === 'no-videos' ) {
+				createErrorNotice( NOT_A_VIDEO_MESSAGE, { id: INVALID_FILE_NOTICE_ID } );
+				return 0;
+			}
+
+			if ( decision.kind === 'at-limit' ) {
+				createErrorNotice( FREE_TIER_AT_LIMIT_MESSAGE, {
+					actions: [ { label: __( 'Upgrade', 'jetpack-videopress-pkg' ), onClick: runUpgrade } ],
+				} );
+				return 0;
+			}
+
+			decision.toUpload.forEach( file => startUpload( file ) );
+
+			if ( decision.skipped > 0 ) {
+				createErrorNotice(
+					sprintf(
+						/* translators: %d: number of videos that could not be uploaded because the plan limit was reached. */
+						_n(
+							'%d video wasn’t uploaded because it exceeds your plan’s limit.',
+							'%d videos weren’t uploaded because they exceed your plan’s limit.',
+							decision.skipped,
+							'jetpack-videopress-pkg'
+						),
+						decision.skipped
+					)
+				);
+			}
+
+			return decision.toUpload.length;
+		},
+		[ isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice, runUpgrade ]
+	);
+}

--- a/projects/packages/videopress/src/dashboard/utils/test/upload-drop.test.ts
+++ b/projects/packages/videopress/src/dashboard/utils/test/upload-drop.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for the drag-and-drop upload decision logic powering the
- * VideoPress Library DropZone (see routes/library/stage.tsx).
+ * Unit tests for the upload decision logic powering the shared upload intake
+ * (see hooks/use-upload-intake.ts and routes/library/stage.tsx).
  */
 
 import { filterVideoFiles, planVideoDrop } from '../upload-drop';

--- a/projects/packages/videopress/src/dashboard/utils/upload-drop.ts
+++ b/projects/packages/videopress/src/dashboard/utils/upload-drop.ts
@@ -1,4 +1,4 @@
-import type { FreeTierState } from '../../src/dashboard/hooks/use-free-tier';
+import type { FreeTierState } from '../hooks/use-free-tier';
 
 // Fallback accepted-upload extensions, used only when the server-provided
 // allow-list is absent (unit tests, or a render before the initial state is

--- a/projects/plugins/jetpack/changelog/vidp-378-make-upload-video-button-open-file-selector
+++ b/projects/plugins/jetpack/changelog/vidp-378-make-upload-video-button-open-file-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: Open the file picker directly from the dashboard welcome modal's Upload a video button, then land on the Library to follow the upload's progress.

--- a/projects/plugins/jetpack/changelog/vidp-378-subscriptions-controls-test-timeout
+++ b/projects/plugins/jetpack/changelog/vidp-378-subscriptions-controls-test-timeout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Raise the subscriptions block controls test timeout so coverage-instrumented CI runs don't fail on timing; test-only change
+
+

--- a/projects/plugins/jetpack/changelog/vidp-378-welcome-param-vs-dismissal
+++ b/projects/plugins/jetpack/changelog/vidp-378-welcome-param-vs-dismissal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Make the welcome=1 review parameter reopen the dashboard welcome modal after it has been dismissed.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/controls.jsx
@@ -4,6 +4,12 @@ import { addFilter, removeFilter } from '@wordpress/hooks';
 import { DEFAULT_FONTSIZE_VALUE } from '../constants';
 import SubscriptionsInspectorControls from '../controls';
 
+// The popover interactions here can exceed jest's 5s default under coverage
+// instrumentation on a loaded CI runner. A mid-interaction timeout also leaks
+// pending Tabs state updates into the NEXT test, failing it on an act()
+// console.error — so one slow test read as two unrelated failures.
+jest.setTimeout( 30_000 );
+
 // These settings need to be set. Easiest way to do that seems to be to use a hook.
 const overrideSettings = {
 	'typography.customFontSize': true,

--- a/projects/plugins/videopress/changelog/vidp-378-make-upload-video-button-open-file-selector
+++ b/projects/plugins/videopress/changelog/vidp-378-make-upload-video-button-open-file-selector
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Open the file picker directly from the welcome modal's Upload a video button, then land on the Library to follow the upload's progress.

--- a/projects/plugins/videopress/changelog/vidp-378-welcome-param-vs-dismissal
+++ b/projects/plugins/videopress/changelog/vidp-378-welcome-param-vs-dismissal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Make the welcome=1 review parameter reopen the welcome modal after it has been dismissed.


### PR DESCRIPTION
Fixes VIDP-378

## Proposed changes

* The VideoPress dashboard welcome modal's **"Upload a video"** button now opens the OS file picker directly — the same gesture as the Library header's "Upload video" button — instead of only navigating to the Library and leaving the user in front of another upload affordance.
* Once files are picked, they run through the same intake pipeline as the Library's own picker and DropZone (free-tier gating, refusal/skipped notices, upload queue), the modal dismisses, and the user lands on the Library tab where the queued rows show live upload progress. Cancelling the OS dialog leaves the modal open.
* The modal's hidden picker uses the shared `videoFileAccept()` allow-list (dotted extensions the backend actually accepts) and honors the capped free tier's single-file rule for `multiple`.
* Refactor: the Library stage's `handleFilesSelected` pipeline is extracted into a shared `useUploadIntake` hook so the two surfaces can't drift, and the pure `upload-drop.ts` planning module moves from `routes/library/` into `src/dashboard/utils/` so shared code doesn't import from a route bundle. The Library's behavior is unchanged, except its "not a video" notice now carries the shared stable notice id (so repeated refusals replace rather than stack).

## Related product discussion/links

* [VIDP-378](https://linear.app/a8c/issue/VIDP-378/make-upload-video-button-open-file-selector)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the package: `jp build packages/videopress --deps` (or watch), on a site with the Jetpack (or VideoPress) plugin connected.
2. Go to **Jetpack → VideoPress** and append `&welcome=1` to the URL (`wp-admin/admin.php?page=jetpack-videopress&welcome=1`) to force the welcome modal open.
3. Click **"Upload a video"**:
   * The OS file picker should open immediately; the modal stays open behind it.
   * Cancel the picker — the modal should remain open, nothing navigates.
4. Click **"Upload a video"** again and pick a real video file (`.mp4`/`.mov`):
   * The modal closes and you land on the **Library** tab.
   * The picked video appears as an in-flight row with live upload progress, then becomes a normal library row when the upload finishes.
5. Regression-check the Library's own upload paths (header "Upload video" button, page-wide drag-and-drop, empty-state dropzone) — they share the extracted hook and should behave exactly as before, including the free-tier at-limit notice and the "Only video files can be uploaded." refusal.
6. On a **free plan** site, the modal's picker should only allow selecting a single file; picking more than the plan allows via drag-select still uploads only the first and raises the skipped-file notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uQVG457PPZ7CQ2ydFs7tA
