### PR TITLE
Backup: stop the file preview corrupting binary and truncated files

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2308-g3-file-preview-integrity
+++ b/projects/packages/backup/changelog/jetpack-2308-g3-file-preview-integrity
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the flag: the file browser's preview no longer serves a binary or non-UTF-8 file with its bytes silently replaced by "?", and now says when a preview stops at the 64 KB cap.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -140,10 +140,12 @@ function PreviewBody( {
 			</Text>
 		);
 	}
+	// Deliberately not the unpreviewable-extension wording: the extension said
+	// this file was previewable, and the bytes turned out not to be text.
 	if ( ! isText ) {
 		return (
 			<Text variant="body-sm" className="jpb-text-muted">
-				{ __( 'Preview unavailable for this file.', 'jetpack-backup-pkg' ) }
+				{ __( 'This file is not text and cannot be previewed.', 'jetpack-backup-pkg' ) }
 			</Text>
 		);
 	}

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -78,8 +78,9 @@ type Props = {
 /**
  * Renders the preview slot's body: a spinner while loading, the file
  * contents in a `<pre>` when available, a muted line when the fetch
- * failed, or a generic "preview unavailable" muted line when the
- * filename's extension is not one this card can render.
+ * failed or the bytes turned out not to be text, or a generic "preview
+ * unavailable" muted line when the filename's extension is not one this
+ * card can render.
  *
  * The error branch says nothing about *why*, on purpose. It used to
  * blame blob storage having outlived the manifest entry, which was
@@ -96,6 +97,8 @@ type Props = {
  * @param props.showPreview - Whether the filename's extension is in the previewable map.
  * @param props.isLoading   - Whether the file-contents query is in flight.
  * @param props.content     - The fetched body, or null when not yet resolved.
+ * @param props.isText      - Whether the bridge could read the fetched bytes as text.
+ * @param props.truncated   - Whether the body stops at the bridge's preview cap.
  * @param props.error       - The fetch error, or null on success.
  * @return The preview body.
  */
@@ -103,11 +106,15 @@ function PreviewBody( {
 	showPreview,
 	isLoading,
 	content,
+	isText,
+	truncated,
 	error,
 }: {
 	showPreview: boolean;
 	isLoading: boolean;
 	content: string | null;
+	isText: boolean;
+	truncated: boolean;
 	error: Error | null;
 } ) {
 	if ( ! showPreview ) {
@@ -136,6 +143,13 @@ function PreviewBody( {
 			</Text>
 		);
 	}
+	if ( ! isText ) {
+		return (
+			<Text variant="body-sm" className="jpb-text-muted">
+				{ __( 'This file is not text and cannot be previewed.', 'jetpack-backup-pkg' ) }
+			</Text>
+		);
+	}
 	if ( content === null ) {
 		return (
 			<Text variant="body-sm" className="jpb-text-muted">
@@ -143,7 +157,26 @@ function PreviewBody( {
 			</Text>
 		);
 	}
-	return <pre>{ content }</pre>;
+	return (
+		<>
+			{ /* Above the `<pre>` rather than after it: this whole panel is the
+			     scroll container, so a note underneath would only be reachable
+			     by scrolling past the very content it is warning about. */ }
+			{ truncated && (
+				<Text
+					variant="body-sm"
+					className="jpb-text-muted jpb-file-info-card__preview-note"
+					render={ <p /> }
+				>
+					{ __(
+						'Preview truncated: this file is too large to show in full.',
+						'jetpack-backup-pkg'
+					) }
+				</Text>
+			) }
+			<pre>{ content }</pre>
+		</>
+	);
 }
 
 /**
@@ -172,6 +205,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	const showPreview = Boolean( mimeType );
 	const {
 		content,
+		isText,
+		truncated,
 		isLoading: contentsLoading,
 		error: contentsError,
 	} = useFileContents( file.period, file.manifestPath, showPreview );
@@ -266,6 +301,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 					showPreview={ showPreview }
 					isLoading={ contentsLoading }
 					content={ content }
+					isText={ isText }
+					truncated={ truncated }
 					error={ contentsError }
 				/>
 			</div>

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -78,8 +78,8 @@ type Props = {
 /**
  * Renders the preview slot's body: a spinner while loading, the file
  * contents in a `<pre>` when available, a muted line when the fetch
- * failed or the bytes turned out not to be text, or a generic "preview
- * unavailable" muted line when the filename's extension is not one this
+ * failed, or a generic "preview unavailable" muted line when the bytes
+ * turned out not to be text or the filename's extension is not one this
  * card can render.
  *
  * The error branch says nothing about *why*, on purpose. It used to
@@ -146,7 +146,7 @@ function PreviewBody( {
 	if ( ! isText ) {
 		return (
 			<Text variant="body-sm" className="jpb-text-muted">
-				{ __( 'This file is not text and cannot be previewed.', 'jetpack-backup-pkg' ) }
+				{ __( 'Preview unavailable for this file.', 'jetpack-backup-pkg' ) }
 			</Text>
 		);
 	}

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -77,10 +77,7 @@ type Props = {
 
 /**
  * Renders the preview slot's body: a spinner while loading, the file
- * contents in a `<pre>` when available, a muted line when the fetch
- * failed, or a generic "preview unavailable" muted line when the bytes
- * turned out not to be text or the filename's extension is not one this
- * card can render.
+ * contents in a `<pre>`, or a muted line when there is nothing to show.
  *
  * The error branch says nothing about *why*, on purpose. It used to
  * blame blob storage having outlived the manifest entry, which was
@@ -159,9 +156,8 @@ function PreviewBody( {
 	}
 	return (
 		<>
-			{ /* Above the `<pre>` rather than after it: this whole panel is the
-			     scroll container, so a note underneath would only be reachable
-			     by scrolling past the very content it is warning about. */ }
+			{ /* Above the `<pre>`, not after: the panel is the scroll container, so
+			     a note below is reachable only past the content it warns about. */ }
 			{ truncated && (
 				<Text
 					variant="body-sm"

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -39,6 +39,11 @@
 		word-break: break-all;
 	}
 
+	&__preview-note {
+		margin-block: 0 8px;
+		margin-inline: 0;
+	}
+
 	&__preview {
 		max-height: 320px;
 		overflow: auto;

--- a/projects/packages/backup/src/dashboard/data/api/file-contents.ts
+++ b/projects/packages/backup/src/dashboard/data/api/file-contents.ts
@@ -1,7 +1,16 @@
 import { apiCall, apiPath } from './_helpers';
 
+/**
+ * The bridge's preview payload.
+ *
+ * `content` is null unless `is_text`: bytes that are not UTF-8 text would
+ * reach the browser with the invalid ones replaced by `?`, so the bridge
+ * withholds them rather than serve a corrupted file as the real one.
+ */
 export type FileContentsResponse = {
-	content: string;
+	content: string | null;
+	is_text: boolean;
+	truncated: boolean;
 };
 
 /**
@@ -14,7 +23,7 @@ export type FileContentsResponse = {
  *
  * @param filePeriod          - The file's own snapshot timestamp (Unix seconds, as returned in /ls's `period`).
  * @param encodedManifestPath - Standard base64 of the full manifest path (with `f5:/`-style volume prefix).
- * @return The decoded file content.
+ * @return The preview payload.
  */
 export async function fetchFileContents(
 	filePeriod: string,

--- a/projects/packages/backup/src/dashboard/data/api/file-contents.ts
+++ b/projects/packages/backup/src/dashboard/data/api/file-contents.ts
@@ -3,9 +3,8 @@ import { apiCall, apiPath } from './_helpers';
 /**
  * The bridge's preview payload.
  *
- * `content` is null unless `is_text`: bytes that are not UTF-8 text would
- * reach the browser with the invalid ones replaced by `?`, so the bridge
- * withholds them rather than serve a corrupted file as the real one.
+ * `content` is null unless `is_text`: the bridge withholds bytes it cannot
+ * serve as text rather than let them reach the browser corrupted.
  */
 export type FileContentsResponse = {
 	content: string | null;

--- a/projects/packages/backup/src/dashboard/hooks/use-file-contents.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-contents.ts
@@ -4,6 +4,8 @@ import { keys } from '../data/query-client';
 
 type Result = {
 	content: string | null;
+	isText: boolean;
+	truncated: boolean;
 	isLoading: boolean;
 	error: Error | null;
 };
@@ -40,7 +42,7 @@ function encodeManifestPath( manifestPath: string ): string {
  * @param filePeriod   - The file's own snapshot timestamp (from /ls `period`).
  * @param manifestPath - The volume-prefixed manifest path (from /ls `manifest_path`, e.g. `f5:/wp-config.php`). Base64-encoded before sending.
  * @param enabled      - When false, the query is skipped (an extension the preview card cannot render).
- * @return Content + loading state.
+ * @return Content, the bridge's text and truncation verdicts, and loading state.
  */
 export function useFileContents(
 	filePeriod: string | undefined,
@@ -57,6 +59,10 @@ export function useFileContents(
 
 	return {
 		content: query.data?.content ?? null,
+		// Both fall back to the innocent answer, so a query that has not
+		// resolved cannot make the card call a file unreadable or clipped.
+		isText: query.data?.is_text ?? true,
+		truncated: query.data?.truncated ?? false,
 		isLoading: query.isLoading,
 		error: query.error ?? null,
 	};

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -220,9 +220,8 @@ class File_Browser_Bridge {
 	 * WPCOM's signed-URL stream endpoint doesn't send CORS headers, so
 	 * the browser can't fetch it directly.
 	 *
-	 * Answers `content`, `is_text` and `truncated`. `content` is null
-	 * unless `is_text`, and `truncated` says the cap cut the body short —
-	 * neither condition is a failure, so both come back with a 200.
+	 * Answers `content`, `is_text` and `truncated`; `content` is null unless
+	 * `is_text`. A binary or capped body is not an error — both answer 200.
 	 *
 	 * VaultPress stores file content per the file's own snapshot
 	 * `period` — the timestamp when the file last changed — not by the

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -220,6 +220,10 @@ class File_Browser_Bridge {
 	 * WPCOM's signed-URL stream endpoint doesn't send CORS headers, so
 	 * the browser can't fetch it directly.
 	 *
+	 * Answers `content`, `is_text` and `truncated`. `content` is null
+	 * unless `is_text`, and `truncated` says the cap cut the body short —
+	 * neither condition is a failure, so both come back with a 200.
+	 *
 	 * VaultPress stores file content per the file's own snapshot
 	 * `period` — the timestamp when the file last changed — not by the
 	 * parent backup's rewindId. Files don't get re-snapshotted every
@@ -353,7 +357,68 @@ class File_Browser_Bridge {
 			);
 		}
 
-		return rest_ensure_response( array( 'content' => wp_remote_retrieve_body( $stream_response ) ) );
+		$body = wp_remote_retrieve_body( $stream_response );
+
+		// A body at the cap is reported truncated even in the rare case where
+		// the file ends exactly there — the transport cannot tell the two apart.
+		$truncated = strlen( $body ) >= self::PREVIEW_MAX_BYTES;
+		if ( $truncated ) {
+			$body = self::drop_partial_trailing_character( $body );
+		}
+
+		// Bytes that are not text must never go out as `content`: the REST
+		// server's `wp_json_encode()` sanity fallback re-encodes invalid UTF-8
+		// into `?`, so a 200 would hand the reader a corrupted file as if it
+		// were the real one.
+		$is_text = self::is_text( $body );
+
+		return rest_ensure_response(
+			array(
+				'content'   => $is_text ? $body : null,
+				'is_text'   => $is_text,
+				'truncated' => $truncated,
+			)
+		);
+	}
+
+	/**
+	 * Whether a fetched body can be shown in a text preview.
+	 *
+	 * A NUL byte is valid UTF-8 but does not occur in text, so rejecting it
+	 * also catches UTF-16 and the binaries that happen to decode cleanly.
+	 *
+	 * @param string $body The fetched body.
+	 * @return bool
+	 */
+	private static function is_text( $body ) {
+		if ( false !== strpos( $body, "\0" ) ) {
+			return false;
+		}
+		// mbstring is not guaranteed on every host, and a `//u` pattern fails
+		// to match on invalid UTF-8, which is the same verdict.
+		return function_exists( 'mb_check_encoding' )
+			? mb_check_encoding( $body, 'UTF-8' )
+			: 1 === preg_match( '//u', $body );
+	}
+
+	/**
+	 * Drop a character the byte cap cut in half.
+	 *
+	 * The transport counts bytes, so the cut can land inside a multi-byte
+	 * sequence and leave a text file looking like binary. A UTF-8 character
+	 * is at most four bytes, so at most three can be left over.
+	 *
+	 * @param string $body The capped body.
+	 * @return string
+	 */
+	private static function drop_partial_trailing_character( $body ) {
+		for ( $dropped = 0; $dropped < 3 && '' !== $body; $dropped++ ) {
+			if ( self::is_text( $body ) ) {
+				break;
+			}
+			$body = substr( $body, 0, -1 );
+		}
+		return $body;
 	}
 
 	/**

--- a/projects/packages/backup/src/rest/class-file-browser-bridge.php
+++ b/projects/packages/backup/src/rest/class-file-browser-bridge.php
@@ -394,11 +394,9 @@ class File_Browser_Bridge {
 		if ( false !== strpos( $body, "\0" ) ) {
 			return false;
 		}
-		// mbstring is not guaranteed on every host, and a `//u` pattern fails
-		// to match on invalid UTF-8, which is the same verdict.
-		return function_exists( 'mb_check_encoding' )
-			? mb_check_encoding( $body, 'UTF-8' )
-			: 1 === preg_match( '//u', $body );
+		// A `//u` pattern fails to match on exactly the bytes `json_encode()`
+		// rejects, and unlike mbstring, PCRE cannot be absent from a host.
+		return 1 === preg_match( '//u', $body );
 	}
 
 	/**

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -55,9 +55,8 @@ beforeEach( () => {
 } );
 
 describe( 'preview integrity', () => {
-	// Content is in the fixture on purpose: the verdict, not an empty payload, has
-	// to be what keeps it off screen. The `Type:` row witnesses that the extension is
-	// previewable, the other branch rendering this same line.
+	// Content is in the fixture on purpose: the verdict, not an empty payload, has to
+	// be what keeps it off screen. `Type:` witnesses that the extension is previewable.
 	it( 'withholds bytes the bridge flagged unreadable', async () => {
 		await renderCard( { content: 'raw ? bytes', is_text: false, truncated: false } );
 
@@ -92,8 +91,7 @@ describe( 'preview integrity', () => {
 	} );
 
 	// `manifestPath` is optional on an `/ls` row, so a previewable file can leave the
-	// query disabled — the state the truncation verdict defaults to the innocent
-	// answer for.
+	// query disabled — the state the hook's innocent defaults are there for.
 	it( 'accuses nothing when the preview query never ran', async () => {
 		mockApiFetch.mockResolvedValue( {} );
 

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -54,9 +54,8 @@ beforeEach( () => {
 } );
 
 describe( 'preview integrity', () => {
-	// The bridge withholds bytes it could not read as text, because serving them
-	// puts a `?` where every invalid byte was and calls it the file's contents.
-	// Content is in the fixture anyway, so the verdict has to be what suppresses it.
+	// Content is in the fixture on purpose: the verdict, not an empty payload, has
+	// to be what keeps it off screen.
 	it( 'says a file is not text rather than showing bytes flagged unreadable', async () => {
 		await renderCard( { content: 'raw ? bytes', is_text: false, truncated: false } );
 
@@ -81,13 +80,29 @@ describe( 'preview integrity', () => {
 		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
 	} );
 
-	// Both verdicts default to the innocent answer, so a payload without them —
-	// a pending query, or a response from a site still running the old bridge —
-	// previews rather than accusing the file of being binary.
 	it( 'previews a payload carrying neither verdict', async () => {
 		await renderCard( { content: 'define( "X", 1 );' } );
 
 		await expect( screen.findByText( 'define( "X", 1 );' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
+	} );
+
+	// `manifestPath` is optional on an `/ls` row, so a previewable file can leave the
+	// query disabled — the state both verdicts default to the innocent answer for.
+	it( 'accuses nothing when the preview query never ran', async () => {
+		mockApiFetch.mockResolvedValue( {} );
+
+		render(
+			<QueryClientProvider>
+				<FileInfoCard file={ { ...FILE, manifestPath: undefined } } onClose={ noop } />
+			</QueryClientProvider>
+		);
+
+		// The `Type:` row witnesses that the extension is previewable, so an absent
+		// message here is the unresolved query and not the card refusing the file.
+		await expect( screen.findByText( 'Type:' ) ).resolves.toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -23,7 +23,8 @@ const FILE: FileNodeFile = {
 	manifestPath: 'f5:/error.log',
 };
 
-const NOT_TEXT = 'This file is not text and cannot be previewed.';
+const UNAVAILABLE = 'Preview unavailable for this file.';
+const FETCH_FAILED = 'Preview could not be loaded for this file.';
 const TRUNCATED = 'Preview truncated: this file is too large to show in full.';
 
 /**
@@ -55,11 +56,13 @@ beforeEach( () => {
 
 describe( 'preview integrity', () => {
 	// Content is in the fixture on purpose: the verdict, not an empty payload, has
-	// to be what keeps it off screen.
-	it( 'says a file is not text rather than showing bytes flagged unreadable', async () => {
+	// to be what keeps it off screen. The `Type:` row witnesses that the extension is
+	// previewable, the other branch rendering this same line.
+	it( 'withholds bytes the bridge flagged unreadable', async () => {
 		await renderCard( { content: 'raw ? bytes', is_text: false, truncated: false } );
 
-		await expect( screen.findByText( NOT_TEXT ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Type:' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'raw ? bytes' ) ).not.toBeInTheDocument();
 	} );
 
@@ -77,19 +80,20 @@ describe( 'preview integrity', () => {
 
 		await expect( screen.findByText( 'the whole file' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'previews a payload carrying neither verdict', async () => {
 		await renderCard( { content: 'define( "X", 1 );' } );
 
 		await expect( screen.findByText( 'define( "X", 1 );' ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
 	} );
 
 	// `manifestPath` is optional on an `/ls` row, so a previewable file can leave the
-	// query disabled — the state both verdicts default to the innocent answer for.
+	// query disabled — the state the truncation verdict defaults to the innocent
+	// answer for.
 	it( 'accuses nothing when the preview query never ran', async () => {
 		mockApiFetch.mockResolvedValue( {} );
 
@@ -99,11 +103,12 @@ describe( 'preview integrity', () => {
 			</QueryClientProvider>
 		);
 
-		// The `Type:` row witnesses that the extension is previewable, so an absent
-		// message here is the unresolved query and not the card refusing the file.
+		// The `Type:` row witnesses that the extension is previewable, so the neutral
+		// line below is the unresolved query and not the card refusing the file.
 		await expect( screen.findByText( 'Type:' ) ).resolves.toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
-		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.getByText( UNAVAILABLE ) ).toBeInTheDocument();
+		expect( screen.queryByText( FETCH_FAILED ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -24,6 +24,7 @@ const FILE: FileNodeFile = {
 };
 
 const UNAVAILABLE = 'Preview unavailable for this file.';
+const NOT_TEXT = 'This file is not text and cannot be previewed.';
 const FETCH_FAILED = 'Preview could not be loaded for this file.';
 const TRUNCATED = 'Preview truncated: this file is too large to show in full.';
 
@@ -60,9 +61,11 @@ describe( 'preview integrity', () => {
 	it( 'withholds bytes the bridge flagged unreadable', async () => {
 		await renderCard( { content: 'raw ? bytes', is_text: false, truncated: false } );
 
-		await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NOT_TEXT ) ).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Type:' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'raw ? bytes' ) ).not.toBeInTheDocument();
+		// The bytes were refused, not the extension: the two say different things.
+		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'marks a preview the bridge cut short', async () => {
@@ -79,14 +82,14 @@ describe( 'preview integrity', () => {
 
 		await expect( screen.findByText( 'the whole file' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'previews a payload carrying neither verdict', async () => {
 		await renderCard( { content: 'define( "X", 1 );' } );
 
 		await expect( screen.findByText( 'define( "X", 1 );' ) ).resolves.toBeInTheDocument();
-		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
 	} );
 
@@ -106,6 +109,7 @@ describe( 'preview integrity', () => {
 		await expect( screen.findByText( 'Type:' ) ).resolves.toBeInTheDocument();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( screen.getByText( UNAVAILABLE ) ).toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( FETCH_FAILED ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -1,0 +1,94 @@
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import FileInfoCard from '../src/dashboard/components/file-info-card';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { FileNodeFile } from '../src/dashboard/types/file-tree';
+
+/** Closing is irrelevant to these assertions; the card renders regardless. */
+const noop = () => {};
+
+const FILE: FileNodeFile = {
+	name: 'error.log',
+	path: '/error.log',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/error.log',
+};
+
+const NOT_TEXT = 'This file is not text and cannot be previewed.';
+const TRUNCATED = 'Preview truncated: this file is too large to show in full.';
+
+/**
+ * Answer the preview fetch with the given payload and render the card.
+ *
+ * @param payload - What `/rewind/backup/file-content` returns.
+ */
+async function renderCard( payload: Record< string, unknown > ): Promise< void > {
+	mockApiFetch.mockImplementation( ( options: { path: string } ) =>
+		Promise.resolve( options.path.includes( '/file-content' ) ? payload : { size: 42 } )
+	);
+
+	render(
+		<QueryClientProvider>
+			<FileInfoCard file={ FILE } onClose={ noop } />
+		</QueryClientProvider>
+	);
+
+	await expect(
+		screen.findByRole( 'heading', { name: FILE.name, level: 3 } )
+	).resolves.toBeInTheDocument();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	mockApiFetch.mockReset();
+} );
+
+describe( 'preview integrity', () => {
+	// The bridge withholds bytes it could not read as text, because serving them
+	// puts a `?` where every invalid byte was and calls it the file's contents.
+	// Content is in the fixture anyway, so the verdict has to be what suppresses it.
+	it( 'says a file is not text rather than showing bytes flagged unreadable', async () => {
+		await renderCard( { content: 'raw ? bytes', is_text: false, truncated: false } );
+
+		await expect( screen.findByText( NOT_TEXT ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'raw ? bytes' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'marks a preview the bridge cut short', async () => {
+		await renderCard( { content: 'first 64 KB', is_text: true, truncated: true } );
+
+		await expect( screen.findByText( TRUNCATED ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'first 64 KB' ) ).toBeInTheDocument();
+	} );
+
+	// The note has to earn its way on screen: one that always renders would pass
+	// the test above and tell every reader their file was clipped.
+	it( 'says nothing about truncation for a whole file', async () => {
+		await renderCard( { content: 'the whole file', is_text: true, truncated: false } );
+
+		await expect( screen.findByText( 'the whole file' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+	} );
+
+	// Both verdicts default to the innocent answer, so a payload without them —
+	// a pending query, or a response from a site still running the old bridge —
+	// previews rather than accusing the file of being binary.
+	it( 'previews a payload carrying neither verdict', async () => {
+		await renderCard( { content: 'define( "X", 1 );' } );
+
+		await expect( screen.findByText( 'define( "X", 1 );' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NOT_TEXT ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( TRUNCATED ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Bridge_Dispatch_Test.php
@@ -179,7 +179,11 @@ class Rest_Bridge_Dispatch_Test extends TestCase {
 					array( 'body' => self::SIGNED_URL_BODY ),
 					array( 'body' => "<?php\ndefine( 'DB_NAME', 'wordpress' );\n" ),
 				),
-				array( 'content' => "<?php\ndefine( 'DB_NAME', 'wordpress' );\n" ),
+				array(
+					'content'   => "<?php\ndefine( 'DB_NAME', 'wordpress' );\n",
+					'is_text'   => true,
+					'truncated' => false,
+				),
 			),
 			'/jetpack/v4/backups/download/(?P<rewind_id>[A-Za-z0-9.\-]+)' => array(
 				'POST',

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -587,8 +587,7 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * @return array<string, mixed>
 	 */
 	private static function served( $response ) {
-		// The flag is `WP_REST_Server::serve_request()`'s own, so this encodes the
-		// payload the way the server really would.
+		// `JSON_UNESCAPED_SLASHES` is `WP_REST_Server::serve_request()`'s own flag.
 		return json_decode( wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ), true );
 	}
 
@@ -725,14 +724,13 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * Bodies the storage host can answer with that no `<pre>` should be shown.
+	 * Bodies the storage host can answer with that must never reach a `<pre>`.
 	 *
 	 * @return array<string, array{0: string, 1: string}>
 	 */
 	public static function provide_bodies_that_are_not_text() {
 		return array(
-			// The exact sequence from the report: `\xC3\x28` is a lead byte followed by
-			// something that cannot continue it.
+			// `\xC3\x28`: a lead byte followed by something that cannot continue it.
 			'latin-1 text' => array( 'latin-1 text', "valid \xC3\x28 tail" ),
 			'a PNG header' => array( 'a PNG header', "\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR" ),
 			// Valid UTF-8 byte for byte, so the NUL check is the only thing that

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -608,14 +608,19 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * A body cut mid-character by the byte cap loses the half-written character and
 	 * comes back marked truncated.
 	 *
-	 * Left in place, the lone lead byte the cut keeps would fail the UTF-8 check and
-	 * report a perfectly good text file as unpreviewable.
+	 * Left in place, the bytes the cut keeps would fail the UTF-8 check and report a
+	 * perfectly good text file as unpreviewable.
+	 *
+	 * @param string $character A multi-byte character the cap lands inside of.
+	 * @param int    $kept      How many of its bytes survive the cut.
+	 * @dataProvider provide_characters_the_cap_cuts
 	 */
-	public function test_file_content_drops_the_character_the_byte_cap_cut_in_half() {
+	#[DataProvider( 'provide_characters_the_cap_cuts' )]
+	public function test_file_content_drops_the_character_the_byte_cap_cut_in_half( $character, $kept ) {
 		$this->assert_preview_cap_is_testable();
 
-		$whole = str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - 1 );
-		$cut   = substr( $whole . "\xE6\x97\xA5", 0, File_Browser_Bridge::PREVIEW_MAX_BYTES );
+		$whole = str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - $kept );
+		$cut   = substr( $whole . $character, 0, File_Browser_Bridge::PREVIEW_MAX_BYTES );
 
 		$this->arrange_wpcom_answers(
 			array(
@@ -629,6 +634,20 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 		$this->assertTrue( $served['truncated'] );
 		$this->assertTrue( $served['is_text'] );
 		$this->assertSame( $whole, $served['content'] );
+	}
+
+	/**
+	 * Every count of leftover bytes a cut can produce, up to the three a four-byte
+	 * character leaves — the count the repair loop's own bound is set to.
+	 *
+	 * @return array<string, array{0: string, 1: int}>
+	 */
+	public static function provide_characters_the_cap_cuts() {
+		return array(
+			'one byte of three'   => array( "\xE6\x97\xA5", 1 ),
+			'two bytes of four'   => array( "\xF0\x9F\x92\xA9", 2 ),
+			'three bytes of four' => array( "\xF0\x9F\x92\xA9", 3 ),
+		);
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -608,10 +608,8 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * A body cut mid-character by the byte cap loses the half-written character and
 	 * comes back marked truncated.
 	 *
-	 * The transport counts bytes with no idea where characters begin: 65,535 ASCII bytes
-	 * followed by U+65E5 is 65,538, and the cut at 65,536 keeps the lead byte and drops
-	 * its two continuations. Left in place that lone byte makes a perfectly good text
-	 * file fail the UTF-8 check and report as unpreviewable.
+	 * Left in place, the lone lead byte the cut keeps would fail the UTF-8 check and
+	 * report a perfectly good text file as unpreviewable.
 	 */
 	public function test_file_content_drops_the_character_the_byte_cap_cut_in_half() {
 		$this->assert_preview_cap_is_testable();
@@ -637,9 +635,8 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	 * A body that fills the cap without being cut mid-character is still marked
 	 * truncated, and keeps every byte.
 	 *
-	 * The flag is what the card renders its "preview truncated" line off, and the two
-	 * halves are independent: an implementation that only flagged the mid-character case
-	 * would leave a clipped ASCII file looking complete.
+	 * An implementation that only flagged the mid-character case would leave a clipped
+	 * ASCII file looking complete.
 	 */
 	public function test_file_content_marks_a_body_that_fills_the_cap_as_truncated() {
 		$this->assert_preview_cap_is_testable();
@@ -686,10 +683,8 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	/**
 	 * Bytes that are not UTF-8 text, as the REST server would serve them.
 	 *
-	 * `wp_json_encode()`'s sanity fallback re-encodes invalid UTF-8 through
-	 * `mb_convert_encoding()`, so the second `json_encode()` succeeds and the serve
-	 * error branch never runs: a latin-1 or binary file came back HTTP 200 with its
-	 * bytes replaced by `?` and nothing anywhere saying so.
+	 * `wp_json_encode()`'s sanity fallback re-encodes invalid UTF-8 rather than failing,
+	 * so the serve error branch never runs and the `?`-substituted body goes out as 200.
 	 *
 	 * @param string $label What kind of body this is.
 	 * @param string $body  Raw bytes the storage host answered with.

--- a/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_File_Browser_Bridge_Test.php
@@ -578,31 +578,46 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A preview cut short by the byte cap is forwarded exactly as it arrived,
-	 * mid-character and all.
+	 * The preview payload as the REST server would really serve it.
 	 *
-	 * The transport counts bytes with no idea where characters begin, so the cut can land
-	 * inside a multi-byte sequence: 65,535 ASCII bytes followed by U+65E5 is 65,538, and
-	 * the cut at 65,536 keeps the lead byte and drops its two continuations.
+	 * `get_data()` is the wrong layer to assert an intact preview at: the corruption
+	 * this guards against happens in `wp_json_encode()`, on the way out.
 	 *
-	 * What is under test is what the bridge does with that: nothing. Re-cutting or
-	 * repairing it would be a silently different file from the one on disk, which is
-	 * worse in a preview than a visibly damaged tail.
+	 * @param \WP_REST_Response $response The bridge's response.
+	 * @return array<string, mixed>
 	 */
-	public function test_file_content_forwards_a_body_cut_mid_character_unrepaired() {
-		// Checked before allocating: the fixture is the cap's own size, so a cap raised
-		// into the megabytes would fatal the run rather than fail this test.
+	private static function served( $response ) {
+		// The flag is `WP_REST_Server::serve_request()`'s own, so this encodes the
+		// payload the way the server really would.
+		return json_decode( wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES ), true );
+	}
+
+	/**
+	 * Guard the fixtures below: they allocate the cap's own size, so a cap raised into
+	 * the megabytes should fail here rather than fatal the run.
+	 */
+	private function assert_preview_cap_is_testable() {
 		$this->assertLessThanOrEqual(
 			1024 * 1024,
 			File_Browser_Bridge::PREVIEW_MAX_BYTES,
 			'A preview cap this large cannot be exercised in a unit test, and should not be buffered in PHP memory on a real site either.'
 		);
+	}
 
-		$cut = substr(
-			str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - 1 ) . "\xE6\x97\xA5",
-			0,
-			File_Browser_Bridge::PREVIEW_MAX_BYTES
-		);
+	/**
+	 * A body cut mid-character by the byte cap loses the half-written character and
+	 * comes back marked truncated.
+	 *
+	 * The transport counts bytes with no idea where characters begin: 65,535 ASCII bytes
+	 * followed by U+65E5 is 65,538, and the cut at 65,536 keeps the lead byte and drops
+	 * its two continuations. Left in place that lone byte makes a perfectly good text
+	 * file fail the UTF-8 check and report as unpreviewable.
+	 */
+	public function test_file_content_drops_the_character_the_byte_cap_cut_in_half() {
+		$this->assert_preview_cap_is_testable();
+
+		$whole = str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES - 1 );
+		$cut   = substr( $whole . "\xE6\x97\xA5", 0, File_Browser_Bridge::PREVIEW_MAX_BYTES );
 
 		$this->arrange_wpcom_answers(
 			array(
@@ -611,16 +626,130 @@ class Rest_File_Browser_Bridge_Test extends TestCase {
 			)
 		);
 
-		$response = File_Browser_Bridge::get_file_content( self::file_content_request() );
+		$served = self::served( File_Browser_Bridge::get_file_content( self::file_content_request() ) );
 
-		$this->assertNotInstanceOf( WP_Error::class, $response );
-		$content = $response->get_data()['content'];
-		$this->assertSame( $cut, $content );
-		$this->assertSame( File_Browser_Bridge::PREVIEW_MAX_BYTES, strlen( $content ) );
-		// Both halves of "the cut landed inside a character". A bridge that repaired or
-		// re-cut the body would pass the length check and fail these.
-		$this->assertSame( "\xE6", substr( $content, -1 ) );
-		$this->assertFalse( mb_check_encoding( $content, 'UTF-8' ) );
+		$this->assertTrue( $served['truncated'] );
+		$this->assertTrue( $served['is_text'] );
+		$this->assertSame( $whole, $served['content'] );
+	}
+
+	/**
+	 * A body that fills the cap without being cut mid-character is still marked
+	 * truncated, and keeps every byte.
+	 *
+	 * The flag is what the card renders its "preview truncated" line off, and the two
+	 * halves are independent: an implementation that only flagged the mid-character case
+	 * would leave a clipped ASCII file looking complete.
+	 */
+	public function test_file_content_marks_a_body_that_fills_the_cap_as_truncated() {
+		$this->assert_preview_cap_is_testable();
+
+		$full = str_repeat( 'a', File_Browser_Bridge::PREVIEW_MAX_BYTES );
+
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => $full ),
+			)
+		);
+
+		$served = self::served( File_Browser_Bridge::get_file_content( self::file_content_request() ) );
+
+		$this->assertTrue( $served['truncated'] );
+		$this->assertSame( $full, $served['content'] );
+	}
+
+	/**
+	 * A file that fits under the cap is not marked truncated, and survives the wire
+	 * byte for byte.
+	 *
+	 * The negative half of the flag, and the reason multi-byte text is in the fixture:
+	 * a check that rejected valid UTF-8 would blank out every file with an accent in it.
+	 */
+	public function test_file_content_serves_a_short_utf8_file_whole_and_unflagged() {
+		$body = "<?php\n// \xC3\xA9t\xC3\xA9 \xE6\x97\xA5\xE6\x9C\xAC\n";
+
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => $body ),
+			)
+		);
+
+		$served = self::served( File_Browser_Bridge::get_file_content( self::file_content_request() ) );
+
+		$this->assertSame( $body, $served['content'] );
+		$this->assertTrue( $served['is_text'] );
+		$this->assertFalse( $served['truncated'] );
+	}
+
+	/**
+	 * Bytes that are not UTF-8 text, as the REST server would serve them.
+	 *
+	 * `wp_json_encode()`'s sanity fallback re-encodes invalid UTF-8 through
+	 * `mb_convert_encoding()`, so the second `json_encode()` succeeds and the serve
+	 * error branch never runs: a latin-1 or binary file came back HTTP 200 with its
+	 * bytes replaced by `?` and nothing anywhere saying so.
+	 *
+	 * @param string $label What kind of body this is.
+	 * @param string $body  Raw bytes the storage host answered with.
+	 * @dataProvider provide_bodies_that_are_not_text
+	 */
+	#[DataProvider( 'provide_bodies_that_are_not_text' )]
+	public function test_file_content_withholds_bytes_it_cannot_serve_as_text( $label, $body ) {
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => $body ),
+			)
+		);
+
+		$served = self::served( File_Browser_Bridge::get_file_content( self::file_content_request() ) );
+
+		$this->assertFalse( $served['is_text'], $label );
+		$this->assertNull( $served['content'], $label );
+	}
+
+	/**
+	 * Bodies the storage host can answer with that no `<pre>` should be shown.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function provide_bodies_that_are_not_text() {
+		return array(
+			// The exact sequence from the report: `\xC3\x28` is a lead byte followed by
+			// something that cannot continue it.
+			'latin-1 text' => array( 'latin-1 text', "valid \xC3\x28 tail" ),
+			'a PNG header' => array( 'a PNG header', "\x89PNG\r\n\x1A\n\x00\x00\x00\rIHDR" ),
+			// Valid UTF-8 byte for byte, so the NUL check is the only thing that
+			// refuses it — and rendered as text it is every other character blank.
+			'UTF-16LE'     => array( 'UTF-16LE', "h\x00i\x00\n\x00" ),
+		);
+	}
+
+	/**
+	 * A file that is both over the cap and not text is refused, not repaired into
+	 * something that looks like text.
+	 *
+	 * Dropping the trailing partial character runs before the text check, so a large
+	 * binary reaches that check three bytes shorter — it must still be refused.
+	 */
+	public function test_file_content_withholds_a_capped_binary_body() {
+		$this->assert_preview_cap_is_testable();
+
+		$binary = str_repeat( "\x89PNG\r\n\x1A\n", (int) ceil( File_Browser_Bridge::PREVIEW_MAX_BYTES / 8 ) );
+
+		$this->arrange_wpcom_answers(
+			array(
+				array( 'body' => self::signed_url_body() ),
+				array( 'body' => substr( $binary, 0, File_Browser_Bridge::PREVIEW_MAX_BYTES ) ),
+			)
+		);
+
+		$served = self::served( File_Browser_Bridge::get_file_content( self::file_content_request() ) );
+
+		$this->assertFalse( $served['is_text'] );
+		$this->assertNull( $served['content'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes JETPACK-2308

The modernized Backup dashboard's file browser previewed any file the extension map let through, and the bridge returned the fetched bytes verbatim.

WordPress's `wp_json_encode()` has a sanity fallback: when the first `json_encode()` fails it re-encodes every string through `mb_convert_encoding()` and tries again. The second attempt succeeds, `json_last_error()` is 0, and `WP_REST_Server::serve_request()`'s error branch never runs. So a binary or latin-1 file came back **HTTP 200 with each invalid byte replaced by `?`** — corruption shown to the reader as the file's contents:

```
json_encode( [ 'content' => "valid \xC3\x28 tail" ] ) === false
after the fallback: {"content":"valid ?( tail"}   json_last_error() === 0
```

The second half is silent truncation. `limit_response_size => 64 * 1024` is a byte-exact cut, so a valid UTF-8 file crossing 65,536 bytes lost its final character to a `?` as well, and nothing marked the body as clipped — the card rendered it as if it were the whole file.

## Proposed changes

* `File_Browser_Bridge::get_file_content()` now answers `is_text` and `truncated` alongside `content`, still with a 200: neither condition is a transport failure.
* Bytes that are not UTF-8 text, or that contain a NUL byte (UTF-16 and binaries that happen to decode cleanly), come back as `content: null` rather than being handed to `wp_json_encode()`.
* A body that fills the cap drops the character the cut left half-written, so a large text file is not mistaken for binary on account of its last three bytes.
* `useFileContents` carries both verdicts through to the info card, defaulting to the innocent answer so an unresolved query never accuses a file of being unreadable.
* The card says `This file is not text and cannot be previewed.` in place of the empty preview, and shows a truncation line above the contents. The line sits above the `<pre>` because the panel is the scroll container — underneath, it would only be reachable by scrolling past the very content it warns about.

Not in scope, and left alone deliberately: JETPACK-2353 (`wp-config.php` credentials shown in the clear) and JETPACK-2356 (preview card off-screen). Neither is made harder by this — 2353 gets a new, cheap lever if it wants one, since the bridge now shapes the payload rather than passing bytes straight through.

## Related product discussion/links

* JETPACK-2308

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The whole file browser is behind `rsm_jetpack_ui_modernization_backup`, off by default, so nothing here is reachable without the flag.

Automated (this is where the behaviour is actually pinned):

* `jp test php packages/backup` — 375 tests. Seven of them are new and all seven fail against the previous bridge; the sharpest is `test_file_content_withholds_bytes_it_cannot_serve_as_text`, which asserts on `json_decode( wp_json_encode( … ) )` rather than `get_data()`, because the corruption happens on the way out.
* `jp test js packages/backup` — 691 tests, 4 new in `tests/file-preview-integrity.test.tsx`.

By hand, on a site with the flag on and a Backup plan:

1. Open **Jetpack → Backup**, pick a backup, and open the file browser.
2. Click a text file (`wp-config.php`, a theme's `style.css`). It previews exactly as before, with no truncation line.
3. Rename a small binary — a `.png`, or a UTF-16 file — to `.log` or `.txt` so the extension map lets it through, and click it. Expect **"This file is not text and cannot be previewed."** Before this change, the preview showed the file's bytes with each invalid one replaced by `?`.
4. Click a text file larger than 64 KB (a big `error.log`, or a SQL dump). Expect the contents plus **"Preview truncated: this file is too large to show in full."** above them. Before, the preview stopped mid-file with nothing saying so, and the final character was replaced by `?`.

What I did not test: a live site. Everything above was verified against unit tests and a direct PHP reproduction of the `wp_json_encode()` fallback; the file browser itself needs a real backup to browse.
