### PR TITLE
Jetpack AI: bring the AI Hub to feature parity on WordPress.com Simple

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/.phan/config.php
+++ b/projects/packages/jetpack-mu-wpcom/.phan/config.php
@@ -16,6 +16,7 @@ return make_phan_config(
 		'+stubs'                          => array( 'full-site-editing', 'gutenberg', 'photon-opencv', 'wpcom' ),
 		'exclude_file_list'               => array(
 			'tests/lib/class-wpcom-features.php',
+			'tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php',
 		),
 		'exclude_file_regex'              => array(
 			'build/',

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-ai-hub-simple-parity
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-jetpack-ai-hub-simple-parity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI Hub: Show every view on WordPress.com Simple sites and supply the plan info for the Overview.

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
+
 /**
  * Point the upstream Hub at WordPress.com's native site-scoped MCP API and
  * supply the Simple answers for the host-specific configuration.
@@ -21,6 +23,8 @@ function configure( $config ) {
 	// when the Hub is deliberately loaded here, every view shows. No second
 	// predicate — turning Simple on stays exactly one filter flip.
 	$config['showGatedViews'] = true;
+	// Host-opened, not internal-gated: no "A12s only" badge on the tabs.
+	$config['gatedViewsBadge'] = false;
 	// Simple users are WordPress.com users by construction, so the usage
 	// endpoint can always proxy as the current user.
 	$config['isUserConnected'] = true;
@@ -39,9 +43,11 @@ function configure( $config ) {
  * Name, renewal date, and auto-renew state of the site's WordPress.com plan,
  * for the Hub's Overview plan card.
  *
- * Answered from the WordPress.com store — the site's `bundle` purchase,
- * named via the product list — because My Jetpack's purchase lookup signs a
- * blog-token request Simple sites cannot make.
+ * Answered from the WordPress.com store — the site's plan purchase, named
+ * via the product list — because My Jetpack's purchase lookup signs a
+ * blog-token request Simple sites cannot make. All-or-nothing like the
+ * upstream lookup: a plan that cannot be named reports the empty shape
+ * rather than dates without a name.
  *
  * @return array{name: string, renews_on: string, auto_renew: bool}
  */
@@ -52,28 +58,35 @@ function get_plan_info() {
 		'auto_renew' => true,
 	);
 
-	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+	if ( ! function_exists( 'wpcom_get_site_purchases' ) || ! class_exists( '\Store_Product_List' ) ) {
 		return $info;
 	}
 
-	$bundles = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
-	$plan    = array_pop( $bundles );
+	// A site can hold several plan rows (a lapsed plan beside the current
+	// one); the expiry-notices picker already selects the latest-expiring.
+	$plan = Expiry_Data::pick_primary_plan_purchase( wpcom_get_site_purchases() );
 	if ( ! is_object( $plan ) ) {
 		return $info;
 	}
 
-	$info['renews_on'] = (string) ( $plan->expiry_date ?? '' );
-	// Absent means unknown, not off: only a purchase that positively reports
-	// auto-renew off should relabel the renewal date as an expiry.
-	$info['auto_renew'] = (bool) ( $plan->auto_renew ?? true );
-
-	if ( class_exists( '\Store_Product_List' ) ) {
-		$products = \Store_Product_List::get_from_cache();
-		$name     = $products[ (int) $plan->product_id ]['product_name'] ?? '';
-		// The card shows the bare plan name ("Business"), matching the
-		// upstream page's own trim of the store's brand prefixes.
-		$info['name'] = (string) preg_replace( '/^(Jetpack|WordPress\.com) /', '', (string) $name );
+	$name = \Store_Product_List::get_from_cache()[ (int) ( $plan->product_id ?? 0 ) ]['product_name'] ?? '';
+	if ( ! is_string( $name ) || '' === $name ) {
+		return $info;
 	}
+
+	// An unparseable expiry ('0000-00-00…' marks never-expiring subscriptions)
+	// is no date, not an expired plan; a parseable past one means it lapsed.
+	$expiry_ts = strtotime( (string) ( $plan->expiry_date ?? '' ) );
+	if ( false !== $expiry_ts && $expiry_ts < time() ) {
+		return $info;
+	}
+
+	// Raw store name; the Hub page trims the brand prefixes in one place.
+	$info['name']      = $name;
+	$info['renews_on'] = false === $expiry_ts ? '' : (string) $plan->expiry_date;
+	// Absent means unknown, not off — and Simple store rows historically carry
+	// the flag as user_allows_auto_renew, with auto_renew as its alias.
+	$info['auto_renew'] = (bool) ( $plan->user_allows_auto_renew ?? $plan->auto_renew ?? true );
 
 	return $info;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
@@ -8,7 +8,8 @@
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
 
 /**
- * Point the upstream Hub at WordPress.com's native site-scoped MCP API.
+ * Point the upstream Hub at WordPress.com's native site-scoped MCP API and
+ * supply the Simple answers for the host-specific configuration.
  *
  * @param array $config Upstream AI Hub host configuration.
  * @return array WordPress.com Simple configuration.
@@ -16,14 +17,65 @@ namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Hub;
 function configure( $config ) {
 	$blog_id = get_current_blog_id();
 
-	$config['showGatedViews']  = false;
+	// On Simple the jetpack_mu_wpcom_load_jetpack_ai_hub filter is the gate:
+	// when the Hub is deliberately loaded here, every view shows. No second
+	// predicate — turning Simple on stays exactly one filter flip.
+	$config['showGatedViews'] = true;
+	// Simple users are WordPress.com users by construction, so the usage
+	// endpoint can always proxy as the current user.
 	$config['isUserConnected'] = true;
-	$config['mcpSettingsApi']  = array(
+	// The Overview plan card, answered the WordPress.com-native way — the
+	// upstream My Jetpack purchase lookup cannot run on Simple.
+	$config['planInfo']       = get_plan_info();
+	$config['mcpSettingsApi'] = array(
 		'path'   => '/wpcom/v2/sites/' . $blog_id . '/mcp-abilities',
 		'format' => 'wpcom',
 	);
 
 	return $config;
+}
+
+/**
+ * Name, renewal date, and auto-renew state of the site's WordPress.com plan,
+ * for the Hub's Overview plan card.
+ *
+ * Answered from the WordPress.com store — the site's `bundle` purchase,
+ * named via the product list — because My Jetpack's purchase lookup signs a
+ * blog-token request Simple sites cannot make.
+ *
+ * @return array{name: string, renews_on: string, auto_renew: bool}
+ */
+function get_plan_info() {
+	$info = array(
+		'name'       => '',
+		'renews_on'  => '',
+		'auto_renew' => true,
+	);
+
+	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+		return $info;
+	}
+
+	$bundles = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
+	$plan    = array_pop( $bundles );
+	if ( ! is_object( $plan ) ) {
+		return $info;
+	}
+
+	$info['renews_on'] = (string) ( $plan->expiry_date ?? '' );
+	// Absent means unknown, not off: only a purchase that positively reports
+	// auto-renew off should relabel the renewal date as an expiry.
+	$info['auto_renew'] = (bool) ( $plan->auto_renew ?? true );
+
+	if ( class_exists( '\Store_Product_List' ) ) {
+		$products = \Store_Product_List::get_from_cache();
+		$name     = $products[ (int) $plan->product_id ]['product_name'] ?? '';
+		// The card shows the bare plan name ("Business"), matching the
+		// upstream page's own trim of the store's brand prefixes.
+		$info['name'] = (string) preg_replace( '/^(Jetpack|WordPress\.com) /', '', (string) $name );
+	}
+
+	return $info;
 }
 
 // Scheduled tasks are a WordPress.com-backed experience and should be visible

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-hub/jetpack-ai-hub.php
@@ -28,8 +28,7 @@ function configure( $config ) {
 	// Simple users are WordPress.com users by construction, so the usage
 	// endpoint can always proxy as the current user.
 	$config['isUserConnected'] = true;
-	// The Overview plan card, answered the WordPress.com-native way — the
-	// upstream My Jetpack purchase lookup cannot run on Simple.
+	// The Overview plan card — get_plan_info() says why Simple answers it.
 	$config['planInfo']       = get_plan_info();
 	$config['mcpSettingsApi'] = array(
 		'path'   => '/wpcom/v2/sites/' . $blog_id . '/mcp-abilities',
@@ -45,9 +44,8 @@ function configure( $config ) {
  *
  * Answered from the WordPress.com store — the site's plan purchase, named
  * via the product list — because My Jetpack's purchase lookup signs a
- * blog-token request Simple sites cannot make. All-or-nothing like the
- * upstream lookup: a plan that cannot be named reports the empty shape
- * rather than dates without a name.
+ * blog-token request Simple sites cannot make. All-or-nothing like upstream:
+ * a plan that cannot be named reports the empty shape.
  *
  * @return array{name: string, renews_on: string, auto_renew: bool}
  */
@@ -62,8 +60,8 @@ function get_plan_info() {
 		return $info;
 	}
 
-	// A site can hold several plan rows (a lapsed plan beside the current
-	// one); the expiry-notices picker already selects the latest-expiring.
+	// The store returns active subscriptions only; the expiry-notices picker
+	// selects the latest-expiring plan row if several are active at once.
 	$plan = Expiry_Data::pick_primary_plan_purchase( wpcom_get_site_purchases() );
 	if ( ! is_object( $plan ) ) {
 		return $info;
@@ -74,16 +72,11 @@ function get_plan_info() {
 		return $info;
 	}
 
-	// An unparseable expiry ('0000-00-00…' marks never-expiring subscriptions)
-	// is no date, not an expired plan; a parseable past one means it lapsed.
-	$expiry_ts = strtotime( (string) ( $plan->expiry_date ?? '' ) );
-	if ( false !== $expiry_ts && $expiry_ts < time() ) {
-		return $info;
-	}
-
 	// Raw store name; the Hub page trims the brand prefixes in one place.
-	$info['name']      = $name;
-	$info['renews_on'] = false === $expiry_ts ? '' : (string) $plan->expiry_date;
+	$info['name'] = $name;
+	// Always an ISO8601 string: the store normalizer rewrites empty and
+	// '0000-00-00' (never-expiring) expiries before they reach purchases.
+	$info['renews_on'] = (string) ( $plan->expiry_date ?? '' );
 	// Absent means unknown, not off — and Simple store rows historically carry
 	// the flag as user_allows_auto_renew, with auto_renew as its alias.
 	$info['auto_renew'] = (bool) ( $plan->user_allows_auto_renew ?? $plan->auto_renew ?? true );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -105,9 +105,9 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The plan info comes from the WordPress.com store: the current (not the
-	 * lapsed) plan purchase carries the dates in the Simple row shape, and the
-	 * store product list names it — raw, the Hub page owns the brand trim.
+	 * The plan info comes from the WordPress.com store: the latest-expiring
+	 * plan row carries the dates in the Simple row shape, and the store
+	 * product list names it — raw, the Hub page owns the brand trim.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -123,7 +123,7 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				'name'       => 'WordPress.com Business',
-				'renews_on'  => '2027-08-30 00:00:00',
+				'renews_on'  => '2027-08-30T00:00:00+00:00',
 				'auto_renew' => false,
 			),
 			$info

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -57,20 +57,22 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The integration uses the native site-scoped WordPress.com MCP endpoint.
+	 * The integration uses the native site-scoped WordPress.com MCP endpoint,
+	 * shows every view — the load filter is the gate on Simple — and reports
+	 * the current user connected.
 	 */
 	public function test_configures_native_wpcom_mcp_api() {
 		$this->load_integration();
 
 		$config = configure(
 			array(
-				'showGatedViews'  => true,
+				'showGatedViews'  => false,
 				'isUserConnected' => false,
 				'mcpSettingsApi'  => array(),
 			)
 		);
 
-		$this->assertFalse( $config['showGatedViews'] );
+		$this->assertTrue( $config['showGatedViews'] );
 		$this->assertTrue( $config['isUserConnected'] );
 		$this->assertSame(
 			array(
@@ -78,6 +80,51 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 				'format' => 'wpcom',
 			),
 			$config['mcpSettingsApi']
+		);
+	}
+
+	/**
+	 * Without the WordPress.com store available the plan info degrades to the
+	 * empty shape rather than erroring — the Overview card then shows no plan.
+	 */
+	public function test_plan_info_degrades_without_the_wpcom_store() {
+		$this->load_integration();
+
+		$config = configure( array() );
+
+		$this->assertSame(
+			array(
+				'name'       => '',
+				'renews_on'  => '',
+				'auto_renew' => true,
+			),
+			$config['planInfo']
+		);
+	}
+
+	/**
+	 * The plan info comes from the WordPress.com store: the site's `bundle`
+	 * purchase carries the dates, and the store product list names it — with
+	 * the brand prefix trimmed the way the upstream page trims it.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_plan_info_reads_the_wpcom_store() {
+		$this->load_integration();
+		require_once __DIR__ . '/fixtures/wpcom-store-fakes.php';
+
+		$info = get_plan_info();
+
+		$this->assertSame(
+			array(
+				'name'       => 'Business',
+				'renews_on'  => '2027-08-30 00:00:00',
+				'auto_renew' => false,
+			),
+			$info
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/Jetpack_AI_Hub_Test.php
@@ -67,12 +67,14 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 		$config = configure(
 			array(
 				'showGatedViews'  => false,
+				'gatedViewsBadge' => true,
 				'isUserConnected' => false,
 				'mcpSettingsApi'  => array(),
 			)
 		);
 
 		$this->assertTrue( $config['showGatedViews'] );
+		$this->assertFalse( $config['gatedViewsBadge'], 'Host-opened views must not carry the internal-audience badge.' );
 		$this->assertTrue( $config['isUserConnected'] );
 		$this->assertSame(
 			array(
@@ -103,9 +105,9 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The plan info comes from the WordPress.com store: the site's `bundle`
-	 * purchase carries the dates, and the store product list names it — with
-	 * the brand prefix trimmed the way the upstream page trims it.
+	 * The plan info comes from the WordPress.com store: the current (not the
+	 * lapsed) plan purchase carries the dates in the Simple row shape, and the
+	 * store product list names it — raw, the Hub page owns the brand trim.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -120,7 +122,7 @@ class Jetpack_AI_Hub_Test extends BaseTestCase {
 
 		$this->assertSame(
 			array(
-				'name'       => 'Business',
+				'name'       => 'WordPress.com Business',
 				'renews_on'  => '2027-08-30 00:00:00',
 				'auto_renew' => false,
 			),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
@@ -10,8 +10,9 @@
 // phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- the fixture mirrors two store surfaces that ship together.
 
 /**
- * Fake of the WordPress.com purchases lookup: one non-plan purchase and one
- * `bundle` (the site's plan), mirroring the store row shape.
+ * Fake of the WordPress.com purchases lookup, in the Simple store-row shape
+ * (`user_allows_auto_renew`, no product_name): a non-plan purchase, a lapsed
+ * plan, and the current plan.
  *
  * @return object[]
  */
@@ -22,16 +23,22 @@ function wpcom_get_site_purchases() {
 			'product_id'   => '9',
 		),
 		(object) array(
-			'product_type' => 'bundle',
-			'product_id'   => '1008',
-			'expiry_date'  => '2027-08-30 00:00:00',
-			'auto_renew'   => false,
+			'product_type'           => 'bundle',
+			'product_id'             => '1009',
+			'expiry_date'            => '2020-01-01 00:00:00',
+			'user_allows_auto_renew' => true,
+		),
+		(object) array(
+			'product_type'           => 'bundle',
+			'product_id'             => '1008',
+			'expiry_date'            => '2027-08-30 00:00:00',
+			'user_allows_auto_renew' => false,
 		),
 	);
 }
 
 /**
- * Fake of the WordPress.com store product list, naming the plan product.
+ * Fake of the WordPress.com store product list, naming the plan products.
  */
 class Store_Product_List {
 	/**
@@ -42,6 +49,7 @@ class Store_Product_List {
 	public static function get_from_cache() {
 		return array(
 			1008 => array( 'product_name' => 'WordPress.com Business' ),
+			1009 => array( 'product_name' => 'WordPress.com Personal' ),
 		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
@@ -1,0 +1,47 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Global-namespace fakes for the WordPress.com store surface that
+ * Jetpack_AI_Hub\get_plan_info() reads on Simple. Loaded only inside a
+ * separate-process test so the definitions cannot leak into other tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+// phpcs:disable Universal.Files.SeparateFunctionsFromOO.Mixed -- the fixture mirrors two store surfaces that ship together.
+
+/**
+ * Fake of the WordPress.com purchases lookup: one non-plan purchase and one
+ * `bundle` (the site's plan), mirroring the store row shape.
+ *
+ * @return object[]
+ */
+function wpcom_get_site_purchases() {
+	return array(
+		(object) array(
+			'product_type' => 'search',
+			'product_id'   => '9',
+		),
+		(object) array(
+			'product_type' => 'bundle',
+			'product_id'   => '1008',
+			'expiry_date'  => '2027-08-30 00:00:00',
+			'auto_renew'   => false,
+		),
+	);
+}
+
+/**
+ * Fake of the WordPress.com store product list, naming the plan product.
+ */
+class Store_Product_List {
+	/**
+	 * Products keyed by product id, as the real cache returns them.
+	 *
+	 * @return array
+	 */
+	public static function get_from_cache() {
+		return array(
+			1008 => array( 'product_name' => 'WordPress.com Business' ),
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-hub/fixtures/wpcom-store-fakes.php
@@ -11,8 +11,8 @@
 
 /**
  * Fake of the WordPress.com purchases lookup, in the Simple store-row shape
- * (`user_allows_auto_renew`, no product_name): a non-plan purchase, a lapsed
- * plan, and the current plan.
+ * (active rows only, ISO8601 dates, `user_allows_auto_renew`, no
+ * product_name): a non-plan purchase, a superseded plan row, and the plan.
  *
  * @return object[]
  */
@@ -25,13 +25,13 @@ function wpcom_get_site_purchases() {
 		(object) array(
 			'product_type'           => 'bundle',
 			'product_id'             => '1009',
-			'expiry_date'            => '2020-01-01 00:00:00',
+			'expiry_date'            => '2026-10-01T00:00:00+00:00',
 			'user_allows_auto_renew' => true,
 		),
 		(object) array(
 			'product_type'           => 'bundle',
 			'product_id'             => '1008',
-			'expiry_date'            => '2027-08-30 00:00:00',
+			'expiry_date'            => '2027-08-30T00:00:00+00:00',
 			'user_allows_auto_renew' => false,
 		),
 	);

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -15,13 +15,12 @@ import { __ } from '@wordpress/i18n';
 import { Badge, Card, Link, Notice, Popover, Stack, Text, VisuallyHidden } from '@wordpress/ui';
 import analytics from 'lib/analytics';
 
-// Server-computed link targets, read at call time (not module scope) so the
-// injected page data is honoured wherever this mounts. A missing key keeps
-// the wp-admin default (tests, older payloads); an explicit empty string
-// means the surface does not exist on this host and the link is hidden.
+// Server-computed link targets, read at call time so the injected page data
+// is honoured wherever this mounts. Missing key = wp-admin default (tests,
+// older payloads); explicit '' = surface absent on this host, link hidden.
 const getLinkTargets = () => {
 	const {
-		seoSettingsUrl,
+		seoSettingsUrl = 'admin.php?page=jetpack#/traffic',
 		searchSettingsUrl = 'admin.php?page=jetpack-search#/ai-answers',
 		myJetpackUrl = 'admin.php?page=my-jetpack#/products',
 	} = window?.jetpackAiSettings ?? {};
@@ -29,10 +28,8 @@ const getLinkTargets = () => {
 };
 
 // Per the design, a row's action link depends on the toggle state: enabled
-// features invite you to try them (AI SEO opens its settings), disabled ones
-// link to documentation via registered Jetpack Redirects handlers. A row with
-// a single `action` shows that link in both states; a row whose settings
-// surface does not exist on this host gets no enabled-state link at all.
+// features invite you to try them, disabled ones link to documentation. A
+// single `action` shows in both states; a missing enabledAction shows none.
 export const getSections = ( { seoSettingsUrl, searchSettingsUrl } ) => [
 	{
 		key: 'content',
@@ -92,10 +89,12 @@ export const getSections = ( { seoSettingsUrl, searchSettingsUrl } ) => [
 					'AI recommendations to optimize titles, meta descriptions, and content for search engines.',
 					'jetpack'
 				),
-				enabledAction: {
-					label: __( 'Open SEO Settings', 'jetpack' ),
-					href: seoSettingsUrl || 'admin.php?page=jetpack#/traffic',
-				},
+				enabledAction: seoSettingsUrl
+					? {
+							label: __( 'Open SEO Settings', 'jetpack' ),
+							href: seoSettingsUrl,
+					  }
+					: undefined,
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),
 					href: getRedirectUrl( 'jetpack-ai-settings-seo-learn-more' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -15,16 +15,25 @@ import { __ } from '@wordpress/i18n';
 import { Badge, Card, Link, Notice, Popover, Stack, Text, VisuallyHidden } from '@wordpress/ui';
 import analytics from 'lib/analytics';
 
-// Server-computed target for the AI SEO row: the dedicated Jetpack SEO page
-// where it exists, the Traffic settings card otherwise. Falls back to Traffic
-// when jetpackAiSettings is unavailable (e.g. in tests).
-const { seoSettingsUrl } = window?.jetpackAiSettings ?? {};
+// Server-computed link targets, read at call time (not module scope) so the
+// injected page data is honoured wherever this mounts. A missing key keeps
+// the wp-admin default (tests, older payloads); an explicit empty string
+// means the surface does not exist on this host and the link is hidden.
+const getLinkTargets = () => {
+	const {
+		seoSettingsUrl,
+		searchSettingsUrl = 'admin.php?page=jetpack-search#/ai-answers',
+		myJetpackUrl = 'admin.php?page=my-jetpack#/products',
+	} = window?.jetpackAiSettings ?? {};
+	return { seoSettingsUrl, searchSettingsUrl, myJetpackUrl };
+};
 
 // Per the design, a row's action link depends on the toggle state: enabled
 // features invite you to try them (AI SEO opens its settings), disabled ones
 // link to documentation via registered Jetpack Redirects handlers. A row with
-// a single `action` shows that link in both states.
-const SECTIONS = [
+// a single `action` shows that link in both states; a row whose settings
+// surface does not exist on this host gets no enabled-state link at all.
+export const getSections = ( { seoSettingsUrl, searchSettingsUrl } ) => [
 	{
 		key: 'content',
 		title: __( 'Content', 'jetpack' ),
@@ -106,11 +115,14 @@ const SECTIONS = [
 					'Help visitors and AI agents find answers in your content, via Jetpack Search.',
 					'jetpack'
 				),
-				enabledAction: {
-					label: __( 'Open Search Settings', 'jetpack' ),
-					// The toggle lives on the Search dashboard's AI tab, not Overview.
-					href: 'admin.php?page=jetpack-search#/ai-answers',
-				},
+				// The toggle lives on the Search dashboard's AI tab — a page some
+				// hosts (WordPress.com Simple) never register.
+				enabledAction: searchSettingsUrl
+					? {
+							label: __( 'Open Search Settings', 'jetpack' ),
+							href: searchSettingsUrl,
+					  }
+					: undefined,
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),
 					href: getRedirectUrl( 'jetpack-ai-settings-search-learn-more' ),
@@ -246,7 +258,11 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 				/* dummy arg to avoid bad minification */ 0
 		  );
 
-	const sections = visibleSections( SECTIONS, features );
+	const { seoSettingsUrl, searchSettingsUrl, myJetpackUrl } = getLinkTargets();
+	const sections = visibleSections(
+		getSections( { seoSettingsUrl, searchSettingsUrl } ),
+		features
+	);
 
 	const handleToggle = useCallback(
 		( key, enabled ) => {
@@ -303,13 +319,16 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 						{ __(
 							'Your feature settings are saved and will apply again when AI is turned back on.',
 							'jetpack'
-						) }{ ' ' }
-						<Link
-							href="admin.php?page=my-jetpack#/products"
-							className="jetpack-ai-features__notice-link"
-						>
-							{ __( 'Manage in My Jetpack', 'jetpack' ) }
-						</Link>
+						) }
+						{ /* No remedy link on hosts without My Jetpack (Simple). */ }
+						{ myJetpackUrl && (
+							<>
+								{ ' ' }
+								<Link href={ myJetpackUrl } className="jetpack-ai-features__notice-link">
+									{ __( 'Manage in My Jetpack', 'jetpack' ) }
+								</Link>
+							</>
+						) }
 					</Notice.Description>
 				</Notice.Root>
 			) }

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -9,6 +9,10 @@ import AiFeatures from '../index';
 jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
 
 describe( 'AiFeatures rendering', () => {
+	afterEach( () => {
+		delete window.jetpackAiSettings;
+	} );
+
 	const renderFeatures = ( overrides = {} ) =>
 		render(
 			<AiFeatures
@@ -207,6 +211,28 @@ describe( 'AiFeatures rendering', () => {
 		expect( toggle ).toBeDisabled();
 
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'host without My Jetpack: master-off notice renders without the manage link', () => {
+		// An explicit empty myJetpackUrl (WordPress.com Simple) means the page
+		// the link would open never registers there.
+		window.jetpackAiSettings = { myJetpackUrl: '' };
+		renderFeatures( { master_enabled: false } );
+
+		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Manage in My Jetpack' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'host without a Search dashboard: the AI Search row keeps its toggle, loses its link', () => {
+		window.jetpackAiSettings = { searchSettingsUrl: '' };
+		renderFeatures( { features: { ai_search: { enabled: true } } } );
+
+		expect( screen.getByRole( 'checkbox', { name: /AI Search/ } ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Open Search Settings' } )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'not connected: connect notice, toggles keep saved values but disable, links and badge hidden', () => {

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -34,8 +34,8 @@ const SETTINGS_REF = 'jetpack-ai-mcp-settings';
 
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 
-// Views that only exist in internal testing environments. MCP Settings ships
-// publicly, so it is not in here.
+// Views behind the host's gate (internal testing off WordPress.com Simple;
+// Simple opens them via its load filter). MCP Settings ships publicly.
 const GATED_VIEWS = [ 'overview', 'features' ];
 
 // Read at call time, not module scope, so the flag reflects the injected page data.
@@ -267,14 +267,15 @@ export default function App() {
 							{ tabViews.map( tab => (
 								<Tabs.Tab key={ tab } value={ tab }>
 									{ VIEW_TITLES[ tab ] }
-									{ /* Overview and Features ship behind the internal-testing gate;
-									     label them so Automatticians don't mistake them for public UI.
-									     Remove with the gate. */ }
-									{ GATED_VIEWS.includes( tab ) && (
-										<Badge intent="medium" className="jetpack-ai-admin__tab-badge">
-											{ __( 'A12s only', 'jetpack' ) }
-										</Badge>
-									) }
+									{ /* The badge marks tabs shown only by the internal-testing
+									     gate; hosts that open them for real users (Simple) inject
+									     the flag as false. Remove with the gate. */ }
+									{ GATED_VIEWS.includes( tab ) &&
+										!! window?.jetpackAiSettings?.showGatedViewsBadge && (
+											<Badge intent="medium" className="jetpack-ai-admin__tab-badge">
+												{ __( 'A12s only', 'jetpack' ) }
+											</Badge>
+										) }
 								</Tabs.Tab>
 							) ) }
 						</Tabs.List>

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -207,15 +207,27 @@ describe( 'AI admin page (main.jsx)', () => {
 
 	test( 'internal-testing flag: every gated tab carries an A12s only badge', async () => {
 		// Overview and Features are both gated to internal testing environments;
-		// when the injected flag says we are in one, each tab must say so —
-		// Automatticians should not mistake either view for public UI. MCP
-		// Settings ships publicly, so it must not be labelled.
-		window.jetpackAiSettings = { showFeaturesView: true };
+		// when the injected flags say the gate (not a host) opened them, each
+		// tab must say so — Automatticians should not mistake either view for
+		// public UI. MCP Settings ships publicly, so it must not be labelled.
+		window.jetpackAiSettings = { showFeaturesView: true, showGatedViewsBadge: true };
 		mockApiFetch();
 
 		render( <App /> );
 
 		await expect( screen.findAllByText( 'A12s only' ) ).resolves.toHaveLength( 2 );
+	} );
+
+	test( 'host-opened views: the tabs show with no A12s only badge', async () => {
+		// A host that opens the gated views for real users (WordPress.com
+		// Simple) does not inject the badge flag — no internal label ships.
+		window.jetpackAiSettings = { showFeaturesView: true };
+		mockApiFetch();
+
+		render( <App /> );
+
+		await expect( screen.findByText( 'Overview' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'A12s only' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'scheduled tasks flag: exposes the gated hash route and Figma empty state', async () => {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -215,8 +215,10 @@ class Jetpack_AI_Page {
 		// the approach used by jetpack-mu-wpcom for the sidebar Activity Log link.
 		$site_host         = wp_parse_url( home_url(), PHP_URL_HOST );
 		$activity_log_site = ( is_string( $site_host ) && '' !== $site_host ) ? $site_host : $site_suffix;
-		// On Atomic link to WPCOM activity log; on self-hosted link to the local wp-admin page.
-		$activity_log_url = ( new Host() )->is_woa_site()
+		// On WordPress.com (Simple and Atomic) link to the WPCOM activity log —
+		// matching the wpcom admin menu, which hides the local Jetpack Activity
+		// Log page there. On self-hosted link to the local wp-admin page.
+		$activity_log_url = ( new Host() )->is_wpcom_platform()
 			? 'https://wordpress.com/activity-log/' . $activity_log_site
 			: admin_url( 'admin.php?page=jetpack-activity-log' );
 
@@ -287,11 +289,19 @@ class Jetpack_AI_Page {
 
 		$show_gated_views = ! empty( $config['showGatedViews'] );
 
-		$plan_info = $show_gated_views ? self::get_ai_plan_info() : array(
+		$plan_info = array(
 			'name'       => '',
 			'renews_on'  => '',
 			'auto_renew' => true,
 		);
+		if ( $show_gated_views ) {
+			// The host integration may precompute the plan the platform-native
+			// way — My Jetpack's signed purchase lookup cannot run on
+			// WordPress.com Simple, so its mu-wpcom configure() supplies this.
+			$plan_info = isset( $config['planInfo'] ) && is_array( $config['planInfo'] )
+				? array_merge( $plan_info, $config['planInfo'] )
+				: self::get_ai_plan_info();
+		}
 
 		$settings = array(
 			'blogId'           => $blog_id ? (int) $blog_id : 0,

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -284,16 +284,21 @@ class Jetpack_AI_Page {
 				// Pre-release gate for the Overview and Features views. When opening
 				// them to everyone, also drop the matching gate in My Jetpack's
 				// Jetpack_Ai::get_manage_url() so its links land here too.
-				'showGatedViews'  => $is_internal_test,
+				'showGatedViews'    => $is_internal_test,
 				// Whether the gated views carry the internal-audience badge: on by
 				// default only when the internal gate is why they show, so a host
 				// that opens them (Simple) does not ship the badge to customers.
-				'gatedViewsBadge' => $is_internal_test,
-				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
-				'mcpSettingsApi'  => array(
+				'gatedViewsBadge'   => $is_internal_test,
+				'isUserConnected'   => ( new Connection_Manager() )->is_user_connected(),
+				'mcpSettingsApi'    => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
 					'format' => 'jetpack',
 				),
+				// Link targets the Features view cannot compute host-aware itself.
+				// Empty means the surface does not exist here; the view hides the link.
+				'seoSettingsUrl'    => $seo_settings_url,
+				'searchSettingsUrl' => $is_simple ? '' : 'admin.php?page=jetpack-search#/ai-answers',
+				'myJetpackUrl'      => $is_simple ? '' : 'admin.php?page=my-jetpack#/products',
 			)
 		);
 
@@ -305,9 +310,8 @@ class Jetpack_AI_Page {
 			'auto_renew' => true,
 		);
 		if ( $show_gated_views ) {
-			// The host integration may precompute the plan the platform-native
-			// way — My Jetpack's signed purchase lookup cannot run on
-			// WordPress.com Simple, so its mu-wpcom configure() supplies this.
+			// A host may precompute the plan platform-natively (WordPress.com
+			// Simple's mu-wpcom configure() does — see its get_plan_info()).
 			$plan_info = isset( $config['planInfo'] ) && is_array( $config['planInfo'] )
 				? array_merge( $plan_info, $config['planInfo'] )
 				: self::get_ai_plan_info();
@@ -320,7 +324,7 @@ class Jetpack_AI_Page {
 		$settings = array(
 			'blogId'              => $blog_id ? (int) $blog_id : 0,
 			'activityLogUrl'      => $activity_log_url,
-			'seoSettingsUrl'      => $seo_settings_url,
+			'seoSettingsUrl'      => (string) ( $config['seoSettingsUrl'] ?? '' ),
 			'siteAdminUrl'        => admin_url(),
 			'apiRoot'             => esc_url_raw( rest_url() ),
 			'apiNonce'            => wp_create_nonce( 'wp_rest' ),
@@ -343,11 +347,8 @@ class Jetpack_AI_Page {
 			// Label the gated tabs as internal-only wherever that is still why
 			// they show — a host that opened them keeps the badge off.
 			'showGatedViewsBadge' => $show_gated_views && ! empty( $config['gatedViewsBadge'] ),
-			// Row-action targets the Features view cannot compute host-aware
-			// itself. Empty means the surface does not exist here (Simple), and
-			// the view hides the link.
-			'searchSettingsUrl'   => $is_simple ? '' : 'admin.php?page=jetpack-search#/ai-answers',
-			'myJetpackUrl'        => $is_simple ? '' : 'admin.php?page=my-jetpack#/products',
+			'searchSettingsUrl'   => (string) ( $config['searchSettingsUrl'] ?? '' ),
+			'myJetpackUrl'        => (string) ( $config['myJetpackUrl'] ?? '' ),
 			// The tab and its Agents Manager sidebar ship disabled by default.
 			'featureFlags'        => array(
 				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -207,6 +207,8 @@ class Jetpack_AI_Page {
 			$script_version = $asset_manifest['version'];
 		}
 
+		$host        = new Host();
+		$is_simple   = $host->is_wpcom_simple();
 		$blog_id     = Connection_Manager::get_site_id( true );
 		$status      = new Status();
 		$site_suffix = $status->get_site_suffix();
@@ -218,7 +220,7 @@ class Jetpack_AI_Page {
 		// On WordPress.com (Simple and Atomic) link to the WPCOM activity log —
 		// matching the wpcom admin menu, which hides the local Jetpack Activity
 		// Log page there. On self-hosted link to the local wp-admin page.
-		$activity_log_url = ( new Host() )->is_wpcom_platform()
+		$activity_log_url = $host->is_wpcom_platform()
 			? 'https://wordpress.com/activity-log/' . $activity_log_site
 			: admin_url( 'admin.php?page=jetpack-activity-log' );
 
@@ -233,7 +235,11 @@ class Jetpack_AI_Page {
 		$seo_settings_url          = admin_url( 'admin.php?page=jetpack#/traffic' );
 		$is_internal_test          = jetpack_is_internal_testing_environment();
 		$show_scheduled_tasks_view = self::is_scheduled_tasks_enabled();
-		if (
+		if ( $is_simple ) {
+			// Simple registers neither the Traffic card nor the SEO page; its SEO
+			// settings live on wordpress.com, same target as the wpcom admin menu's.
+			$seo_settings_url = 'https://wordpress.com/marketing/traffic/' . $activity_log_site;
+		} elseif (
 			// The exact-symbol guard matters: the autoloader can select an older
 			// jetpack-seo copy from another plugin that has the class but not
 			// this method, and class_exists alone would then fatal here.
@@ -279,6 +285,10 @@ class Jetpack_AI_Page {
 				// them to everyone, also drop the matching gate in My Jetpack's
 				// Jetpack_Ai::get_manage_url() so its links land here too.
 				'showGatedViews'  => $is_internal_test,
+				// Whether the gated views carry the internal-audience badge: on by
+				// default only when the internal gate is why they show, so a host
+				// that opens them (Simple) does not ship the badge to customers.
+				'gatedViewsBadge' => $is_internal_test,
 				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
 				'mcpSettingsApi'  => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
@@ -301,47 +311,59 @@ class Jetpack_AI_Page {
 			$plan_info = isset( $config['planInfo'] ) && is_array( $config['planInfo'] )
 				? array_merge( $plan_info, $config['planInfo'] )
 				: self::get_ai_plan_info();
+
+			// The card shows the bare plan name ("Business"); trimming the store
+			// brands here keeps one trim site for every producer of the name.
+			$plan_info['name'] = (string) preg_replace( '/^(Jetpack|WordPress\.com) /', '', (string) $plan_info['name'] );
 		}
 
 		$settings = array(
-			'blogId'           => $blog_id ? (int) $blog_id : 0,
-			'activityLogUrl'   => $activity_log_url,
-			'seoSettingsUrl'   => $seo_settings_url,
-			'siteAdminUrl'     => admin_url(),
-			'apiRoot'          => esc_url_raw( rest_url() ),
-			'apiNonce'         => wp_create_nonce( 'wp_rest' ),
-			'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			'blogId'              => $blog_id ? (int) $blog_id : 0,
+			'activityLogUrl'      => $activity_log_url,
+			'seoSettingsUrl'      => $seo_settings_url,
+			'siteAdminUrl'        => admin_url(),
+			'apiRoot'             => esc_url_raw( rest_url() ),
+			'apiNonce'            => wp_create_nonce( 'wp_rest' ),
+			'pluginUrl'           => plugins_url( '', JETPACK__PLUGIN_FILE ),
 			// The redirect entry bakes in the jetpack_ai_yearly product and
 			// a post-checkout return to this page, so both can be
 			// retargeted without shipping a code change.
-			'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
+			'upgradeUrl'          => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
 			// The purchase granting AI, for the Overview usage card — the
 			// usage endpoint cannot name it. Only looked up when a gated
 			// view can render it.
-			'planName'         => $plan_info['name'],
+			'planName'            => $plan_info['name'],
 			// The plan's own renewal date, matching My Jetpack — the
 			// usage-period rollover is a different, monthly date.
-			'planRenewsOn'     => $plan_info['renews_on'],
+			'planRenewsOn'        => $plan_info['renews_on'],
 			// The same date reads "Renews on" or "Expires on" depending on
 			// auto-renew, matching My Jetpack and the wpcom subscriptions page.
-			'planAutoRenew'    => $plan_info['auto_renew'],
-			'showFeaturesView' => $show_gated_views,
+			'planAutoRenew'       => $plan_info['auto_renew'],
+			'showFeaturesView'    => $show_gated_views,
+			// Label the gated tabs as internal-only wherever that is still why
+			// they show — a host that opened them keeps the badge off.
+			'showGatedViewsBadge' => $show_gated_views && ! empty( $config['gatedViewsBadge'] ),
+			// Row-action targets the Features view cannot compute host-aware
+			// itself. Empty means the surface does not exist here (Simple), and
+			// the view hides the link.
+			'searchSettingsUrl'   => $is_simple ? '' : 'admin.php?page=jetpack-search#/ai-answers',
+			'myJetpackUrl'        => $is_simple ? '' : 'admin.php?page=my-jetpack#/products',
 			// The tab and its Agents Manager sidebar ship disabled by default.
-			'featureFlags'     => array(
+			'featureFlags'        => array(
 				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
 			),
 			// The usage endpoint proxies as the current user, which needs
 			// their own WordPress.com account linked — not just the site.
-			'isUserConnected'  => ! empty( $config['isUserConnected'] ),
+			'isUserConnected'     => ! empty( $config['isUserConnected'] ),
 			// Tracks audience properties for the jetpack_mcp_* events, per the
 			// Tracks standards for AI product events (AIINT-586). The client
 			// sends them as the strings 'true'/'false' (AIINT-576).
-			'isA11n'           => self::is_current_user_automattician(),
-			'isTest'           => $is_internal_test,
+			'isA11n'              => self::is_current_user_automattician(),
+			'isTest'              => $is_internal_test,
 			// Identity for Tracks; the lookup can call WordPress.com on a
 			// cache miss, so it shares the sender's guard.
-			'tracksUserData'   => $can_send_tracks ? self::get_tracks_user_data() : null,
-			'mcpSettingsApi'   => $config['mcpSettingsApi'],
+			'tracksUserData'      => $can_send_tracks ? self::get_tracks_user_data() : null,
+			'mcpSettingsApi'      => $config['mcpSettingsApi'],
 		);
 
 		wp_add_inline_script(
@@ -466,9 +488,8 @@ class Jetpack_AI_Page {
 
 		$info = $empty;
 		if ( $purchase && ! empty( $purchase->product_name ) && 'expired' !== ( $purchase->expiry_status ?? '' ) ) {
-			// The design shows the bare plan name ("Complete", "Business"), so
-			// trim the store names' brand prefixes; they are untranslated.
-			$info['name']      = (string) preg_replace( '/^(Jetpack|WordPress\.com) /', '', (string) $purchase->product_name );
+			// Raw store name; the caller trims the brand prefixes in one place.
+			$info['name']      = (string) $purchase->product_name;
 			$info['renews_on'] = (string) ( $purchase->expiry_date ?? '' );
 			// Absent means unknown, not off: only a purchase that positively
 			// reports auto-renew off should relabel the date as an expiry.

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -328,12 +328,10 @@ class Jetpack_AI_Settings {
 			return false;
 		}
 
-		// The toggles this class owns stay on wherever they do not apply: Simple keeps
-		// the existing wp.com settings contract, and elsewhere they are not publicly
-		// launched. The reused Search option ships today with its own settings
-		// surface, so it always honors its stored value.
-		if ( in_array( $feature, self::OWNED_FEATURES, true )
-			&& ( ( new Host() )->is_wpcom_simple() || ! self::should_enforce_ai_controls() ) ) {
+		// The owned toggles are not publicly launched, so off Simple they apply on
+		// internal testing environments only. On Simple they honor their stored
+		// values — the feature-settings endpoint is the writable surface there.
+		if ( in_array( $feature, self::OWNED_FEATURES, true ) && ! self::should_enforce_ai_controls() ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -174,29 +174,34 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	 * @return array
 	 */
 	private function build_settings_response() {
-		$search_plan = class_exists( Search_Plan::class ) ? new Search_Plan() : null;
-
-		// Entitlement: the plan includes some Search product (Classic or Instant).
-		$supports_search = $search_plan && $search_plan->supports_search();
-
-		// AI Answers only runs with the paid Search product provisioned. Mirror
-		// the gate the Search dashboard's AI Answers tab uses for its upsell:
-		// gated when the plan is free or lacks Instant Search.
-		$ai_search_requires_upgrade = ! ( $search_plan && $search_plan->supports_instant_search() && ! $search_plan->is_free_plan() );
-
-		// The free Search tier reports supports_search too, but its remedy for
-		// the gated AI Search row is still an upgrade — the settings page needs
-		// this flag to pick the right badge copy.
-		$is_free_search_plan = $supports_search && $search_plan->is_free_plan();
-
 		if ( ( new Host() )->is_wpcom_simple() && function_exists( 'wpcom_site_has_feature' ) ) {
 			// Search\Plan's cache never populates on Simple (its refresh signs a
-			// blog-token request), so read the WordPress.com feature gates directly.
-			$supports_search            = (bool) wpcom_site_has_feature( 'search' );
-			$ai_search_requires_upgrade = ! wpcom_site_has_feature( 'instant-search' );
-			// Everything granting instant-search on Simple is a paid product —
-			// the free Jetpack Search tier is not offered there.
-			$is_free_search_plan = false;
+			// blog-token request), so read the WordPress.com feature gates instead.
+			// AI Answers needs Instant Search: classic-search-only plans
+			// (Business and higher) still need the Search purchase.
+			$has_instant = (bool) wpcom_site_has_feature( 'instant-search' );
+			// The free Search tier grants instant-search but cannot run AI
+			// Answers; free and paid Search do not coexist on Simple.
+			$is_free_search_plan = function_exists( 'wpcom_get_site_purchases' )
+				&& (bool) wp_list_filter( wpcom_get_site_purchases(), array( 'product_slug' => 'jetpack_search_free' ) );
+
+			$supports_search            = $has_instant && ! $is_free_search_plan;
+			$ai_search_requires_upgrade = ! $supports_search;
+		} else {
+			$search_plan = class_exists( Search_Plan::class ) ? new Search_Plan() : null;
+
+			// Entitlement: the plan includes some Search product (Classic or Instant).
+			$supports_search = $search_plan && $search_plan->supports_search();
+
+			// AI Answers only runs with the paid Search product provisioned. Mirror
+			// the gate the Search dashboard's AI Answers tab uses for its upsell:
+			// gated when the plan is free or lacks Instant Search.
+			$ai_search_requires_upgrade = ! ( $search_plan && $search_plan->supports_instant_search() && ! $search_plan->is_free_plan() );
+
+			// The free Search tier reports supports_search too, but its remedy for
+			// the gated AI Search row is still an upgrade — the settings page needs
+			// this flag to pick the right badge copy.
+			$is_free_search_plan = $supports_search && $search_plan->is_free_plan();
 		}
 
 		$stored = array();

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -184,6 +184,21 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 		// gated when the plan is free or lacks Instant Search.
 		$ai_search_requires_upgrade = ! ( $search_plan && $search_plan->supports_instant_search() && ! $search_plan->is_free_plan() );
 
+		// The free Search tier reports supports_search too, but its remedy for
+		// the gated AI Search row is still an upgrade — the settings page needs
+		// this flag to pick the right badge copy.
+		$is_free_search_plan = $supports_search && $search_plan->is_free_plan();
+
+		if ( ( new Host() )->is_wpcom_simple() && function_exists( 'wpcom_site_has_feature' ) ) {
+			// Search\Plan's cache never populates on Simple (its refresh signs a
+			// blog-token request), so read the WordPress.com feature gates directly.
+			$supports_search            = (bool) wpcom_site_has_feature( 'search' );
+			$ai_search_requires_upgrade = ! wpcom_site_has_feature( 'instant-search' );
+			// Everything granting instant-search on Simple is a paid product —
+			// the free Jetpack Search tier is not offered there.
+			$is_free_search_plan = false;
+		}
+
 		$stored = array();
 		foreach ( Jetpack_AI_Settings::FEATURE_OPTIONS as $key => $option ) {
 			$stored[ $key ] = (bool) get_option(
@@ -199,10 +214,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 			'plan'              => array(
 				'supports_ai'         => class_exists( Current_Plan::class ) && Current_Plan::supports( 'ai-assistant' ),
 				'supports_search'     => $supports_search,
-				// The free Search tier reports supports_search too, but its
-				// remedy for the gated AI Search row is still an upgrade — the
-				// settings page needs this flag to pick the right badge copy.
-				'is_free_search_plan' => $supports_search && $search_plan->is_free_plan(),
+				'is_free_search_plan' => $is_free_search_plan,
 			),
 			'master_enabled'    => Jetpack_AI_Settings::is_master_enabled(),
 			'features'          => array(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -12,11 +12,8 @@
  *
  * Unlike the MCP settings endpoint, nothing here proxies to WPCOM: the
  * settings are site-local wp_options, so the endpoint works the same on
- * Atomic and self-hosted sites. On WordPress.com Simple the route does not
- * register at all — Simple keeps the existing wp.com settings contract, and
- * with core settings REST also refusing these options there, the new
- * per-feature options stay unwritten on Simple while the reused SEO/Search
- * options keep their existing owning surfaces.
+ * every host. On WordPress.com Simple it is the only writable surface for
+ * these options — core settings REST refuses them there.
  *
  * @package automattic/jetpack
  */
@@ -65,15 +62,11 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	/**
 	 * Register routes.
 	 *
-	 * Not on WordPress.com Simple: the per-feature toggles and their write
-	 * endpoint apply to Atomic and self-hosted sites only, while Simple keeps
-	 * the existing wp.com settings contract.
+	 * Registered on every host, WordPress.com Simple included: the Hub's
+	 * WordPress Agent view reads and writes through this route wherever the
+	 * page loads (see the file header for Simple).
 	 */
 	public function register_routes() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
-			return;
-		}
-
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-simple-parity
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-hub-simple-parity
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Bring the AI Hub's Overview and WordPress Agent views to feature parity on WordPress.com Simple sites.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -370,20 +370,67 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	}
 
 	/**
-	 * On WordPress.com Simple the route must not register: Simple keeps the
-	 * existing wp.com settings contract, and the per-feature toggles apply to
-	 * Atomic and self-hosted sites only.
+	 * The route registers on WordPress.com Simple too: the Hub's WordPress
+	 * Agent view reads and writes through it wherever the page loads, and on
+	 * Simple it is the only writable surface for the options.
 	 */
-	public function test_route_is_not_registered_on_wpcom_simple() {
-		// Control: rebuilding the server off-Simple re-registers the route,
-		// proving the rebuild below exercises registration at all.
-		$this->rebuild_rest_server();
-		$this->assertArrayHasKey( self::ROUTE, $this->server->get_routes() );
-
+	public function test_route_is_registered_on_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		$this->rebuild_rest_server();
 
-		$this->assertArrayNotHasKey( self::ROUTE, $this->server->get_routes() );
+		$this->assertArrayHasKey( self::ROUTE, $this->server->get_routes() );
+	}
+
+	/**
+	 * On WordPress.com Simple the master switch is the jetpack_ai_enabled
+	 * option: POST writes it, GET reports it, and the jetpack_ai_enabled
+	 * filter every load point consults follows — with no internal-testing
+	 * scoping, since the controls always apply on Simple.
+	 */
+	public function test_post_master_switch_on_wpcom_simple() {
+		wp_set_current_user( self::$admin_id );
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->rebuild_rest_server();
+
+		$this->assertTrue( $this->dispatch( 'GET' )->get_data()['master_enabled'], 'Precondition: the master defaults on.' );
+
+		$data = $this->dispatch( 'POST', array( 'master_enabled' => false ) )->get_data();
+
+		$this->assertFalse( $data['master_enabled'] );
+		$this->assertFalse( (bool) get_option( Jetpack_AI_Settings::MASTER_OPTION, true ), 'The setter routed the write to the option, the master store on Simple.' );
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
+		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
+	}
+
+	/**
+	 * On WordPress.com Simple the per-feature toggles write their options and
+	 * the load-point predicate honors them — the same partial-POST semantics
+	 * as everywhere else, with no internal-testing scoping.
+	 */
+	public function test_post_features_on_wpcom_simple() {
+		wp_set_current_user( self::$admin_id );
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->rebuild_rest_server();
+
+		$data = $this->dispatch(
+			'POST',
+			array(
+				'features' => array(
+					'writing_assistant' => false,
+					'ai_seo'            => array( 'enabled' => false ),
+				),
+			)
+		)->get_data();
+
+		$this->assertFalse( $data['features']['writing_assistant']['enabled'] );
+		$this->assertFalse( $data['features']['ai_seo']['enabled'] );
+		// Untouched keys keep their defaults.
+		$this->assertTrue( $data['features']['image_editor']['enabled'] );
+
+		// The options actually changed and the load points read them on Simple.
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
+		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -287,6 +287,8 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$settings = $this->get_injected_settings();
 
 		$this->assertTrue( $settings['showFeaturesView'] );
+		// Internal-gated views are labelled for their internal audience.
+		$this->assertTrue( $settings['showGatedViewsBadge'] );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
 	}
 
@@ -350,7 +352,7 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 			function ( $config ) {
 				$config['showGatedViews'] = true;
 				$config['planInfo']       = array(
-					'name'      => 'Business',
+					'name'      => 'WordPress.com Business',
 					'renews_on' => '2027-08-30 00:00:00',
 				);
 
@@ -361,10 +363,32 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$settings = $this->get_injected_settings();
 
 		$this->assertTrue( $settings['showFeaturesView'] );
+		// Host-opened views carry no internal-audience badge.
+		$this->assertFalse( $settings['showGatedViewsBadge'] );
+		// The brand prefix is trimmed at the merge point for every producer.
 		$this->assertSame( 'Business', $settings['planName'] );
 		$this->assertSame( '2027-08-30 00:00:00', $settings['planRenewsOn'] );
 		// The key the host left out keeps its default.
 		$this->assertTrue( $settings['planAutoRenew'] );
+	}
+
+	/**
+	 * The Features view's link targets follow the host: wp-admin pages where
+	 * they exist, empty (hidden link) or the wordpress.com surface on Simple.
+	 */
+	public function test_link_targets_follow_the_host() {
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( 'admin.php?page=jetpack-search#/ai-answers', $settings['searchSettingsUrl'] );
+		$this->assertSame( 'admin.php?page=my-jetpack#/products', $settings['myJetpackUrl'] );
+		$this->assertStringContainsString( 'admin.php?page=jetpack#/traffic', $settings['seoSettingsUrl'] );
+
+		Constants::set_constant( 'IS_WPCOM', true );
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( '', $settings['searchSettingsUrl'] );
+		$this->assertSame( '', $settings['myJetpackUrl'] );
+		$this->assertStringStartsWith( 'https://wordpress.com/marketing/traffic/', $settings['seoSettingsUrl'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -319,10 +319,11 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		add_filter(
 			'jetpack_ai_admin_config',
 			function ( $config ) {
-				$config['mcpSettingsApi'] = array(
+				$config['mcpSettingsApi']    = array(
 					'path'   => '/wpcom/v2/sites/123/mcp-abilities',
 					'format' => 'wpcom',
 				);
+				$config['searchSettingsUrl'] = 'https://example.com/search-settings';
 
 				return $config;
 			}
@@ -337,14 +338,14 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 			),
 			$settings['mcpSettingsApi']
 		);
+		// The link targets ride the same filter, so hosts can retarget them.
+		$this->assertSame( 'https://example.com/search-settings', $settings['searchSettingsUrl'] );
 	}
 
 	/**
-	 * Hosts can precompute the Overview plan info — WordPress.com Simple
-	 * answers from its own store because My Jetpack's signed purchase lookup
-	 * cannot run there. A partial answer merges over the empty shape, and the
-	 * host's showGatedViews decision alone opens the views, with no
-	 * internal-testing environment in play.
+	 * Hosts can precompute the Overview plan info: a partial answer merges
+	 * over the empty shape, and the host's showGatedViews decision alone
+	 * opens the views — no internal-testing environment in play.
 	 */
 	public function test_plan_info_can_be_supplied_by_the_host() {
 		add_filter(

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -338,6 +338,36 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Hosts can precompute the Overview plan info — WordPress.com Simple
+	 * answers from its own store because My Jetpack's signed purchase lookup
+	 * cannot run there. A partial answer merges over the empty shape, and the
+	 * host's showGatedViews decision alone opens the views, with no
+	 * internal-testing environment in play.
+	 */
+	public function test_plan_info_can_be_supplied_by_the_host() {
+		add_filter(
+			'jetpack_ai_admin_config',
+			function ( $config ) {
+				$config['showGatedViews'] = true;
+				$config['planInfo']       = array(
+					'name'      => 'Business',
+					'renews_on' => '2027-08-30 00:00:00',
+				);
+
+				return $config;
+			}
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertTrue( $settings['showFeaturesView'] );
+		$this->assertSame( 'Business', $settings['planName'] );
+		$this->assertSame( '2027-08-30 00:00:00', $settings['planRenewsOn'] );
+		// The key the host left out keeps its default.
+		$this->assertTrue( $settings['planAutoRenew'] );
+	}
+
+	/**
 	 * The Scheduled tasks experience is registered as a default-off feature flag.
 	 */
 	public function test_scheduled_tasks_feature_flag_is_registered() {

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -508,15 +508,19 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * On WordPress.com Simple the owned features have no per-feature toggles,
-	 * so a stored off value cannot switch the SEO feature off there.
+	 * On WordPress.com Simple the owned toggles honor their stored values —
+	 * the feature-settings endpoint is the writable surface there — so a
+	 * stored off value switches the SEO feature off.
 	 */
-	public function test_seo_feature_forced_on_for_wpcom_simple() {
+	public function test_seo_feature_follows_its_option_on_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+
+		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled(), 'Defaults on with the master on.' );
+
 		update_option( 'jetpack_ai_seo_enabled', 0 );
 
-		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled() );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled() );
 	}
 
 	/**
@@ -531,19 +535,24 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * WordPress.com Simple has no per-feature toggles: the options Jetpack owns
-	 * are ignored there, so a stored `off` cannot switch a feature off. Simple
-	 * keeps the existing wp.com settings contract instead.
+	 * On WordPress.com Simple the owned toggles honor their stored values: the
+	 * feature-settings endpoint is the writable surface there, so a stored
+	 * `off` switches the feature off and the default keeps it on.
 	 */
-	public function test_owned_features_ignore_their_option_on_wpcom_simple() {
+	public function test_owned_features_follow_their_option_on_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		foreach ( Jetpack_AI_Settings::OWNED_FEATURES as $feature ) {
-			update_option( Jetpack_AI_Settings::FEATURE_OPTIONS[ $feature ], 0 );
-
 			$this->assertTrue(
 				Jetpack_AI_Settings::is_feature_enabled( $feature ),
-				"$feature should stay on for WordPress.com Simple"
+				"$feature should default on for WordPress.com Simple"
+			);
+
+			update_option( Jetpack_AI_Settings::FEATURE_OPTIONS[ $feature ], 0 );
+
+			$this->assertFalse(
+				Jetpack_AI_Settings::is_feature_enabled( $feature ),
+				"$feature should honor a stored off on WordPress.com Simple"
 			);
 		}
 	}


### PR DESCRIPTION

Follows #51661. Makes the Overview and WordPress Agent views work on WordPress.com Simple
the way they do elsewhere. Everything stays behind the `jetpack_mu_wpcom_load_jetpack_ai_hub`
filter (default off) — enabling Simple remains a one-line flip.

## Proposed changes

* Register `/wpcom/v2/jetpack-ai/feature-settings` on Simple and make the feature toggles
  honor their stored options there (the endpoint is their only writer on Simple).
* mu-wpcom: show every Hub view on Simple and supply the Overview plan info from the
  WordPress.com store (My Jetpack's purchase lookup can't run there).
* Host-aware config via `jetpack_ai_admin_config`: plan info, Search entitlement, link
  targets, and the internal-only tab badge — so Simple gets no dead wp-admin links and no
  "A12s only" badge.
* Link the Activity log to wordpress.com on both WordPress.com platforms.

## Related product discussion/links

* pdtkmj-4Vi-p2

## Does this pull request change what data or activity we track or use?

No new tracking; existing AI Hub events can fire from Simple once a host opts in.

## Testing instructions

Off-Simple regression (JN or Atomic on this branch):

* Jetpack → Jetpack AI, proxied: page behaves as on trunk.

WordPress.com Simple (sandbox):

* Install this branch's `jetpack` + `jetpack-mu-wpcom-plugin`, add
  `add_filter( 'jetpack_mu_wpcom_load_jetpack_ai_hub', '__return_true' );` to a sandbox
  mu-plugin.
* Jetpack → Jetpack AI: four tabs, no "A12s only" badge, plan card names the site's plan.
* WordPress Agent: rows load and save; toggling Writing Assistant off removes the editor AI
  surfaces; `feature-settings` returns 200 on GET and POST.
