### PR TITLE
Docs: lint-style needs an explicit path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Run from the monorepo root:
 ```bash
 pnpm run lint-changed             # ESLint, changed files only (fastest)
 pnpm run lint                     # ESLint, everything
-pnpm run lint-style               # Stylelint (CSS/SCSS)
+pnpm run lint-style .             # Stylelint (CSS/SCSS) — needs an explicit path
 pnpm run typecheck                # TypeScript, every project that defines it
 composer phpcs:changed            # PHPCS on changed files
 composer phpcs:lint               # PHPCS, everything

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,7 +185,7 @@ Run from the monorepo root:
 ```bash
 pnpm run lint-changed             # ESLint, changed files only (fastest)
 pnpm run lint                     # ESLint, everything
-pnpm run lint-style .             # Stylelint (CSS/SCSS) — needs an explicit path
+pnpm run lint-style               # Stylelint (CSS/SCSS) — needs an explicit path
 pnpm run typecheck                # TypeScript, every project that defines it
 composer phpcs:changed            # PHPCS on changed files
 composer phpcs:lint               # PHPCS, everything

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ See [Automated Testing](docs/automated-testing.md) for full details and setup re
 ## Linting and static analysis
 ```sh
 pnpm lint                    # JS/TS (ESLint)
-pnpm lint-style .            # CSS/SCSS (Stylelint) — needs an explicit path
+pnpm lint-style              # CSS/SCSS (Stylelint) — needs an explicit path
 composer phpcs:lint <path>   # PHP (PHPCS)
 jetpack phan <project>       # Static analysis (Phan)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ See [Automated Testing](docs/automated-testing.md) for full details and setup re
 ## Linting and static analysis
 ```sh
 pnpm lint                    # JS/TS (ESLint)
-pnpm lint-style              # CSS/SCSS (Stylelint)
+pnpm lint-style .            # CSS/SCSS (Stylelint) — needs an explicit path
 composer phpcs:lint <path>   # PHP (PHPCS)
 jetpack phan <project>       # Static analysis (Phan)
 ```


### PR DESCRIPTION
## Proposed changes

* Document `pnpm run lint-style` with the path argument it actually needs, in `AGENTS.md` and `CONTRIBUTING.md`.

Unlike `lint` — which is `pnpm run lint-file .`, with the path baked in — `lint-style` passes its arguments straight to stylelint and bakes in no path. Copying the documented command verbatim therefore leaves stylelint reading stdin, and it exits 2 with:

```
<input css d9XDte>
  1:1  ✖  Empty source  no-empty-source
```

Which reads like a repo-wide lint failure rather than a usage error. `--allow-empty-input` doesn't help, because stdin isn't empty input in the globby sense.

CI already gets this right — `.github/workflows/linting.yml:466` runs `pnpm lint-style --formatter=compact .`, and the comment two lines above it states the local equivalent as `pnpm run lint-style .`. The docs were simply out of step.

I left the script alone rather than defaulting it to `.`, since CI appends its own path and would then pass two.

## Related product discussion/links

* None — spotted while running the documented lint commands on an unrelated PR.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From the monorepo root, run `pnpm run lint-style` with no argument and confirm it fails with `Empty source  no-empty-source` and exit code 2.
* Run `pnpm run lint-style .` and confirm it completes cleanly.
* Confirm the two documentation blocks now show the second form.

No changelog entries: the change is confined to `AGENTS.md` and `CONTRIBUTING.md`, both outside `/projects`.
