### PR TITLE
Social: remove the unreleased Activity Log page

### DIFF
--- a/projects/plugins/social/changelog/add-activity-log-page
+++ b/projects/plugins/social/changelog/add-activity-log-page
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the Activity Log page to wp-admin, so it is available without the Jetpack plugin installed.

--- a/projects/plugins/social/changelog/remove-social-activity-log
+++ b/projects/plugins/social/changelog/remove-social-activity-log
@@ -1,0 +1,3 @@
+Significance: patch
+Type: removed
+Comment: Revert the unreleased addition of the Activity Log page (#51223); it never shipped in a release.

--- a/projects/plugins/social/composer.json
+++ b/projects/plugins/social/composer.json
@@ -4,7 +4,6 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"require": {
-		"automattic/jetpack-activity-log": "@dev",
 		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-autoloader": "@dev",

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b1a4ef02e28cc96f82aada0e66afb13",
+    "content-hash": "654b89c6ccb8f184415abbf868231609",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -118,82 +118,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
-            "transport-options": {
-                "relative": true
-            }
-        },
-        {
-            "name": "automattic/jetpack-activity-log",
-            "version": "dev-trunk",
-            "dist": {
-                "type": "path",
-                "url": "../../packages/activity-log",
-                "reference": "8c0a84c51bdefcafd33e48001bddf72a46330f49"
-            },
-            "require": {
-                "automattic/jetpack-admin-ui": "@dev",
-                "automattic/jetpack-assets": "@dev",
-                "automattic/jetpack-autoloader": "@dev",
-                "automattic/jetpack-composer-plugin": "@dev",
-                "automattic/jetpack-connection": "@dev",
-                "automattic/jetpack-status": "@dev",
-                "automattic/jetpack-wp-build-polyfills": "@dev",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "@dev",
-                "automattic/jetpack-test-environment": "@dev",
-                "automattic/phpunit-select-config": "@dev",
-                "yoast/phpunit-polyfills": "^4.0.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-activity-log",
-                "textdomain": "jetpack-activity-log",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-package-version.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-activity-log/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "scripts": {
-                "build-development": [
-                    "pnpm run build"
-                ],
-                "build-production": [
-                    "pnpm run build-production"
-                ],
-                "watch": [
-                    "Composer\\Config::disableProcessTimeout",
-                    "pnpm run watch"
-                ],
-                "phpunit": [
-                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
-                ],
-                "test-php": [
-                    "@composer phpunit"
-                ],
-                "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
-                ]
-            },
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Activity Log UI for the Jetpack plugin in wp-admin.",
             "transport-options": {
                 "relative": true
             }
@@ -4354,7 +4278,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "automattic/jetpack-activity-log": 20,
         "automattic/jetpack-admin-ui": 20,
         "automattic/jetpack-assets": 20,
         "automattic/jetpack-autoloader": 20,

--- a/projects/plugins/social/src/class-jetpack-social.php
+++ b/projects/plugins/social/src/class-jetpack-social.php
@@ -9,7 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
-use Automattic\Jetpack\Activity_Log\Jetpack_Activity_Log;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
 use Automattic\Jetpack\Current_Plan;
@@ -94,9 +93,6 @@ class Jetpack_Social {
 			'plugins_loaded',
 			function () {
 				My_Jetpack_Initializer::init();
-				// Activity Log. Idempotent, so it no-ops when the Jetpack plugin
-				// already initialized the package on this request.
-				Jetpack_Activity_Log::initialize();
 			}
 		);
 


### PR DESCRIPTION
## Proposed changes
* Revert #51223, which added the native Activity Log page (`automattic/jetpack-activity-log`) to the standalone Jetpack Social plugin.
* Social was never integrated with the Activity Log. The My Jetpack "Activity Log" link that #51223 restored was there by accident in the first place, and product confirmed a Social-only install should not show it.
* The addition never shipped: stable Social is 9.0.3, cut before #51223 merged. So this revert changes nothing for existing users — it stops the menu from appearing in the next release. It also drops the bundled activity-log package (~2 MB extracted) from the plugin.
* Backup (#51154) and Protect (#51157) keep the page on purpose; this PR touches only Social.

## Related product discussion/links
* p1788222599350729-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a Jetpack-connected site with only Jetpack Social active, build and load the plugin: `jp build plugins/social --deps`.
* Check the Jetpack admin menu: Social and My Jetpack appear, and there is no "Activity Log" submenu.
* Activate the Jetpack plugin as well and confirm Activity Log still appears there (its own wiring is untouched).
