### PR TITLE
Backup: stop the Overview querying WordPress.com behind the no-plan gate

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
+++ b/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: stop the modernized dashboard's Overview asking WordPress.com for the activity log, the backup list and the site size — and polling the backup list — on a site with no Backup plan. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
+++ b/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Backup: stop the modernized dashboard querying WordPress.com on a site with no Backup plan or no connection. Its Overview, Restore and Download screens read the activity log, the backup list, the site size and the restores collection, polled three of those, and asked for a download archive to be built. No-op when the modernization filter is off.
+Comment: Backup: stop the modernized dashboard querying WordPress.com on a site with no Backup plan or no connection. Its Overview, Restore and Download screens read the activity log, the backup list, the site size and the restores collection, polled some of those and a running restore's and download's progress, and asked for a download archive to be built. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
+++ b/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Backup: stop the modernized dashboard's Overview asking WordPress.com for the activity log, the backup list and the site size — and polling the backup list — on a site with no Backup plan. No-op when the modernization filter is off.
+Comment: Backup: stop the modernized dashboard's Overview and Restore screens asking WordPress.com for the activity log, the backup list, the site size and the restores collection — and polling the backup list and a running restore's status — on a site with no Backup plan or no connection. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
+++ b/projects/packages/backup/changelog/fix-backup-no-requests-behind-no-plan-gate
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Backup: stop the modernized dashboard's Overview and Restore screens asking WordPress.com for the activity log, the backup list, the site size and the restores collection — and polling the backup list and a running restore's status — on a site with no Backup plan or no connection. No-op when the modernization filter is off.
+Comment: Backup: stop the modernized dashboard querying WordPress.com on a site with no Backup plan or no connection. Its Overview, Restore and Download screens read the activity log, the backup list, the site size and the restores collection, polled three of those, and asked for a download archive to be built. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -10,23 +10,34 @@ import { useSiteSize } from '../../hooks/use-site-size';
 /**
  * Header action that asks WPCOM to back the site up now.
  *
- * Ports the legacy button's label and tooltip cycle
- * (`src/js/components/back-up-now/index.jsx`) onto the modernized data
- * layer, with two behavioural fixes.
- *
- * Failures are reported. The legacy click handler has no rejection
- * handler and discards the response body, so every outcome — including a
- * WPCOM refusal and a permissions error — shows "Backup enqueued".
- *
- * The button gates itself, on the same `useGateState` verdict `<Gates>` renders from: it
- * sits in `<Page>`'s header actions, above the gate, so an unconnected or unlicensed site
- * would otherwise be offered a control that cannot work.
+ * It sits in `<Page>`'s header actions, above `<Gates>`, so it gates itself on the same
+ * `useGateState` verdict — and does so before mounting `<BackupNow>`, since nothing else
+ * would stop that component's reads on a site with no plan.
  *
  * @return The rendered button, or null when the site can't use it.
  */
 export default function BackupNowButton() {
-	const { tracks } = useAnalytics();
 	const gate = useGateState();
+
+	if ( gate.status !== 'ready' ) {
+		return null;
+	}
+
+	return <BackupNow />;
+}
+
+/**
+ * The button itself, mounted only for a site that can press it.
+ *
+ * Ports the legacy label and tooltip cycle (`src/js/components/back-up-now/index.jsx`)
+ * onto the modernized data layer, with one behavioural fix: legacy's click handler has no
+ * rejection handler and discards the body, so every outcome — a WPCOM refusal, a
+ * permissions error — shows "Backup enqueued".
+ *
+ * @return The rendered button.
+ */
+function BackupNow() {
+	const { tracks } = useAnalytics();
 	const { backupsStopped } = useSiteSize();
 	const { state: enqueueState, errorMessage, enqueue, reset } = useEnqueueBackup();
 
@@ -55,10 +66,6 @@ export default function BackupNowButton() {
 		tracks.recordEvent( 'jetpack_backup_plugin_backup_now' );
 		enqueue();
 	}, [ tracks, enqueue ] );
-
-	if ( gate.status !== 'ready' ) {
-		return null;
-	}
 
 	const isEnqueuing = enqueueState === 'enqueuing';
 	const isEnqueued = enqueueState === 'enqueued';

--- a/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-now-button/index.tsx
@@ -11,8 +11,7 @@ import { useSiteSize } from '../../hooks/use-site-size';
  * Header action that asks WPCOM to back the site up now.
  *
  * It sits in `<Page>`'s header actions, above `<Gates>`, so it gates itself on the same
- * `useGateState` verdict — and does so before mounting `<BackupNow>`, since nothing else
- * would stop that component's reads on a site with no plan.
+ * verdict — before mounting `<BackupNow>`, since nothing else stops that component's reads.
  *
  * @return The rendered button, or null when the site can't use it.
  */
@@ -29,10 +28,8 @@ export default function BackupNowButton() {
 /**
  * The button itself, mounted only for a site that can press it.
  *
- * Ports the legacy label and tooltip cycle (`src/js/components/back-up-now/index.jsx`)
- * onto the modernized data layer, with one behavioural fix: legacy's click handler has no
- * rejection handler and discards the body, so every outcome — a WPCOM refusal, a
- * permissions error — shows "Backup enqueued".
+ * Ports legacy's label and tooltip cycle (`src/js/components/back-up-now/index.jsx`) with
+ * one fix: legacy discards the response, so a WPCOM refusal also shows "Backup enqueued".
  *
  * @return The rendered button.
  */

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -52,11 +52,9 @@ export const ACTIVITY_LOG_NEWEST_FIRST: ActivitySortOrder = 'desc';
  * page's request is in flight — DataViews' pagination feels smooth
  * instead of flashing a spinner over the list on every page change.
  *
- * `useDefaultBackupRewindId` mounts in the Overview screen's own body,
- * which React renders before `<Gates>` — so this query has to decide for
- * itself whether the bridge can answer, rather than relying on the gate
- * to not render it. Consumers inside the gated body get `enabled: true`
- * for free, since they only mount once the connection checks pass.
+ * Every consumer mounts inside `<Gates>`, so `enabled` is the backstop for a
+ * future one that does not — the bridge can only answer 403 without a
+ * user-level WPCOM connection.
  *
  * WPCOM sorts the whole result set server-side, so `sortOrder` is part of the
  * cache key rather than something applied to the page after it arrives.

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -52,9 +52,8 @@ export const ACTIVITY_LOG_NEWEST_FIRST: ActivitySortOrder = 'desc';
  * page's request is in flight — DataViews' pagination feels smooth
  * instead of flashing a spinner over the list on every page change.
  *
- * Every consumer mounts inside `<Gates>`, so `enabled` is the backstop for a
- * future one that does not — the bridge can only answer 403 without a
- * user-level WPCOM connection.
+ * Every consumer mounts inside `<Gates>`, so `enabled` is the backstop for a future
+ * one that does not: without a user-level WPCOM connection the bridge only 403s.
  *
  * WPCOM sorts the whole result set server-side, so `sortOrder` is part of the
  * cache key rather than something applied to the page after it arrives.

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -189,13 +189,9 @@ type Result = BackupsSummary & {
  * and signed with the blog token, so unlike the modernized bridges it
  * needs no new PHP.
  *
- * That route would in fact answer without a user-level WPCOM connection
- * — its permission callback is a bare `manage_options` check. The query
- * is gated on one anyway, because every screen that reads this hook sits
- * behind `<Gates>`, which blocks the page for those users regardless:
- * issuing the request would only spend a round trip on a page nobody is
- * going to see. The looser route is a property worth knowing about if a
- * future caller does need to read backups outside the gate.
+ * Both consumers mount only behind a `ready` gate verdict, so this never fetches
+ * — or polls — for a site that cannot use the answer. `useCanQueryWpcom` below is
+ * the backstop for a future caller outside that arrangement.
  *
  * @param args           - Hook args.
  * @param args.forcePoll - Poll regardless of derived state.

--- a/projects/packages/backup/src/dashboard/hooks/use-backups.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-backups.ts
@@ -189,9 +189,8 @@ type Result = BackupsSummary & {
  * and signed with the blog token, so unlike the modernized bridges it
  * needs no new PHP.
  *
- * Both consumers mount only behind a `ready` gate verdict, so this never fetches
- * — or polls — for a site that cannot use the answer. `useCanQueryWpcom` below is
- * the backstop for a future caller outside that arrangement.
+ * Every consumer mounts only behind a `ready` gate verdict, so this never fetches — or
+ * polls — for a site that cannot use the answer; `useCanQueryWpcom` is the backstop.
  *
  * @param args           - Hook args.
  * @param args.forcePoll - Poll regardless of derived state.

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -36,10 +36,15 @@ const POLL_INTERVAL_MS = 1500;
  * The bridge derives `status` for us, because WPCOM's own payload has no
  * status field — it signals lifecycle by which keys are present.
  *
+ * Every read is gated on `enabled`, which the screen supplies from the gate
+ * verdict — see `useRestore` for why the gating lives here rather than below
+ * `<Gates>`.
+ *
  * @param rewindId - The backup's rewind id.
+ * @param enabled  - Whether this site may query WordPress.com at all.
  * @return state + submit + submitFiles + reset.
  */
-export function useDownload( rewindId: string ): Result {
+export function useDownload( rewindId: string, enabled = true ): Result {
 	const [ downloadId, setDownloadId ] = useState< number | null >( null );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
 
@@ -65,8 +70,9 @@ export function useDownload( rewindId: string ): Result {
 	const statusQuery = useQuery( {
 		queryKey: keys.downloadStatus( rewindId, effectiveDownloadId ),
 		queryFn: () => fetchDownloadStatus( rewindId, effectiveDownloadId ),
-		enabled: downloadId !== null,
-		refetchInterval: query => ( query.state.data?.status === 'running' ? POLL_INTERVAL_MS : false ),
+		enabled: downloadId !== null && enabled,
+		refetchInterval: query =>
+			query.state.data?.status === 'running' && enabled ? POLL_INTERVAL_MS : false,
 	} );
 
 	const submit = useCallback(

--- a/projects/packages/backup/src/dashboard/hooks/use-download.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-download.ts
@@ -71,8 +71,7 @@ export function useDownload( rewindId: string, enabled = true ): Result {
 		queryKey: keys.downloadStatus( rewindId, effectiveDownloadId ),
 		queryFn: () => fetchDownloadStatus( rewindId, effectiveDownloadId ),
 		enabled: downloadId !== null && enabled,
-		refetchInterval: query =>
-			query.state.data?.status === 'running' && enabled ? POLL_INTERVAL_MS : false,
+		refetchInterval: query => ( query.state.data?.status === 'running' ? POLL_INTERVAL_MS : false ),
 	} );
 
 	const submit = useCallback(

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -364,7 +364,7 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 		queryKey: keys.recentRestores(),
 		queryFn: fetchRecentRestores,
 		enabled: recovering && enabled,
-		refetchInterval: recovering && enabled ? POLL_INTERVAL_MS : false,
+		refetchInterval: recovering ? POLL_INTERVAL_MS : false,
 	} );
 
 	const recoveredId = useMemo( () => {

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -223,10 +223,16 @@ function deriveState( input: DeriveInput ): RestoreState {
  * stopping it, because the failure this replaces was a bar frozen
  * forever at its first reading.
  *
+ * Every read is gated on `enabled`, which the screen supplies from the gate
+ * verdict. Gating here rather than mounting the screen's body below `<Gates>`:
+ * the state below is what stops a second concurrent restore, and unmounting it
+ * on a gate flip re-arms Confirm while the first restore is still running.
+ *
  * @param rewindId - The backup's rewind id, in full.
+ * @param enabled  - Whether this site may query WordPress.com at all.
  * @return state + submit + reset.
  */
-export function useRestore( rewindId: string ): Result {
+export function useRestore( rewindId: string, enabled = true ): Result {
 	const [ submittedId, setSubmittedId ] = useState< number | null >( null );
 	const [ errorMessage, setErrorMessage ] = useState< string | null >( null );
 	// Non-null while a submission's outcome is unknown, holding the
@@ -320,7 +326,7 @@ export function useRestore( rewindId: string ): Result {
 	// restore on screen is ours, and the lookup would only be a second
 	// opinion about a question we can already answer.
 	const hasOwnSubmission = startedRewindId !== null || isPending;
-	const { adopted: found, isChecking } = useAdoptedRestore( ! hasOwnSubmission );
+	const { adopted: found, isChecking } = useAdoptedRestore( ! hasOwnSubmission && enabled );
 
 	// Latched, not read live, and that distinction is the whole
 	// lifecycle. `useAdoptedRestore` derives its answer from a
@@ -357,8 +363,8 @@ export function useRestore( rewindId: string ): Result {
 	const restoresQuery = useQuery( {
 		queryKey: keys.recentRestores(),
 		queryFn: fetchRecentRestores,
-		enabled: recovering,
-		refetchInterval: recovering ? POLL_INTERVAL_MS : false,
+		enabled: recovering && enabled,
+		refetchInterval: recovering && enabled ? POLL_INTERVAL_MS : false,
 	} );
 
 	const recoveredId = useMemo( () => {
@@ -392,7 +398,7 @@ export function useRestore( rewindId: string ): Result {
 	const statusQuery = useQuery( {
 		queryKey: keys.restoreStatus( effectiveRestoreId ),
 		queryFn: () => fetchRestoreStatus( effectiveRestoreId ),
-		enabled: restoreId !== null,
+		enabled: restoreId !== null && enabled,
 		refetchInterval: query => {
 			// Keep asking through anything unrecognised — stopping there
 			// is what froze this before — but not past the deadline.

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -10,6 +10,7 @@ import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
 import { splitFileSelection } from '../data/api/download';
 import { useDownload } from '../hooks/use-download';
+import { useGateState } from '../hooks/use-gate-state';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
 import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
 
@@ -41,13 +42,17 @@ type DownloadSearch = Record< string, unknown > & { files?: string };
  */
 export default function DownloadScreen() {
 	const { rewindId } = useParams( { from: '/download/$rewindId' } );
+	const gate = useGateState();
 	// `strict: false` is the unvalidated read, and it is the whole option:
 	// passing `from` as well would send it down the route-id lookup that
 	// throws on a mismatch, which is the opposite of what is wanted for a
 	// param no route declares.
 	const search = useSearch( { strict: false } ) as DownloadSearch;
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	const { state, submit, submitFiles, reset } = useDownload( rewindId );
+	// This screen's body renders below `<Gates>`, but its hooks run above it, so the
+	// reads and the auto-submit take the verdict rather than the tree withholding them.
+	const isGateReady = gate.status === 'ready';
+	const { state, submit, submitFiles, reset } = useDownload( rewindId, isGateReady );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would ask WPCOM for the *whole* archive, not for
 	// nothing — see `hasSelectedItems`.
@@ -62,12 +67,17 @@ export default function DownloadScreen() {
 	// came back for a second archive. This only stops StrictMode asking twice.
 	const hasAutoStarted = useRef( false );
 	useEffect( () => {
-		if ( ! hasFileSelection || hasAutoStarted.current || ! isValidRewindId( rewindId ) ) {
+		if (
+			! isGateReady ||
+			! hasFileSelection ||
+			hasAutoStarted.current ||
+			! isValidRewindId( rewindId )
+		) {
 			return;
 		}
 		hasAutoStarted.current = true;
 		submitFiles( files );
-	}, [ hasFileSelection, rewindId, submitFiles, files ] );
+	}, [ isGateReady, hasFileSelection, rewindId, submitFiles, files ] );
 
 	// With a file selection there is no checklist to send the reader back
 	// to, so a failed attempt has to re-submit rather than return to a

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -49,8 +49,6 @@ export default function DownloadScreen() {
 	// param no route declares.
 	const search = useSearch( { strict: false } ) as DownloadSearch;
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	// This screen's body renders below `<Gates>`, but its hooks run above it, so the
-	// reads and the auto-submit take the verdict rather than the tree withholding them.
 	const isGateReady = gate.status === 'ready';
 	const { state, submit, submitFiles, reset } = useDownload( rewindId, isGateReady );
 	const handleGenerate = useCallback( () => submit( items ), [ submit, items ] );

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -73,11 +73,9 @@ export function resetPageViewForTesting(): void {
 /**
  * Overview screen for the modernized Backup dashboard.
  *
- * Renders the shared `<DashboardLayout>` chrome around a two-pane body: the
- * left pane is a paginated activity list; the right pane resolves the
- * selected row to a detail card. Selection is persisted in the URL via
- * `?selected=<id>` so a refresh preserves it; on first visit the newest
- * backup is preselected so the right pane mirrors Calypso's behaviour.
+ * Records the page view and mounts the shared `<DashboardLayout>` chrome; the body
+ * lives below `<Gates>`. The view is recorded above the gate, so a visit without a
+ * plan still counts — as it does in legacy.
  *
  * @return The rendered Overview screen.
  */
@@ -111,6 +109,23 @@ export default function OverviewScreen() {
 		tracks.recordEvent( 'jetpack_backup_admin_page_view' );
 	}, [ tracks ] );
 
+	return (
+		<DashboardLayout actions={ <BackupNowButton /> }>
+			<OverviewBody />
+		</DashboardLayout>
+	);
+}
+
+/**
+ * The Overview's body: a paginated activity list beside a detail pane for the row
+ * selected by `?selected=<id>`, defaulting to the newest backup.
+ *
+ * Mounted by `<Gates>`, not rendered above it: React runs a component's hooks before
+ * its children, so reads left in the screen fetched — and polled — behind the upsell.
+ *
+ * @return The rendered body.
+ */
+function OverviewBody() {
 	const search = useSearch( {
 		from: '/' as unknown as never,
 		strict: false,
@@ -180,15 +195,11 @@ export default function OverviewScreen() {
 			restorePointsLoading || restorePointsError || hasRestorePoints
 		)
 	) {
-		return (
-			<DashboardLayout actions={ <BackupNowButton /> }>
-				<BackupStatusPanel state={ backupsState } progress={ progress } />
-			</DashboardLayout>
-		);
+		return <BackupStatusPanel state={ backupsState } progress={ progress } />;
 	}
 
 	return (
-		<DashboardLayout actions={ <BackupNowButton /> }>
+		<>
 			{ /*
 			 * A backup running on a site that already has restore points is
 			 * reported alongside the list rather than in place of it. The
@@ -291,7 +302,7 @@ export default function OverviewScreen() {
 					sortOrder={ sortOrder }
 				/>
 			</div>
-		</DashboardLayout>
+		</>
 	);
 }
 

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -73,9 +73,8 @@ export function resetPageViewForTesting(): void {
 /**
  * Overview screen for the modernized Backup dashboard.
  *
- * Records the page view and mounts the shared `<DashboardLayout>` chrome; the body
- * lives below `<Gates>`. The view is recorded above the gate, so a visit without a
- * plan still counts — as it does in legacy.
+ * Records the page view and mounts `<DashboardLayout>` around a body that lives below
+ * `<Gates>` — the view is recorded above the gate, so a plan-less visit still counts.
  *
  * @return The rendered Overview screen.
  */
@@ -120,8 +119,8 @@ export default function OverviewScreen() {
  * The Overview's body: a paginated activity list beside a detail pane for the row
  * selected by `?selected=<id>`, defaulting to the newest backup.
  *
- * Mounted by `<Gates>`, not rendered above it: React runs a component's hooks before
- * its children, so reads left in the screen fetched — and polled — behind the upsell.
+ * Mounted by `<Gates>`, not rendered above it: React runs a component's hooks before its
+ * children, so reads moved up into the screen would fetch — and poll — behind the upsell.
  *
  * @return The rendered body.
  */

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -8,6 +8,7 @@ import { Button, Card, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
+import { useGateState } from '../hooks/use-gate-state';
 import { useRestore } from '../hooks/use-restore';
 import { DEFAULT_RESTORE_ITEMS, hasSelectedItems } from '../types/restore';
 import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
@@ -30,8 +31,11 @@ const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
  */
 export default function RestoreScreen() {
 	const { rewindId } = useParams( { from: '/restore/$rewindId' } );
+	const gate = useGateState();
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	const { state, submit, reset, adopted } = useRestore( rewindId );
+	// This screen's body renders below `<Gates>`, but its hooks run above it, so
+	// the reads need the verdict passed in rather than the tree to withhold them.
+	const { state, submit, reset, adopted } = useRestore( rewindId, gate.status === 'ready' );
 	const handleConfirm = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would restore *everything* rather than nothing —
 	// see `hasSelectedItems`. On this screen that is unrecoverable.

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -33,8 +33,7 @@ export default function RestoreScreen() {
 	const { rewindId } = useParams( { from: '/restore/$rewindId' } );
 	const gate = useGateState();
 	const [ items, setItems ] = useState( DEFAULT_RESTORE_ITEMS );
-	// This screen's body renders below `<Gates>`, but its hooks run above it, so
-	// the reads need the verdict passed in rather than the tree to withhold them.
+
 	const { state, submit, reset, adopted } = useRestore( rewindId, gate.status === 'ready' );
 	const handleConfirm = useCallback( () => submit( items ), [ submit, items ] );
 	// An empty checklist would restore *everything* rather than nothing —

--- a/projects/packages/backup/tests/first-run-state.test.tsx
+++ b/projects/packages/backup/tests/first-run-state.test.tsx
@@ -323,10 +323,17 @@ describe( 'BackupNowButton', () => {
 
 		renderWithClient( <BackupNowButton /> );
 
-		const button = await screen.findByRole( 'button', { name: 'Back up now' } );
-		// Waits for the storage answer to arrive and disable it, rather
-		// than assuming it already has.
-		await waitFor( () => expect( button ).toHaveAttribute( 'aria-disabled', 'true' ) );
+		await expect(
+			screen.findByRole( 'button', { name: 'Back up now' } )
+		).resolves.toBeInTheDocument();
+		// Re-queried inside the wait, not held from above: the storage answer lands
+		// after the button and moves it into the tooltip branch, a different element.
+		await waitFor( () =>
+			expect( screen.getByRole( 'button', { name: 'Back up now' } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			)
+		);
 	} );
 
 	it( 'queues a backup and reports it as enqueued', async () => {

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -201,11 +201,11 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 
 		const view = within( renderShell() );
 
-		// The other two queries are answered, so this separates "still starting up"
-		// from "held by capabilities".
+		// Nothing else in this tree fetches until capabilities answers, so its own
+		// request is what separates "still starting up" from "held by capabilities".
 		await waitFor( () =>
 			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( { path: '/jetpack/v4/backups' } )
+				expect.objectContaining( { path: CAPABILITIES_PATH } )
 			)
 		);
 
@@ -288,13 +288,11 @@ describe( 'The header button on its own, with no gate above it', () => {
 
 		const { client, container } = renderButtonAlone();
 
-		// The button's other read is answered, so capabilities is all that is left.
+		// Capabilities is the button's only read until the verdict is `ready`, so a
+		// query in flight is what says the render got that far.
 		await waitFor( () =>
-			expect( mockApiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( { path: '/jetpack/v4/backups' } )
-			)
+			expect( client.getQueryState( keys.capabilities() )?.fetchStatus ).toBe( 'fetching' )
 		);
-		expect( client.getQueryState( keys.capabilities() )?.fetchStatus ).toBe( 'fetching' );
 		expect( container ).toBeEmptyDOMElement();
 
 		// And only that: releasing the read brings the button back, unchanged.

--- a/projects/packages/backup/tests/invalid-rewind-id.test.tsx
+++ b/projects/packages/backup/tests/invalid-rewind-id.test.tsx
@@ -170,7 +170,11 @@ describe.each( [
 		);
 
 		await expect( screen.findByText( heading ) ).resolves.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: new RegExp( submit ) } ) ).toBeInTheDocument();
+		// Awaited: Restore's reads wait on the gate verdict, so its form arms a
+		// round trip after the heading. Download still arms with it.
+		await expect(
+			screen.findByRole( 'button', { name: new RegExp( submit ) } )
+		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( notFound ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -1,10 +1,7 @@
-// JETPACK-2322 — behind the no-plan upsell the Overview still read the
-// activity log, the backup list and the site size, and kept polling the
-// backup list. Nothing on that screen can act on any of it.
-//
-// Every assertion here is a call count on the `apiFetch` spy, paired with a
-// positive that proves the screen rendered: "no request was made" is also
-// true of a tree that threw before it reached the hook.
+// JETPACK-2322: behind the no-plan upsell the Overview kept reading — and polling —
+// WordPress.com for answers nothing there could act on. Each negative below is an
+// `apiFetch` call count paired with a positive that proves the screen rendered, since
+// "no request was made" is also true of a tree that threw first.
 
 const mockApiFetch = jest.fn();
 
@@ -38,9 +35,8 @@ const ACTIVITY_PATH = '/jetpack/v4/site/rewindable-activity';
 const SITE_SIZE_PATH = '/jetpack/v4/site/backup/size';
 
 /**
- * A backup still running, which is what makes `useBackups` want the poll.
- * Without it the polling negative below would hold on a site whose state
- * never asked for one.
+ * A backup still running, so `useBackups` wants the poll — without it the polling
+ * negative below would hold on a site that never asked for one.
  */
 const RUNNING_BACKUP = {
 	id: '1',
@@ -135,8 +131,7 @@ describe( 'A connected site with no Backup plan', () => {
 		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
 		await pollTicks( 1 );
 
-		// The gate's own read, which is what decided this screen — so the spy is
-		// wired and the tree did reach WordPress.com.
+		// The gate's own read: the positive that says this screen came from a real answer.
 		expect( asked( CAPABILITIES_PATH ) ).toBe( 1 );
 
 		// Reported together so a failure names every route still being read,
@@ -172,9 +167,8 @@ describe( 'A connected site with no Backup plan', () => {
 } );
 
 describe( 'The same site once it has a plan', () => {
-	// The control for all three negatives above: same fixtures, same timers,
-	// same tree — only the entitlement differs. Without it, a harness in which
-	// nothing ever fetches or no timer ever fires would pass this file.
+	// The control for the three negatives above: same fixtures, same timers, same tree,
+	// only the entitlement differs — without it a harness that never fetches would pass.
 	it( 'reads all three, and keeps polling the running backup', async () => {
 		hasBackupPlan = true;
 

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -1,7 +1,7 @@
-// JETPACK-2322: behind the no-plan upsell the Overview kept reading — and polling —
-// WordPress.com for answers nothing there could act on. Each negative below is an
-// `apiFetch` call count paired with a positive that proves the screen rendered, since
-// "no request was made" is also true of a tree that threw first.
+// JETPACK-2322: behind the no-plan upsell the Overview and the Restore screen kept
+// reading — and polling — WordPress.com for answers nothing there could act on. Each
+// negative below is an `apiFetch` call count paired with a positive that proves the
+// screen rendered, since "no request was made" is also true of a tree that threw first.
 
 const mockApiFetch = jest.fn();
 
@@ -13,26 +13,39 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( {} ),
 	useNavigate: () => () => {},
-	useParams: () => ( {} ),
+	useParams: () => ( { rewindId: '1786644531.123' } ),
 	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
 } ) );
 
 // Imports must come after the jest.mock factories above.
 import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
-import { queryClient } from '../src/dashboard/data/query-client';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
 import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const DISCONNECTED = { isRegistered: false, hasConnectedOwner: false, isUserConnected: false };
 const SETTLE = { timeout: 10000 };
 
 const NO_PLAN = "This site doesn't have an active Backup plan";
 const UPSELL_CTA = /^Get VaultPress Backup$/;
+const NOT_CONNECTED = 'Connect Jetpack to get started';
+const RESTORING = 'Restoring your site';
 
 const CAPABILITIES_PATH = '/jetpack/v4/site/capabilities';
 const BACKUPS_PATH = '/jetpack/v4/backups';
 const ACTIVITY_PATH = '/jetpack/v4/site/rewindable-activity';
 const SITE_SIZE_PATH = '/jetpack/v4/site/backup/size';
+const RESTORES_PATH = '/jetpack/v4/restores';
+
+const RESTORE_ID = 912682;
+const STATUS_PATH = `/jetpack/v4/rewind/restore/${ RESTORE_ID }/status`;
+
+// Must match the literal in the `@wordpress/route` factory above, which jest
+// hoists above every declaration and so cannot reference this.
+const REWIND_ID = '1786644531.123';
 
 /**
  * A backup still running, so `useBackups` wants the poll — without it the polling
@@ -49,8 +62,31 @@ const RUNNING_BACKUP = {
 	is_scan: '0',
 };
 
+/**
+ * A restore already under way upstream, so `useRestore` adopts it and wants the status
+ * poll — without one the polling negative below would hold on a quiet site.
+ */
+const RUNNING_RESTORE = {
+	restore_id: RESTORE_ID,
+	rewind_id: REWIND_ID,
+	when: '2026-08-20T10:00:00+00:00',
+	status: 'running',
+};
+
+const RUNNING_STATUS = {
+	id: RESTORE_ID,
+	status: 'running',
+	progress: 47,
+	rewind_id: REWIND_ID,
+	error_code: '',
+	message: '',
+};
+
 /** Flipped per test; the only difference between the negatives and their control. */
 let hasBackupPlan = false;
+
+/** Flipped per test; whether the site has a restore for the Restore screen to adopt. */
+let restoreRunning = false;
 
 // jsdom implements no scrolling, and DataViews' list layout calls
 // `scrollIntoView` on the selected row.
@@ -95,6 +131,7 @@ beforeEach( () => {
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
 
 	hasBackupPlan = false;
+	restoreRunning = false;
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 		const path = options?.path ?? '';
@@ -109,6 +146,12 @@ beforeEach( () => {
 		}
 		if ( path === BACKUPS_PATH ) {
 			return Promise.resolve( [ RUNNING_BACKUP ] );
+		}
+		if ( path === RESTORES_PATH ) {
+			return Promise.resolve( restoreRunning ? [ RUNNING_RESTORE ] : [] );
+		}
+		if ( path === STATUS_PATH ) {
+			return Promise.resolve( RUNNING_STATUS );
 		}
 		// The promoted-product catalogue the upsell prices itself from.
 		return Promise.resolve( null );
@@ -188,5 +231,132 @@ describe( 'The same site once it has a plan', () => {
 
 		await pollTicks( 2 );
 		expect( asked( BACKUPS_PATH ) ).toBeGreaterThan( before );
+	} );
+} );
+
+describe( 'The Restore screen behind the same gates', () => {
+	it( 'renders the upsell without asking what restores exist', async () => {
+		render( <RestoreStage /> );
+
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await pollTicks( 1 );
+
+		// The gate's own read: the positive that says this screen came from a real answer.
+		expect( asked( CAPABILITIES_PATH ) ).toBe( 1 );
+		expect( asked( RESTORES_PATH ) ).toBe( 0 );
+	} );
+
+	it( 'never polls a restore that is already running upstream', async () => {
+		restoreRunning = true;
+
+		render( <RestoreStage /> );
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+
+		await pollTicks( 4 );
+
+		// Reported together so a failure names every route still being read,
+		// not just the first one.
+		expect( { restores: asked( RESTORES_PATH ), status: asked( STATUS_PATH ) } ).toEqual( {
+			restores: 0,
+			status: 0,
+		} );
+	} );
+
+	it( 'asks nothing at all on a site that is not connected', async () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: DISCONNECTED,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		render( <RestoreStage /> );
+
+		await expect( screen.findByText( NOT_CONNECTED, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await pollTicks( 1 );
+
+		// `useCapabilities` is disabled without a user connection, so the gate itself
+		// asks nothing here and the rendered screen is the only positive available.
+		expect( {
+			capabilities: asked( CAPABILITIES_PATH ),
+			restores: asked( RESTORES_PATH ),
+		} ).toEqual( { capabilities: 0, restores: 0 } );
+	} );
+} );
+
+describe( 'The Restore screen across a gate flip', () => {
+	// The reason the reads are gated inside `useRestore` rather than by mounting the
+	// screen's body below `<Gates>`: that state is what withholds Confirm while a
+	// restore WordPress.com accepted without naming is still unlisted, and a body
+	// that unmounts on a flip re-arms it into a second concurrent restore.
+	it( 'keeps withholding Confirm when the verdict flips away and back', async () => {
+		hasBackupPlan = true;
+		mockApiFetch.mockImplementation( ( o: { path?: string; method?: string } ) => {
+			const path = o?.path ?? '';
+			if ( path.startsWith( CAPABILITIES_PATH ) ) {
+				return Promise.resolve( { hasBackupPlan, hasScan: false } );
+			}
+			if ( o?.method === 'POST' ) {
+				return Promise.resolve( { id: null, rewind_id: REWIND_ID } );
+			}
+			if ( path === RESTORES_PATH ) {
+				return Promise.resolve( [] );
+			}
+			return Promise.resolve( {} );
+		} );
+
+		// `advanceTimers`, because this file runs on fake timers.
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+
+		render( <RestoreStage /> );
+		await user.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+		await expect(
+			screen.findByText( /queued and will begin shortly/, undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		const posts = () => mockApiFetch.mock.calls.filter( ( [ o ] ) => o?.method === 'POST' ).length;
+		expect( posts() ).toBe( 1 );
+
+		// ready -> no-plan -> ready, the shape a failed capabilities refetch and a
+		// retry produce.
+		hasBackupPlan = false;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+
+		hasBackupPlan = true;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+		await expect(
+			screen.findByText( /queued and will begin shortly/, undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		expect( screen.queryByRole( 'button', { name: /Confirm restore/ } ) ).not.toBeInTheDocument();
+		expect( posts() ).toBe( 1 );
+	} );
+} );
+
+describe( 'The Restore screen once the site has a plan', () => {
+	// The control for the three negatives above: the polling negative's own fixtures,
+	// timers and tree, with only the entitlement flipped — without it a harness that
+	// never fetches would pass.
+	it( 'reads the restores collection and polls the restore it adopts', async () => {
+		hasBackupPlan = true;
+		restoreRunning = true;
+
+		render( <RestoreStage /> );
+
+		await expect(
+			screen.findByRole( 'progressbar', { name: RESTORING }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+
+		const before = asked( STATUS_PATH );
+		expect( { restores: asked( RESTORES_PATH ) > 0, status: before > 0 } ).toEqual( {
+			restores: true,
+			status: true,
+		} );
+
+		await pollTicks( 2 );
+		expect( asked( STATUS_PATH ) ).toBeGreaterThan( before );
 	} );
 } );

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -1,9 +1,11 @@
-// JETPACK-2322: behind the no-plan upsell the Overview and the Restore screen kept
-// reading — and polling — WordPress.com for answers nothing there could act on. Each
-// negative below is an `apiFetch` call count paired with a positive that proves the
-// screen rendered, since "no request was made" is also true of a tree that threw first.
+// JETPACK-2322: behind the no-plan upsell the Overview, Restore and Download screens
+// kept reading — and polling, and on Download writing — WordPress.com for answers
+// nothing there could act on. Each negative below is an `apiFetch` call count paired
+// with a positive that proves the screen rendered, since "no request was made" is also
+// true of a tree that threw first.
 
 const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
 
 jest.mock( '@wordpress/api-fetch', () => ( {
 	__esModule: true,
@@ -11,7 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
+	useSearch: () => mockSearch(),
 	useNavigate: () => () => {},
 	useParams: () => ( { rewindId: '1786644531.123' } ),
 	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
@@ -21,6 +23,7 @@ jest.mock( '@wordpress/route', () => ( {
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { stage as DownloadStage } from '../routes/download/stage';
 import { stage as RestoreStage } from '../routes/restore/stage';
 import { keys, queryClient } from '../src/dashboard/data/query-client';
 import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
@@ -33,6 +36,7 @@ const NO_PLAN = "This site doesn't have an active Backup plan";
 const UPSELL_CTA = /^Get VaultPress Backup$/;
 const NOT_CONNECTED = 'Connect Jetpack to get started';
 const RESTORING = 'Restoring your site';
+const PREPARING = 'Preparing your download';
 
 const CAPABILITIES_PATH = '/jetpack/v4/site/capabilities';
 const BACKUPS_PATH = '/jetpack/v4/backups';
@@ -46,6 +50,14 @@ const STATUS_PATH = `/jetpack/v4/rewind/restore/${ RESTORE_ID }/status`;
 // Must match the literal in the `@wordpress/route` factory above, which jest
 // hoists above every declaration and so cannot reference this.
 const REWIND_ID = '1786644531.123';
+
+const DOWNLOAD_ID = 4242;
+const DOWNLOAD_PATH = `/jetpack/v4/backups/download/${ REWIND_ID }`;
+const DOWNLOAD_STATUS_PATH = `${ DOWNLOAD_PATH }/status`;
+
+// The comma-joined `ls` entry ids the file browser's Download link carries;
+// `ZjU6L3dwLWNvbmZpZy5waHA=` decodes to `f5:/wp-config.php`.
+const FILE_SELECTION = 'ZjU6L3dwLWNvbmZpZy5waHA=,ZjI6L3JlYWRtZS5odG1s';
 
 /**
  * A backup still running, so `useBackups` wants the poll — without it the polling
@@ -80,6 +92,19 @@ const RUNNING_STATUS = {
 	rewind_id: REWIND_ID,
 	error_code: '',
 	message: '',
+};
+
+/**
+ * An archive still being built, so `useDownload` wants the poll — without it the
+ * polling negative below would hold on a download that had already finished.
+ */
+const RUNNING_DOWNLOAD = {
+	id: DOWNLOAD_ID,
+	status: 'running',
+	progress: 36,
+	url: '',
+	valid_until: '',
+	error: '',
 };
 
 /** Flipped per test; the only difference between the negatives and their control. */
@@ -132,6 +157,8 @@ beforeEach( () => {
 
 	hasBackupPlan = false;
 	restoreRunning = false;
+	mockSearch.mockReset();
+	mockSearch.mockReturnValue( {} );
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
 		const path = options?.path ?? '';
@@ -152,6 +179,14 @@ beforeEach( () => {
 		}
 		if ( path === STATUS_PATH ) {
 			return Promise.resolve( RUNNING_STATUS );
+		}
+		// Ordered before the initiate branch: the poll path extends the initiate
+		// path, so the reverse order would answer the poll with `{ id }` alone.
+		if ( path.startsWith( DOWNLOAD_STATUS_PATH ) ) {
+			return Promise.resolve( RUNNING_DOWNLOAD );
+		}
+		if ( path === DOWNLOAD_PATH ) {
+			return Promise.resolve( { id: DOWNLOAD_ID } );
 		}
 		// The promoted-product catalogue the upsell prices itself from.
 		return Promise.resolve( null );
@@ -358,5 +393,115 @@ describe( 'The Restore screen once the site has a plan', () => {
 
 		await pollTicks( 2 );
 		expect( asked( STATUS_PATH ) ).toBeGreaterThan( before );
+	} );
+} );
+
+// Reachable by direct URL alone — a bookmark, or a tab left open when the plan lapsed
+// — and the POST asks WordPress.com to build an archive, so this is a write.
+describe( 'The Download screen behind the same gates', () => {
+	beforeEach( () => {
+		mockSearch.mockReturnValue( { files: FILE_SELECTION } );
+	} );
+
+	it( 'renders the upsell without asking for the archive the link named', async () => {
+		render( <DownloadStage /> );
+
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await pollTicks( 4 );
+
+		// The gate's own read: the positive that says this screen came from a real answer.
+		expect( asked( CAPABILITIES_PATH ) ).toBe( 1 );
+		// Reported together so a failure names the write and the poll, not just the first.
+		expect( {
+			initiate: asked( DOWNLOAD_PATH ),
+			status: asked( DOWNLOAD_STATUS_PATH ),
+		} ).toEqual( { initiate: 0, status: 0 } );
+	} );
+
+	it( 'asks nothing at all on a site that is not connected', async () => {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			connectionStatus: DISCONNECTED,
+		} as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		render( <DownloadStage /> );
+
+		await expect( screen.findByText( NOT_CONNECTED, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await pollTicks( 4 );
+
+		// `useCapabilities` is disabled without a user connection, so the gate itself
+		// asks nothing here and the rendered screen is the only positive available.
+		expect( {
+			capabilities: asked( CAPABILITIES_PATH ),
+			initiate: asked( DOWNLOAD_PATH ),
+			status: asked( DOWNLOAD_STATUS_PATH ),
+		} ).toEqual( { capabilities: 0, initiate: 0, status: 0 } );
+	} );
+} );
+
+describe( 'The Download screen across a gate flip', () => {
+	// `hasAutoStarted` is a per-mount ref, so a body remounted below `<Gates>` would
+	// reset it and build a second archive. The first count is also the ordering: the
+	// verdict is `loading` on first commit, so a build means the effect re-ran.
+	it( 'builds one archive when the verdict arrives, and none on a later flip', async () => {
+		hasBackupPlan = true;
+		mockSearch.mockReturnValue( { files: FILE_SELECTION } );
+
+		render( <DownloadStage /> );
+		await expect(
+			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( asked( DOWNLOAD_PATH ) ).toBe( 1 );
+
+		// ready -> no-plan -> ready, the shape a failed capabilities refetch and a
+		// retry produce.
+		hasBackupPlan = false;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+
+		// The archive is still being built, so only the hook's own gate can stop the
+		// poll: nothing about the download itself has changed.
+		const parked = asked( DOWNLOAD_STATUS_PATH );
+		await pollTicks( 4 );
+		expect( asked( DOWNLOAD_STATUS_PATH ) ).toBe( parked );
+
+		hasBackupPlan = true;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+		await expect(
+			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		expect( asked( DOWNLOAD_PATH ) ).toBe( 1 );
+	} );
+} );
+
+describe( 'The Download screen once the site has a plan', () => {
+	// The control for the two negatives above: the same link, fixtures, timers and
+	// tree, with only the entitlement flipped — without it a harness that never
+	// fetches would pass.
+	it( 'builds the archive and polls it while it is being prepared', async () => {
+		hasBackupPlan = true;
+		mockSearch.mockReturnValue( { files: FILE_SELECTION } );
+
+		render( <DownloadStage /> );
+
+		await expect(
+			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+
+		await pollTicks( 1 );
+		const before = asked( DOWNLOAD_STATUS_PATH );
+		expect( { initiate: asked( DOWNLOAD_PATH ), status: before > 0 } ).toEqual( {
+			initiate: 1,
+			status: true,
+		} );
+
+		await pollTicks( 2 );
+		expect( asked( DOWNLOAD_STATUS_PATH ) ).toBeGreaterThan( before );
 	} );
 } );

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -1,0 +1,198 @@
+// JETPACK-2322 — behind the no-plan upsell the Overview still read the
+// activity log, the backup list and the site size, and kept polling the
+// backup list. Nothing on that screen can act on any of it.
+//
+// Every assertion here is a call count on the `apiFetch` spy, paired with a
+// positive that proves the screen rendered: "no request was made" is also
+// true of a tree that threw before it reached the hook.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( {} ),
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { act, render, screen } from '@testing-library/react';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SETTLE = { timeout: 10000 };
+
+const NO_PLAN = "This site doesn't have an active Backup plan";
+const UPSELL_CTA = /^Get VaultPress Backup$/;
+
+const CAPABILITIES_PATH = '/jetpack/v4/site/capabilities';
+const BACKUPS_PATH = '/jetpack/v4/backups';
+const ACTIVITY_PATH = '/jetpack/v4/site/rewindable-activity';
+const SITE_SIZE_PATH = '/jetpack/v4/site/backup/size';
+
+/**
+ * A backup still running, which is what makes `useBackups` want the poll.
+ * Without it the polling negative below would hold on a site whose state
+ * never asked for one.
+ */
+const RUNNING_BACKUP = {
+	id: '1',
+	started: '2026-08-14 17:25:46',
+	last_updated: '2026-08-14 17:36:04',
+	status: 'started',
+	period: '1786644532',
+	percent: '50',
+	is_backup: '1',
+	is_scan: '0',
+};
+
+/** Flipped per test; the only difference between the negatives and their control. */
+let hasBackupPlan = false;
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * How many times `apiFetch` has been asked for a route, ignoring query args.
+ *
+ * @param route - The fully-qualified path, without query args.
+ * @return The call count.
+ */
+function asked( route: string ): number {
+	return mockApiFetch.mock.calls.filter( ( [ options ] ) => {
+		const path = String( options?.path ?? '' );
+		return path === route || path.startsWith( `${ route }?` );
+	} ).length;
+}
+
+/**
+ * Run `count` poll intervals and let everything they trigger settle, so a
+ * count read afterwards is final rather than mid-flight.
+ *
+ * @param count - How many intervals to advance.
+ */
+async function pollTicks( count: number ): Promise< void > {
+	for ( let i = 0; i < count; i++ ) {
+		await act( async () => {
+			await jest.advanceTimersByTimeAsync( BACKUPS_POLL_INTERVAL_MS );
+		} );
+	}
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( 0 );
+	} );
+}
+
+beforeEach( () => {
+	jest.useFakeTimers();
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	hasBackupPlan = false;
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.startsWith( CAPABILITIES_PATH ) ) {
+			return Promise.resolve( { hasBackupPlan, hasScan: false } );
+		}
+		if ( path.startsWith( ACTIVITY_PATH ) ) {
+			return Promise.resolve( { current: { orderedItems: [] }, totalItems: 0, totalPages: 1 } );
+		}
+		if ( path.startsWith( SITE_SIZE_PATH ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === BACKUPS_PATH ) {
+			return Promise.resolve( [ RUNNING_BACKUP ] );
+		}
+		// The promoted-product catalogue the upsell prices itself from.
+		return Promise.resolve( null );
+	} );
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+afterEach( () => {
+	jest.useRealTimers();
+} );
+
+describe( 'A connected site with no Backup plan', () => {
+	it( 'asks WordPress.com only what the upsell itself can act on', async () => {
+		render( <OverviewStage /> );
+
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await pollTicks( 1 );
+
+		// The gate's own read, which is what decided this screen — so the spy is
+		// wired and the tree did reach WordPress.com.
+		expect( asked( CAPABILITIES_PATH ) ).toBe( 1 );
+
+		// Reported together so a failure names every route still being read,
+		// not just the first one.
+		expect( {
+			activity: asked( ACTIVITY_PATH ),
+			backups: asked( BACKUPS_PATH ),
+			siteSize: asked( SITE_SIZE_PATH ),
+		} ).toEqual( { activity: 0, backups: 0, siteSize: 0 } );
+	} );
+
+	it( 'offers no header action, so nothing reads the site size on its behalf', async () => {
+		render( <OverviewStage /> );
+
+		// `/site/backup/size` is the header button's read alone, so the absence
+		// above is only meaningful next to the absence of the button.
+		await expect(
+			screen.findByRole( 'link', { name: UPSELL_CTA }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: /Back up now|Backup in progress/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'never starts the backup poll', async () => {
+		render( <OverviewStage /> );
+		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+
+		await pollTicks( 4 );
+
+		expect( asked( BACKUPS_PATH ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'The same site once it has a plan', () => {
+	// The control for all three negatives above: same fixtures, same timers,
+	// same tree — only the entitlement differs. Without it, a harness in which
+	// nothing ever fetches or no timer ever fires would pass this file.
+	it( 'reads all three, and keeps polling the running backup', async () => {
+		hasBackupPlan = true;
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Backup in progress' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+
+		const before = asked( BACKUPS_PATH );
+		expect( {
+			activity: asked( ACTIVITY_PATH ) > 0,
+			backups: before > 0,
+			siteSize: asked( SITE_SIZE_PATH ) > 0,
+		} ).toEqual( { activity: true, backups: true, siteSize: true } );
+
+		await pollTicks( 2 );
+		expect( asked( BACKUPS_PATH ) ).toBeGreaterThan( before );
+	} );
+} );

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -180,8 +180,6 @@ beforeEach( () => {
 		if ( path === STATUS_PATH ) {
 			return Promise.resolve( RUNNING_STATUS );
 		}
-		// Ordered before the initiate branch: the poll path extends the initiate
-		// path, so the reverse order would answer the poll with `{ id }` alone.
 		if ( path.startsWith( DOWNLOAD_STATUS_PATH ) ) {
 			return Promise.resolve( RUNNING_DOWNLOAD );
 		}
@@ -349,8 +347,7 @@ describe( 'The Restore screen across a gate flip', () => {
 		const posts = () => mockApiFetch.mock.calls.filter( ( [ o ] ) => o?.method === 'POST' ).length;
 		expect( posts() ).toBe( 1 );
 
-		// ready -> no-plan -> ready, the shape a failed capabilities refetch and a
-		// retry produce.
+		// ready -> no-plan -> ready, the shape a plan lapsing mid-session produces.
 		hasBackupPlan = false;
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
@@ -453,8 +450,7 @@ describe( 'The Download screen across a gate flip', () => {
 		).resolves.toBeInTheDocument();
 		expect( asked( DOWNLOAD_PATH ) ).toBe( 1 );
 
-		// ready -> no-plan -> ready, the shape a failed capabilities refetch and a
-		// retry produce.
+		// ready -> no-plan -> ready, the shape a plan lapsing mid-session produces.
 		hasBackupPlan = false;
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
@@ -475,6 +471,11 @@ describe( 'The Download screen across a gate flip', () => {
 			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
 		).resolves.toBeInTheDocument();
 
+		// The bar alone only proves `downloadId` survived; the count proves the poll
+		// restarted rather than staying parked.
+		const resumed = asked( DOWNLOAD_STATUS_PATH );
+		await pollTicks( 2 );
+		expect( asked( DOWNLOAD_STATUS_PATH ) ).toBeGreaterThan( resumed );
 		expect( asked( DOWNLOAD_PATH ) ).toBe( 1 );
 	} );
 } );

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -179,6 +179,16 @@ describe( 'Overview page view', () => {
 
 	beforeEach( async () => {
 		( await import( '../src/dashboard/screens/overview' ) ).resetPageViewForTesting();
+		// Declared, not incidental: these tests are what pin the page view firing on a
+		// plan-less visit, which is why the event sits above `<Gates>`. The bare
+		// `mockResolvedValue( null )` produced the same verdict, but silently.
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/site/capabilities' ) ) {
+				return Promise.resolve( { hasBackupPlan: false, hasScan: false } );
+			}
+			return Promise.resolve( null );
+		} );
 	} );
 
 	it( 'records one page view per visit', async () => {


### PR DESCRIPTION
Fixes JETPACK-2322

## Proposed changes

* A connected site with **no Backup plan** issued four WordPress.com round trips behind the upsell — `/site/capabilities`, `/site/rewindable-activity`, `/backups` and `/site/backup/size` — and `/backups` kept polling every five seconds for as long as the tab stayed open. Only the first is something that screen can act on: it is the read the gate decides from.
* The cause was structural. `<Gates>` wrapped `children` only, but the Overview screen called its query hooks in its own body and handed `<BackupNowButton>` to `<Page>`'s header `actions` — both of which React runs *above* the gate. Every one of those queries was gated on `useCanQueryWpcom()`, which checks connection and never plan.
* `screens/overview.tsx`: the body moves into an `<OverviewBody>` child, so `<Gates>` is what mounts it. Its takeover branch now returns the status panel rather than a second `<DashboardLayout>`.
* `components/backup-now-button/index.tsx`: split into a wrapper that reads `useGateState()` and returns `null`, and an inner `<BackupNow>` holding the query hooks. The verdict is read *before* any of them runs, rather than after.
* The page-view Tracks event deliberately stays above the gate. Legacy counts a view whatever the site's plan, and moving it below would be a silent step change in the metric at flag-flip.
* `hooks/use-backups.ts` stated the old assumption out loud — "every screen that reads this hook sits behind `<Gates>`", which was not true of the Overview body. That assumption is now true, so the docblock says so instead. `hooks/use-activity-log.ts` carried the inverse claim and is corrected the same way.

### Which option, and why

The issue offered two: a plan-aware `enabled` alongside `useCanQueryWpcom()`, or restructuring so the screen body mounts inside the gate. It leaned towards the second partly because it "would also remove the duplication behind JETPACK-2313" — that reason is stale. 2313 shipped in #51685 and `hooks/use-gate-state.ts` already owns the decision, so there is no duplication left to remove.

Re-derived against trunk as it stands, the restructure is still the right choice, and 2313 landing is now what makes it *cheap* rather than what justified it:

* The wrapper reads one hook. Before 2313, splitting the button meant re-deriving the gate walk in a second place; now it is `gate.status !== 'ready'`.
* It fixes the cause instead of each symptom. A plan-aware `enabled` is a per-hook opt-in — a checklist every future hook added to the Overview body or the header actions has to be on, with silence as the failure mode. The restructure makes "nothing above the gate fetches" a property of the tree.
* It needs no change to `use-site-size.ts` or to the activity-log query. Those hooks simply never mount, which also keeps the diff inside this task's territory.
* It is the only one of the two that makes `use-backups.ts`'s docblock true rather than leaving it contradicting the code.

There is one cost, and it belongs to the requirement rather than to the option chosen: for an entitled site the body's first reads now start once capabilities resolves instead of alongside it, so a cold load costs one extra serialized round trip before content appears. A plan-aware `enabled` has exactly the same serialization — a flag that depends on the plan cannot fire before the plan is known — so the only way to avoid it is to keep speculatively fetching, which is the bug. Capabilities carries a five-minute `staleTime`, so this is a first-load cost, not a per-navigation one. The gate rendered a spinner over that window before this change too, so nothing that used to be on screen is delayed.

The one place that serialization is visible rather than merely slower is a site whose storage is full: `/site/backup/size` now starts when the button mounts rather than alongside capabilities, so "Back up now" is briefly enabled before the answer disables it. It was already possible for that window to be non-zero — it was the difference between the two upstreams' latencies — and a click inside it lands on the rejection handler this component added, so it reports the refusal rather than claiming success. `tests/first-run-state.test.tsx` had been holding the pre-answer button node and is updated to re-query, since the answer arriving moves the button into the tooltip branch.

## Related product discussion/links

* Linear: JETPACK-2322 (task F12), under the Backup modernization project.
* This closes the second half of an accepted risk on JETPACK-2319's flip checklist. That line pairs JETPACK-2308 (now #51797) with this issue, so once both merge the risk can be struck rather than signed.
* JETPACK-2313 (#51685) is the prerequisite that made the wrapper a one-line verdict read.

## Does this pull request change what data or activity we track or use?

It reduces it: a site with no Backup plan no longer sends three WordPress.com requests, one of them a five-second poll, whose answers that screen cannot use.

No Tracks event is added, removed or re-timed. `jetpack_backup_admin_page_view` is deliberately left above the gate so it keeps firing on a no-plan visit, exactly as it does today and as the legacy dashboard does.

## Testing instructions

Automated, from `projects/packages/backup`:

* `pnpm test` — 70 suites, 691 tests, all passing (baseline on trunk was 69 / 687).
* `pnpm test -- tests/no-plan-quiet.test.tsx` is the new file. It renders the real `routes/dashboard/stage` with `@tanstack/react-query` unmocked and asserts **call counts on the `apiFetch` spy**, never a component-owned flag. Each negative is paired with a positive: the no-plan assertions only run after the upsell screen has actually rendered, and the last test is a control that flips `hasBackupPlan` to `true` and proves the same fixtures and the same fake timers do produce all three reads and a growing `/backups` count. Against trunk's code the file fails with `{ activity: 1, backups: 2, siteSize: 1 }` instead of zeroes, and with 5 `/backups` calls across 4 poll intervals instead of 0.
* Two existing tests changed because they leaned on the bug: both `gate-decision.test.tsx` cases used "`/jetpack/v4/backups` has been requested" as the witness that a render had got going while capabilities was in flight. That request no longer happens, which is the point, so they now witness the capabilities read itself. `first-run-state.test.tsx`'s storage-limit case held a button node from before the storage answer landed; it re-queries inside the `waitFor` now, because the answer arriving switches the button into the tooltip branch and mounts a different element.

Manual, with `rsm_jetpack_ui_modernization_backup` filtered on:

1. On a connected site **without** a Backup plan, open Jetpack → Backup with DevTools Network filtered to `jetpack/v4`.
2. Expect exactly two requests: `/site/capabilities` and `/backup-promoted-product-info` (the upsell's own price). Before this change you would also see `/site/rewindable-activity`, `/site/backup/size` and `/backups`.
3. Leave the tab open for a minute or two. `/backups` must never appear — before this change it reappeared every five seconds.
4. On a site **with** a plan, confirm the Overview still loads the activity list, the storage meter, the next-scheduled line and the "Back up now" button, and that starting a backup still updates the progress bar (i.e. the poll still works where it should).

Not tested: no live-site run — everything above was verified in jsdom. No build was run, since nothing here changes module boundaries or styles, and no PHP is touched, so Phan and PHPCS are not in scope.
