### PR TITLE
AGENTS.md: give the comment rule a length budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,25 +96,30 @@ The `$$next-version$$` placeholder is automatically replaced with the correct ve
 
 One sentence, at most two lines — the summary rule the WordPress documentation standards
 already impose on our PHP, applied to JavaScript too. Anything past it must carry a why, a
-gotcha, or provenance, **and must fit in two more lines**. That budget is the rule: "it is all
-rationale" does not buy more room, because the comments worth cutting are always all rationale.
-Omit what the signature already says, and prefer a clearer name over a comment explaining a bad
-one. If reading the comment costs as much as reading the code, delete it. Never invent
-rationale: a comment that contradicts the code is worse than no comment.
+gotcha, or a durable pointer (an issue or upstream bug link), **and must fit in two more
+lines**. The budget is per comment, not per file: three separate traps in one function get three
+short comments, not one essay. "It is all rationale" does not buy more room, because the
+comments worth cutting are always all rationale. Omit what the signature already says, and
+prefer a clearer name over a comment explaining a bad one. If reading the comment costs as much
+as reading the code, delete it. Never invent rationale: a comment that contradicts the code is
+worse than no comment.
 
 The same budget applies to test files, where it is most often missed: no file-header essays, and
 no per-test narration the test name already carries.
 
-Four shapes exceed the budget however well they explain themselves:
+Five shapes exceed the budget however well they explain themselves:
 
-- **Design essays** — the alternative you rejected, what a future reader must not "fix", what a
-  trade-off costs. That is PR-description or issue material, not code.
+- **Design essays** — the alternative you rejected, the paragraph arguing why the code is shaped
+  this way, what a trade-off costs. That is PR-description or issue material, not code. A
+  one-line warning is a gotcha and stays: `// Do not reorder: bar() reads what foo() sets.`
 - **A mechanic explained on one member of a list** whose siblings share it. Say it once above the
   list, or not at all.
 - **A block that would survive copy-paste verbatim into another file.** That is domain
   background, not a comment.
-- **Provenance for a decision the code already makes** — upstream file-and-line citations,
-  "before this PR…", benchmark numbers, mutation-testing counts.
+- **Provenance that rots** — upstream file-and-line citations, "before this PR…", benchmark
+  numbers, mutation-testing counts. A stable link survives; a line number does not.
+- **The same explanation in more than one place.** Put it in the file that owns the thing,
+  nowhere else. N copies drift independently, so a reader cannot tell which is current.
 
 Keep every functional annotation regardless: `@param`, `@return`, `@covers`, `translators:`,
 `phpcs:ignore`, `eslint-disable`, `@ts-expect-error`. Those are required tooling or load-bearing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,29 @@ The `$$next-version$$` placeholder is automatically replaced with the correct ve
 
 One sentence, at most two lines — the summary rule the WordPress documentation standards
 already impose on our PHP, applied to JavaScript too. Anything past it must carry a why, a
-gotcha, or provenance. Omit what the signature already says, and prefer a clearer name over a
-comment explaining a bad one. If reading the comment costs as much as reading the code, delete
-it. Never invent rationale: a comment that contradicts the code is worse than no comment.
+gotcha, or provenance, **and must fit in two more lines**. That budget is the rule: "it is all
+rationale" does not buy more room, because the comments worth cutting are always all rationale.
+Omit what the signature already says, and prefer a clearer name over a comment explaining a bad
+one. If reading the comment costs as much as reading the code, delete it. Never invent
+rationale: a comment that contradicts the code is worse than no comment.
+
+The same budget applies to test files, where it is most often missed: no file-header essays, and
+no per-test narration the test name already carries.
+
+Four shapes exceed the budget however well they explain themselves:
+
+- **Design essays** — the alternative you rejected, what a future reader must not "fix", what a
+  trade-off costs. That is PR-description or issue material, not code.
+- **A mechanic explained on one member of a list** whose siblings share it. Say it once above the
+  list, or not at all.
+- **A block that would survive copy-paste verbatim into another file.** That is domain
+  background, not a comment.
+- **Provenance for a decision the code already makes** — upstream file-and-line citations,
+  "before this PR…", benchmark numbers, mutation-testing counts.
+
+Keep every functional annotation regardless: `@param`, `@return`, `@covers`, `translators:`,
+`phpcs:ignore`, `eslint-disable`, `@ts-expect-error`. Those are required tooling or load-bearing
+code, not prose.
 
 ## Testing
 


### PR DESCRIPTION
## Proposed changes

Gives `AGENTS.md` § Comments an actual length budget.

The section capped the docblock **summary** at two lines, then allowed "anything past it" on a purely qualitative test — it "must carry a why, a gotcha, or provenance" — with no cap at all. Design essays pass that test comfortably, so the rule as written permitted a 20+ line docblock as long as every line was rationale. In practice that is exactly what has been shipping: on six recent Backup PRs, added comment lines ran 30–48% of the added diff, including a 24-line docblock whose closing paragraph instructed future readers not to "fix" the function.

This PR:

* Extends the two-line budget past the summary, and says plainly that "it is all rationale" does not buy more room.
* States that the bar covers test files, where it is most often missed — file-header essays and per-test narration the test name already carries.
* Names four shapes that always exceed the budget: design essays, a mechanic explained on one member of a list whose siblings share it, a block that would survive copy-paste verbatim into another file, and provenance for a decision the code already makes.
* Keeps functional annotations (`@param`, `@return`, `@covers`, `translators:`, `phpcs:ignore`, `eslint-disable`, `@ts-expect-error`) explicitly out of scope, since those are tooling requirements or load-bearing code rather than prose.

Documentation only — no code, and no changelog entry (the change is outside `/projects`).

## Related product discussion/links

* Raised in review on #51742: "the agentic comment bloating is still a thing … visually it feels like a big chunk."
* Earlier instance on #51686: "Unnecessary. If explanation really is needed, it shouldn't be only on this one entry in the array."

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Read the `### Comments` section of `AGENTS.md` on this branch and confirm the guidance is clear and the budget is one you'd want applied to your own PRs.
* No build, test, or runtime behaviour is affected.
