### PR TITLE
Omnibar: add free domain upsell experiment

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: Add a "Free domain" upsell chip, shown in wp-admin and the omnibar, and hide the matching free-to-paid and monthly-to-annual sidebar notices for users in the omnibar upsell experiment treatment.

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-free-domain-upsell-experiment.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Resolves the calypso_omnibar_free_domain_upsell_20260825 experiment variation server-side.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Reads the omnibar free-domain upsell variation for the current user.
+ */
+class Free_Domain_Upsell_Experiment {
+
+	const EXPERIMENT_NAME = 'calypso_omnibar_free_domain_upsell_test';
+
+	/**
+	 * Which sidebar JITM the current user/site would qualify for, or null.
+	 *
+	 * @return string|null 'free_to_paid_plan', 'monthly_to_annual_plan', or null.
+	 */
+	public static function get_upsell_source() {
+		if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) ) {
+			return null;
+		}
+
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			return null;
+		}
+
+		if ( (bool) get_option( 'wpcom_is_staging_site' ) ) {
+			return null;
+		}
+
+		$host = wp_parse_url( home_url(), PHP_URL_HOST );
+		if ( ! is_string( $host ) || ! str_ends_with( $host, '.wordpress.com' ) ) {
+			return null;
+		}
+
+		$current_plan = self::get_current_plan();
+		if ( ! is_array( $current_plan ) ) {
+			return null;
+		}
+
+		if ( ! empty( $current_plan['is_free'] ) && empty( get_option( 'options' )['is_domain_only'] ) ) {
+			return 'free_to_paid_plan';
+		}
+
+		if ( str_ends_with( (string) ( $current_plan['product_slug'] ?? '' ), '-monthly' ) ) {
+			return 'monthly_to_annual_plan';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the current user/site is eligible for the omnibar free-domain upsell.
+	 *
+	 * @return bool
+	 */
+	public static function is_eligible() {
+		return null !== self::get_upsell_source();
+	}
+
+	/**
+	 * Whether the winning sidebar notice should be suppressed for this user.
+	 *
+	 * @param string $notice_id The id of the winning sidebar notice.
+	 * @return bool
+	 */
+	public static function should_suppress_sidebar_notice( $notice_id ) {
+		if ( ! in_array( $notice_id, array( 'free_to_paid_plan', 'monthly_to_annual_plan' ), true ) ) {
+			return false;
+		}
+
+		if ( ! self::is_eligible() ) {
+			return false;
+		}
+
+		return 'treatment' === self::get_variation();
+	}
+
+	/**
+	 * The current plan data for this blog, or null when unavailable.
+	 *
+	 * @return array|null
+	 */
+	private static function get_current_plan() {
+		if ( ! class_exists( '\WPCOM_Store_API' ) ) {
+			return null;
+		}
+
+		$plan = \WPCOM_Store_API::get_current_plan( get_current_blog_id() );
+
+		return is_array( $plan ) ? $plan : null;
+	}
+
+	/**
+	 * The current user's variation: 'control' or 'treatment'.
+	 *
+	 * @return string
+	 */
+	public static function get_variation() {
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return 'control';
+		}
+
+		$cache_key = 'free-domain-upsell-variation-' . $user_id;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (string) $cached;
+		}
+
+		$raw = self::fetch_variation();
+
+		if ( null === $raw ) {
+			return 'control';
+		}
+
+		$variation = self::normalize( $raw );
+		set_transient( $cache_key, $variation, HOUR_IN_SECONDS );
+
+		return $variation;
+	}
+
+	/**
+	 * Fetch the raw variation name from ExPlat, or null.
+	 *
+	 * @return string|null
+	 */
+	private static function fetch_variation() {
+		if ( ! ( new Host() )->is_wpcom_simple() ) {
+			return null;
+		}
+
+		if ( function_exists( '\ExPlat\assign_current_user' ) ) {
+			return \ExPlat\assign_current_user( self::EXPERIMENT_NAME );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Map any variation onto a known value; unknown/null becomes 'control'.
+	 *
+	 * @param string|null $variation The raw variation name.
+	 * @return string
+	 */
+	private static function normalize( $variation ) {
+		return 'treatment' === $variation ? 'treatment' : 'control';
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -16,4 +16,20 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			wpcomTrackEvent( 'wpcom_adminbar_command_palette_clicked' );
 		} );
 	}
+
+	const freeDomainUpsell = document.querySelector( '#wp-admin-bar-free-domain-upsell a' );
+	if ( freeDomainUpsell ) {
+		const source = window.wpcomAdminBarUpsellSource || 'wp_admin';
+		const props = {
+			upsell_id: 'omnibar-free-domain',
+			source,
+		};
+		if ( window.wpcomAdminBarFreeDomainUpsellSource ) {
+			props.upsell_source = window.wpcomAdminBarFreeDomainUpsellSource;
+		}
+		wpcomTrackEvent( 'wpcom_omnibar_upsell_impression', props );
+		freeDomainUpsell.addEventListener( 'click', () => {
+			wpcomTrackEvent( 'wpcom_omnibar_upsell_click', props );
+		} );
+	}
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.php
@@ -10,6 +10,7 @@
 use Automattic\Jetpack\Connection\Urls;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status;
 
@@ -76,6 +77,14 @@ function wpcom_enqueue_admin_bar_assets() {
 		plugins_url( 'build/wpcom-admin-bar/wpcom-admin-bar.css', Jetpack_Mu_Wpcom::BASE_FILE ),
 		array(),
 		$asset_file['version'] ?? filemtime( Jetpack_Mu_Wpcom::BASE_DIR . 'build/wpcom-admin-bar/wpcom-admin-bar.css' )
+	);
+
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+	wp_add_inline_script(
+		'wpcom-admin-bar',
+		'var wpcomAdminBarUpsellSource = ' . wp_json_encode( wpcom_admin_bar_upsell_get_source(), JSON_HEX_TAG | JSON_HEX_AMP ) . ';'
+		. 'var wpcomAdminBarFreeDomainUpsellSource = ' . wp_json_encode( Free_Domain_Upsell_Experiment::get_upsell_source(), JSON_HEX_TAG | JSON_HEX_AMP ) . ';',
+		'before'
 	);
 
 	/**
@@ -550,3 +559,68 @@ function wpcom_add_stats_to_site_menu( $wp_admin_bar ) {
 	);
 }
 add_action( 'admin_bar_menu', 'wpcom_add_stats_to_site_menu', 40 );
+
+/**
+ * Which source the admin bar upsell is rendering on, for tracking.
+ *
+ * @return string One of 'site_frontend', 'site_editor', 'post_editor', 'wp_admin'.
+ */
+function wpcom_admin_bar_upsell_get_source() {
+	if ( ! is_admin() ) {
+		return 'site_frontend';
+	}
+
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	if ( $screen && 'site-editor' === $screen->id ) {
+		return 'site_editor';
+	}
+	if ( $screen && $screen->is_block_editor() ) {
+		return 'post_editor';
+	}
+
+	return 'wp_admin';
+}
+
+/**
+ * Adds a "Free domain" upsell chip to the admin bar for users in the treatment
+ * of the omnibar upsell experiment.
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar core object.
+ */
+function wpcom_add_free_domain_upsell( $wp_admin_bar ) {
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+
+	if ( ! Free_Domain_Upsell_Experiment::is_eligible() ) {
+		return;
+	}
+
+	if ( 'treatment' !== Free_Domain_Upsell_Experiment::get_variation() ) {
+		return;
+	}
+
+	$icon = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M18.9397 9.87999L15.4197 6.06999L15.3597 6.00999C15.2897 5.93999 15.1997 5.89999 15.0997 5.89999H8.87973C8.77973 5.89999 8.68973 5.93999 8.61973 6.00999L5.05973 9.87999C4.93973 10.01 4.93973 10.21 5.05973 10.34L11.5397 17.86C11.6497 17.99 11.8197 18.07 11.9997 18.07C12.1797 18.07 12.3397 17.99 12.4597 17.86L18.9397 10.34C19.0597 10.21 19.0497 10.01 18.9397 9.87999ZM15.4097 7.53999L17.3297 9.63999H15.1697L15.4097 7.53999ZM14.4297 6.83999L14.1097 9.63999H10.2897L9.64973 6.83999H14.4297ZM8.68973 7.42999L9.19973 9.63999H6.66973L8.68973 7.42999ZM6.61973 10.6H9.42973L10.8397 15.49L6.61973 10.6ZM12.0397 15.87L10.5297 10.6H13.8597L12.0397 15.87ZM14.9697 10.6H17.3797L13.3697 15.24L14.9697 10.6Z" fill="currentColor" />
+	</svg>';
+
+	$wp_admin_bar->add_menu(
+		array(
+			'id'     => 'free-domain-upsell',
+			'parent' => null,
+			'title'  => '<span class="ab-icon" aria-hidden="true">' . $icon . '</span><span class="ab-label">' . esc_html__( 'Free domain', 'jetpack-mu-wpcom' ) . '</span>',
+			'href'   => add_query_arg(
+				array(
+					'siteSlug' => wpcom_get_site_slug(),
+					'ref'      => 'omnibar-free-domain',
+				),
+				'https://wordpress.com/setup/domain-and-plan'
+			),
+			'meta'   => array(
+				'class'         => 'free-domain-upsell',
+				'title'         => __( 'Free domain with an annual plan', 'jetpack-mu-wpcom' ),
+				'menu_title'    => __( 'Free domain', 'jetpack-mu-wpcom' ),
+				'upsell_source' => Free_Domain_Upsell_Experiment::get_upsell_source(),
+			),
+		)
+	);
+}
+add_action( 'admin_bar_menu', 'wpcom_add_free_domain_upsell', 500 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -450,3 +450,76 @@
 		}
 	}
 }
+
+#wpadminbar #wp-admin-bar-free-domain-upsell {
+	display: flex;
+	align-items: center;
+
+	> .ab-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		height: 24px;
+		margin-inline: 6px;
+		padding-inline: 4px 8px;
+		border-radius: 4px;
+		background: rgba(56, 88, 233, 0.22);
+		box-shadow: inset 0 0 0 1px rgba(120, 150, 255, 0.45);
+		color: #dcdcde;
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 24px;
+		white-space: nowrap;
+		transition: background 0.12s linear, box-shadow 0.12s linear, color 0.12s linear;
+
+		.ab-icon {
+			display: inline-flex;
+			align-items: center;
+			height: auto;
+			margin: 0;
+			padding: 0;
+			font-size: 0;
+
+			svg {
+				display: block;
+				fill: #8ba4ff;
+				transition: fill 0.12s linear;
+			}
+		}
+
+		.ab-label {
+			height: auto;
+			line-height: 24px;
+		}
+
+		// Keep the full pill (icon + label) on mobile, where core hides
+		// ab-labels and squeezes items to 46px.
+		@media screen and (max-width: 782px) {
+			width: auto;
+			height: 24px;
+			margin-block: 11px;
+
+			.ab-label {
+				display: inline;
+			}
+
+			.ab-icon {
+				width: auto;
+				height: auto;
+				padding: 0;
+				font-size: 0;
+			}
+		}
+	}
+
+	&:hover > .ab-item,
+	> .ab-item:focus-visible {
+		background: rgba(56, 88, 233, 0.42);
+		box-shadow: inset 0 0 0 1px rgba(150, 175, 255, 0.8);
+		color: #fff;
+
+		.ab-icon svg {
+			fill: #b8c8ff;
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php
@@ -10,6 +10,26 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
+/**
+ * Hides the masterbar-rendered upsell nudge for omnibar upsell experiment treatment users.
+ *
+ * @param array|null $nudge The nudge data, or null to render nothing.
+ * @return array|null
+ */
+function wpcom_suppress_upsell_nudge_for_free_domain_experiment( $nudge ) {
+	if ( ! isset( $nudge['id'] ) ) {
+		return $nudge;
+	}
+
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( $nudge['id'] ) ) {
+		return null;
+	}
+
+	return $nudge;
+}
+add_filter( 'jetpack_masterbar_upsell_nudge', 'wpcom_suppress_upsell_nudge_for_free_domain_experiment' );
+
 remove_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option' );
 $is_wp_admin = get_option( 'wpcom_admin_interface' ) === 'wp-admin';
 add_filter( 'pre_option_wpcom_admin_interface', 'wpcom_admin_interface_pre_get_option', 10 );
@@ -101,6 +121,11 @@ function wpcom_get_sidebar_notice() {
 		'id'            => $message->id,
 		'tracks'        => $message->tracks ?? null,
 	);
+
+	require_once __DIR__ . '/../../common/class-free-domain-upsell-experiment.php';
+	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Free_Domain_Upsell_Experiment::should_suppress_sidebar_notice( $cached_notice['id'] ) ) {
+		$cached_notice = null;
+	}
 
 	return $cached_notice;
 }

--- a/projects/packages/masterbar/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/packages/masterbar/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin menu: Add the jetpack_masterbar_upsell_nudge filter so the rendered upsell nudge can be suppressed.

--- a/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
+++ b/projects/packages/masterbar/src/admin-menu/class-admin-menu.php
@@ -174,6 +174,9 @@ class Admin_Menu extends Base_Admin_Menu {
 		}
 
 		$nudge = $this->get_upsell_nudge();
+
+		$nudge = apply_filters( 'jetpack_masterbar_upsell_nudge', $nudge );
+
 		if ( ! $nudge ) {
 			return;
 		}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -33,7 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	 *
 	 * @var string[]
 	 */
-	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'command-palette', 'comments', 'new-content', 'my-account', 'agents-manager', 'agents-manager-ai-chat' );
+	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'command-palette', 'comments', 'new-content', 'my-account', 'agents-manager', 'agents-manager-ai-chat', 'free-domain-upsell' );
 
 	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Bar constructor.

--- a/projects/plugins/jetpack/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/plugins/jetpack/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin bar: Return the WordPress.com free domain upsell chip from the site admin-bar endpoint so the omnibar renders it.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-omnibar-free-domain-upsell-chip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin bar: Add a "Free domain" upsell chip, shown in wp-admin and the omnibar, and hide the matching free-to-paid and monthly-to-annual sidebar notices for users in the omnibar upsell experiment treatment.


### PR DESCRIPTION
Part of DOTMSD-1529

Reworked version of https://github.com/Automattic/jetpack/pull/51565

## Proposed changes

- Add a "Free domain" chip to the admin bar under a new omnibar upsell experiment (`calypso_omnibar_free_domain_upsell_test`, TODO: replace with real experiment!). It links to `/setup/domain-and-plan`.
- Hide the `free_to_paid_plan` and `monthly_to_annual_plan` JITM sidebar notices when the upsell is shown in the omnibar.

## Related product discussion/links


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

WIP