### PR TITLE
Charts: stop the Area Chart composition-legend story rendering two legends

### DIFF
--- a/projects/js-packages/charts/changelog/charts-265-composition-legend-story
+++ b/projects/js-packages/charts/changelog/charts-265-composition-legend-story
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Storybook-only fix to the Area Chart composition legend story; the shipped package is unchanged.
+
+

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -277,7 +277,6 @@ export const WithCompositionLegend: StoryObj< StoryArgs > = {
 		const legend = extractLegendConfig< ChartLegendConfig< SeriesData[] > >( args );
 		return (
 			<AreaChart
-				{ ...Default.args }
 				{ ...args }
 				legend={ { interactive: legend?.interactive } }
 				chartId="composition-area-chart"
@@ -286,7 +285,7 @@ export const WithCompositionLegend: StoryObj< StoryArgs > = {
 			</AreaChart>
 		);
 	},
-	args: { ...Default.args },
+	args: { ...Default.args, showLegend: false },
 	parameters: {
 		docs: {
 			description: {


### PR DESCRIPTION
Fixes CHARTS-265

## Why

The Area Chart `WithCompositionLegend` story drew two identical legends stacked on top of each other. It is the story the docs page points at to show the composition API, so the one canvas meant to demonstrate `<AreaChart.Legend />` was showing something no consumer should copy.

The story spread `Default.args` into the chart, and `Default.args` sets `showLegend: true`. `ChartLayout` renders the prop-driven legend and the composition legend children into the same slot, so asking for both gets both. The chart was doing what it was told; the story was telling it the wrong thing.

## Proposed changes

* Set `showLegend: false` in the `WithCompositionLegend` story's args, so it demonstrates the composition API alone — matching its own description and the snippet in `index.docs.mdx`.
* Drop the `{ ...Default.args }` spread from the story's `render`. Storybook merges those args before it calls `render`, so the spread was redundant, and it was the thing that made it easy to inherit a prop the story does not want.

No library code changes; the shipped package is unchanged.

### Screenshots

**Before — two identical legends**

<img width="832" height="436" alt="before-two-legends" src="https://github.com/user-attachments/assets/57021256-1af3-42ac-a8ee-c8cc5db4c420" />

**After — the composition legend only**

<img width="832" height="436" alt="after-one-legend" src="https://github.com/user-attachments/assets/717f6d77-d4ba-4215-b8cc-3227318787c3" />

Whether the library should suppress the `showLegend` legend when a `<Chart.Legend>` child is present is a separate question, left out of scope on CHARTS-265. Rendering both is a defensible reading of two explicit requests, and silently dropping one would be surprising.

## Related product discussion/links

* CHARTS-265

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run Storybook: `pnpm --filter @automattic/jetpack-storybook run storybook:dev`
* Go to **JS Packages / Charts Library / Charts / Area Chart → WithCompositionLegend**.
* The chart shows **one** legend below it. Before this change it showed two.
* Toggle the `showLegend` control on — the second legend comes back, confirming the control still works and the fix is in the story's args, not in the library.
* Check the neighboring **WithLegend** story still shows its prop-driven legend, and the Area Chart docs page renders one legend in its Legends canvas.

### Evidence

* `pnpm run test` in `projects/js-packages/charts` — 74 suites, 1312 tests, all passing.
* `tsc --noEmit` on the charts package — clean.
* ESLint on the changed file — clean.
* Verified in Storybook; before/after below.
