### PR TITLE
Backup: share one query cache across the modernized dashboard routes

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2327-i2b-share-one-query-cache-across-dashboard-routes
+++ b/projects/packages/backup/changelog/jetpack-2327-i2b-share-one-query-cache-across-dashboard-routes
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the Overview, Download and Restore routes now share one React Query cache, so moving between them no longer re-fetches the site's backup capabilities behind a spinner. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -4,26 +4,40 @@ import type { ActivitySortOrder } from './api/activity-log';
 const STALE_TIME_DEFAULT_MS = 30_000;
 const GC_TIME_DEFAULT_MS = 5 * 60_000;
 
+const CLIENT_KEY = '__jetpackBackupQueryClient' as const;
+
+declare global {
+	interface Window {
+		[ CLIENT_KEY ]?: QueryClient;
+	}
+}
+
 /**
- * Module-scope QueryClient for the modernized Backup dashboard.
+ * The one QueryClient every route of the modernized Backup dashboard renders against.
  *
- * Each wp-build route is its own JS bundle and ends up with its own
- * copy of this module, so the cache is per-route — it does NOT survive
- * Overview ↔ Restore ↔ Download navigation. The screens don't depend on
- * cross-route cache reuse today (each derives its rewindId from the
- * URL), so this is fine; revisit if a future screen needs to read cache
- * a sibling route populated.
+ * Parked on `window` because each wp-build route bundles its own copy of this module: a
+ * module-scope client gave every Overview ↔ Restore ↔ Download hop a cold cache.
+ *
+ * @return The shared client, created on first use.
  */
-export const queryClient = new QueryClient( {
-	defaultOptions: {
-		queries: {
-			staleTime: STALE_TIME_DEFAULT_MS,
-			gcTime: GC_TIME_DEFAULT_MS,
-			retry: 1,
-			refetchOnWindowFocus: false,
-		},
-	},
-} );
+function sharedClient(): QueryClient {
+	if ( ! window[ CLIENT_KEY ] ) {
+		window[ CLIENT_KEY ] = new QueryClient( {
+			defaultOptions: {
+				queries: {
+					staleTime: STALE_TIME_DEFAULT_MS,
+					gcTime: GC_TIME_DEFAULT_MS,
+					retry: 1,
+					refetchOnWindowFocus: false,
+				},
+			},
+		} );
+	}
+
+	return window[ CLIENT_KEY ];
+}
+
+export const queryClient = sharedClient();
 
 /**
  * Stable cache keys for each query the dashboard issues.

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -16,7 +16,7 @@ declare global {
  * The one QueryClient every route of the modernized Backup dashboard renders against.
  *
  * Parked on `window` because each wp-build route bundles its own copy of this module: a
- * module-scope client gave every Overview ↔ Restore ↔ Download hop a cold cache.
+ * module-scope client left every route with its own cache, cold on first arrival.
  *
  * @return The shared client, created on first use.
  */

--- a/projects/packages/backup/src/dashboard/data/query-client.ts
+++ b/projects/packages/backup/src/dashboard/data/query-client.ts
@@ -37,6 +37,8 @@ function sharedClient(): QueryClient {
 	return window[ CLIENT_KEY ];
 }
 
+// Each route also bundles its own react-query, so sentinels compared by identity —
+// `skipToken`, `isCancelledError` — never match against a client another route created.
 export const queryClient = sharedClient();
 
 /**

--- a/projects/packages/backup/tests/shared-query-cache.test.tsx
+++ b/projects/packages/backup/tests/shared-query-cache.test.tsx
@@ -1,0 +1,149 @@
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( { rewindId: '1777035492' } ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import Gates from '../src/dashboard/components/gates';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
+import type { QueryClient } from '@tanstack/react-query';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
+const CAPABILITIES_PATH = '/site/capabilities';
+const SIBLING_BODY = 'sibling route body';
+
+type QueryClientModule = { queryClient: QueryClient; keys: typeof keys };
+
+/**
+ * The copy of the data module a sibling route's bundle evaluates.
+ *
+ * `jest.isolateModules` stands in for wp-build's per-route bundling: without it every
+ * assertion here would pass on a module-scope client, which is the bug.
+ *
+ * @return The sibling bundle's exports.
+ */
+function siblingBundle(): QueryClientModule {
+	let copy!: QueryClientModule;
+	jest.isolateModules( () => {
+		copy = jest.requireActual< QueryClientModule >( '../src/dashboard/data/query-client' );
+	} );
+	return copy;
+}
+
+/**
+ * How many times the capabilities route has been asked, across every render so far.
+ *
+ * @return The call count.
+ */
+function capabilitiesCalls(): number {
+	return mockApiFetch.mock.calls.filter( ( [ options ] ) =>
+		String( ( options as { path?: string } )?.path ?? '' ).includes( CAPABILITIES_PATH )
+	).length;
+}
+
+/**
+ * The gate's first-load spinner, if it is on screen.
+ *
+ * @return The skeleton element, or null.
+ */
+function skeleton(): HTMLElement | null {
+	return document.querySelector( '.jpb-gates__skeleton' );
+}
+
+/**
+ * Load the Overview route, wait for its capabilities read to land, then leave it.
+ *
+ * The unmount is the navigation: it is what a per-route client would not survive.
+ *
+ * @return Nothing.
+ */
+async function visitOverview(): Promise< void > {
+	const view = render( <OverviewStage /> );
+	await waitFor( () => expect( queryClient.getQueryData( keys.capabilities() ) ).toBeDefined() );
+	view.unmount();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( CAPABILITIES_PATH ) ) {
+			return Promise.resolve( CAPABILITIES );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path.includes( '/backups' ) ) {
+			return Promise.resolve( [] );
+		}
+		return Promise.resolve( null );
+	} );
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'one query cache across the dashboard routes', () => {
+	it( 'hands every route bundle the same client', () => {
+		expect( siblingBundle().queryClient ).toBe( queryClient );
+	} );
+
+	it( 'serves a sibling bundle the capabilities the first route fetched', async () => {
+		await visitOverview();
+
+		const sibling = siblingBundle();
+
+		expect( sibling.queryClient.getQueryData( sibling.keys.capabilities() ) ).toEqual(
+			CAPABILITIES
+		);
+	} );
+
+	it( 'renders a sibling route past the gate with no spinner and no second request', async () => {
+		await visitOverview();
+		const callsAfterOverview = capabilitiesCalls();
+		expect( callsAfterOverview ).toBeGreaterThan( 0 );
+
+		render(
+			<QueryClientProvider client={ siblingBundle().queryClient }>
+				<Gates>
+					<div>{ SIBLING_BODY }</div>
+				</Gates>
+			</QueryClientProvider>
+		);
+
+		expect( screen.getByText( SIBLING_BODY ) ).toBeInTheDocument();
+		expect( skeleton() ).toBeNull();
+		expect( capabilitiesCalls() ).toBe( callsAfterOverview );
+	} );
+
+	it( 'asks once when StrictMode remounts the route', async () => {
+		render(
+			<StrictMode>
+				<OverviewStage />
+			</StrictMode>
+		);
+
+		await waitFor( () => expect( capabilitiesCalls() ).toBeGreaterThan( 0 ) );
+
+		expect( capabilitiesCalls() ).toBe( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-2327

## Proposed changes

* `src/dashboard/data/query-client.ts` now parks the dashboard's `QueryClient` on `window` instead of module scope, so all three wp-build route bundles render against one cache. Same pattern VideoPress's dashboard already uses (`packages/videopress/src/dashboard/components/query-client-wrapper`).
* Adds `tests/shared-query-cache.test.tsx`. Nothing else changes — the export name, the keys, and the default options are untouched, so every existing caller and test keeps working.

### Root cause

The three routes (`/`, `/download/$rewindId`, `/restore/$rewindId`) share a single wp-admin page (`jetpack-backup-dashboard`) and navigate client-side through `@wordpress/route`, but each is its own esbuild bundle with its own copy of every module — including `query-client.ts` **and** `@tanstack/react-query`. Each route's `<QueryClientProvider>` therefore held a *different* `QueryClient`, and the first visit to a route re-entered `<Gates>` with an empty cache: a spinner, plus another `/jetpack/v4/site/capabilities` round trip for data the page already had.

The file's own docblock described this and concluded it was fine. It isn't, and that docblock is replaced.

### The issue's "Why now" is stale — the change stands without it

JETPACK-2327 says JETPACK-2321 needs the Download screen to read the file tree the Overview fetched. **That is no longer true.** #51740 shipped the file-browser selection through a `?files=` URL search param, not the cache, so nothing is blocked on this work. The justification that remains is the honest one: every first visit to a route repaints a spinner and re-fetches capabilities the app already had. This PR is scoped to that, and deliberately does not add any cross-route cache read.

The docblock's other claim — "each derives its rewindId from the URL" — does still hold. Download and Restore both read `useParams()`, and #51740's selection is URL-derived too. So nothing in the dashboard was relying on a cold cache per route.

### `staleTime` / `gcTime` now that the cache outlives a route

Both stay as they are, and both are still right:

* **`staleTime` 30s** (5 min for capabilities). React Query's default `refetchOnMount: true` means a sibling route paints cached data immediately and revalidates behind it whenever the entry is past its stale window. Nothing freezes — the spinner is what goes away, not the refresh. Where that revalidation is visible, the activity list already renders a stale-rows affordance.
* **`gcTime` 5 min** comfortably covers the gap between one route unmounting and its sibling mounting (a couple of frames), so the entry is never collected in transit. It was also what made the old bug intermittent: come back to a route within five minutes and *its own* client was still warm, so only the first visit to each route spun.
* Every key that could show one route's data under another route's id is already parameterised on that id — `fileTree`, `fileContents`, `downloadStatus`, `restoreStatus`, `pathInfo`. The rest (`capabilities`, `backups`, `siteSize`, `sitePolicies`, the activity log) are site-wide. A shared cache cannot cross them.

### Second mounts

`QueryClient.mount()`/`unmount()` only ref-count the focus and online subscriptions; neither touches the cache. So StrictMode's mount → unmount → remount, and a re-entered route, are both safe. There is a test pinning that the capabilities route is asked exactly once under StrictMode.

## Related product discussion/links

* JETPACK-2327 (task I2b)
* #51740 — the PR that made this issue's stated "Why now" obsolete.

## Does this pull request change what data or activity we track or use?

No. It reduces how many REST requests the dashboard makes; it does not change what is requested, sent, or stored.

## Testing instructions

The modernized dashboard is behind the `rsm_jetpack_ui_modernization_backup` filter, which defaults to **off**. With it off this PR is a no-op — `query-client.ts` is only reachable from the wp-build route bundles.

**Live click-through**

1. On a Jetpack-connected site with a Backup plan, turn the filter on:
   ```php
   add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );
   ```
2. `jp build packages/backup` (in a fresh checkout, `jp build packages/backup --deps` once first).
3. Open **Jetpack → VaultPress Backup** and let the Overview finish loading.
4. Open DevTools → Network, filter on `site/capabilities`, and clear it.
5. Click **Download backup** on a backup row, then **Back to overview**, then **Restore to this point**.
6. **Expected:** no new `site/capabilities` request on any of those hops, and no spinner between screens — each one renders its body on the first paint.
7. On trunk, the same steps produce one extra `site/capabilities` request on the first visit to Download and another on the first visit to Restore, with the gate skeleton visible in between.

**Automated**

```
jp test js packages/backup
# or, from projects/packages/backup, for per-test detail:
pnpm test
```

`tests/shared-query-cache.test.tsx` uses `jest.isolateModules` to stand in for wp-build's per-route bundling — without that, its assertions would pass on a module-scope client too, which is the bug. Three of its four tests fail on trunk (verified by reverting `query-client.ts` alone and re-running).

**What I tested**

* Full package suite: 70 suites / 691 tests pass. `pnpm run typecheck` (tsgo) clean, ESLint and Prettier clean on both changed files.
* `jp build packages/backup --deps` succeeds, and all three built route bundles (`build/routes/{dashboard,download,restore}/content.js`) contain the shared window key — while each still carries its own react-query copy, which is exactly the situation the shared client resolves.
* The **bug** was reproduced live in a browser against trunk: clicking through Overview → Download showed the gate skeleton and fired a second `site/capabilities`; Overview → Restore fired a third.

**What I did NOT test**

* The **fix** has not been clicked through in a browser. Doing so would have meant repointing a running local Docker environment at this branch, which I left alone. The live evidence above is of the bug on trunk; the fix is covered by the jest tests and the built-bundle check.
* PHP is untouched, so no PHPUnit or Phan run.
