### PR TITLE
Backup: cache the promoted product so the no-plan screen stops refetching it

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-cache-promoted-product
+++ b/projects/packages/backup/changelog/fix-backup-cache-promoted-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cache the promoted Backup subscription price so the screen shown to sites without a plan stops fetching it from WordPress.com on every load.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -78,6 +78,27 @@ class Jetpack_Backup {
 	const JETPACK_BACKUP_PROMOTED_PRODUCT = 'jetpack_backup_t1_yearly';
 
 	/**
+	 * Transient key prefix for the cached promoted product.
+	 *
+	 * Suffixed with the locale, because the locale is a query arg on the
+	 * catalogue request — one shared key would serve one reader's language
+	 * to another.
+	 *
+	 * @var string
+	 */
+	const PROMOTED_PRODUCT_TRANSIENT_PREFIX = 'jetpack_backup_promoted_product_';
+
+	/**
+	 * How long a fetched promoted product stays cached.
+	 *
+	 * The catalogue turns over on a marketing schedule rather than a
+	 * session's, so half a day bounds how stale a price can get.
+	 *
+	 * @var int
+	 */
+	const PROMOTED_PRODUCT_CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+	/**
 	 * Licenses product ID.
 	 *
 	 * @var string
@@ -713,10 +734,21 @@ class Jetpack_Backup {
 	/**
 	 * Gets information about the currently promoted backup product.
 	 *
+	 * Answers from a per-locale transient when one is warm; only a product
+	 * that was actually read is ever stored.
+	 *
 	 * @return object|WP_Error The promoted product, or a WP_Error if it could not be read.
 	 */
 	public static function get_backup_promoted_product_info() {
-		$request_url   = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . get_user_locale() . '&type=jetpack';
+		$locale        = get_user_locale();
+		$transient_key = self::PROMOTED_PRODUCT_TRANSIENT_PREFIX . sanitize_key( $locale );
+		$cached        = get_transient( $transient_key );
+
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$request_url   = 'https://public-api.wordpress.com/rest/v1.1/products?locale=' . $locale . '&type=jetpack';
 		$wpcom_request = wp_remote_get( esc_url_raw( $request_url ) );
 		// Cast: the transport may report the status as a numeric string, which
 		// a strict comparison against 200 sends down the failure path.
@@ -752,7 +784,14 @@ class Jetpack_Backup {
 			);
 		}
 
-		return $products->{ self::JETPACK_BACKUP_PROMOTED_PRODUCT };
+		$product = $products->{ self::JETPACK_BACKUP_PROMOTED_PRODUCT };
+
+		// Only a product that was read is cached: storing either failure above
+		// would keep the no-plan screen priceless for hours after
+		// WordPress.com recovered.
+		set_transient( $transient_key, $product, self::PROMOTED_PRODUCT_CACHE_TTL );
+
+		return $product;
 	}
 
 	/**

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -80,9 +80,8 @@ class Jetpack_Backup {
 	/**
 	 * Transient key prefix for the cached promoted product.
 	 *
-	 * Suffixed with the locale, because the locale is a query arg on the
-	 * catalogue request — one shared key would serve one reader's language
-	 * to another.
+	 * Suffixed with the locale: it is a query arg on the catalogue request, so
+	 * one shared key would serve one reader's language to another.
 	 *
 	 * @var string
 	 */
@@ -734,8 +733,7 @@ class Jetpack_Backup {
 	/**
 	 * Gets information about the currently promoted backup product.
 	 *
-	 * Answers from a per-locale transient when one is warm; only a product
-	 * that was actually read is ever stored.
+	 * Answers from a per-locale transient when one is warm; failures are not cached.
 	 *
 	 * @return object|WP_Error The promoted product, or a WP_Error if it could not be read.
 	 */
@@ -786,9 +784,8 @@ class Jetpack_Backup {
 
 		$product = $products->{ self::JETPACK_BACKUP_PROMOTED_PRODUCT };
 
-		// Only a product that was read is cached: storing either failure above
-		// would keep the no-plan screen priceless for hours after
-		// WordPress.com recovered.
+		// Must stay below both guards: a cached failure would leave the no-plan
+		// screen without a price for the whole TTL after WordPress.com recovered.
 		set_transient( $transient_key, $product, self::PROMOTED_PRODUCT_CACHE_TTL );
 
 		return $product;

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -525,9 +525,8 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
-	 * The catalogue is priced and translated per locale, which is a query arg
-	 * on the request — one shared key would serve one reader's language to
-	 * another.
+	 * The catalogue is localized by the `locale` query arg, so one shared key
+	 * would serve one reader's language to another.
 	 */
 	public function test_promoted_product_info_caches_per_locale() {
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -64,18 +64,35 @@ class Jetpack_Backup_Test extends TestCase {
 	private $http_requests = 0;
 
 	/**
+	 * Locale reported to the code under test.
+	 *
+	 * @var string
+	 */
+	private $locale = 'en_US';
+
+	/**
 	 * Undo the request mocking. Done here rather than after each assertion so
 	 * that a failing assertion cannot leak a filter into the next test.
+	 *
+	 * WorDBless keeps the database between tests in this class, so a warmed
+	 * promoted-product transient would otherwise answer a later test before
+	 * it reached the transport.
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ) );
+		remove_filter( 'locale', array( $this, 'mock_locale' ) );
 		wp_set_current_user( 0 );
+
+		foreach ( array( 'en_US', $this->locale ) as $locale ) {
+			delete_transient( Jetpack_Backup::PROMOTED_PRODUCT_TRANSIENT_PREFIX . sanitize_key( $locale ) );
+		}
 
 		$this->wpcom_status  = 200;
 		$this->wpcom_body    = '{}';
 		$this->http_requests = 0;
+		$this->locale        = 'en_US';
 
 		parent::tearDown();
 	}
@@ -449,6 +466,97 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
+	 * A no-plan screen rendered twice costs the site one catalogue request.
+	 */
+	public function test_promoted_product_info_serves_a_second_read_from_cache() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		$first  = Jetpack_Backup::get_backup_promoted_product_info();
+		$second = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+
+		$this->assertSame( 1, $this->http_requests );
+		$this->assertEquals( $first, $second );
+		$this->assertSame( 539.4, $second->cost );
+	}
+
+	/**
+	 * Neither failure is cached, so an outage cannot hold the no-plan screen
+	 * priceless past its own duration.
+	 *
+	 * @param string      $error_code The error code the failing call reports.
+	 * @param int|string  $status     Status for the failing response.
+	 * @param string|null $body      Body for the failing response, or null for the well-formed catalogue.
+	 * @dataProvider provide_uncacheable_failures
+	 */
+	#[DataProvider( 'provide_uncacheable_failures' )]
+	public function test_promoted_product_info_does_not_cache_a_failure( $error_code, $status, $body ) {
+		$this->catalogue_status = $status;
+		$this->catalogue_body   = $body;
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		$failed = Jetpack_Backup::get_backup_promoted_product_info();
+
+		$this->catalogue_status = 200;
+		$this->catalogue_body   = null;
+
+		$recovered = Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $failed, $error_code );
+		$this->assertSame( $error_code, $failed->get_error_code() );
+		$this->assertSame( 2, $this->http_requests, $error_code );
+		$this->assertIsObject( $recovered, $error_code );
+		$this->assertSame( 539.4, $recovered->cost, $error_code );
+	}
+
+	/**
+	 * The two failures the route distinguishes, as error code, status, body.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_uncacheable_failures() {
+		return array(
+			'a non-200'         => array( 'failed_to_fetch_data', 503, null ),
+			'an unreadable 200' => array( 'promoted_product_unreadable', 200, '{"jetpack_scan":{"cost":10}}' ),
+		);
+	}
+
+	/**
+	 * The catalogue is priced and translated per locale, which is a query arg
+	 * on the request — one shared key would serve one reader's language to
+	 * another.
+	 */
+	public function test_promoted_product_info_caches_per_locale() {
+		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
+
+		Jetpack_Backup::get_backup_promoted_product_info();
+
+		$this->locale = 'pt_BR';
+		add_filter( 'locale', array( $this, 'mock_locale' ) );
+
+		Jetpack_Backup::get_backup_promoted_product_info();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ) );
+
+		$this->assertSame( 2, $this->http_requests );
+		$this->assertStringContainsString( 'locale=pt_BR', $this->captured_url );
+		$this->assertNotFalse( get_transient( Jetpack_Backup::PROMOTED_PRODUCT_TRANSIENT_PREFIX . 'en_us' ) );
+		$this->assertNotFalse( get_transient( Jetpack_Backup::PROMOTED_PRODUCT_TRANSIENT_PREFIX . 'pt_br' ) );
+	}
+
+	/**
+	 * Report the configured locale.
+	 *
+	 * @return string
+	 */
+	public function mock_locale() {
+		return $this->locale;
+	}
+
+	/**
 	 * Mock the product catalogue endpoint.
 	 *
 	 * @param false  $preempt     Short-circuit value (unused).
@@ -458,6 +566,7 @@ class Jetpack_Backup_Test extends TestCase {
 	 */
 	public function mock_request_as_product_catalogue( $preempt, $parsed_args, $url ) {
 		$this->captured_url = (string) $url;
+		++$this->http_requests;
 
 		$body = $this->catalogue_body;
 

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -316,17 +316,8 @@ class Jetpack_Backup_Test extends TestCase {
 
 	public function test_list_backup_events_returns_response_and_pins_backup_actions_on_success() {
 		$this->captured_url = '';
+		$this->sign_in_as_connected_admin();
 
-		$admin_id = wp_insert_user(
-			array(
-				'user_login' => 'backup_events_admin',
-				'user_pass'  => 'pass',
-				'role'       => 'administrator',
-			)
-		);
-		wp_set_current_user( $admin_id );
-
-		add_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ), 10, 2 );
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_activity_collection' ), 10, 3 );
 
 		// Caller-supplied `action` must be overridden with the curated backup list.

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -74,9 +74,8 @@ class Jetpack_Backup_Test extends TestCase {
 	 * Undo the request mocking. Done here rather than after each assertion so
 	 * that a failing assertion cannot leak a filter into the next test.
 	 *
-	 * WorDBless keeps the database between tests in this class, so a warmed
-	 * promoted-product transient would otherwise answer a later test before
-	 * it reached the transport.
+	 * The database survives between tests here, so a warmed promoted-product
+	 * transient would answer a later test before it reached the transport.
 	 */
 	protected function tearDown(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
@@ -482,12 +481,12 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
-	 * Neither failure is cached, so an outage cannot hold the no-plan screen
-	 * priceless past its own duration.
+	 * Neither failure is cached, so an outage cannot leave the no-plan screen
+	 * without a price for longer than it lasts.
 	 *
 	 * @param string      $error_code The error code the failing call reports.
 	 * @param int|string  $status     Status for the failing response.
-	 * @param string|null $body      Body for the failing response, or null for the well-formed catalogue.
+	 * @param string|null $body       Body for the failing response, or null for the well-formed catalogue.
 	 * @dataProvider provide_uncacheable_failures
 	 */
 	#[DataProvider( 'provide_uncacheable_failures' )]
@@ -525,8 +524,7 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
-	 * The catalogue is localized by the `locale` query arg, so one shared key
-	 * would serve one reader's language to another.
+	 * The request carries the locale, so the key has to as well.
 	 */
 	public function test_promoted_product_info_caches_per_locale() {
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -514,9 +514,6 @@ class Jetpack_Backup_Test extends TestCase {
 		);
 	}
 
-	/**
-	 * The request carries the locale, so the key has to as well.
-	 */
 	public function test_promoted_product_info_caches_per_locale() {
 		add_filter( 'pre_http_request', array( $this, 'mock_request_as_product_catalogue' ), 10, 3 );
 

--- a/projects/plugins/backup/changelog/fix-backup-cache-promoted-product
+++ b/projects/plugins/backup/changelog/fix-backup-cache-promoted-product
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cache the promoted Backup subscription price so the screen shown to sites without a plan stops fetching it from WordPress.com on every load.


### PR DESCRIPTION
Fixes JETPACK-2359

## Proposed changes

`Jetpack_Backup::get_backup_promoted_product_info()` issued an **uncached, blocking** `wp_remote_get` against `https://public-api.wordpress.com/rest/v1.1/products` on every call. Both the legacy dashboard (`no-backup-capabilities.jsx`, `use-backup-product-info.js`) and the modernized one (`usePromotedProduct`) read it from the no-plan screen, so a site without Backup paid an external round trip every single time that screen rendered — and the modernized dashboard's client `retry: 1` could turn one render into two of them.

* Cache the promoted product in a transient on the **success path only**, keyed on the locale.
* Leave both failure paths uncached: `failed_to_fetch_data` (transport failure or non-200) and `promoted_product_unreadable` (a 200 whose body carries no promoted product). Caching either would hold the no-plan screen priceless for hours after WordPress.com recovered.
* Add PHPUnit coverage for the cache hit, for both uncached failures, and for the per-locale keying.

### Why keyed on the locale

The locale is already a query arg on the catalogue request (`?locale=` … `&type=jetpack`), so a single shared key would serve one reader's language to another. The key is `jetpack_backup_promoted_product_<sanitize_key( locale )>`.

The cache is site-wide rather than per-user, unlike the `get_user_meta()` caches in `packages/videopress` and `packages/protect-status`. That is deliberate: WordPress.com prices this catalogue by **site** geography, not by reader, so locale is the only axis that actually varies the answer.

### Why 12 hours

The catalogue turns over on a marketing schedule — campaign and introductory-offer prices change in days, not minutes — so the TTL only needs to be short enough that a new campaign reaches the screen the same day. Half a day does that while collapsing every render in an admin session (and every render across all admins on the site) into one upstream request. For reference, `packages/my-jetpack` caches the same upstream catalogue for `DAY_IN_SECONDS` and `packages/videopress` / `packages/protect-status` for `7 * DAY_IN_SECONDS`, so 12 hours is the most conservative of the four.

### Notes for the reviewer

* `use-promoted-product.ts` keeps its `retry: false` guard. With this cache a retry is much cheaper (the second attempt is a transient read), but the guard is still doing real work when the *first* attempt is the one that failed — a failure is never cached, so a retry is a second live request. Removing it is a separate call; deliberately left alone here.
* **Hardcoded currency symbol, not fixed here:** `src/js/components/Admin/no-backup-capabilities.jsx` builds its price detail string as `` __( 'trial for the first month, then $%s /month, billed yearly' ) `` — a literal `$` baked into a translatable string, and `currencyCode` defaults to `'USD'` in the same component. Prices from this endpoint are geo-located by site, so a BRL or EUR site sees a dollar sign in front of a non-dollar amount (and an unformatted raw float). That file is outside this PR's scope; flagging it for a follow-up.

## Related product discussion/links

* JETPACK-2359

## Does this pull request change what data or activity we track or use?

No. Same request, same data, made less often.

## Testing instructions

Requires the standalone **Jetpack Backup** plugin on a connected site **without** a Backup plan (the no-plan screen is only registered by `Jetpack_Backup::initialize()`, which only that plugin calls).

**Cache hit — the main claim**

1. `wp transient delete jetpack_backup_promoted_product_en_us`
2. Go to *Jetpack > Backup*. You should land on the no-plan/upgrade screen and see a price.
3. `wp transient get jetpack_backup_promoted_product_en_us` — it now holds the product object.
4. Reload the screen several times. Watch outbound traffic (a `pre_http_request` log filter, Query Monitor's HTTP panel, or the network tab against `/wp-json/jetpack/v4/backup-promoted-product-info`). **The catalogue is fetched once**, not once per render. Before this PR every reload produced a fresh `public-api.wordpress.com` request.
5. Do the same with the modernized dashboard (`rsm_jetpack_ui_modernization_backup` filtered to `true`) — same route, same result.

**Failures are not cached — the other half**

6. Delete the transient again, then make the upstream call fail. Easiest is a mu-plugin:
   ```php
   add_filter( 'pre_http_request', function ( $pre, $args, $url ) {
       return str_contains( $url, '/rest/v1.1/products' )
           ? new WP_Error( 'http_request_failed', 'nope' )
           : $pre;
   }, 10, 3 );
   ```
7. Load the no-plan screen. No price renders, and `wp transient get jetpack_backup_promoted_product_en_us` reports nothing stored.
8. Remove the filter and reload. The price comes back **immediately** — no waiting out a TTL. Repeat with the filter returning a 200 whose body is `{"jetpack_scan":{"cost":10}}` (the `promoted_product_unreadable` path) for the same result.

**Per-locale keying**

9. Set your user's admin language to something else (Users > Profile > Language, e.g. Português do Brasil) and reload. A second transient appears — `jetpack_backup_promoted_product_pt_br` — rather than the `en_us` one being reused.

**Automated**

* `jp test php packages/backup` — 373 tests, 957 assertions, green.
* The four new tests were mutation-checked: dropping the locale from the key, and caching either failure path, each make them fail.

**Not tested:** anything behind an external object cache (the transients go through the normal `set_transient` API, so `wp_cache`-backed sites behave the same way, but I did not exercise one). No JS changed, so no UI screenshots.
