### PR TITLE
Backup: drop "real-time" from the review card's question

### DIFF
--- a/projects/packages/backup/changelog/update-backup-review-card-drop-realtime
+++ b/projects/packages/backup/changelog/update-backup-review-card-drop-realtime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Review request: Ask about backups instead of real-time backups, which was inaccurate on daily plans.

--- a/projects/packages/backup/src/dashboard/components/review-request/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/review-request/index.tsx
@@ -12,9 +12,6 @@ import type { ReviewReason } from '../../data/api/review-request';
  *
  * Two whole returns, not one `__()` over a ternary: the minifier factors the
  * shared call out and leaves a non-literal msgid the extractor cannot read.
- * Both msgids are legacy's character for character, so they arrive already
- * translated — including the backups line's unconditional "real-time", which is
- * ported as-is rather than reworded at a translation cost.
  *
  * @param reason - Why the reader is being asked.
  * @return The question to show.
@@ -24,7 +21,7 @@ function reviewQuestion( reason: ReviewReason ): string {
 		return __( 'Was it easy to restore your site?', 'jetpack-backup-pkg' );
 	}
 
-	return __( 'Do you enjoy the peace of mind of having real-time backups?', 'jetpack-backup-pkg' );
+	return __( 'Do you enjoy the peace of mind of having backups?', 'jetpack-backup-pkg' );
 }
 
 /**

--- a/projects/packages/backup/src/js/components/Admin/index.jsx
+++ b/projects/packages/backup/src/js/components/Admin/index.jsx
@@ -255,10 +255,7 @@ const ReviewMessage = connectionLoaded => {
 		reviewText = __( 'Was it easy to restore your site?', 'jetpack-backup-pkg' );
 	} else if ( hasFiveSuccessfulBackups() ) {
 		requestReason = 'backups';
-		reviewText = __(
-			'Do you enjoy the peace of mind of having real-time backups?',
-			'jetpack-backup-pkg'
-		);
+		reviewText = __( 'Do you enjoy the peace of mind of having backups?', 'jetpack-backup-pkg' );
 	}
 
 	const [ dismissedReview, dismissMessage ] = useDismissedReviewRequest(

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -46,7 +46,7 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 const SETTLE = { timeout: 10000 };
 
 const RESTORE_QUESTION = 'Was it easy to restore your site?';
-const BACKUPS_QUESTION = 'Do you enjoy the peace of mind of having real-time backups?';
+const BACKUPS_QUESTION = 'Do you enjoy the peace of mind of having backups?';
 // Matched loosely: `Link` appends its own "opens in a new tab" text to
 // the accessible name, so an exact match would pin this test to that
 // wording rather than to ours.

--- a/projects/plugins/backup/changelog/update-backup-review-card-drop-realtime
+++ b/projects/plugins/backup/changelog/update-backup-review-card-drop-realtime
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Review request: Ask about backups instead of real-time backups, which was inaccurate on daily plans.


### PR DESCRIPTION
Fixes JETPACK-2447

## Proposed changes

The Backup review-request card asks every reader:

> Do you enjoy the peace of mind of having real-time backups?

That claim is false for a daily-tier site, and daily-tier sites do reach this card.

**Evidence.** From wpcom's `rewind-permissions.php`, `/sites/{id}/rewind/capabilities` returns exactly one of `backup-realtime` or `backup-daily`, never both — *"We don't report backup-daily + backup-realtime, just the better of the two."* Daily products are still on sale. Nothing between that endpoint and this card narrows the audience: the card's gate needs only the `backup` capability, and its trigger needs five usable backups, which a daily site reaches in five days. So a daily-tier reader is told they have a tier they did not buy.

**The fix is to drop the qualifier, not to split the string.**

* `'Do you enjoy the peace of mind of having real-time backups?'` → `'Do you enjoy the peace of mind of having backups?'`
* One new msgid instead of two. No tier detection, no branch, no read of `backup-realtime`/`backup-daily` — the daily/real-time distinction is not something the reader can act on from a review prompt, and the simpler sentence is true for all of them. Same call made earlier on the file-preview copy.
* Both call sites move together, since they share the one msgid: the modernized card (`src/dashboard/components/review-request/index.tsx`) and the legacy dashboard (`src/js/components/Admin/index.jsx`). Changing one alone would have created a spurious second string.
* The sibling `'Was it easy to restore your site?'` is untouched, as is the marketing copy on the no-plan screen (`backup-promotion/`, `no-backup-capabilities.jsx`) — that describes what the product offers rather than what the reader has.
* A docblock in `review-request/index.tsx` claimed the backups msgid was ported from legacy character-for-character specifically to avoid a retranslation cost. That is no longer true, so it is gone. The `useReviewRequest` docblock and the test comment at `review-request.test.tsx` both paraphrase only "peace of mind", which survives verbatim.

**Translation cost.** The new msgid starts untranslated in every locale. Until GlotPress catches up, non-English readers see the English sentence where they previously saw a translated one. That is the real price of this change, and it is worth paying to stop making a false claim.

**Changelog: `packages/backup` and `plugins/backup`, not `plugins/jetpack`.** This is genuinely user-facing — `rsm_jetpack_ui_modernization_backup` defaults to `false` (`class-jetpack-backup.php`, `apply_filters( self::MODERNIZATION_FILTER, false )`), so the legacy dashboard is what ships today and the legacy call site is on it. `jp dependencies list packages/backup --add-dependents` names `plugins/jetpack`, but the card is unreachable there: `Jetpack_Backup::initialize()` — which registers the REST routes and the `admin_menu` submenu that renders this dashboard — has exactly one caller repo-wide, `projects/plugins/backup/jetpack-backup.php:185`. The Jetpack plugin's own references to the package are `Helper_Script_Manager` only (`uninstall.php` and two `json-endpoints/` classes), plus one admin-menu unit test; its `3rd-party/jetpack-backup.php` merely offers to install the standalone plugin. No Backup admin page, so no entry.

## Related product discussion/links

* JETPACK-2447

## Does this pull request change what data or activity we track or use?

No. Copy only — the `jetpack_backup_new_review_click` and `jetpack_backup_dismiss_review_click` events and their `reason` values are unchanged.

## Testing instructions

Legacy dashboard (what ships today):

* On a site with Backup connected and at least five consecutive successful, non-discarded backups, go to **Jetpack → Backup**.
* Confirm the review card reads *"Do you enjoy the peace of mind of having backups?"* with no mention of real-time.
* Confirm the card's button and dismissal still work.

Modernized dashboard:

* Add `add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );` and reload **Jetpack → Backup**.
* Confirm the same wording on the modernized card.

Both dashboards, unchanged path:

* Trigger the restore prompt instead (a successful restore in the last 15 days) and confirm it still reads *"Was it easy to restore your site?"* — the restore branch is untouched, and it wins when both triggers fire.
* On a site with no Backup plan, confirm the no-plan screen still advertises "Automated real-time backups". That copy is deliberately left alone: it describes the product on sale, not the reader's tier.

**Tested:** `pnpm test` in `projects/packages/backup` (69 suites, 687 tests, all passing, including the `review-request` suite that asserts the new string); `eslint` on all three changed files, clean; `pnpm run typecheck`, clean.

**Not tested:** no live site run-through — the change is a string literal with no branching, and the assertions above cover both dashboards. No screenshots for the same reason; the only visual delta is two words inside an existing card. No PHP is in scope.
