### PR TITLE
Backup: send the file selection to WordPress.com as a path list

### DIFF
--- a/projects/packages/backup/changelog/update-backup-granular-download-paths-2321
+++ b/projects/packages/backup/changelog/update-backup-granular-download-paths-2321
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Granular download paths reach WordPress.com; behind the modernization flag, which is off by default.
+
+

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -71,14 +71,10 @@ export default function BackupDetail( { item }: Props ) {
 		);
 	}, [] );
 
-	// Comma-joined into one string rather than repeated params, because
-	// that is the form upstream's `include_path_list` takes — and it has
-	// to be a string: a single `ls` entry id can itself contain a comma,
-	// which works precisely because upstream flattens on comma.
-	//
-	// Absent when nothing is ticked, so a whole-backup download links
-	// exactly as it did before. JETPACK-2321 turns what arrives on the
-	// Download screen into the granular request.
+	// One comma-joined string rather than repeated params: the comma is
+	// upstream's own separator between `ls` entries, so an id may already
+	// carry one. Absent when nothing is ticked, so a whole-backup download
+	// links exactly as it did before.
 	const downloadSearch = useMemo(
 		() => ( selectedIds.length > 0 ? { files: selectedIds.join( ',' ) } : undefined ),
 		[ selectedIds ]

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -56,9 +56,8 @@ export async function initiateDownload(
 /**
  * The `ls` entry ids carried in a `?files=` param.
  *
- * The comma is upstream's own separator — a folder's `ls` id is the
- * joined ids of the manifest entries it covers — so splitting yields
- * exactly the entries upstream's comma-string branch would.
+ * The comma is upstream's own separator: a folder's id is the joined ids
+ * of the entries it covers, so splitting yields exactly those entries.
  *
  * @param files - The comma-joined `?files=` value.
  * @return One trimmed, non-empty entry per id.
@@ -73,10 +72,8 @@ export function splitFileSelection( files: string ): string[] {
 /**
  * Initiate a download scoped to named files.
  *
- * `types: { paths: true }` and nothing else: upstream reads
- * `include_path_list` only for the `paths` type and validates neither
- * half, so a list beside any other category answers 200 with the
- * whole-site archive.
+ * `types: { paths: true }` and nothing else — the bridge refuses any other
+ * pairing, and upstream would not.
  *
  * @param  rewindId - The backup's rewind id, in full.
  * @param  files    - The comma-joined `ls` entry ids the file browser produced.

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -78,10 +78,6 @@ export function splitFileSelection( files: string ): string[] {
  * half, so a list beside any other category answers 200 with the
  * whole-site archive.
  *
- * Sent as an array because upstream trims array entries individually,
- * while its comma-string branch sanitises the whole string first and
- * leaves the space in `"a, b"` on the second entry.
- *
  * @param  rewindId - The backup's rewind id, in full.
  * @param  files    - The comma-joined `ls` entry ids the file browser produced.
  * @throws {ApiError} When the selection names no entry.

--- a/projects/packages/backup/src/dashboard/data/api/download.ts
+++ b/projects/packages/backup/src/dashboard/data/api/download.ts
@@ -1,4 +1,5 @@
-import { apiCall, apiPath, requireTypes } from './_helpers';
+import { __ } from '@wordpress/i18n';
+import { ApiError, apiCall, apiPath, requireTypes } from './_helpers';
 import type { RestoreItems } from '../../types/restore';
 
 export type InitiateDownloadResponse = {
@@ -49,6 +50,59 @@ export async function initiateDownload(
 		path: apiPath( `/backups/download/${ rewindId }` ),
 		method: 'POST',
 		data: { types: requireTypes( types ) },
+	} );
+}
+
+/**
+ * The `ls` entry ids carried in a `?files=` param.
+ *
+ * The comma is upstream's own separator — a folder's `ls` id is the
+ * joined ids of the manifest entries it covers — so splitting yields
+ * exactly the entries upstream's comma-string branch would.
+ *
+ * @param files - The comma-joined `?files=` value.
+ * @return One trimmed, non-empty entry per id.
+ */
+export function splitFileSelection( files: string ): string[] {
+	return files
+		.split( ',' )
+		.map( part => part.trim() )
+		.filter( Boolean );
+}
+
+/**
+ * Initiate a download scoped to named files.
+ *
+ * `types: { paths: true }` and nothing else: upstream reads
+ * `include_path_list` only for the `paths` type and validates neither
+ * half, so a list beside any other category answers 200 with the
+ * whole-site archive.
+ *
+ * Sent as an array because upstream trims array entries individually,
+ * while its comma-string branch sanitises the whole string first and
+ * leaves the space in `"a, b"` on the second entry.
+ *
+ * @param  rewindId - The backup's rewind id, in full.
+ * @param  files    - The comma-joined `ls` entry ids the file browser produced.
+ * @throws {ApiError} When the selection names no entry.
+ * @return The download id.
+ */
+export async function initiateFileDownload(
+	rewindId: string,
+	files: string
+): Promise< InitiateDownloadResponse > {
+	const paths = splitFileSelection( files );
+	if ( ! paths.length ) {
+		throw new ApiError(
+			'no_files_selected',
+			__( 'Select at least one file to download.', 'jetpack-backup-pkg' )
+		);
+	}
+
+	return apiCall< InitiateDownloadResponse >( {
+		path: apiPath( `/backups/download/${ rewindId }` ),
+		method: 'POST',
+		data: { types: { paths: true }, include_path_list: paths },
 	} );
 }
 

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useCallback, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { fetchDownloadStatus, initiateDownload } from '../data/api/download';
+import { fetchDownloadStatus, initiateDownload, initiateFileDownload } from '../data/api/download';
 import { keys } from '../data/query-client';
 import type { RestoreItems } from '../types/restore';
 
@@ -12,9 +12,14 @@ type DownloadState =
 	| { phase: 'success'; downloadUrl: string; validUntil: string }
 	| { phase: 'error'; message: string };
 
+// A download is scoped by categories *or* by named files, never both:
+// upstream models `paths` as one of the six categories.
+type DownloadRequest = { items: RestoreItems } | { files: string };
+
 type Result = {
 	state: DownloadState;
 	submit: ( items: RestoreItems ) => void;
+	submitFiles: ( files: string ) => void;
 	reset: () => void;
 };
 
@@ -32,7 +37,7 @@ const POLL_INTERVAL_MS = 1500;
  * status field — it signals lifecycle by which keys are present.
  *
  * @param rewindId - The backup's rewind id.
- * @return state + submit + reset.
+ * @return state + submit + submitFiles + reset.
  */
 export function useDownload( rewindId: string ): Result {
 	const [ downloadId, setDownloadId ] = useState< number | null >( null );
@@ -43,7 +48,10 @@ export function useDownload( rewindId: string ): Result {
 		reset: resetMutation,
 		isPending: isInitiating,
 	} = useMutation( {
-		mutationFn: ( items: RestoreItems ) => initiateDownload( rewindId, items ),
+		mutationFn: ( request: DownloadRequest ) =>
+			'files' in request
+				? initiateFileDownload( rewindId, request.files )
+				: initiateDownload( rewindId, request.items ),
 		onSuccess: result => {
 			setDownloadId( result.id );
 			setErrorMessage( null );
@@ -62,7 +70,11 @@ export function useDownload( rewindId: string ): Result {
 	} );
 
 	const submit = useCallback(
-		( items: RestoreItems ) => mutateInitiate( items ),
+		( items: RestoreItems ) => mutateInitiate( { items } ),
+		[ mutateInitiate ]
+	);
+	const submitFiles = useCallback(
+		( files: string ) => mutateInitiate( { files } ),
 		[ mutateInitiate ]
 	);
 	const reset = useCallback( () => {
@@ -121,5 +133,5 @@ export function useDownload( rewindId: string ): Result {
 		state = { phase: 'submitting' };
 	}
 
-	return { state, submit, reset };
+	return { state, submit, submitFiles, reset };
 }

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -1,6 +1,6 @@
 import { Notice, ProgressBar, Spinner } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams, useSearch } from '@wordpress/route';
@@ -8,6 +8,7 @@ import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
+import { splitFileSelection } from '../data/api/download';
 import { useDownload } from '../hooks/use-download';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
 import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
@@ -21,8 +22,8 @@ const SELECTION_HINT_ID = 'jpb-download__selection-hint';
  * The Download route's own search params.
  *
  * `files` carries the file browser's selection as the comma-joined `ls`
- * entry ids the detail pane built — the same string upstream's
- * `include_path_list` takes.
+ * entry ids the detail pane built; `splitFileSelection` turns it into the
+ * `include_path_list` sent upstream.
  */
 type DownloadSearch = Record< string, unknown > & { files?: string };
 
@@ -47,17 +48,17 @@ export default function DownloadScreen() {
 	// param no route declares.
 	const search = useSearch( { strict: false } ) as DownloadSearch;
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	const { state, submit, reset } = useDownload( rewindId );
+	const { state, submit, submitFiles, reset } = useDownload( rewindId );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would ask WPCOM for the *whole* archive, not for
 	// nothing — see `hasSelectedItems`.
 	const hasSelection = hasSelectedItems( items );
 
-	// Kept as one string: it is already the `include_path_list` value
-	// JETPACK-2321 forwards, and a single `ls` entry id can contain a comma, so
-	// the pieces between commas are not entries.
+	// Kept as the one string the link carried, so the request is built from
+	// exactly what the detail pane counted; `splitFileSelection` is the only
+	// place it is taken apart.
 	const files = typeof search.files === 'string' ? search.files : '';
-	const hasFileSelection = files.replace( /,/g, '' ) !== '';
+	const hasFileSelection = useMemo( () => splitFileSelection( files ).length > 0, [ files ] );
 
 	// A ref, not Overview's module latch: a second mount here means the reader
 	// came back for a second archive. This only stops StrictMode asking twice.
@@ -67,8 +68,8 @@ export default function DownloadScreen() {
 			return;
 		}
 		hasAutoStarted.current = true;
-		submit( items );
-	}, [ hasFileSelection, rewindId, submit, items ] );
+		submitFiles( files );
+	}, [ hasFileSelection, rewindId, submitFiles, files ] );
 
 	// With a file selection there is no checklist to send the reader back
 	// to, so a failed attempt has to re-submit rather than return to a
@@ -76,8 +77,8 @@ export default function DownloadScreen() {
 	// until something succeeds.
 	const handleRetry = useCallback( () => {
 		reset();
-		submit( items );
-	}, [ reset, submit, items ] );
+		submitFiles( files );
+	}, [ reset, submitFiles, files ] );
 
 	// A file selection has no form stage: the screen is waiting from the
 	// moment it mounts, before the mutation has even been sent.

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -22,8 +22,7 @@ const SELECTION_HINT_ID = 'jpb-download__selection-hint';
  * The Download route's own search params.
  *
  * `files` carries the file browser's selection as the comma-joined `ls`
- * entry ids the detail pane built; `splitFileSelection` turns it into the
- * `include_path_list` sent upstream.
+ * entry ids the detail pane built.
  */
 type DownloadSearch = Record< string, unknown > & { files?: string };
 
@@ -55,8 +54,7 @@ export default function DownloadScreen() {
 	const hasSelection = hasSelectedItems( items );
 
 	// Kept as the one string the link carried, so the request is built from
-	// exactly what the detail pane counted; `splitFileSelection` is the only
-	// place it is taken apart.
+	// exactly what the detail pane counted.
 	const files = typeof search.files === 'string' ? search.files : '';
 	const hasFileSelection = useMemo( () => splitFileSelection( files ).length > 0, [ files ] );
 

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -123,7 +123,11 @@ class Download_Bridge {
 		// nothing between here and there checks the pairing: a list sent
 		// beside any other category answers 200 and builds a *full-site*
 		// archive, so the mismatch has to be refused here or not at all.
-		if ( $include || $exclude ) {
+		//
+		// Gated on the include list having been *sent*, because
+		// `path_list()` trims a blank one away and a caller that names
+		// files must not fall through as one that named none.
+		if ( $include || $exclude || $request->has_param( 'include_path_list' ) ) {
 			if ( array( 'paths' ) !== array_keys( $named_types ) ) {
 				return new WP_Error(
 					'path_list_needs_paths_type',
@@ -131,7 +135,9 @@ class Download_Bridge {
 					array( 'status' => 400 )
 				);
 			}
-		} elseif ( isset( $named_types['paths'] ) ) {
+		}
+
+		if ( ! $include && ! $exclude && isset( $named_types['paths'] ) ) {
 			// The mirror image, and just as silent upstream: `paths` with
 			// nothing to scope it by yields an archive of everything.
 			return new WP_Error(

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -38,11 +38,11 @@ class Download_Bridge {
 				'callback'            => array( __CLASS__, 'initiate_download' ),
 				'permission_callback' => array( Rest_Controller::class, 'permission_check' ),
 				'args'                => array(
-					'rewind_id' => array(
+					'rewind_id'         => array(
 						'type'     => 'string',
 						'required' => true,
 					),
-					'types'     => array(
+					'types'             => array(
 						'type'                 => 'object',
 						// Values must be booleans. WordPress validates
 						// `object` with `rest_is_object()`, which is just
@@ -53,6 +53,17 @@ class Download_Bridge {
 						// runs; `Rest_Controller::named_types()` makes the
 						// shape guarantee that a value check cannot.
 						'additionalProperties' => array( 'type' => 'boolean' ),
+					),
+					// Opaque `/rewind/backup/ls` entry ids, only meaningful
+					// alongside `types: { paths: true }` — see the pairing
+					// guard in `initiate_download()`.
+					'include_path_list' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
+					),
+					'exclude_path_list' => array(
+						'type'  => 'array',
+						'items' => array( 'type' => 'string' ),
 					),
 				),
 			)
@@ -104,6 +115,32 @@ class Download_Bridge {
 		$rewind_id = (string) $request->get_param( 'rewind_id' );
 		$types     = $request->get_param( 'types' );
 
+		$named_types = Rest_Controller::named_types( $types );
+		$include     = self::path_list( $request, 'include_path_list' );
+		$exclude     = self::path_list( $request, 'exclude_path_list' );
+
+		// VaultPress reads the path lists only for the `paths` type, and
+		// nothing between here and there checks the pairing: a list sent
+		// beside any other category answers 200 and builds a *full-site*
+		// archive, so the mismatch has to be refused here or not at all.
+		if ( $include || $exclude ) {
+			if ( array( 'paths' ) !== array_keys( $named_types ) ) {
+				return new WP_Error(
+					'path_list_needs_paths_type',
+					__( 'A file selection can only be downloaded on its own.', 'jetpack-backup-pkg' ),
+					array( 'status' => 400 )
+				);
+			}
+		} elseif ( isset( $named_types['paths'] ) ) {
+			// The mirror image, and just as silent upstream: `paths` with
+			// nothing to scope it by yields an archive of everything.
+			return new WP_Error(
+				'paths_type_needs_path_list',
+				__( 'No files were named for this download.', 'jetpack-backup-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// A supplied `types` that names nothing is refused rather than
 		// dropped. Omitting the key is not "download nothing" — WPCOM
 		// reads an absent `types` as every category, so forwarding an
@@ -121,9 +158,17 @@ class Download_Bridge {
 		$body = array( 'rewindId' => $rewind_id );
 		// Absent when the caller named no categories at all, which is how
 		// a whole-archive download is spelled upstream.
-		$named_types = Rest_Controller::named_types( $types );
 		if ( ! empty( $named_types ) ) {
 			$body['types'] = $named_types;
+		}
+		// Arrays rather than the comma-joined string upstream also accepts:
+		// that branch sanitises the whole string before splitting, so
+		// `"a, b"` reaches VaultPress as `" b"`.
+		if ( $include ) {
+			$body['include_path_list'] = $include;
+		}
+		if ( $exclude ) {
+			$body['exclude_path_list'] = $exclude;
 		}
 
 		$response = Client::wpcom_json_api_request_as_user(
@@ -164,6 +209,35 @@ class Download_Bridge {
 		}
 
 		return rest_ensure_response( array( 'id' => $download_id ) );
+	}
+
+	/**
+	 * One path-list parameter as a clean list of entries.
+	 *
+	 * Entries are trimmed and empties dropped, and the result is a PHP
+	 * list so `wp_json_encode()` emits a JSON array rather than an object.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @param string          $key     Parameter name.
+	 * @return string[] The entries, empty when the parameter is absent or names nothing.
+	 */
+	private static function path_list( WP_REST_Request $request, $key ) {
+		$value = $request->get_param( $key );
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$entries = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_scalar( $entry ) ) {
+				continue;
+			}
+			$entry = trim( (string) $entry );
+			if ( '' !== $entry ) {
+				$entries[] = $entry;
+			}
+		}
+		return $entries;
 	}
 
 	/**

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -55,8 +55,7 @@ class Download_Bridge {
 						'additionalProperties' => array( 'type' => 'boolean' ),
 					),
 					// Opaque `/rewind/backup/ls` entry ids, only meaningful
-					// alongside `types: { paths: true }` — see the pairing
-					// guard in `initiate_download()`.
+					// alongside `types: { paths: true }` — see `initiate_download()`.
 					'include_path_list' => array(
 						'type'  => 'array',
 						'items' => array( 'type' => 'string' ),
@@ -119,14 +118,12 @@ class Download_Bridge {
 		$include     = self::path_list( $request, 'include_path_list' );
 		$exclude     = self::path_list( $request, 'exclude_path_list' );
 
-		// VaultPress reads the path lists only for the `paths` type, and
-		// nothing between here and there checks the pairing: a list sent
-		// beside any other category answers 200 and builds a *full-site*
-		// archive, so the mismatch has to be refused here or not at all.
+		// Nothing upstream checks this pairing: VaultPress reads the path
+		// lists only for the `paths` type, so a list beside any other
+		// category answers 200 with a *full-site* archive.
 		//
-		// Gated on the include list having been *sent*, because
-		// `path_list()` trims a blank one away and a caller that names
-		// files must not fall through as one that named none.
+		// `has_param()` too: `path_list()` trims a blank list away, and a
+		// caller that named files must not fall through as one that named none.
 		if ( $include || $exclude || $request->has_param( 'include_path_list' ) ) {
 			if ( array( 'paths' ) !== array_keys( $named_types ) ) {
 				return new WP_Error(
@@ -167,9 +164,8 @@ class Download_Bridge {
 		if ( ! empty( $named_types ) ) {
 			$body['types'] = $named_types;
 		}
-		// Arrays rather than the comma-joined string upstream also accepts:
-		// that branch sanitises the whole string before splitting, so
-		// `"a, b"` reaches VaultPress as `" b"`.
+		// Arrays, not the comma-joined string upstream also takes: that branch
+		// sanitises the whole string before splitting, so `"a, b"` arrives as `" b"`.
 		if ( $include ) {
 			$body['include_path_list'] = $include;
 		}

--- a/projects/packages/backup/src/rest/class-download-bridge.php
+++ b/projects/packages/backup/src/rest/class-download-bridge.php
@@ -122,9 +122,12 @@ class Download_Bridge {
 		// lists only for the `paths` type, so a list beside any other
 		// category answers 200 with a *full-site* archive.
 		//
-		// `has_param()` too: `path_list()` trims a blank list away, and a
-		// caller that named files must not fall through as one that named none.
-		if ( $include || $exclude || $request->has_param( 'include_path_list' ) ) {
+		// `has_param()` too, for both keys: `path_list()` trims a blank list
+		// away, and a caller that named files must not fall through as one
+		// that named none.
+		if ( $include || $exclude
+			|| $request->has_param( 'include_path_list' )
+			|| $request->has_param( 'exclude_path_list' ) ) {
 			if ( array( 'paths' ) !== array_keys( $named_types ) ) {
 				return new WP_Error(
 					'path_list_needs_paths_type',

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -1,7 +1,5 @@
 // The file browser's selection has to survive the trip to the Download screen,
-// and the screen has to send it. Upstream models `paths` as one *of* the six
-// categories, not a filter across them, so the request names files or
-// categories and never both.
+// and the screen has to send it.
 
 const mockApiFetch = jest.fn();
 const mockSearch = jest.fn< Record< string, unknown >, [] >();
@@ -213,8 +211,6 @@ describe( 'Download link carrying the file selection', () => {
 		const link = await screen.findByRole( 'link', { name: /Download 2 selected items/ } );
 		const href = link.getAttribute( 'href' ) ?? '';
 		const query = new URLSearchParams( href.slice( href.indexOf( '?' ) ) );
-		// One comma-joined string, not repeated params: the comma is
-		// upstream's separator, so an id may already carry one.
 		expect( query.get( 'files' ) ).toBe( `${ WP_CONFIG_ID },${ README_ID }` );
 
 		// Restore is the outside witness. It sits beside Download and looks
@@ -368,9 +364,7 @@ describe( 'Download screen with a file selection', () => {
 		expect( posts[ 0 ]?.path ).toContain( '/backups/download/1786644531.123' );
 	} );
 
-	// The pairing nothing upstream checks: VaultPress reads the path list
-	// only for the `paths` type, so a list beside any other category
-	// answers 200 and builds the whole-site archive instead.
+	// The pairing the bridge guards and upstream does not.
 	it( 'names the paths type and the entries, and no other category', async () => {
 		render( <DownloadStage /> );
 
@@ -521,7 +515,7 @@ describe( 'From the file browser to the request', () => {
 		).resolves.toBeInTheDocument();
 
 		// Three entries for two ticked rows: the folder's id is itself a
-		// comma-joined pair, and the comma is upstream's own separator.
+		// comma-joined pair.
 		expect( initiateCalls()[ 0 ]?.data ).toEqual( {
 			types: { paths: true },
 			include_path_list: [ 'cjI6', 'ZjI6Lw==', WP_CONFIG_ID ],

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -1,9 +1,7 @@
 // The file browser's selection has to survive the trip to the Download screen,
-// and the screen has to act on it. What travels is the opaque per-entry `id`
-// from `/rewind/backup/ls`, comma-joined as one string, since an id can itself
-// contain a comma. The checklist is skipped when files are named because
-// upstream models `paths` as one *of* the six categories, not a filter across
-// them — so a request naming files cannot also name categories.
+// and the screen has to send it. Upstream models `paths` as one *of* the six
+// categories, not a filter across them, so the request names files or
+// categories and never both.
 
 const mockApiFetch = jest.fn();
 const mockSearch = jest.fn< Record< string, unknown >, [] >();
@@ -71,9 +69,9 @@ const ITEM: BackupActivityItem = {
 // mocked out here, so these do not exercise a URL round trip.
 const WP_CONFIG_ID = 'ZjU6L3dwLWNvbmZpZy5waHA=';
 const README_ID = 'ZjI6L3JlYWRtZS5odG1s';
-// A directory id, which is itself a comma-joined token pair (`base64("r2:")
-// + "," + base64("f2:/")`). It is why the include list is one comma-joined
-// string upstream flattens, rather than a list of discrete values.
+// A directory id, itself a comma-joined token pair (`base64("r2:") + "," +
+// base64("f2:/")`) — the comma is upstream's own separator, so this single
+// tree entry is two entries in the path list.
 const THEMES_DIR_ID = 'cjI6,ZjI6Lw==';
 
 /**
@@ -167,8 +165,19 @@ beforeEach( () => {
  */
 function postCalls() {
 	return mockApiFetch.mock.calls
-		.map( ( [ options ] ) => options as { method?: string; path?: string } | undefined )
+		.map(
+			( [ options ] ) => options as { method?: string; path?: string; data?: unknown } | undefined
+		)
 		.filter( options => options?.method === 'POST' );
+}
+
+/**
+ * The initiate POSTs, which the file browser's own `ls` calls are not.
+ *
+ * @return The matching apiFetch option objects, in call order.
+ */
+function initiateCalls() {
+	return postCalls().filter( options => options?.path?.includes( '/backups/download/' ) );
 }
 
 describe( 'Download link carrying the file selection', () => {
@@ -204,8 +213,8 @@ describe( 'Download link carrying the file selection', () => {
 		const link = await screen.findByRole( 'link', { name: /Download 2 selected items/ } );
 		const href = link.getAttribute( 'href' ) ?? '';
 		const query = new URLSearchParams( href.slice( href.indexOf( '?' ) ) );
-		// Comma-joined as one string, not repeated params: upstream flattens
-		// on comma, and an id can contain one.
+		// One comma-joined string, not repeated params: the comma is
+		// upstream's separator, so an id may already carry one.
 		expect( query.get( 'files' ) ).toBe( `${ WP_CONFIG_ID },${ README_ID }` );
 
 		// Restore is the outside witness. It sits beside Download and looks
@@ -359,6 +368,52 @@ describe( 'Download screen with a file selection', () => {
 		expect( posts[ 0 ]?.path ).toContain( '/backups/download/1786644531.123' );
 	} );
 
+	// The pairing nothing upstream checks: VaultPress reads the path list
+	// only for the `paths` type, so a list beside any other category
+	// answers 200 and builds the whole-site archive instead.
+	it( 'names the paths type and the entries, and no other category', async () => {
+		render( <DownloadStage /> );
+
+		await expect(
+			screen.findByText( 'Preparing download…', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		expect( initiateCalls()[ 0 ]?.data ).toEqual( {
+			types: { paths: true },
+			include_path_list: [ WP_CONFIG_ID, README_ID ],
+		} );
+	} );
+
+	it( 'retries with the file selection rather than the whole site', async () => {
+		let attempts = 0;
+		mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+			const path = o?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+			}
+			if ( path.includes( '/backups/download/' ) && path.includes( '/status' ) ) {
+				return Promise.resolve( downloadStatus );
+			}
+			if ( path.includes( '/backups/download/' ) ) {
+				attempts += 1;
+				return attempts === 1
+					? Promise.reject( { code: 'download_initiate_failed', message: 'No luck.' } )
+					: Promise.resolve( { id: 4242 } );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		render( <DownloadStage /> );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: /Try again/ }, SETTLE ) );
+
+		await waitFor( () => expect( initiateCalls() ).toHaveLength( 2 ), SETTLE );
+		expect( initiateCalls()[ 1 ]?.data ).toEqual( {
+			types: { paths: true },
+			include_path_list: [ WP_CONFIG_ID, README_ID ],
+		} );
+	} );
+
 	// StrictMode is load-bearing: its simulated unmount detaches React Query's
 	// mutation observer and never reattaches it, latching `isPending` true while
 	// `onSuccess` still lands the id. Drop the wrapper and this passes either way.
@@ -430,5 +485,46 @@ describe( 'Download screen with a file selection', () => {
 			screen.findByText( "This download link isn't valid.", undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( postCalls() ).toHaveLength( 0 );
+	} );
+} );
+
+describe( 'From the file browser to the request', () => {
+	// The one place the label's list and the request's list are checked
+	// against each other, by carrying the real `?files=` between them.
+	it( 'sends the entries the detail pane counted', async () => {
+		lsContents = {
+			themes: { type: 'dir', has_children: true, id: THEMES_DIR_ID },
+			'wp-config.php': TWO_FILES[ 'wp-config.php' ],
+		};
+		const view = render(
+			<QueryClientProvider>
+				<BackupDetail item={ ITEM } />
+			</QueryClientProvider>
+		);
+		await expect(
+			screen.findByRole( 'button', { name: 'Folder: themes' }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select themes' } ) );
+		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } ) );
+
+		const link = await screen.findByRole( 'link', { name: /Download 2 selected items/ } );
+		const href = link.getAttribute( 'href' ) ?? '';
+		view.unmount();
+
+		mockSearch.mockReturnValue( {
+			files: new URLSearchParams( href.slice( href.indexOf( '?' ) ) ).get( 'files' ) ?? '',
+		} );
+		render( <DownloadStage /> );
+		await expect(
+			screen.findByText( 'Preparing download…', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		// Three entries for two ticked rows: the folder's id is itself a
+		// comma-joined pair, and the comma is upstream's own separator.
+		expect( initiateCalls()[ 0 ]?.data ).toEqual( {
+			types: { paths: true },
+			include_path_list: [ 'cjI6', 'ZjI6Lw==', WP_CONFIG_ID ],
+		} );
 	} );
 } );

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -657,24 +657,23 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * An include list that trims away to nothing is still an include list.
+	 * A path list that trims away to nothing is still a path list.
 	 *
 	 * `path_list()` drops blank entries before the guard sees them, so
 	 * gating on its result alone would let this through as a full download.
 	 *
-	 * @param string $label   Case description.
-	 * @param mixed  $include The `include_path_list` to send.
-	 * @dataProvider provide_include_lists_that_survive_into_nothing
+	 * @param string $label Case description.
+	 * @param string $key   The path-list parameter to send.
+	 * @param mixed  $list  The list sent under it.
+	 * @dataProvider provide_path_lists_that_survive_into_nothing
 	 */
-	#[DataProvider( 'provide_include_lists_that_survive_into_nothing' )]
-	public function test_initiate_refuses_a_blank_path_list_without_the_paths_type( $label, $include ) {
+	#[DataProvider( 'provide_path_lists_that_survive_into_nothing' )]
+	public function test_initiate_refuses_a_blank_path_list_without_the_paths_type( $label, $key, $list ) {
 		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
 
 		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/1786663613.9425' );
 		$request->set_header( 'content-type', 'application/json' );
-		$request->set_body(
-			wp_json_encode( array( 'include_path_list' => $include ), JSON_UNESCAPED_SLASHES )
-		);
+		$request->set_body( wp_json_encode( array( $key => $list ), JSON_UNESCAPED_SLASHES ) );
 
 		$response = $this->server->dispatch( $request );
 
@@ -684,14 +683,16 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * Every include list that reaches the guard empty.
+	 * Every path list that reaches the guard empty, under both keys.
 	 *
-	 * @return array<string, array{0: string, 1: mixed}>
+	 * @return array<string, array{0: string, 1: string, 2: mixed}>
 	 */
-	public static function provide_include_lists_that_survive_into_nothing() {
+	public static function provide_path_lists_that_survive_into_nothing() {
 		return array(
-			'blank entries' => array( 'blank entries', array( '  ', '' ) ),
-			'empty list'    => array( 'empty list', array() ),
+			'include, blank entries' => array( 'include, blank entries', 'include_path_list', array( '  ', '' ) ),
+			'include, empty list'    => array( 'include, empty list', 'include_path_list', array() ),
+			'exclude, blank entries' => array( 'exclude, blank entries', 'exclude_path_list', array( '  ', '' ) ),
+			'exclude, empty list'    => array( 'exclude, empty list', 'exclude_path_list', array() ),
 		);
 	}
 

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -267,6 +267,9 @@ class Rest_Download_Bridge_Test extends TestCase {
 			),
 			$sent['types']
 		);
+		// A category download names no paths, which is the other half of
+		// the pairing the granular tests below assert.
+		$this->assertArrayNotHasKey( 'include_path_list', $sent );
 	}
 
 	/**
@@ -544,5 +547,205 @@ class Rest_Download_Bridge_Test extends TestCase {
 
 		$this->assertSame( 'failed', $failed['status'] );
 		$this->assertSame( 'Archive expired', $failed['error'] );
+	}
+
+	/**
+	 * A granular download reaches WordPress.com as `types: { paths: true }`
+	 * plus the entry ids, and nothing else.
+	 *
+	 * Dispatched from a JSON body rather than a hand-built request, so the
+	 * route's own schema is part of what passes.
+	 */
+	public function test_initiate_forwards_a_path_list_with_the_paths_type() {
+		$this->arrange_wpcom( array( 'downloadId' => 7 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/1786663613.9425' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'types'             => array( 'paths' => true ),
+					'include_path_list' => array( 'cjI6', 'ZjI6Lw==' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'rewindId'          => '1786663613.9425',
+				'types'             => array( 'paths' => true ),
+				'include_path_list' => array( 'cjI6', 'ZjI6Lw==' ),
+			),
+			(array) $this->captured_body
+		);
+		// An array, not the comma-joined string upstream also takes: that
+		// branch sanitises before splitting, so `"a, b"` arrives as `" b"`.
+		$this->assertStringContainsString(
+			'"include_path_list":["cjI6","ZjI6Lw=="]',
+			$this->captured_request_args[0]['body']
+		);
+	}
+
+	/**
+	 * A path list sent beside anything but `types: { paths: true }` is
+	 * refused before it reaches the network.
+	 *
+	 * Nothing upstream catches this. VaultPress reads the lists only for
+	 * the `paths` type, so the mismatch answers 200 and builds a full-site
+	 * archive over a request that named three files.
+	 *
+	 * @param string $label Case description.
+	 * @param mixed  $types The `types` parameter to send, or null to omit it.
+	 * @dataProvider provide_types_that_cannot_carry_a_path_list
+	 */
+	#[DataProvider( 'provide_types_that_cannot_carry_a_path_list' )]
+	public function test_initiate_refuses_a_path_list_without_the_paths_type( $label, $types ) {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		if ( null !== $types ) {
+			$request->set_param( 'types', $types );
+		}
+		$request->set_param( 'include_path_list', array( 'cjI6' ) );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'path_list_needs_paths_type', $response->get_error_code(), $label );
+		$this->assertSame( 400, $response->get_error_data()['status'], $label );
+		$this->assertNull( $this->captured_body, $label );
+	}
+
+	/**
+	 * Every `types` a path list must not travel with.
+	 *
+	 * `omitted` is the dangerous one: an absent `types` is upstream's
+	 * shorthand for all six categories, so it is the case that silently
+	 * returns the whole site.
+	 *
+	 * @return array<string, array{0: string, 1: mixed}>
+	 */
+	public static function provide_types_that_cannot_carry_a_path_list() {
+		return array(
+			'omitted'            => array( 'omitted', null ),
+			'another category'   => array( 'another category', array( 'sqls' => true ) ),
+			'paths plus another' => array(
+				'paths plus another',
+				array(
+					'paths' => true,
+					'sqls'  => true,
+				),
+			),
+			'paths turned off'   => array( 'paths turned off', array( 'paths' => false ) ),
+		);
+	}
+
+	/**
+	 * `exclude_path_list` is under the same rule, and is registered so a
+	 * request carrying it fails loudly rather than losing it silently.
+	 */
+	public function test_initiate_refuses_an_exclude_list_without_the_paths_type() {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'uploads' => true ) );
+		$request->set_param( 'exclude_path_list', array( 'cjI6' ) );
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'path_list_needs_paths_type', $response->get_error_code() );
+		$this->assertNull( $this->captured_body );
+	}
+
+	/**
+	 * The mirror image: `paths` with nothing to scope it by is refused,
+	 * because upstream reads that as the whole site too.
+	 *
+	 * @param string $label   Case description.
+	 * @param mixed  $include The `include_path_list` to send, or null to omit it.
+	 * @dataProvider provide_path_lists_that_name_nothing
+	 */
+	#[DataProvider( 'provide_path_lists_that_name_nothing' )]
+	public function test_initiate_refuses_the_paths_type_without_a_path_list( $label, $include ) {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'paths' => true ) );
+		if ( null !== $include ) {
+			$request->set_param( 'include_path_list', $include );
+		}
+		$response = Download_Bridge::initiate_download( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response, $label );
+		$this->assertSame( 'paths_type_needs_path_list', $response->get_error_code(), $label );
+		$this->assertSame( 400, $response->get_error_data()['status'], $label );
+		$this->assertNull( $this->captured_body, $label );
+	}
+
+	/**
+	 * Every path list that names no entry.
+	 *
+	 * @return array<string, array{0: string, 1: mixed}>
+	 */
+	public static function provide_path_lists_that_name_nothing() {
+		return array(
+			'omitted'       => array( 'omitted', null ),
+			'empty list'    => array( 'empty list', array() ),
+			'blank entries' => array( 'blank entries', array( '', '   ' ) ),
+		);
+	}
+
+	/**
+	 * A keyed object of ids never reaches the callback.
+	 *
+	 * Unregistered parameters are not stripped — WordPress only skips
+	 * *validating* them — so without the schema this would be silently
+	 * flattened to its values and forwarded as a list.
+	 */
+	public function test_a_keyed_path_list_is_rejected_by_the_schema() {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'types'             => array( 'paths' => true ),
+					'include_path_list' => array( 'first' => 'cjI6' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $data['code'] );
+		$this->assertArrayHasKey( 'include_path_list', $data['data']['params'] );
+		$this->assertNull( $this->captured_body );
+	}
+
+	/**
+	 * Entries are trimmed and blanks dropped, so a stray space cannot
+	 * become part of an id.
+	 */
+	public function test_initiate_trims_the_path_list() {
+		$this->arrange_wpcom( array( 'downloadId' => 9 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/123' );
+		$request->set_param( 'rewind_id', '123' );
+		$request->set_param( 'types', array( 'paths' => true ) );
+		$request->set_param( 'include_path_list', array( ' cjI6 ', '', 'ZjI6Lw==' ) );
+		Download_Bridge::initiate_download( $request );
+
+		$sent = (array) $this->captured_body;
+		$this->assertSame( array( 'cjI6', 'ZjI6Lw==' ), $sent['include_path_list'] );
 	}
 }

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -582,8 +582,8 @@ class Rest_Download_Bridge_Test extends TestCase {
 			),
 			(array) $this->captured_body
 		);
-		// An array, not the comma-joined string upstream also takes: that
-		// branch sanitises before splitting, so `"a, b"` arrives as `" b"`.
+		// A JSON array on the wire rather than an object, which is what
+		// `path_list()` rebuilding the entries as a PHP list buys.
 		$this->assertStringContainsString(
 			'"include_path_list":["cjI6","ZjI6Lw=="]',
 			$this->captured_request_args[0]['body']
@@ -702,7 +702,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A keyed object of ids never reaches the callback.
+	 * A path list keyed by name never reaches the callback.
 	 *
 	 * Unregistered parameters are not stripped — WordPress only skips
 	 * *validating* them — so without the schema this would be silently

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -267,8 +267,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 			),
 			$sent['types']
 		);
-		// A category download names no paths, which is the other half of
-		// the pairing the granular tests below assert.
+		// A category download names no paths — the other half of the pairing.
 		$this->assertArrayNotHasKey( 'include_path_list', $sent );
 	}
 
@@ -594,10 +593,6 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 * A path list sent beside anything but `types: { paths: true }` is
 	 * refused before it reaches the network.
 	 *
-	 * Nothing upstream catches this. VaultPress reads the lists only for
-	 * the `paths` type, so the mismatch answers 200 and builds a full-site
-	 * archive over a request that named three files.
-	 *
 	 * @param string $label Case description.
 	 * @param mixed  $types The `types` parameter to send, or null to omit it.
 	 * @dataProvider provide_types_that_cannot_carry_a_path_list
@@ -624,8 +619,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 * Every `types` a path list must not travel with.
 	 *
 	 * `omitted` is the dangerous one: an absent `types` is upstream's
-	 * shorthand for all six categories, so it is the case that silently
-	 * returns the whole site.
+	 * shorthand for all six categories, not for none.
 	 *
 	 * @return array<string, array{0: string, 1: mixed}>
 	 */
@@ -666,9 +660,7 @@ class Rest_Download_Bridge_Test extends TestCase {
 	 * An include list that trims away to nothing is still an include list.
 	 *
 	 * `path_list()` drops blank entries before the guard sees them, so
-	 * gating on its result would let this through as a plain whole-archive
-	 * download: 200, and every file on the site, for a request that asked
-	 * for a file selection.
+	 * gating on its result alone would let this through as a full download.
 	 *
 	 * @param string $label   Case description.
 	 * @param mixed  $include The `include_path_list` to send.
@@ -745,9 +737,8 @@ class Rest_Download_Bridge_Test extends TestCase {
 	/**
 	 * A path list keyed by name never reaches the callback.
 	 *
-	 * Unregistered parameters are not stripped — WordPress only skips
-	 * *validating* them — so without the schema this would be silently
-	 * flattened to its values and forwarded as a list.
+	 * Without the schema this would reach WPCOM flattened to its values:
+	 * WordPress skips *validating* unregistered params, it does not strip them.
 	 */
 	public function test_a_keyed_path_list_is_rejected_by_the_schema() {
 		$this->arrange_wpcom( array( 'downloadId' => 1 ) );

--- a/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Download_Bridge_Test.php
@@ -663,6 +663,47 @@ class Rest_Download_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * An include list that trims away to nothing is still an include list.
+	 *
+	 * `path_list()` drops blank entries before the guard sees them, so
+	 * gating on its result would let this through as a plain whole-archive
+	 * download: 200, and every file on the site, for a request that asked
+	 * for a file selection.
+	 *
+	 * @param string $label   Case description.
+	 * @param mixed  $include The `include_path_list` to send.
+	 * @dataProvider provide_include_lists_that_survive_into_nothing
+	 */
+	#[DataProvider( 'provide_include_lists_that_survive_into_nothing' )]
+	public function test_initiate_refuses_a_blank_path_list_without_the_paths_type( $label, $include ) {
+		$this->arrange_wpcom( array( 'downloadId' => 1 ) );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/backups/download/1786663613.9425' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode( array( 'include_path_list' => $include ), JSON_UNESCAPED_SLASHES )
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status(), $label );
+		$this->assertSame( 'path_list_needs_paths_type', $response->get_data()['code'], $label );
+		$this->assertNull( $this->captured_body, $label );
+	}
+
+	/**
+	 * Every include list that reaches the guard empty.
+	 *
+	 * @return array<string, array{0: string, 1: mixed}>
+	 */
+	public static function provide_include_lists_that_survive_into_nothing() {
+		return array(
+			'blank entries' => array( 'blank entries', array( '  ', '' ) ),
+			'empty list'    => array( 'empty list', array() ),
+		);
+	}
+
+	/**
 	 * The mirror image: `paths` with nothing to scope it by is refused,
 	 * because upstream reads that as the whole site too.
 	 *


### PR DESCRIPTION
Fixes JETPACK-2321

## Proposed changes

The Download screen has read the file browser's `?files=` selection since #51740, but nothing forwarded it. Arriving with a selection, the screen auto-submitted the whole-site category checklist — so picking three files produced a **full-site archive**, silently. The bridge could not have forwarded a selection either: it had no `include_path_list` to send.

* **Client.** A new `initiateFileDownload()` posts `types: { paths: true }` together with `include_path_list`, and never a path list beside another category. The Download screen's auto-start and its "Try again" both go through it now; the category path is untouched.
* **Bridge.** `POST /jetpack/v4/backups/download/{rewindId}` declares `include_path_list` / `exclude_path_list` and forwards them, refusing the two mismatches upstream does not catch:
  * a path list without exactly `types: { paths: true }` → 400 `path_list_needs_paths_type`
  * `types: { paths: true }` without a path list → 400 `paths_type_needs_path_list`

**Why the bridge has to enforce that pairing.** `/rewind/downloads` reads `include_path_list` / `exclude_path_list` independently of `types` and forwards both to VaultPress ungated, and VaultPress reads them *only* for the `paths` type. So a request sending a path list beside `sqls`, or with `types` omitted altogether, answers **200** and builds an archive that ignores the paths entirely. There is no upstream validation to lean on and no error anywhere — the customer asks for three files and gets the whole site. Tests pin the pairing on both sides.

**Array, not a comma-joined string.** The entries reach WordPress.com as a JSON array. The comma in `?files=` is upstream's own separator — a folder's `ls` id is the joined ids of the manifest entries it covers — so splitting on it yields exactly the entries upstream's own comma-string branch would derive, while skipping that branch's bug: it sanitises the whole string before splitting, so `"/a.jpg, /b.jpg"` sends `" /b.jpg"` with a leading space. Splitting locally also lets each entry be trimmed and blanks dropped.

**Label and include list cannot disagree.** #51740 already made `<BackupDetail>` build both the button label and the `?files=` value from one list of nameable entries, so the loaded-tree count is settled at the source. This PR keeps it that way: the Download screen never recounts, and `splitFileSelection()` is both the "is this a selection at all" test and the thing that builds the request. A test carries a real `?files=` from the detail pane into the screen and asserts the resulting body, including a folder whose id is itself a comma-joined pair (one ticked row, two path-list entries).

**Not included, deliberately:** any "selected files plus categories" affordance. JETPACK-2350 decided a file selection *skips* the checklist, because a combined request is implied by the docs but demonstrated by no caller in wpcom or VaultPress, and fails silently if it does not work.

One note for the record: the issue expected an unregistered `include_path_list` to be *stripped* by WordPress. It is not — `WP_REST_Request::sanitize_params()` skips unregistered params rather than removing them, verified by deleting the arg and watching the value still arrive. Registering the args still earns its place: without the schema a keyed object like `{"first": "id"}` is silently flattened to a list and forwarded, and there is a test for that.

Behind `rsm_jetpack_ui_modernization_backup`, off by default. The legacy dashboard is unchanged.

## Related product discussion/links

* JETPACK-2321 (task C3), following #51740
* JETPACK-2350 — the decision that a file selection skips the category checklist

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated:

* `jp test php packages/backup` — or, for detail, `vendor/bin/phpunit -c phpunit.12.xml.dist --filter Rest_Download_Bridge_Test` from `projects/packages/backup`
* `jp test js packages/backup` — or `pnpm test` from `projects/packages/backup` for per-suite detail
* Phan: `composer install` at the repo root, then from `projects/packages/backup` run `../../../vendor/bin/phan -B .phan/baseline.php`

Manually, in wp-admin:

1. Turn on the modernized Backup dashboard: `add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );` in a mu-plugin, on a site connected to a WordPress.com account with an active Backup plan.
2. Go to **Jetpack → VaultPress Backup** and pick a backup in the activity list.
3. In the **Files** browser, tick two or three files. The Download action should read "Download 2 selected items".
4. Click it. The Download screen should skip the category checklist and go straight to "Preparing download…".
5. Watch the outgoing request (`POST /jetpack/v4/backups/download/{rewindId}`). The body should be `{"types":{"paths":true},"include_path_list":["…","…"]}` — no `themes`, `sqls`, or any other category.
6. **Verifying the archive contents end-to-end needs a site with a real Backup plan** — WordPress.com has to actually build it. When the link appears, download the zip and confirm it holds the files that were ticked and nothing else. Ticking a folder nobody expanded should bring the whole folder as one unit.
7. Regression: with **nothing** ticked, the Download action should still read "Download backup", the screen should still show the six-item category checklist, and the request should carry `types` and no `include_path_list`.
8. Refusals (curl or the browser console, as an admin): `types` omitted with an `include_path_list` should answer 400 `path_list_needs_paths_type`; `types: {"paths": true}` with no list should answer 400 `paths_type_needs_path_list`.
