### PR TITLE
Premium Analytics: name the selected period on the date range control

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-date-range-natural-language
+++ b/projects/packages/premium-analytics/changelog/update-date-range-natural-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Date range control: name a custom range covering a whole month or year by that period, and spell the dates out in the button's tooltip.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -16,6 +16,7 @@ import {
 	formatDateRange,
 	formatDateRangeCompact,
 	formatDateRangeMinimal,
+	formatDateRangeNatural,
 } from '../format-date-range';
 
 // The en dash between thin spaces that CLDR puts between the ends of a range.
@@ -361,5 +362,89 @@ describe( 'formatDateRangeMinimal', () => {
 				formatDateRangeMinimal( { from: utcDate( 2026, 7, 13 ), to: utcDate( 2026, 7, 26 ) } )
 			).toBe( `13/07${ FALLBACK_SEP }26/07` );
 		} );
+	} );
+} );
+
+describe( 'formatDateRangeNatural', () => {
+	beforeAll( () => jest.useFakeTimers().setSystemTime( utcDate( 2026, 8, 13 ) ) );
+	afterAll( () => jest.useRealTimers() );
+
+	describe( 'en_US site', () => {
+		beforeEach( () => setSettings( EN_US_SETTINGS ) );
+
+		it( 'names a whole calendar month', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2025, 3, 1 ), to: utcDate( 2025, 3, 31 ) } )
+			).toBe( 'March 2025' );
+		} );
+
+		// The label is alone on the control, so the year is not redundant the way
+		// it is in a range with both ends on screen.
+		it( 'keeps the year on a whole month of the current year', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2026, 3, 1 ), to: utcDate( 2026, 3, 31 ) } )
+			).toBe( 'March 2026' );
+		} );
+
+		it( 'names a whole calendar year', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2025, 1, 1 ), to: utcDate( 2025, 12, 31 ) } )
+			).toBe( '2025' );
+		} );
+
+		it( 'measures the month by its own length', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2024, 2, 1 ), to: utcDate( 2024, 2, 29 ) } )
+			).toBe( 'February 2024' );
+		} );
+
+		it( 'names the month whatever time of day the range ends at', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2025, 3, 1 ), to: utcDate( 2025, 3, 31, 23 ) } )
+			).toBe( 'March 2025' );
+		} );
+
+		it( 'falls back on a range that stops short of the month', () => {
+			const range = { from: utcDate( 2026, 3, 1 ), to: utcDate( 2026, 3, 30 ) };
+
+			expect( formatDateRangeNatural( range ) ).toBe( formatDateRangeMinimal( range ) );
+		} );
+
+		it( 'falls back on February shortened to 28 days in a leap year', () => {
+			const range = { from: utcDate( 2024, 2, 1 ), to: utcDate( 2024, 2, 28 ) };
+
+			expect( formatDateRangeNatural( range ) ).toBe( formatDateRangeMinimal( range ) );
+		} );
+
+		// Two whole months name no single period, and the design asks for the
+		// shortest form rather than a made-up one.
+		it( 'falls back across two whole months', () => {
+			const range = { from: utcDate( 2026, 3, 1 ), to: utcDate( 2026, 4, 30 ) };
+
+			expect( formatDateRangeNatural( range ) ).toBe( formatDateRangeMinimal( range ) );
+		} );
+
+		it( 'falls back on a month-long window that sits between two months', () => {
+			const range = { from: utcDate( 2026, 3, 15 ), to: utcDate( 2026, 4, 14 ) };
+
+			expect( formatDateRangeNatural( range ) ).toBe( formatDateRangeMinimal( range ) );
+		} );
+	} );
+
+	describe( 'es_ES site', () => {
+		beforeEach( () => setSettings( ES_ES_SETTINGS ) );
+
+		it( 'names a whole month the way the site orders its dates', () => {
+			expect(
+				formatDateRangeNatural( { from: utcDate( 2025, 3, 1 ), to: utcDate( 2025, 3, 31 ) } )
+			).toBe( 'marzo de 2025' );
+		} );
+	} );
+
+	it( 'returns an empty string when an end is missing', () => {
+		setSettings( EN_US_SETTINGS );
+
+		expect( formatDateRangeNatural( { from: utcDate( 2025, 3, 1 ), to: undefined } ) ).toBe( '' );
+		expect( formatDateRangeNatural() ).toBe( '' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -29,6 +29,10 @@ describe( 'formatDate', () => {
 			expect( formatDate( JUNE_21, 'short' ) ).toBe( 'June 21' );
 		} );
 
+		it( 'formats "monthYear" as the site format without its day', () => {
+			expect( formatDate( JUNE_21, 'monthYear' ) ).toBe( 'June 2025' );
+		} );
+
 		it( 'formats "year"', () => {
 			expect( formatDate( JUNE_21, 'year' ) ).toBe( '2025' );
 		} );
@@ -59,6 +63,10 @@ describe( 'formatDate', () => {
 			expect( formatDate( JUNE_21, 'short' ) ).toBe( '21 de junio' );
 		} );
 
+		it( 'drops the leading "<day> de" for "monthYear"', () => {
+			expect( formatDate( JUNE_21, 'monthYear' ) ).toBe( 'junio de 2025' );
+		} );
+
 		it( 'keeps "iso" untranslated so it stays machine-readable', () => {
 			expect( formatDate( JUNE_21, 'iso' ) ).toBe( '2025-06-21' );
 		} );
@@ -72,6 +80,12 @@ describe( 'formatDate', () => {
 		setSettings( settingsFor( 'year-only-test', 'Y' ) );
 
 		expect( formatDate( JUNE_21, 'short' ) ).toBe( '2025' );
+	} );
+
+	it( 'falls back to the site format when removing the day leaves nothing', () => {
+		setSettings( settingsFor( 'day-only-test', 'j' ) );
+
+		expect( formatDate( JUNE_21, 'monthYear' ) ).toBe( '21' );
 	} );
 
 	it( 'does not add a second weekday when the site format already names one', () => {

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/php-format.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/php-format.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { withShortMonth, withWeekday, withoutYear } from '../php-format';
+import { withShortMonth, withWeekday, withoutDay, withoutYear } from '../php-format';
 
 describe( 'withoutYear', () => {
 	// Real `date_format` defaults taken from the WordPress core language packs,
@@ -113,5 +113,56 @@ describe( 'withWeekday', () => {
 		// the weekday token, so both formats still need a weekday put in front.
 		expect( withWeekday( 'j \\d\\e F \\d\\e Y' ) ).toBe( 'l, j \\d\\e F \\d\\e Y' );
 		expect( withWeekday( '\\l\\a j F' ) ).toBe( 'l, \\l\\a j F' );
+	} );
+} );
+
+describe( 'withoutDay', () => {
+	it( 'drops a day and the separator that follows it', () => {
+		expect( withoutDay( 'F j, Y' ) ).toBe( 'F Y' );
+	} );
+
+	it( 'drops a trailing day and the separator that introduces it', () => {
+		expect( withoutDay( 'Y-m-d' ) ).toBe( 'Y-m' );
+	} );
+
+	it( 'removes the day from an all-numeric format', () => {
+		expect( withoutDay( 'd/m/Y' ) ).toBe( 'm/Y' );
+	} );
+
+	it( 'drops the words a leading day introduces', () => {
+		// es_ES. The first "de" belongs to the day, the second to the year.
+		expect( withoutDay( 'j \\d\\e F \\d\\e Y' ) ).toBe( 'F \\d\\e Y' );
+	} );
+
+	it( 'drops the ordinal suffix along with the day it trails', () => {
+		expect( withoutDay( 'jS F Y' ) ).toBe( 'F Y' );
+	} );
+
+	it( 'drops the ordinal dot of a day-first numeric format', () => {
+		// Finnish and Czech. The dot marks the day as ordinal, so it goes too.
+		expect( withoutDay( 'j.n.Y' ) ).toBe( 'n.Y' );
+		expect( withoutDay( 'j. n. Y' ) ).toBe( 'n. Y' );
+	} );
+
+	it( 'drops a prefix bound to the month by the day it needed', () => {
+		// he_IL. "בF" reads "in March", which only a dated form asks for.
+		expect( withoutDay( 'j בF Y' ) ).toBe( 'F Y' );
+	} );
+
+	it( 'drops the weekday, which names no month either', () => {
+		expect( withoutDay( 'l, F j, Y' ) ).toBe( 'F Y' );
+		expect( withoutDay( 'D, d M Y' ) ).toBe( 'M Y' );
+	} );
+
+	it( 'leaves an escaped day character alone', () => {
+		expect( withoutDay( '\\j F Y' ) ).toBe( '\\j F Y' );
+	} );
+
+	it( 'returns the format unchanged when it carries no day', () => {
+		expect( withoutDay( 'F Y' ) ).toBe( 'F Y' );
+	} );
+
+	it( 'returns an empty string when the format is only a day', () => {
+		expect( withoutDay( 'j' ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
@@ -110,3 +110,97 @@ export const formatDateRangeMinimal = ( range?: DateRange ): string => {
 
 	return formatRange( isCurrentYear ? 'compactNoYear' : 'compact', range );
 };
+
+/** A site-local calendar date, as the parts a boundary check compares. */
+type CalendarDate = {
+	year: number;
+	month: number;
+	day: number;
+};
+
+/**
+ * Read a date as its site-local calendar parts.
+ *
+ * Through the ISO form, since the `Date` getters answer in the browser's
+ * timezone and would name a different day for anyone offset from the site.
+ *
+ * @param date - The instant to read.
+ * @return Its year, 1-based month, and day of the month.
+ */
+function toCalendarDate( date: Date ): CalendarDate {
+	const [ year, month, day ] = formatDate( date, 'iso' ).split( '-' ).map( Number );
+
+	return { year, month, day };
+}
+
+/**
+ * The length of a calendar month.
+ *
+ * @param date - Any date in the month.
+ * @return Its number of days.
+ */
+function getMonthLength( date: CalendarDate ): number {
+	// Day zero of the next month is the last day of this one.
+	return new Date( Date.UTC( date.year, date.month, 0 ) ).getUTCDate();
+}
+
+/**
+ * Whether the range covers one calendar month, first day to last.
+ *
+ * @param from - The range's start, in calendar parts.
+ * @param to   - The range's end, in calendar parts.
+ * @return Whether the range is that month.
+ */
+function isWholeMonth( from: CalendarDate, to: CalendarDate ): boolean {
+	return (
+		from.year === to.year &&
+		from.month === to.month &&
+		from.day === 1 &&
+		to.day === getMonthLength( to )
+	);
+}
+
+/**
+ * Whether the range covers one calendar year, January 1 to December 31.
+ *
+ * @param from - The range's start, in calendar parts.
+ * @param to   - The range's end, in calendar parts.
+ * @return Whether the range is that year.
+ */
+function isWholeYear( from: CalendarDate, to: CalendarDate ): boolean {
+	return (
+		from.year === to.year && from.month === 1 && from.day === 1 && to.month === 12 && to.day === 31
+	);
+}
+
+/**
+ * Format a date range as the period it names, where it names one.
+ *
+ * A range covering exactly one calendar month or year reads as that month or
+ * year, and anything else falls back to `formatDateRangeMinimal`. Both forms
+ * keep the year, the current one included: this label is the only thing naming
+ * the period on the control it sits on.
+ *
+ * @param range - The range to format.
+ * @return The formatted range, or `''` when `range`, `from`, or `to` is missing.
+ */
+export const formatDateRangeNatural = ( range?: DateRange ): string => {
+	const { from, to } = range ?? {};
+
+	if ( ! from || ! to ) {
+		return '';
+	}
+
+	const start = toCalendarDate( from );
+	const end = toCalendarDate( to );
+
+	if ( isWholeYear( start, end ) ) {
+		return formatDate( from, 'year' );
+	}
+
+	if ( isWholeMonth( start, end ) ) {
+		return formatDate( from, 'monthYear' );
+	}
+
+	return formatDateRangeMinimal( range );
+};

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -6,7 +6,7 @@ import { dateI18n, getSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { intlLocale } from './elide-range';
-import { hasToken, withShortMonth, withWeekday, withoutYear } from './php-format';
+import { hasToken, withShortMonth, withWeekday, withoutDay, withoutYear } from './php-format';
 
 /** Fixed because this format backs form values and query parameters. */
 const ISO_FORMAT = 'Y-m-d';
@@ -19,6 +19,7 @@ export type DateFormatName =
 	| 'compact'
 	| 'compactNoYear'
 	| 'short'
+	| 'monthYear'
 	| 'year'
 	| 'iso'
 	| 'full'
@@ -65,6 +66,10 @@ function formatFor( name: DateFormatName ): string {
 
 	if ( name === 'short' ) {
 		return withoutYearFormat;
+	}
+
+	if ( name === 'monthYear' ) {
+		return withoutDay( siteFormat ) || siteFormat;
 	}
 
 	if ( name === 'full' ) {

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -9,5 +9,6 @@ export {
 	formatDateRange,
 	formatDateRangeCompact,
 	formatDateRangeMinimal,
+	formatDateRangeNatural,
 } from './format-date-range';
 export { formatDateRangeLong } from './format-date-range-long';

--- a/projects/packages/premium-analytics/packages/formatters/src/date/php-format.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/php-format.ts
@@ -12,6 +12,9 @@ const WEEKDAY_TOKENS = new Set( [ 'l', 'D', 'N', 'w' ] );
 /** Full weekday name, the form a date-scale label leads with. */
 const WEEKDAY_FORMAT = 'l';
 
+/** Tokens that render a day of the month: unpadded, padded, and its ordinal suffix. */
+const DAY_TOKENS = new Set( [ 'j', 'd', 'S' ] );
+
 /** Textual month, spelled out and abbreviated. */
 const MONTH_FULL_TOKEN = 'F';
 const MONTH_SHORT_TOKEN = 'M';
@@ -165,4 +168,82 @@ export function withWeekday( phpFormat: string ): string {
 	}
 
 	return `${ WEEKDAY_FORMAT }${ WEEKDAY_SEPARATOR }${ phpFormat }`;
+}
+
+/**
+ * The first token at or after `from`, or the segment count where there is none.
+ *
+ * @param segments - The segments to scan.
+ * @param from     - Index to start at.
+ * @return The token's index.
+ */
+function nextTokenAt( segments: Segment[], from: number ): number {
+	let at = from;
+	while ( at < segments.length && ! segments[ at ].isToken ) {
+		at++;
+	}
+
+	return at;
+}
+
+/**
+ * The start of the run of literals that introduces the token at `index`.
+ *
+ * @param segments - The segments to scan.
+ * @param index    - The token's index.
+ * @return The run's first index, or `index` where no literal precedes it.
+ */
+function literalRunStart( segments: Segment[], index: number ): number {
+	let at = index - 1;
+	while ( at >= 0 && ! segments[ at ].isToken ) {
+		at--;
+	}
+
+	return at + 1;
+}
+
+/**
+ * Remove the day from a PHP format string, with its adjoining punctuation.
+ *
+ * The weekday goes too: neither has anything to name in a month-and-year label.
+ * The run to remove is the one after the day (`F j, Y` → `F Y`), or the one
+ * before it where nothing follows (`Y-m-d` → `Y-m`).
+ *
+ * @param phpFormat - PHP `date()` format string.
+ * @return The format without its day, or unchanged when it has none.
+ */
+export function withoutDay( phpFormat: string ): string {
+	const segments = toSegments( phpFormat );
+	const isDay = ( segment: Segment ): boolean =>
+		segment.isToken && ( DAY_TOKENS.has( segment.char ) || WEEKDAY_TOKENS.has( segment.char ) );
+	const dropped = new Set< number >();
+
+	for ( let index = 0; index < segments.length; index++ ) {
+		if ( ! isDay( segments[ index ] ) ) {
+			continue;
+		}
+
+		// `jS` spells the day and its suffix as two adjacent tokens.
+		let last = index;
+		while ( last + 1 < segments.length && isDay( segments[ last + 1 ] ) ) {
+			last++;
+		}
+
+		const following = nextTokenAt( segments, last + 1 );
+		const [ start, end ] =
+			following < segments.length
+				? [ index, following ]
+				: [ literalRunStart( segments, index ), last + 1 ];
+
+		for ( let at = start; at < end; at++ ) {
+			dropped.add( at );
+		}
+
+		index = last;
+	}
+
+	return segments
+		.filter( ( _, at ) => ! dropped.has( at ) )
+		.map( segment => segment.source )
+		.join( '' );
 }

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -6,6 +6,7 @@ export {
 	formatDateRange,
 	formatDateRangeCompact,
 	formatDateRangeMinimal,
+	formatDateRangeNatural,
 	formatDateRangeLong,
 	type DateFormatName,
 } from './date';

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -14,7 +14,7 @@ import {
 	type StepDirection,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
-import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
+import { formatDateRangeNatural } from '@jetpack-premium-analytics/formatters';
 import { BaseControl } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
 import { flushSync } from '@wordpress/element';
@@ -294,7 +294,7 @@ export function DateFiltersPanel( {
 			range,
 			committedRange,
 			customLabel: __( 'Custom', 'jetpack-premium-analytics-pkg' ),
-			formatRange: formatDateRangeMinimal,
+			formatRange: formatDateRangeNatural,
 		} );
 	}, [
 		appliedRange,

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-filter/__tests__/date-range-filter.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-filter/__tests__/date-range-filter.test.tsx
@@ -9,6 +9,11 @@ const APPLIED_RANGE: DateRange = {
 	to: new Date( 2026, 6, 9, 23, 59, 59, 999 ),
 };
 
+const JULY_2026: DateRange = {
+	from: new Date( 2026, 6, 1, 0, 0, 0, 0 ),
+	to: new Date( 2026, 6, 31, 23, 59, 59, 999 ),
+};
+
 function renderFilter( overrides: Partial< Parameters< typeof DateRangeFilter >[ 0 ] > = {} ) {
 	const props = {
 		presetId: 'last-7-days' as const,
@@ -60,6 +65,24 @@ describe( 'DateRangeFilter', () => {
 
 		await user.keyboard( '{ArrowLeft}' );
 		expect( screen.getByRole( 'button', { name: '12 months' } ) ).toHaveFocus();
+	} );
+
+	// A trigger holding a range is wrapped in its tooltip, and the composite item
+	// inside it still has to answer to the toolbar's arrow keys.
+	it( 'moves focus to the custom trigger once it names a period', async () => {
+		const user = userEvent.setup();
+		renderFilter( {
+			presetId: 'custom',
+			appliedPresetId: 'custom',
+			range: JULY_2026,
+			appliedRange: JULY_2026,
+		} );
+		await flushCompositeItems();
+
+		await user.tab();
+		await user.keyboard( '{End}' );
+
+		expect( screen.getByRole( 'button', { name: 'July 2026' } ) ).toHaveFocus();
 	} );
 
 	it( 'applies a preset immediately on click', async () => {

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/date-range-popover.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/date-range-popover.test.tsx
@@ -8,6 +8,11 @@ const APPLIED_RANGE: DateRange = {
 	to: new Date( 2026, 6, 9, 23, 59, 59, 999 ),
 };
 
+const JULY_2026: DateRange = {
+	from: new Date( 2026, 6, 1, 0, 0, 0, 0 ),
+	to: new Date( 2026, 6, 31, 23, 59, 59, 999 ),
+};
+
 function renderPopover( overrides: Partial< Parameters< typeof DateRangePopover >[ 0 ] > = {} ) {
 	const props = {
 		presetId: 'last-30-days' as const,
@@ -29,6 +34,15 @@ function renderPopover( overrides: Partial< Parameters< typeof DateRangePopover 
 
 function getTrigger() {
 	return screen.getByRole( 'button', { name: 'Custom' } );
+}
+
+function renderWholeMonth() {
+	return renderPopover( {
+		presetId: 'custom',
+		appliedPresetId: 'custom',
+		range: JULY_2026,
+		appliedRange: JULY_2026,
+	} );
 }
 
 describe( 'DateRangePopover', () => {
@@ -87,9 +101,26 @@ describe( 'DateRangePopover', () => {
 		expect( screen.getByRole( 'button', { name: 'Custom' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'labels the trigger with the applied custom range', () => {
+	it( 'names the period a custom range covers', () => {
+		renderWholeMonth();
+
+		expect( screen.getByRole( 'button', { name: 'July 2026' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'labels the trigger with the range itself where it names no period', () => {
 		renderPopover( { presetId: 'custom', appliedPresetId: 'custom' } );
 
 		expect( screen.queryByRole( 'button', { name: 'Custom' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'spells the exact dates out in the trigger tooltip', async () => {
+		const user = userEvent.setup();
+		renderWholeMonth();
+
+		await user.hover( screen.getByRole( 'button', { name: 'July 2026' } ) );
+
+		await expect(
+			screen.findByRole( 'tooltip', undefined, { timeout: 3000 } )
+		).resolves.toHaveTextContent( /July 1.+31, 2026/ );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/get-custom-trigger-state.test.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/get-custom-trigger-state.test.ts
@@ -1,4 +1,18 @@
-import { getCustomTriggerLabel, getCustomTriggerState } from '../get-custom-trigger-state';
+import {
+	getCustomTriggerLabel,
+	getCustomTriggerRange,
+	getCustomTriggerState,
+} from '../get-custom-trigger-state';
+
+const stagedRange = {
+	from: new Date( '2026-07-05T00:00:00.000Z' ),
+	to: new Date( '2026-07-10T23:59:59.000Z' ),
+};
+
+const committedRange = {
+	from: new Date( '2026-06-01T00:00:00.000Z' ),
+	to: new Date( '2026-06-30T23:59:59.000Z' ),
+};
 
 describe( 'getCustomTriggerState', () => {
 	it( 'returns idle when a preset is applied and there is no custom draft', () => {
@@ -73,16 +87,6 @@ describe( 'getCustomTriggerLabel', () => {
 	const formatRange = ( { from, to }: { from?: Date; to?: Date } ) =>
 		`${ from?.toISOString() ?? '' }–${ to?.toISOString() ?? '' }`;
 
-	const stagedRange = {
-		from: new Date( '2026-07-05T00:00:00.000Z' ),
-		to: new Date( '2026-07-10T23:59:59.000Z' ),
-	};
-
-	const committedRange = {
-		from: new Date( '2026-06-01T00:00:00.000Z' ),
-		to: new Date( '2026-06-30T23:59:59.000Z' ),
-	};
-
 	it( 'shows the staged range while a custom draft is open', () => {
 		expect(
 			getCustomTriggerLabel( {
@@ -119,5 +123,25 @@ describe( 'getCustomTriggerLabel', () => {
 				formatRange,
 			} )
 		).toBe( customLabel );
+	} );
+} );
+
+describe( 'getCustomTriggerRange', () => {
+	it( 'holds the staged range while a custom draft is open', () => {
+		expect(
+			getCustomTriggerRange( { triggerState: 'staged', range: stagedRange, committedRange } )
+		).toBe( stagedRange );
+	} );
+
+	it( 'holds the committed range once the custom draft is applied', () => {
+		expect(
+			getCustomTriggerRange( { triggerState: 'applied', range: stagedRange, committedRange } )
+		).toBe( committedRange );
+	} );
+
+	it( 'holds no range while a preset drives one', () => {
+		expect(
+			getCustomTriggerRange( { triggerState: 'idle', range: committedRange, committedRange } )
+		).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
@@ -3,8 +3,8 @@
  */
 import { PRESET_CUSTOM, type PrimaryPresetId } from '@jetpack-premium-analytics/datetime';
 import { Button, DateRangeCalendar, Icon, Stack } from '@jetpack-premium-analytics/externals';
-import { formatDateRangeMinimal } from '@jetpack-premium-analytics/formatters';
-import { Composite, Dropdown } from '@wordpress/components';
+import { formatDateRange, formatDateRangeNatural } from '@jetpack-premium-analytics/formatters';
+import { Composite, Dropdown, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { chevronDown } from '@wordpress/icons';
 import clsx from 'clsx';
@@ -13,7 +13,11 @@ import { useState, useCallback, useRef } from 'react';
  * Internal dependencies
  */
 import { DateRangeInput } from '../date-range-input';
-import { getCustomTriggerLabel, getCustomTriggerState } from './get-custom-trigger-state';
+import {
+	getCustomTriggerLabel,
+	getCustomTriggerRange,
+	getCustomTriggerState,
+} from './get-custom-trigger-state';
 import './date-range-filter.scss';
 
 /**
@@ -241,8 +245,12 @@ export function DateRangePopover( {
 		range,
 		committedRange,
 		customLabel: __( 'Custom', 'jetpack-premium-analytics-pkg' ),
-		formatRange: formatDateRangeMinimal,
+		formatRange: formatDateRangeNatural,
 	} );
+
+	// The label names the period, so its dates need somewhere else to live: the
+	// section header subtitle that used to spell them out is gone (WOOA7S-2027).
+	const triggerRange = getCustomTriggerRange( { triggerState, range, committedRange } );
 
 	return (
 		<Dropdown
@@ -266,7 +274,13 @@ export function DateRangePopover( {
 					</Button>
 				);
 
-				return triggerAsCompositeItem ? <Composite.Item render={ trigger } /> : trigger;
+				const item = triggerAsCompositeItem ? <Composite.Item render={ trigger } /> : trigger;
+
+				return triggerRange ? (
+					<Tooltip text={ formatDateRange( triggerRange ) }>{ item }</Tooltip>
+				) : (
+					item
+				);
 			} }
 			renderContent={ ( { onClose } ) => (
 				<DateRangePopoverContent

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/get-custom-trigger-state.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/get-custom-trigger-state.ts
@@ -56,35 +56,45 @@ export function getCustomTriggerState( {
 	return 'idle';
 }
 
-type GetCustomTriggerLabelArgs = {
+type GetCustomTriggerRangeArgs = {
 	triggerState: CustomTriggerState;
 	range: TriggerDateRange;
 	committedRange: TriggerDateRange;
+};
+
+type GetCustomTriggerLabelArgs = GetCustomTriggerRangeArgs & {
 	customLabel: string;
 	formatRange: ( range: TriggerDateRange ) => string;
 };
 
 /**
- * Derives the custom trigger label from its visual state.
+ * The range the trigger itself is holding, staged or applied.
  *
- * Only a custom range the trigger itself is holding — staged or applied — gets
- * a date label. While a preset drives the range the trigger reads "Custom", so
- * two different ranges are never on screen at once (WOOA7S-1936).
+ * Undefined while a preset drives the range: that range is already on screen,
+ * and the trigger must not put a second one there (WOOA7S-1936).
  */
-export function getCustomTriggerLabel( {
+export function getCustomTriggerRange( {
 	triggerState,
 	range,
 	committedRange,
+}: GetCustomTriggerRangeArgs ): TriggerDateRange | undefined {
+	if ( triggerState === 'staged' ) {
+		return range;
+	}
+
+	return triggerState === 'applied' ? committedRange : undefined;
+}
+
+/**
+ * Derives the custom trigger label from its visual state, falling back to the
+ * custom label where the trigger holds no range of its own.
+ */
+export function getCustomTriggerLabel( {
 	customLabel,
 	formatRange,
+	...triggerRangeArgs
 }: GetCustomTriggerLabelArgs ): string {
-	if ( triggerState === 'staged' ) {
-		return formatRange( range );
-	}
+	const triggerRange = getCustomTriggerRange( triggerRangeArgs );
 
-	if ( triggerState === 'applied' ) {
-		return formatRange( committedRange );
-	}
-
-	return customLabel;
+	return triggerRange ? formatRange( triggerRange ) : customLabel;
 }

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/index.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/index.ts
@@ -5,4 +5,8 @@ export type { DateRange } from './date-range-filter';
  * needs the exact string shown, since "Custom" vs. a formatted range differ
  * enough to move the label-mode boundary. Exported so both share one source.
  */
-export { getCustomTriggerLabel, getCustomTriggerState } from './get-custom-trigger-state';
+export {
+	getCustomTriggerLabel,
+	getCustomTriggerRange,
+	getCustomTriggerState,
+} from './get-custom-trigger-state';

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/stories/date-range-popover.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/stories/date-range-popover.stories.tsx
@@ -1,4 +1,4 @@
-import { subDays, startOfDay, endOfDay } from 'date-fns';
+import { subDays, subMonths, startOfDay, startOfMonth, endOfDay, endOfMonth } from 'date-fns';
 import { useState } from 'react';
 import { DateRangePopover, DateRangePopoverContent } from '../date-range-filter';
 import type { DateRange } from '../date-range-filter';
@@ -99,6 +99,34 @@ function DateRangePopoverCustomPreset() {
  */
 export const CustomPreset: Story = {
 	render: () => <DateRangePopoverCustomPreset />,
+};
+
+function DateRangePopoverWholeMonth() {
+	const lastMonth = subMonths( today, 1 );
+	const [ range, setRange ] = useState< DateRange >( {
+		from: startOfMonth( lastMonth ),
+		to: endOfMonth( lastMonth ),
+	} );
+
+	return (
+		<DateRangePopover
+			presetId="custom"
+			range={ range }
+			onChange={ nextRange => nextRange && setRange( nextRange ) }
+			onApply={ () => {} }
+			onCancel={ () => {} }
+			canApply={ false }
+			timeZone={ STORYBOOK_TIMEZONE }
+		/>
+	);
+}
+
+/**
+ * A custom range covering a whole calendar month: the trigger names the month,
+ * and its tooltip carries the dates.
+ */
+export const CustomWholeMonth: Story = {
+	render: () => <DateRangePopoverWholeMonth />,
 };
 
 function DateRangePopoverTodayPreset() {

--- a/projects/plugins/jetpack/changelog/update-date-range-natural-language
+++ b/projects/plugins/jetpack/changelog/update-date-range-natural-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: date range control: name a custom range covering a whole month or year by that period, and spell the dates out in the button's tooltip.

--- a/projects/plugins/premium-analytics/changelog/update-date-range-natural-language
+++ b/projects/plugins/premium-analytics/changelog/update-date-range-natural-language
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Date range control: name a custom range covering a whole month or year by that period, and spell the dates out in the button's tooltip.


### PR DESCRIPTION
## Proposed changes

* The custom date range trigger names the period its range covers, where the range is one: a whole calendar month reads `July 2026`, a whole calendar year reads `2026`. Every other range keeps the shortest form it already had.
* The exact dates move to the trigger's tooltip. `#51707` removed the section header subtitle, so this is now the only place they are readable without opening the calendar.
* New formatter `formatDateRangeNatural` in `packages/formatters`. Its two collapses format a single date rather than a range, so `elideRange` and its CLDR probes are not involved; everything else falls through to `formatDateRangeMinimal` unchanged.
* New named format `monthYear`, derived from the site's own `date_format` by a `withoutDay` transform mirroring the existing `withoutYear`: `F j, Y` → `F Y`, `Y-m-d` → `Y-m`, `j \d\e F \d\e Y` → `F \d\e Y`. The weekday goes with the day, and an ordinal suffix (`jS`) goes with the day it trails.

Both collapses keep the year, including in the current one. This label is the only thing naming the period on the control, so a bare `March` would not say which March.

Both call sites of `getCustomTriggerLabel` move together, since the panel's measuring probe has to measure the string the trigger is actually showing.

Two decisions worth flagging:

* The tooltip appears only while the trigger holds a range of its own, staged or applied. While a preset drives the range the trigger reads `Custom`, and a tooltip there would put the preset's range on a control that is not showing it (WOOA7S-1936).
* No `aria-label`. The button already has visible text, unlike the interval glyph, so an `aria-label` carrying the exact range would replace the accessible name and break its correspondence with the visible label. `Tooltip` supplies `aria-describedby`, which is the right role for a complement.

A range covering two whole months (`Mar 1 – Apr 30`) does not collapse: it names no single period, and the spec asks for the shortest form rather than an invented one.

## Related product discussion/links

* Linear: [WOOA7S-2024](https://linear.app/a8c/issue/WOOA7S-2024/date-controls-render-the-selected-period-in-natural-language). The collapsing rules were confirmed on the issue: the full-month example's `March 30` was a typo, the year stays in the current year too, and only whole months and whole years collapse.
* Spec: Eder's 26 August recap, "Date selection" section.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the dashboard: `jetpack build --deps packages/premium-analytics`.

* Open any analytics page.
The steps below assume the site's date format (Settings → General → Date format) is the English default, `F j, Y`; the last step covers a different one.

* Open the custom range picker, select the first and last day of a past month, and Apply. The trigger reads the month and its year, for example `July 2026`.

<img width="579" height="628" alt="image" src="https://github.com/user-attachments/assets/38645865-2060-44cf-a8d1-41b44717089b" />


* Hover or focus the trigger. Its tooltip spells the exact dates out: `July 1 – 31, 2026`.

<img width="215" height="193" alt="image" src="https://github.com/user-attachments/assets/cb85537e-cdd0-498f-92e4-d65076ab9c9d" />

* Select January 1 to December 31 of a year. The trigger reads just the year.

<img width="577" height="577" alt="image" src="https://github.com/user-attachments/assets/a9cc7f40-b7b3-4031-867f-a32f92cdb321" />

<img width="264" height="126" alt="image" src="https://github.com/user-attachments/assets/e804f86a-4b44-41ea-ad75-3ed41b200780" />

* Select the first to the second-to-last day of a month. The trigger falls back to the range, as before.
* Pick a rolling preset such as `Last 30 days`. The trigger goes back to reading `Custom`, with no tooltip.
* With the trigger showing a period, press Tab into the date controls toolbar and then `End`. Focus lands on the trigger, and the arrow keys still move along the row.
* Change Settings → General → Date format to `d/m/Y` and repeat the first step. The month reads `07/2026`, taken from the site's own format rather than an English one.

Storybook: `Packages/Premium Analytics/UI/DateRangePopover` → `CustomWholeMonth`.
