### PR TITLE
Send blog_id with the front-end Customizer Tracks event

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-customizer-frontend-event-blog-id
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-customizer-frontend-event-blog-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Customizer: Send blog_id with the Tracks event recorded when the Customizer is opened from the front end.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -98,7 +98,7 @@ function wpcom_track_customizer_from_frontend() {
 	<script type="text/javascript">
 		_tkq = window._tkq || [];
 		_tkq.push( [ 'identifyUser', <?php echo (int) $current_user->ID; ?>, '<?php echo esc_js( $current_user->user_login ); ?>' ] );
-		_tkq.push( [ 'recordEvent', 'wpcom_customize_loaded_from_frontend' ] );
+		_tkq.push( [ 'recordEvent', 'wpcom_customize_loaded_from_frontend', { blog_id: '<?php echo (int) \get_wpcom_blog_id(); ?>' } ] );
 	</script>
 	<?php
 }


### PR DESCRIPTION
## Proposed changes

* The Tracks event recorded when the Customizer is opened from the front end now carries `blog_id`. The Customizer only ever runs against one known site, so every event it fires is in a site context, but this one shipped with no properties at all and its rows could not be attributed to a blog.
* The site is resolved the same way the sibling wp-admin page-view event on this screen resolves it, so the two agree on every site.

The rest of the Customizer events with this gap are fired from several places outside this repo and are handled separately. This PR closes the portion that lives here.

## Related product discussion/links

* DOTTHEM-404

## Does this pull request change what data or activity we track or use?

Yes, narrowly: it adds a `blog_id` property to an existing Tracks event. No new event is introduced and no new category of data is collected — `blog_id` is already sent with the other events recorded from these screens, including the Customizer's own save event.

## Testing instructions

* On a WordPress.com Simple or Atomic site, visit the front end while logged in as an admin and follow the "Customize" link in the admin bar. This is the path the event is scoped to — opening the Customizer from within wp-admin, or through Calypso, deliberately does not fire it.
* With the Event Monitor or Tracks Vigilante running, confirm `wpcom_customize_loaded_from_frontend` now fires with a `blog_id` matching the site, where it previously fired with no properties.
