### PR TITLE
Review skill: check code comments against the AGENTS.md budget

### DIFF
--- a/.agents/skills/jetpack-review-pr.md
+++ b/.agents/skills/jetpack-review-pr.md
@@ -1,6 +1,6 @@
 ---
 description: Review a Jetpack pull request for bugs, security, performance, convention compliance, and test coverage
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh auth:*), Bash(jp test:*), Bash(jp docker:*), Bash(jp phan:*), Bash(jp build:*), Bash(jp install:*), Bash(git fetch:*), Bash(git worktree:*), Bash(git branch:*), Bash(git log:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(grep:*), Bash(timeout:*), Bash(mktemp:*), Read, Glob, Grep, Agent
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh auth:*), Bash(jp test:*), Bash(jp docker:*), Bash(jp phan:*), Bash(jp build:*), Bash(jp install:*), Bash(git fetch:*), Bash(git worktree:*), Bash(git branch:*), Bash(git log:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(grep:*), Bash(awk:*), Bash(timeout:*), Bash(mktemp:*), Read, Glob, Grep, Agent
 ---
 
 Review a Jetpack pull request for code quality, bugs, security, performance, Jetpack conventions, and test adequacy.
@@ -135,6 +135,7 @@ Note: `AGENTS.md` is already loaded in your context via the CLAUDE.md `@AGENTS.m
 | Translations | no | if has_strings | yes |
 | Copy consistency (grep codebase) | no | no | yes |
 | Code simplicity / WP reuse | no | yes | yes |
+| Comment budget | yes | yes | yes |
 | WP/PHP version compat | no | yes | yes |
 
 ---
@@ -286,6 +287,41 @@ grep 'MIN_PHP_VERSION' .github/versions.sh
 - Check project's own `composer.json` `require.php` — may differ from monorepo default
 - Common traps (non-exhaustive): named args (8.0+), match (8.0+), `str_contains()`/`str_starts_with()`/`str_ends_with()` (8.0+, polyfilled by WP since 5.9 — check project's minimum WP version), enums (8.1+), readonly properties (8.1+), `array_is_list()` (8.1+, NOT polyfilled by WP), readonly classes (8.2+), `json_validate()` (8.3+)
 
+---
+
+#### Comment budget (all depths — diff-visible, needs no file reading)
+
+`AGENTS.md` § Comments is the rule and is already in your context. Apply it; do not restate it in
+the review. It leaves two things to settle here:
+
+- **The unit.** The budget is *per comment*, so report over-budget **blocks**. A share-of-the-diff
+  percentage measures something the rule does not define and is not comparable against it.
+- **What counts.** Only prose. `/**`, `*/`, `@param`, `@return`, `translators:`, `phpcs:ignore`
+  and `eslint-disable` are mandatory scaffolding, so a compliant PHP docblock is already several
+  lines before it says anything. Budget: a summary (1–2 lines) plus at most 2 more.
+
+Get the candidate list, then judge each entry — the script decides nothing:
+
+```bash
+gh pr diff <PR> | awk -f .agents/skills/jetpack-review-pr/scripts/comment-budget.awk
+```
+
+It prints `path:line<TAB>N prose lines (M total)` for blocks over 4 prose lines. `line` is where
+*this PR's* added prose starts, which is mid-block when the PR edited an existing comment.
+
+- **Discard** — within budget once scaffolding is excluded, or a license header, generated file,
+  or vendored code.
+- **`[suggestion]`** — over budget. Name the shape (design essay / mechanic repeated on one member
+  of a list / copy-paste-survivable background / provenance that rots / the same explanation in
+  two places) and give the shorter version. "Too long" with no concrete cut is not a review.
+- **`[blocker]`** — the comment contradicts the code it describes.
+
+Read the shape of the output, not just its length. A few large blocks are incidents — file them
+individually. Many blocks clustered just over budget are a habit — say so once with two or three
+examples rather than filing fifteen near-identical findings. Check whether the untouched
+neighbours are already written that way; if they are, say so, because that makes it a
+direction-of-travel note rather than a regression this PR introduced.
+
 ### 5. Cross-project dependency check
 
 **Quick**: skip. **Standard**: only if a package changed. **Thorough**: always.
@@ -408,6 +444,7 @@ Review depth: **<depth>** (<lines> lines, <N> projects)
 ### Translation Issues
 ### Copy Review
 ### Code Simplicity / WordPress Reuse
+### Comment Budget
 ### Dependency Changes
 ### PHP / WordPress Version Compatibility
 ### Feature Gating

--- a/.agents/skills/jetpack-review-pr.md
+++ b/.agents/skills/jetpack-review-pr.md
@@ -307,7 +307,9 @@ gh pr diff <PR> | awk -f .agents/skills/jetpack-review-pr/scripts/comment-budget
 ```
 
 It prints `path:line<TAB>N prose lines (M total)` for blocks over 4 prose lines. `line` is where
-*this PR's* added prose starts, which is mid-block when the PR edited an existing comment.
+*this PR's* added prose starts, which is mid-block when the PR edited an existing comment. It reads
+code files only — a `*` or `#` means something else in Markdown, `readme.txt` and CSS — so prose in
+docs never appears and still needs your eyes.
 
 - **Discard** — within budget once scaffolding is excluded, or a license header, generated file,
   or vendored code.

--- a/.agents/skills/jetpack-review-pr/scripts/comment-budget.awk
+++ b/.agents/skills/jetpack-review-pr/scripts/comment-budget.awk
@@ -1,0 +1,35 @@
+# Flags added comment blocks that exceed the AGENTS.md comment budget.
+# Reads a unified diff on stdin; -v MAX=n sets the allowed prose lines (default 4).
+#
+# Counts PROSE only: delimiters, blank continuations and tag lines (@param, translators:,
+# phpcs:ignore, ...) are mandatory scaffolding, so a compliant PHP docblock clears MAX without
+# them. Output is a candidate list for human judgment, never a verdict.
+
+BEGIN { if ( MAX == "" ) MAX = 4 }
+
+function flush(   ) {
+	if ( prose > MAX ) printf "%s:%d\t%d prose lines (%d total)\n", file, start, prose, run
+	run = 0; prose = 0
+}
+
+/^\+\+\+ /	{ flush(); file = substr( $0, 7 ); sub( /^b\//, "", file ); next }
+/^@@/		{ flush(); split( $0, h, "+" ); split( h[2], g, "," ); ln = g[1] + 0; next }
+/^-/		{ next }
+
+/^\+/ {
+	t = substr( $0, 2 )
+	sub( /^[[:space:]]+/, "", t )
+	if ( t ~ /^(\/\/|\/\*|\*)/ ) {
+		if ( run == 0 ) start = ln
+		run++
+		sub( /^(\/\/+|\/\*+|\*+\/?)[[:space:]]*/, "", t )
+		if ( t != "" && t !~ /^@/ && t !~ /^(translators|phpcs|eslint|ts-expect|prettier|stylelint|webpack|istanbul|c8|jshint|codingStandards)/ ) prose++
+	} else {
+		flush()
+	}
+	ln++
+	next
+}
+
+{ flush(); ln++ }
+END { flush() }

--- a/.agents/skills/jetpack-review-pr/scripts/comment-budget.awk
+++ b/.agents/skills/jetpack-review-pr/scripts/comment-budget.awk
@@ -1,9 +1,8 @@
 # Flags added comment blocks that exceed the AGENTS.md comment budget.
 # Reads a unified diff on stdin; -v MAX=n sets the allowed prose lines (default 4).
 #
-# Counts PROSE only: delimiters, blank continuations and tag lines (@param, translators:,
-# phpcs:ignore, ...) are mandatory scaffolding, so a compliant PHP docblock clears MAX without
-# them. Output is a candidate list for human judgment, never a verdict.
+# Counts prose only, because the scaffolding a compliant docblock cannot avoid
+# (delimiters, blank continuations, "@param", "translators:") would clear MAX on its own.
 
 BEGIN { if ( MAX == "" ) MAX = 4 }
 
@@ -12,24 +11,42 @@ function flush(   ) {
 	run = 0; prose = 0
 }
 
-/^\+\+\+ /	{ flush(); file = substr( $0, 7 ); sub( /^b\//, "", file ); next }
-/^@@/		{ flush(); split( $0, h, "+" ); split( h[2], g, "," ); ln = g[1] + 0; next }
+# "*" and "#" only open a comment in languages that say so: otherwise they are markdown
+# bullets, CSS selectors and JS private fields. Extension is the only signal a diff carries.
+function classify( f,   e ) {
+	e = f
+	sub( /^.*\//, "", e )
+	cstyle = ( e ~ /\.(php|js|jsx|ts|tsx|mjs|cjs|css|scss|sass|less|svelte|vue|java|go|rs|swift|kt|c|h|cpp)$/ )
+	hash = ( e ~ /\.(php|sh|bash|zsh|yml|yaml|py|rb|pl|toml|ini|conf|neon|env|awk)$/ || e ~ /^(Dockerfile|Makefile)/ )
+}
+
+# Track an open /* */ so a bare "*" is read as a continuation, not as whatever else it means.
+function scan( s ) { if ( s ~ /\/\*/ ) inblock = 1; if ( s ~ /\*\// ) inblock = 0 }
+
+/^\+\+\+ /	{ flush(); inblock = 0; file = substr( $0, 7 ); sub( /^b\//, "", file ); classify( file ); next }
+/^@@/		{ flush(); inblock = 0; split( $0, h, "+" ); split( h[2], g, "," ); ln = g[1] + 0; next }
 /^-/		{ next }
 
 /^\+/ {
 	t = substr( $0, 2 )
 	sub( /^[[:space:]]+/, "", t )
-	if ( t ~ /^(\/\/|\/\*|\*)/ ) {
+
+	# A hunk can open mid-docblock, leaving inblock unset, so accept the "* " continuation shape too.
+	if ( ( cstyle && t ~ /^(\/\/|\/\*)/ ) ||
+		( cstyle && t ~ /^\*/ && ( inblock || t == "*" || t ~ /^\*[[:space:]]/ || t ~ /^\*\// ) ) ||
+		( hash && t ~ /^#/ && t !~ /^#(!|\[)/ ) ) {
 		if ( run == 0 ) start = ln
 		run++
-		sub( /^(\/\/+|\/\*+|\*+\/?)[[:space:]]*/, "", t )
-		if ( t != "" && t !~ /^@/ && t !~ /^(translators|phpcs|eslint|ts-expect|prettier|stylelint|webpack|istanbul|c8|jshint|codingStandards)/ ) prose++
+		scan( t )
+		sub( /^(\/\/+|\/\*+|\*+\/?|#+)[[:space:]]*/, "", t )
+		if ( t != "" && t !~ /^@/ && t !~ /^(translators:|phpcs:|eslint-|ts-expect-error|ts-ignore|prettier-ignore|stylelint-|webpack[A-Za-z]+[[:space:]]*:|istanbul[[:space:]]+ignore|c8[[:space:]]+ignore|jshint[[:space:]]+ignore|codingStandards)/ ) prose++
 	} else {
+		scan( t )
 		flush()
 	}
 	ln++
 	next
 }
 
-{ flush(); ln++ }
+{ flush(); scan( substr( $0, 2 ) ); ln++ }
 END { flush() }


### PR DESCRIPTION
Fixes #

## Proposed changes

Follow-up to #51793, which gave `AGENTS.md` § Comments a hard length cap. This teaches `/jetpack-review-pr` to check against it.

* Adds **Comment budget** to the depth matrix at `yes | yes | yes`. It reads the diff only and needs no file access, so there is no reason to skip it at `quick`.
* Adds a `#### Comment budget` section covering what the rule leaves to the reviewer: which unit to report, which lines count, how to triage a block, and when a cluster is house style rather than a regression.
* Adds `### Comment Budget` to the full output format.
* Adds `scripts/comment-budget.awk`, which lists added comment blocks over four *prose* lines.
* Adds `Bash(awk:*)` to `allowed-tools` — without it the documented command could not run.

### Why a script, when the reviewer can already read

Reviews *do* act on the rule. Six runs against the current skill all flagged comment bloat unprompted, including at `quick` depth and on a diff whose blocks were only 5–7 lines over.

What they did not agree on was the measurement. On one PR, three runs reported "36% of added lines", "40% of added lines", and "nine of thirteen files" — two different denominators for one diff, in a unit the rule does not define, since the budget is per comment rather than per file. Percentages also punish PHP: `Squiz.Commenting.FunctionComment` requires a docblock per function, so a short PHP file sits above any fixed threshold no matter how terse its prose.

The script counts prose per block and excludes mandatory scaffolding (`/**`, `*/`, `@param`, `@return`, `translators:`, `phpcs:ignore`, `eslint-disable`), which is the unit the rule is written in. It reports candidates; every judgement stays with the reviewer.

### Calibration

Four merged Backup PRs, all reproducible from trunk:

| Commit | Blocks | Largest | Added lines |
| --- | --- | --- | --- |
| `a22e3a5faf` (#51626) | 27 | 49 prose lines | 1,137 |
| `ec5928f75c` (#51741) | 23 | 7 prose lines | 1,201 |
| `e6a690a89d` (#51742) | 1 | 5 prose lines | 802 |
| `8cc2680da9` (#51739) | 0 | — | 284 |

The two middle rows are the reason the output needs reading by shape rather than by count: 27 blocks reaching 49 lines is a handful of design essays, while 23 blocks that never pass 7 is a house style. Those warrant different reviews, and the section says so.

## Related product discussion/links

* #51793 — the `AGENTS.md` rule this checks against

## Does this pull request change what data or activity we track or use?

No. Agent tooling only; no plugin or package code, and nothing that ships to users.

## Testing instructions

No build or environment needed. Run from the monorepo root.

* **Scaffolding is excluded.** A long but compliant PHP docblock should be silent:

  ```bash
  printf 'diff --git a/a.php b/a.php\n--- a/a.php\n+++ b/a.php\n@@ -1,0 +1,9 @@\n+/**\n+ * Short summary.\n+ *\n+ * @param string $a One.\n+ * @param string $b Two.\n+ * @param string $c Three.\n+ * @return bool\n+ */\n+function f( $a, $b, $c ) {}\n' \
    | awk -f .agents/skills/jetpack-review-pr/scripts/comment-budget.awk
  ```

  Expect no output — nine comment lines, only one of prose. This is the case that would make the check unusable on PHP if it counted comment lines instead.

* **Real bloat is flagged**, with the essay and drift cases looking different:

  ```bash
  for c in a22e3a5faf ec5928f75c e6a690a89d 8cc2680da9; do
    echo -n "$c: "
    git diff "$c^" "$c" -- projects/ \
      | awk -f .agents/skills/jetpack-review-pr/scripts/comment-budget.awk | wc -l
  done
  ```

  Expect 27, 23, 1, 0 — matching the table above. Drop the `wc -l` on the first to see a 49-prose-line block in `data/api/_helpers.ts`, and on the second to see nothing above 7.

* **Ordinary work stays quiet.** This PR's own diff should report nothing:

  ```bash
  git diff 'HEAD~1' HEAD | awk -f .agents/skills/jetpack-review-pr/scripts/comment-budget.awk
  ```

* **End to end:** run `/jetpack-review-pr` on any PR and confirm the review reports a **Comment Budget** section in block counts rather than a percentage.
