### PR TITLE
Premium Analytics: don't flash Post traffic on an email-tab deep link

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: stop the Post traffic layout from flashing when an email tab is opened directly, and show placeholder lines in the header while the title loads.

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -66,3 +66,17 @@
 	background: var(--wpds-color-background-surface-brand);
 	color: var(--wpds-color-foreground-interactive-brand);
 }
+
+// Sized to the title and subtitle lines they stand in for, so the pair reads as
+// text arriving rather than as two anonymous bars.
+.titlePlaceholder {
+	block-size: 38px;
+	inline-size: min(100%, 320px);
+	border-radius: var(--wpds-border-radius-md);
+}
+
+.subtitlePlaceholder {
+	block-size: 18px;
+	inline-size: min(100%, 260px);
+	border-radius: var(--wpds-border-radius-md);
+}

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.test.tsx
@@ -29,4 +29,27 @@ describe( 'PostSummaryCard', () => {
 		expect( screen.getByTestId( 'post-summary-email-tile' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'post-summary-image' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'holds the title and subtitle lines while the summary resolves', () => {
+		render( <PostSummaryCard summary={ { ...SUMMARY, title: undefined, isLoading: true } } /> );
+
+		expect( screen.getByText( 'Loading…' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'heading', { level: 1 } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Post published on/ ) ).not.toBeInTheDocument();
+	} );
+
+	// The state an email-tab deep link opens on: the tab fixes the identity, so
+	// the envelope tile is already right while the title is still loading.
+	it( 'keeps the email identity while the summary resolves', () => {
+		render(
+			<PostSummaryCard
+				summary={ { ...SUMMARY, title: undefined, isLoading: true } }
+				variant="email"
+			/>
+		);
+
+		expect( screen.getByTestId( 'post-summary-email-tile' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Loading…' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Email sent on/ ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { parseSiteDateTime, siteTimeZone, toLocalTZ } from '@jetpack-premium-analytics/datetime';
-import { Icon, Text } from '@jetpack-premium-analytics/externals';
+import { Icon, Skeleton, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { __, sprintf } from '@wordpress/i18n';
 import { envelope as envelopeIcon, page as pageIcon, post as postIcon } from '@wordpress/icons';
 import { format, isValid } from 'date-fns';
@@ -57,7 +57,7 @@ export function PostSummaryCard( {
 	variant = 'post',
 	performanceRange,
 }: PostSummaryCardProps ) {
-	const { title, type, publishedDate, imageUrl } = summary;
+	const { title, type, publishedDate, imageUrl, isLoading } = summary;
 
 	// Read and shown in the site timezone, like the Stats data the page reports on.
 	const publishedDateObject = parseSiteDateTime( publishedDate );
@@ -120,10 +120,20 @@ export function PostSummaryCard( {
 		);
 	}
 
-	return (
-		<div className={ styles.card }>
-			{ media }
-			<div className={ styles.details }>
+	// The title lands on its own request, so the header would otherwise read as
+	// blank until well after the grid has drawn (WOOA7S-2059).
+	let details;
+	if ( isLoading ) {
+		details = (
+			<>
+				<VisuallyHidden>{ __( 'Loading…', 'jetpack-premium-analytics-pkg' ) }</VisuallyHidden>
+				<Skeleton className={ styles.titlePlaceholder } />
+				<Skeleton className={ styles.subtitlePlaceholder } />
+			</>
+		);
+	} else {
+		details = (
+			<>
 				{ /* The heading ellipsizes to one line; `title` keeps the full text
 				     reachable on hover. */ }
 				<Text variant="heading-xl" render={ <h1 title={ title } /> } className={ styles.title }>
@@ -134,6 +144,15 @@ export function PostSummaryCard( {
 						{ subtitle }
 					</Text>
 				) : null }
+			</>
+		);
+	}
+
+	return (
+		<div className={ styles.card }>
+			{ media }
+			<div className={ styles.details } aria-busy={ isLoading }>
+				{ details }
 			</div>
 		</div>
 	);

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
@@ -52,14 +52,20 @@ const POST_ID = 91;
  * Mock the opens rate summary that gates the email tabs.
  *
  * @param totalSends - The summary's `total_sends`; `undefined` mocks a query
- *                   with no data (loading or errored, per `isLoading`).
- * @param isLoading  - Whether the query is still on its first load.
+ *                   that has not answered yet, positioned by `state`.
+ * @param state      - Where an answerless query sits: fetching its first load,
+ *                   retrying with the retryer paused (a background tab or an
+ *                   offline blip, which drops `isLoading` without answering),
+ *                   or finally failed.
  */
-function mockEmailSends( totalSends?: number, isLoading = false ) {
+function mockEmailSends( totalSends?: number, state: 'loading' | 'paused' | 'error' = 'loading' ) {
+	const answered = totalSends !== undefined;
+
 	mockUseOpensBreakdown.mockReturnValue( {
-		data: totalSends === undefined ? undefined : { summary: { total_sends: totalSends } },
-		isLoading,
-		isSuccess: totalSends !== undefined,
+		data: answered ? { summary: { total_sends: totalSends } } : undefined,
+		isLoading: ! answered && state === 'loading',
+		isSuccess: answered,
+		isError: ! answered && state === 'error',
 	} as unknown as ReturnType< typeof useStatsEmailOpensBreakdown > );
 }
 
@@ -230,7 +236,7 @@ describe( 'usePostDetailTabs', () => {
 	} );
 
 	it( 'keeps the email tabs hidden while the send summary is still loading', () => {
-		mockEmailSends( undefined, true );
+		mockEmailSends( undefined, 'loading' );
 		mockSearch( 'post-traffic' );
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
@@ -239,7 +245,7 @@ describe( 'usePostDetailTabs', () => {
 	} );
 
 	it( 'shows the deep-linked email tab while the send summary is loading', () => {
-		mockEmailSends( undefined, true );
+		mockEmailSends( undefined, 'loading' );
 		const { stage, commit } = mockSearch( 'email-opens' );
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
@@ -256,9 +262,23 @@ describe( 'usePostDetailTabs', () => {
 		expect( commit ).not.toHaveBeenCalled();
 	} );
 
+	it( 'keeps the deep-linked email tab while a retry is paused', () => {
+		// A background tab or an offline blip pauses the retryer, dropping
+		// `isLoading` with the gate still unanswered. Reading that as "answered"
+		// would swap the page to Post traffic and back on refocus (WOOA7S-2059).
+		mockEmailSends( undefined, 'paused' );
+		const { stage, commit } = mockSearch( 'email-opens' );
+
+		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
+
+		expect( result.current.activeTab ).toBe( 'email-opens' );
+		expect( stage ).not.toHaveBeenCalled();
+		expect( commit ).not.toHaveBeenCalled();
+	} );
+
 	it( 'hides the deep-linked email tab once the gate reports no sends', async () => {
 		const { stage, commit } = mockSearch( 'email-opens' );
-		mockEmailSends( undefined, true );
+		mockEmailSends( undefined, 'loading' );
 
 		const { result, rerender } = renderHook( () => usePostDetailTabs( POST_ID ) );
 		expect( result.current.activeTab ).toBe( 'email-opens' );
@@ -275,8 +295,7 @@ describe( 'usePostDetailTabs', () => {
 	} );
 
 	it( 'preserves an email deep link when the send summary request fails', () => {
-		// Errored: no data, not loading, not success.
-		mockEmailSends( undefined, false );
+		mockEmailSends( undefined, 'error' );
 		const { stage, commit } = mockSearch( 'email-opens' );
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
@@ -295,6 +314,21 @@ describe( 'usePostDetailTabs', () => {
 		renderHook( () => usePostDetailTabs( 0 ) );
 
 		expect( mockUseOpensBreakdown ).toHaveBeenCalledWith( 0, 'rate', { enabled: false } );
+	} );
+
+	it( 'does not hold an email tab open on a scope whose gate never runs', async () => {
+		// The disabled query answers neither way, so only the post scope stops
+		// an email deep link from pinning the tabs open for good.
+		mockEmailSends( undefined, 'loading' );
+		const { stage, commit } = mockSearch( 'email-opens' );
+
+		const { result } = renderHook( () => usePostDetailTabs( 0 ) );
+
+		expect( result.current.tabs.map( tab => tab.id ) ).toEqual( [ 'post-traffic' ] );
+		await waitFor( () => {
+			expect( stage ).toHaveBeenCalledWith( { section: 'post-traffic' } );
+			expect( commit ).toHaveBeenCalledWith( { replace: true } );
+		} );
 	} );
 
 	it( 'does not navigate when the selected tab is visible', () => {

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.test.tsx
@@ -238,17 +238,40 @@ describe( 'usePostDetailTabs', () => {
 		expect( result.current.tabs.map( tab => tab.id ) ).toEqual( [ 'post-traffic' ] );
 	} );
 
-	it( 'does not rewrite an email deep link while the send summary is loading', () => {
+	it( 'shows the deep-linked email tab while the send summary is loading', () => {
 		mockEmailSends( undefined, true );
 		const { stage, commit } = mockSearch( 'email-opens' );
 
 		const { result } = renderHook( () => usePostDetailTabs( POST_ID ) );
 
-		// The visible fallback renders, but the URL keeps the deep link until
-		// the gate settles.
-		expect( result.current.activeTab ).toBe( 'post-traffic' );
+		// Falling back to Post traffic here would render a whole wrong page for
+		// the reader to watch swap out (WOOA7S-2059). The URL still waits.
+		expect( result.current.tabs.map( tab => tab.id ) ).toEqual( [
+			'post-traffic',
+			'email-opens',
+			'email-clicks',
+		] );
+		expect( result.current.activeTab ).toBe( 'email-opens' );
 		expect( stage ).not.toHaveBeenCalled();
 		expect( commit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hides the deep-linked email tab once the gate reports no sends', async () => {
+		const { stage, commit } = mockSearch( 'email-opens' );
+		mockEmailSends( undefined, true );
+
+		const { result, rerender } = renderHook( () => usePostDetailTabs( POST_ID ) );
+		expect( result.current.activeTab ).toBe( 'email-opens' );
+
+		mockEmailSends( 0 );
+		rerender();
+
+		expect( result.current.tabs.map( tab => tab.id ) ).toEqual( [ 'post-traffic' ] );
+		expect( result.current.activeTab ).toBe( 'post-traffic' );
+		await waitFor( () => {
+			expect( stage ).toHaveBeenCalledWith( { section: 'post-traffic' } );
+			expect( commit ).toHaveBeenCalledWith( { replace: true } );
+		} );
 	} );
 
 	it( 'preserves an email deep link when the send summary request fails', () => {

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
@@ -20,7 +20,6 @@ import {
 	POST_DETAIL_TAB_LAYOUTS,
 } from '../config';
 import { useActiveTab } from './use-active-tab';
-import type { PostDetailTabId } from '../config';
 
 /**
  * Resolves visible post-detail tabs and normalizes hidden-tab deep links.
@@ -28,8 +27,11 @@ import type { PostDetailTabId } from '../config';
  * not obvious from the code below.
  *
  * Tabs without a fixed composition stay hidden. Email tabs also require
- * `total_sends` > 0 from the opens-rate summary, and fail closed: they stay
- * hidden while that query is loading or has errored.
+ * `total_sends` > 0 from the opens-rate summary, and fail closed on anything
+ * the gate query has actually answered: a zero count or an error hides them.
+ * While that query is still in flight the answer is unknown, so a URL already
+ * naming an email tab keeps its tabs — otherwise a reload would render the
+ * whole Post traffic page first and throw it away (WOOA7S-2059).
  *
  * A hidden-tab URL is replaced with the first visible tab, without adding a
  * history entry. An email-tab URL is normalized only once the gate query
@@ -55,24 +57,26 @@ export function usePostDetailTabs(
 	const summary = ( opens.data as StatsEmailBreakdown | undefined )?.summary;
 	const hasEmailStats = Number( summary?.total_sends ?? 0 ) > 0;
 
+	const [ storedTab, setActiveTab ] = useActiveTab();
+	const storedIsEmailTab = EMAIL_TAB_IDS.includes( storedTab );
+	const showEmailTabs = hasEmailStats || ( storedIsEmailTab && opens.isLoading );
+
 	const tabs = useMemo( () => {
 		const allTabs = getPostDetailTabs();
 		const withContent = allTabs.filter(
 			tab =>
 				POST_DETAIL_TAB_LAYOUTS[ tab.id ].length > 0 &&
-				( hasEmailStats || ! EMAIL_TAB_IDS.includes( tab.id ) )
+				( showEmailTabs || ! EMAIL_TAB_IDS.includes( tab.id ) )
 		);
 
 		// Keep the page renderable if all compositions are temporarily empty.
 		return withContent.length > 0 ? withContent : allTabs;
-	}, [ hasEmailStats ] );
+	}, [ showEmailTabs ] );
 
-	const [ storedTab, setActiveTab ] = useActiveTab();
 	const activeTab = tabs.find( tab => tab.id === storedTab )?.id ?? tabs[ 0 ]?.id ?? DEFAULT_TAB_ID;
 
 	// Non-email/no-scope deep links normalize immediately; a pending or
 	// failed email-tab gate holds off so a real deep link isn't destroyed.
-	const storedIsEmailTab = EMAIL_TAB_IDS.includes( storedTab as PostDetailTabId );
 	const canNormalize = ! storedIsEmailTab || postId <= 0 || opens.isSuccess;
 
 	useEffect( () => {

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
@@ -29,9 +29,11 @@ import { useActiveTab } from './use-active-tab';
  * Tabs without a fixed composition stay hidden. Email tabs also require
  * `total_sends` > 0 from the opens-rate summary, and fail closed on anything
  * the gate query has actually answered: a zero count or an error hides them.
- * While that query is still in flight the answer is unknown, so a URL already
- * naming an email tab keeps its tabs — otherwise a reload would render the
- * whole Post traffic page first and throw it away (WOOA7S-2059).
+ * Until it answers, a URL already naming an email tab keeps its tabs —
+ * otherwise a reload would render the whole Post traffic page first and throw
+ * it away (WOOA7S-2059). "Answered" is success-or-error rather than
+ * `! isLoading`, which also goes false whenever the retryer pauses (a
+ * background tab, an offline blip) and would flip the page back and forth.
  *
  * A hidden-tab URL is replaced with the first visible tab, without adding a
  * history entry. An email-tab URL is normalized only once the gate query
@@ -59,7 +61,8 @@ export function usePostDetailTabs(
 
 	const [ storedTab, setActiveTab ] = useActiveTab();
 	const storedIsEmailTab = EMAIL_TAB_IDS.includes( storedTab );
-	const showEmailTabs = hasEmailStats || ( storedIsEmailTab && opens.isLoading );
+	const gateAnswered = opens.isSuccess || opens.isError;
+	const showEmailTabs = hasEmailStats || ( storedIsEmailTab && postId > 0 && ! gateAnswered );
 
 	const tabs = useMemo( () => {
 		const allTabs = getPostDetailTabs();

--- a/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/hooks/use-post-detail-tabs.ts
@@ -27,13 +27,10 @@ import { useActiveTab } from './use-active-tab';
  * not obvious from the code below.
  *
  * Tabs without a fixed composition stay hidden. Email tabs also require
- * `total_sends` > 0 from the opens-rate summary, and fail closed on anything
- * the gate query has actually answered: a zero count or an error hides them.
- * Until it answers, a URL already naming an email tab keeps its tabs —
- * otherwise a reload would render the whole Post traffic page first and throw
- * it away (WOOA7S-2059). "Answered" is success-or-error rather than
- * `! isLoading`, which also goes false whenever the retryer pauses (a
- * background tab, an offline blip) and would flip the page back and forth.
+ * `total_sends` > 0 from the opens-rate summary, and fail closed once the gate
+ * query answers: a zero count or an error hides them. Until it answers, a URL
+ * already naming an email tab keeps its tabs, so a reload doesn't render the
+ * whole Post traffic page first and throw it away (WOOA7S-2059).
  *
  * A hidden-tab URL is replaced with the first visible tab, without adding a
  * history entry. An email-tab URL is normalized only once the gate query
@@ -61,6 +58,8 @@ export function usePostDetailTabs(
 
 	const [ storedTab, setActiveTab ] = useActiveTab();
 	const storedIsEmailTab = EMAIL_TAB_IDS.includes( storedTab );
+	// Success-or-error, not `! isLoading`: that also goes false while the retryer
+	// is paused (background tab, offline blip), flipping the page back and forth.
 	const gateAnswered = opens.isSuccess || opens.isError;
 	const showEmailTabs = hasEmailStats || ( storedIsEmailTab && postId > 0 && ! gateAnswered );
 

--- a/projects/plugins/jetpack/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
+++ b/projects/plugins/jetpack/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Post detail: stop the Post traffic layout from flashing when an email tab is opened directly, and show placeholder lines in the header while the title loads.

--- a/projects/plugins/premium-analytics/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
+++ b/projects/plugins/premium-analytics/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: stop the Post traffic layout from flashing when an email tab is opened directly, and show placeholder lines in the header while the title loads.

--- a/projects/plugins/wpcomsh/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
+++ b/projects/plugins/wpcomsh/changelog/fix-wooa7s-2059-post-detail-email-tab-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Post detail: stop the Post traffic layout from flashing when an email tab is opened directly, and show placeholder lines in the header while the title loads.


### PR DESCRIPTION
Fixes WOOA7S-2059

## Why

Someone reading a post's **Email opens** stats and hitting reload — or following a link straight into that tab — watched the wrong page load first: the Post traffic layout, date filter pills and all, which then threw itself away and rebuilt as the email tab. On a fast connection it read as "loading looks jumpy"; throttled, it was clearly two different pages. Now the tab the URL asked for is the tab that paints, so the page fills in instead of swapping out.

## Proposed changes

* `usePostDetailTabs` trusts an email-tab deep link while the send-summary gate (`stats/opens/emails/:id/rate`) is still loading, instead of falling back to Post traffic. First paint is already the tab that wins: no date pills, no wrong widget grid, no 1→3 tab-strip jump, and nothing to re-lay-out when the gate settles.
* Fail-closed is otherwise untouched. A normal load still hides the email tabs until the gate confirms `total_sends > 0`; the gate erroring still falls back to Post traffic with the deep link preserved; and a gate that comes back with no sends still collapses to Post traffic and normalizes the URL.
* `PostSummaryCard` holds placeholder lines for the title and subtitle while the summary resolves, so the header stops arriving on its own beat after the widgets. This is the secondary polish noted on the issue, and it applies to both tabs.

## Screenshots

<img width="1292" height="1064" alt="Post detail email-tab deep link, mid-load: before shows the Post traffic layout with date pills, after shows the Email opens tab already selected" src="https://github.com/user-attachments/assets/dc753657-9eba-4581-b826-1371cab3838b" />

Both frames are the same URL (`?section=email-opens`) at the same point in the load, captured against the local docker env. The connected test blog has no newsletter sends, so `stats/opens/emails/:id/rate` and the email breakdown endpoints were stubbed locally with fixture data and an artificial delay to hold the loading window open — the stub only supplies data the gate needs, it does not touch the code under test.

## Related product discussion/links

* WOOA7S-2059 (follow-up from the review of #51547 / WOOA7S-1945; reported with a screen recording, non-blocking and cosmetic)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This needs a post that was sent to subscribers — the email tabs are gated on `total_sends > 0`. Throttle the network (DevTools → Slow 4G) so the loading window is long enough to watch; the two requests in play are `stats/post/<id>` and `stats/opens/emails/<id>/rate`.

* Open a post's detail page, switch to **Email opens**, then reload the page.
  * The tab strip shows Post traffic / Email opens / Email clicks with **Email opens** already selected, from the first paint.
  * No date filter pills appear at any point.
  * No Post traffic widgets mount; the grid fills in with the email cards once the pinned send window resolves.
  * The header shows the envelope tile with placeholder lines, which become the title and "Email sent on …" in place — the header doesn't resize or jump.
* Open the same post's detail page with no `section` in the URL (or on **Post traffic**).
  * Only the **Post traffic** tab shows while the gate is loading — the email tabs must *not* appear early.
  * Date pills and the Post traffic grid behave as before.
* Deep-link to `?section=email-opens` on a post that was **never** sent to subscribers.
  * It settles on Post traffic only, and the URL rewrites `section` to `post-traffic` without adding a history entry.
* Break the gate request (block `stats/opens/emails/*/rate` in DevTools) and deep-link to an email tab.
  * It falls back to Post traffic, and the URL keeps `section=email-opens` so a later successful refetch can still settle it. This is unchanged behavior.
* Switch tabs back and forth on a warm page.
  * Post traffic ⇄ Email opens swaps the header identity and the date pills correctly, with no spurious loading state.
