### PR TITLE
Changelog: drop the CHARTS-262 entries from two non-product plugins

### DIFF
--- a/projects/plugins/mu-wpcom-plugin/changelog/charts-262-paint-only-colors-in-css
+++ b/projects/plugins/mu-wpcom-plugin/changelog/charts-262-paint-only-colors-in-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Charts: update chart grid, axis and label colors immediately when the theme changes.

--- a/projects/plugins/starter-plugin/changelog/charts-262-paint-only-colors-in-css
+++ b/projects/plugins/starter-plugin/changelog/charts-262-paint-only-colors-in-css
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Charts: update chart grid, axis and label colors immediately when the theme changes.


### PR DESCRIPTION
Fixes # <!-- no issue; follow-up to #51687 -->

## Why

Two changelog entries added by #51687 land in plugins whose changelogs nobody reads, so at release they would put a line about the charts library into `readme.txt` files that no site owner ever sees — and, worse, set the precedent for the next shared-package change to do the same.

`AGENTS.md` § Changelog Entries gained this while #51687 was in review:

> **The plugin's changelog is not a product record.** `starter-plugin` is a scaffolding template, and `mu-wpcom-plugin` is the wrapper that exists so `packages/jetpack-mu-wpcom` can be deployed to WordPress.com Simple at all (it doubles as a test plugin for the package). Nobody installs either one, so nobody reads either changelog to find out what changed on their site.

Both entries predate that guidance. Removing them is the cheapest possible correction, and doing it before the next release means the rule and the repository agree from the start rather than after someone notices the mismatch.

## Proposed changes

* Delete `charts-262-paint-only-colors-in-css` from `plugins/starter-plugin` and `plugins/mu-wpcom-plugin`.

Deliberately **not** touched:

* `plugins/wpcomsh` keeps its entry. It reaches charts through the same `packages/jetpack-mu-wpcom` → `packages/podcast` chain, but Atomic site owners do install and read it, so the podcast chart change is genuinely theirs.
* The other nine plugin entries from #51687, and the `js-packages/charts` entry itself, are all unaffected.

## Related product discussion/links

* Follow-up to #51687 (CHARTS-262). The entries were added at review request, before the `AGENTS.md` rule landed.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is changelog bookkeeping — there is nothing to exercise in a browser.

* Confirm the two files are gone and the rest are untouched:
  ```bash
  git show --stat HEAD
  ls projects/plugins/*/changelog/charts-262-paint-only-colors-in-css
  ```
  Expect `wpcomsh` and the nine original plugins to remain, and `starter-plugin` / `mu-wpcom-plugin` to be absent.
* Confirm the changelog gate is satisfied — deleting an entry does not itself require one:
  ```bash
  php tools/check-changelogger-use.php trunk HEAD; echo $?
  ```
  Expect exit code `0`.
