### PR TITLE
Backup: correct two stale code comments

### DIFF
--- a/projects/packages/backup/changelog/update-backup-stale-comments
+++ b/projects/packages/backup/changelog/update-backup-stale-comments
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comments only: correct the `use-file-tree` note that claimed an `ls` entry id can contain a comma, and narrow the `retry: false` rationale in `usePromotedProduct` so it stays true once the promoted-product catalogue is cached. No code changed.
+
+

--- a/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-file-tree.test.ts
@@ -72,9 +72,8 @@ describe( 'toFileNode', () => {
 	// unsendable however carefully the tree tracked it.
 	test.each( [
 		[ 'file', file( { id: 'ZjY6L2luZGV4LnBocA==' } ), 'ZjY6L2luZGV4LnBocA==' ],
-		// `cjI6,ZjI6Lw==` is a real fixture shape: an id can contain a
-		// comma, which is why the include list is a comma-joined string
-		// upstream flattens rather than a list of discrete values.
+		// A folder id: two entry ids joined on upstream's own separator,
+		// not one value that contains a comma.
 		[ 'folder', file( { type: 'dir', id: 'cjI6,ZjI6Lw==' } ), 'cjI6,ZjI6Lw==' ],
 	] )( 'carries the ls entry id through for a %s', ( _label, raw, expected ) => {
 		expect( toFileNode( 'index.php', raw as WpcomFileNode, '/' ) ).toMatchObject( {

--- a/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-promoted-product.ts
@@ -84,12 +84,10 @@ export function usePromotedProduct(): Result {
 		queryKey: keys.promotedProduct(),
 		queryFn: fetchPromotedProduct,
 		staleTime: PROMOTED_PRODUCT_STALE_MS,
-		// Overrides the client's `retry: 1`. Each attempt costs the *site*
-		// an uncached, blocking request to the product catalogue, so a
-		// retry doubles the expensive hop rather than the cheap one — and
-		// buys a figure the screen is designed to work without. React
-		// Query's default guards the browser-to-site hop; the one that
-		// fails here is site-to-WordPress.com.
+		// Overrides the client's `retry: 1`: a retry only ever follows a
+		// failure, and failures are not cached, so it always costs the site
+		// a live blocking request to WordPress.com for a figure the screen
+		// is designed to work without.
 		retry: false,
 	} );
 


### PR DESCRIPTION
## Proposed changes

Follow-up housekeeping from #51796–#51799. Two comments in `projects/packages/backup` are stale or wrong; this corrects both. **Comments only — no code, fixtures or behaviour change.**

* **`src/dashboard/hooks/test/use-file-tree.test.ts`** — the note on the folder fixture claimed "an id can contain a comma, which is why the include list is a comma-joined string upstream flattens". Both halves are wrong:
  * An `ls` entry id **cannot** contain a comma. Ids are base64, and `,` is not in the base64 alphabet — `echo 'cjI6,ZjI6Lw==' | base64 -d` fails at the comma, while `cjI6` and `ZjI6Lw==` decode cleanly to `r2:` and `f2:/`. The fixture is not one id containing a comma; it is **two** well-formed manifest references joined by one, which is what a directory node's id is.
  * The include list is no longer a comma-joined string either — #51799 changes the bridge to send a JSON array.
  * The replacement is one short note. The full rationale belongs to `src/rest/class-download-bridge.php`, which owns the WordPress.com request body, so it is not restated here.

* **`src/dashboard/hooks/use-promoted-product.ts`** — the justification for `retry: false` rested on "each attempt costs the *site* an uncached, blocking request". #51796 puts a transient in front of the promoted-product catalogue, so once it lands a *first* attempt may be a cache read and that premise is overbroad. The conclusion survives on a narrower footing: a retry only ever follows a failure, and failures are deliberately not cached, so a retry is always a live request. Reworded to say that, and shortened to fit the comment budget added in #51793. `retry: false` itself is unchanged — it is still load-bearing for exactly that reason.

This PR does not depend on #51796 or #51799; both wordings are correct against trunk as it stands.

## Related product discussion/links

* Follow-up to #51793 (comment budget), #51796, #51799.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing is observable at runtime — this is a review-by-reading change. What I ran on the branch:

* `pnpm test` in `projects/packages/backup` → 69 suites, 687 tests, all passing.
* `./node_modules/.bin/eslint` on both changed files → clean.
* `pnpm run typecheck` from the monorepo root → clean (note it does not cover `tests/**`).

To review, check the two claims for yourself:

* `echo 'cjI6,ZjI6Lw==' | base64 -d` (fails), then `echo 'cjI6' | base64 -d` → `r2:` and `echo 'ZjI6Lw==' | base64 -d` → `f2:/`. That is the whole argument for the first comment.
* Read `Jetpack_Backup::get_backup_promoted_product_info()` on #51796: `set_transient()` sits below both failure guards, so a failure is never cached and a retry can never be served from one.

Not tested: nothing was exercised in a browser or on a site, because nothing runs differently.
