### PR TITLE
wpcomsh: read a store row in whichever shape it arrives

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-site-purchase-store-row-shape
+++ b/projects/plugins/wpcomsh/changelog/fix-site-purchase-store-row-shape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site purchases: Fix a fatal error when a cached purchase row arrives in an unexpected shape.

--- a/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
@@ -133,10 +133,33 @@ class WpcomSitePurchaseTest extends WP_UnitTestCase {
 	 * defaults.
 	 */
 	public function test_a_malformed_store_row_does_not_fatal() {
-		$purchase = WPCOM_Site_Purchase::from_store_row( array( 'product_slug' => array( 'not-a-string' ) ), 1 );
+		$purchase = WPCOM_Site_Purchase::from_store_row(
+			array(
+				'product_slug'           => array( 'not-a-string' ),
+				// An ordinary cast reads this as `true`, which would have the purchase claim
+				// auto-renew is on off the back of unreadable data.
+				'user_allows_auto_renew' => array( 'not-a-bool' ),
+			),
+			1
+		);
 
 		$this->assertSame( '', $purchase->product_slug );
 		$this->assertSame( '', $purchase->expiry_date );
 		$this->assertFalse( $purchase->auto_renew );
+		$this->assertFalse( $purchase->user_allows_auto_renew );
+	}
+
+	/**
+	 * A cached entry that is not a row at all cannot be a purchase, but must not be a fatal
+	 * either: it builds an empty one, which matches no feature.
+	 */
+	public function test_a_store_row_that_is_not_a_row_builds_an_empty_purchase() {
+		foreach ( array( 'not-a-row', null, 42 ) as $not_a_row ) {
+			$purchase = WPCOM_Site_Purchase::from_store_row( $not_a_row, 1 );
+
+			$this->assertSame( '', $purchase->product_slug );
+			$this->assertSame( '', $purchase->subscription_id );
+			$this->assertFalse( $purchase->auto_renew );
+		}
 	}
 }

--- a/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
@@ -5,7 +5,8 @@
  * Covers the half of WPCOM_Site_Purchase that actually executes on an Atomic site: the purchases
  * synced into Atomic Persistent Data, read back through wpcom_get_site_purchases(). The Simple-site
  * half, and the billing lookup behind the accessors, are covered on the WordPress.com side, where
- * the billing code-base exists to be asked.
+ * the billing code-base exists to be asked -- except for how a store row is read, which is the
+ * same code wherever it runs and is exercised directly here.
  *
  * @package wpcomsh
  */
@@ -99,5 +100,43 @@ class WpcomSitePurchaseTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $purchases );
 		$this->assertSame( '', $purchases[0]->product_slug );
 		$this->assertSame( 'business-bundle', $purchases[1]->product_slug );
+	}
+
+	/**
+	 * The Simple-site rows are served from an object cache shared across requests, which has been
+	 * seen to hand back arrays rather than the rows the store query returned. An array still
+	 * carries the whole row, so it must produce the same purchase.
+	 */
+	public function test_a_store_row_is_read_in_either_shape() {
+		$row = array(
+			'product_slug'           => 'business-bundle',
+			'product_id'             => '1008',
+			'billing_product_slug'   => 'wp-bundle-business',
+			'product_type'           => 'bundle',
+			'subscribed_date'        => '2026-04-12T18:55:02+00:00',
+			'expiry_date'            => '2027-04-12T00:00:00+00:00',
+			'subscription_id'        => '42',
+			'user_allows_auto_renew' => true,
+		);
+
+		$from_array = WPCOM_Site_Purchase::from_store_row( $row, 1 );
+
+		$this->assertEquals( WPCOM_Site_Purchase::from_store_row( (object) $row, 1 ), $from_array );
+		$this->assertSame( 'business-bundle', $from_array->product_slug );
+		$this->assertSame( '42', $from_array->subscription_id );
+		$this->assertTrue( $from_array->auto_renew );
+	}
+
+	/**
+	 * Feature checks read the rows on nearly every request, so a row of the wrong shape must
+	 * degrade rather than take the site down: missing and malformed fields fall back to their
+	 * defaults.
+	 */
+	public function test_a_malformed_store_row_does_not_fatal() {
+		$purchase = WPCOM_Site_Purchase::from_store_row( array( 'product_slug' => array( 'not-a-string' ) ), 1 );
+
+		$this->assertSame( '', $purchase->product_slug );
+		$this->assertSame( '', $purchase->expiry_date );
+		$this->assertFalse( $purchase->auto_renew );
 	}
 }

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -168,11 +168,13 @@ class WPCOM_Site_Purchase {
 	 * Takes the row in whichever shape it arrives, and treats every field as optional. The rows
 	 * are served from an object cache shared across requests, which has been seen to hand back
 	 * arrays rather than the objects the store query returned; an array still carries the whole
-	 * row, so it is read rather than dropped. This sits behind a feature check, on nearly every
+	 * row, so it is read rather than dropped, and an entry that is not a row at all builds an empty
+	 * purchase, which matches no feature. This sits behind a feature check, on nearly every
 	 * request, where being strict about the shape costs the whole site a fatal.
 	 *
-	 * @param object|array $row     A row as returned by _wpcom_features_get_simple_site_purchases().
-	 * @param int          $blog_id The blog the row belongs to.
+	 * @param mixed $row     A row as returned by _wpcom_features_get_simple_site_purchases(), in
+	 *                       whichever shape it was handed back.
+	 * @param int   $blog_id The blog the row belongs to.
 	 */
 	public static function from_store_row( $row, int $blog_id ): self {
 		$row      = (object) $row;
@@ -186,7 +188,7 @@ class WPCOM_Site_Purchase {
 		$purchase->subscribed_date        = self::text( $row->subscribed_date ?? null );
 		$purchase->expiry_date            = self::text( $row->expiry_date ?? null );
 		$purchase->subscription_id        = self::text( $row->subscription_id ?? null );
-		$purchase->user_allows_auto_renew = (bool) ( $row->user_allows_auto_renew ?? false );
+		$purchase->user_allows_auto_renew = self::flag( $row->user_allows_auto_renew ?? null );
 		$purchase->auto_renew             = $purchase->user_allows_auto_renew;
 
 		return $purchase;
@@ -213,13 +215,26 @@ class WPCOM_Site_Purchase {
 		$purchase->expiry_date            = self::text( $entry->expiry_date ?? null );
 		$purchase->subscription_id        = self::text( $entry->subscription_id ?? null );
 		$purchase->ownership_id           = is_scalar( $entry->ownership_id ?? null ) ? (string) $entry->ownership_id : null;
-		$purchase->user_allows_auto_renew = (bool) ( $entry->auto_renew ?? false );
+		$purchase->user_allows_auto_renew = self::flag( $entry->auto_renew ?? null );
 		$purchase->auto_renew             = $purchase->user_allows_auto_renew;
 
 		$purchase->might_still_auto_renew        = is_bool( $entry->might_still_auto_renew ?? null ) ? $entry->might_still_auto_renew : null;
 		$purchase->first_auto_renew_attempt_date = is_string( $entry->first_auto_renew_attempt_date ?? null ) ? $entry->first_auto_renew_attempt_date : null;
 
 		return $purchase;
+	}
+
+	/**
+	 * Coerces a value to a bool, defaulting anything that is not a scalar.
+	 *
+	 * Sibling of text(), for the same reason: an ordinary cast reads a non-empty array or object
+	 * as `true`, so a field of the wrong shape would arrive claiming auto-renew is on rather than
+	 * defaulting away like every other field.
+	 *
+	 * @param mixed $value Value read off a store row or a decoded payload.
+	 */
+	private static function flag( $value ): bool {
+		return is_scalar( $value ) && (bool) $value;
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -165,21 +165,28 @@ class WPCOM_Site_Purchase {
 	 * value stored here would go stale between refreshes. Only the synced payload carries them
 	 * pre-computed, because an Atomic site has no billing code-base to ask.
 	 *
-	 * @param object $row     A row as returned by _wpcom_features_get_simple_site_purchases().
-	 * @param int    $blog_id The blog the row belongs to.
+	 * Takes the row in whichever shape it arrives, and treats every field as optional. The rows
+	 * are served from an object cache shared across requests, which has been seen to hand back
+	 * arrays rather than the objects the store query returned; an array still carries the whole
+	 * row, so it is read rather than dropped. This sits behind a feature check, on nearly every
+	 * request, where being strict about the shape costs the whole site a fatal.
+	 *
+	 * @param object|array $row     A row as returned by _wpcom_features_get_simple_site_purchases().
+	 * @param int          $blog_id The blog the row belongs to.
 	 */
-	public static function from_store_row( object $row, int $blog_id ): self {
+	public static function from_store_row( $row, int $blog_id ): self {
+		$row      = (object) $row;
 		$purchase = new self();
 
 		$purchase->blog_id                = $blog_id;
-		$purchase->product_slug           = (string) $row->product_slug;
-		$purchase->product_id             = (string) $row->product_id;
-		$purchase->billing_product_slug   = (string) $row->billing_product_slug;
-		$purchase->product_type           = (string) $row->product_type;
-		$purchase->subscribed_date        = (string) $row->subscribed_date;
-		$purchase->expiry_date            = (string) $row->expiry_date;
-		$purchase->subscription_id        = (string) $row->subscription_id;
-		$purchase->user_allows_auto_renew = (bool) $row->user_allows_auto_renew;
+		$purchase->product_slug           = self::text( $row->product_slug ?? null );
+		$purchase->product_id             = self::text( $row->product_id ?? null );
+		$purchase->billing_product_slug   = self::text( $row->billing_product_slug ?? null );
+		$purchase->product_type           = self::text( $row->product_type ?? null );
+		$purchase->subscribed_date        = self::text( $row->subscribed_date ?? null );
+		$purchase->expiry_date            = self::text( $row->expiry_date ?? null );
+		$purchase->subscription_id        = self::text( $row->subscription_id ?? null );
+		$purchase->user_allows_auto_renew = (bool) ( $row->user_allows_auto_renew ?? false );
 		$purchase->auto_renew             = $purchase->user_allows_auto_renew;
 
 		return $purchase;
@@ -216,13 +223,13 @@ class WPCOM_Site_Purchase {
 	}
 
 	/**
-	 * Coerces a decoded JSON value to a string, defaulting anything that is not a scalar.
+	 * Coerces a value to a string, defaulting anything that is not a scalar.
 	 *
-	 * Guards from_synced_payload() against a field arriving with the wrong shape -- an object or
-	 * array where a scalar was expected, which JSON can express trivially and an ordinary cast
-	 * cannot survive.
+	 * Guards both constructors against a field arriving with the wrong shape -- an object or array
+	 * where a scalar was expected, which JSON can express trivially and an ordinary cast cannot
+	 * survive.
 	 *
-	 * @param mixed $value Decoded JSON value.
+	 * @param mixed $value Value read off a store row or a decoded payload.
 	 */
 	private static function text( $value ): string {
 		return is_scalar( $value ) ? (string) $value : '';


### PR DESCRIPTION
Part of DOTCOM-18401

## Proposed changes

* `WPCOM_Site_Purchase::from_store_row()` now takes the store row in whichever shape it arrives, and treats every field as optional — the same defensiveness `from_synced_payload()` already applies to the synced Atomic payload.
* Tests for both shapes, and for a row whose fields are malformed.

This mirrors the matching WordPress.com-side change; the file is one of the pair that must exist verbatim in both places.

`from_store_row()` was declared as `from_store_row( object $row, … )` in #51155. On a Simple site the rows it is handed are served from the `site_purchases` object cache, which has been seen to hand back arrays rather than the objects `$wpdb->get_results()` put in it, and the result is an uncaught `TypeError`:

```
Uncaught TypeError: WPCOM_Site_Purchase::from_store_row(): Argument #1 ($row)
must be of type object, array given
```

The constructor sits behind `wpcom_site_has_feature()`, which runs at `muplugins_loaded`, so that is not one broken feature — it is the whole request. Nothing on this path can afford to be strict about a shape it does not control, and the Atomic branch of the same function already skips entries it cannot read for exactly that reason.

An array row carries the whole row, so it is read rather than dropped: dropping it would silently strip a paid site of its plan features, a worse failure than the one being fixed. A row of any other shape yields an empty purchase, which matches no feature.

**Atomic never reaches this branch**, so this changes no wpcomsh behaviour — it exists so the two copies of the file do not drift, and so the guard is already in place if the Simple-side data shape ever reaches Atomic.

## Related product discussion/links
* The WordPress.com-side fix is the one that stops the fatals in production; this is its mirror.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jp docker up -d && jp docker install`
* `jp docker phpunit wpcomsh -- --filter WpcomSitePurchaseTest` — 5 tests pass.
* The regression is `test_a_store_row_is_read_in_either_shape`: on trunk it fatals with the `TypeError` above, here it passes and builds the same purchase an object row builds.
* Full suite: `jp docker phpunit wpcomsh` (284 passing, 4 skipped), plus `jp phan plugins/wpcomsh` (0 issues).
