### PR TITLE
Jetpack AI: show a connect-account card for admins not connected to WordPress.com

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -15,9 +15,10 @@ import { AdminPage, GlobalNotices, useGlobalNotices } from '@automattic/jetpack-
 import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Badge, Link, Notice, Stack, Tabs } from '@wordpress/ui';
+import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
+import McpConnectCallout from './mcp/connect-callout';
 import McpHub from './mcp/index';
 import McpRead from './mcp/read';
 import McpSetup from './mcp/setup';
@@ -315,19 +316,7 @@ export default function App() {
 							</Notice.Root>
 						) }
 
-						{ showConnectNotice && (
-							<Notice.Root intent="warning">
-								<Notice.Title>
-									{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
-								</Notice.Title>
-								<Notice.Description>
-									{ __( 'Connect your account to manage MCP settings.', 'jetpack' ) }{ ' ' }
-									<Link href="admin.php?page=my-jetpack#/connection">
-										{ __( 'Connect account', 'jetpack' ) }
-									</Link>
-								</Notice.Description>
-							</Notice.Root>
-						) }
+						{ showConnectNotice && <McpConnectCallout /> }
 
 						{ ! isLoading && ! error && !! blogId && ! userUnlinked && ! hasMcpAccess && (
 							<McpUpsell />

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
@@ -1,0 +1,44 @@
+/**
+ * Connect-account callout for a connected site whose current user has no
+ * WordPress.com connection. Mirrors the upsell card, action changed to connect.
+ */
+
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import illustrationUrl from './upsell-illustration.svg';
+import './style.scss';
+
+/**
+ * Connect-account callout card.
+ *
+ * @return {object} Component markup.
+ */
+export default function McpConnectCallout() {
+	return (
+		<div className="jetpack-ai-mcp__upsell-callout">
+			<div className="jetpack-ai-mcp__upsell-callout-content">
+				<h2 className="jetpack-ai-mcp__upsell-callout-title">
+					{ __( 'Connect AI agents to your site', 'jetpack' ) }
+				</h2>
+				<p className="jetpack-ai-mcp__upsell-callout-description">
+					{ __(
+						'Get AI-powered assistance to help you build, edit, and redesign your site with ease.',
+						'jetpack'
+					) }
+				</p>
+				<p className="jetpack-ai-mcp__upsell-callout-description">
+					{ __( 'Connect your account to let agents securely act on your behalf.', 'jetpack' ) }
+				</p>
+				<Button variant="primary" href="admin.php?page=my-jetpack#/connection">
+					{ __( 'Connect your user account', 'jetpack' ) }
+				</Button>
+			</div>
+			<img
+				className="jetpack-ai-mcp__upsell-callout-image"
+				src={ illustrationUrl }
+				alt=""
+				role="presentation"
+			/>
+		</div>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
@@ -1,10 +1,12 @@
 /**
  * Connect-account callout for a connected site whose current user has no
- * WordPress.com connection. Mirrors the upsell card, action changed to connect.
+ * WordPress.com connection.
  */
 
+import { speak } from '@wordpress/a11y';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 import illustrationUrl from './upsell-illustration.svg';
 import './style.scss';
 
@@ -14,6 +16,11 @@ import './style.scss';
  * @return {object} Component markup.
  */
 export default function McpConnectCallout() {
+	// Announce like the notice this replaces: the design system does it via speak().
+	useEffect( () => {
+		speak( __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) );
+	}, [] );
+
 	return (
 		<div className="jetpack-ai-mcp__upsell-callout">
 			<div className="jetpack-ai-mcp__upsell-callout-content">

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
@@ -27,7 +27,7 @@ export default function McpConnectCallout() {
 					) }
 				</p>
 				<p className="jetpack-ai-mcp__upsell-callout-description">
-					{ __( 'Connect your account to let agents securely act on your behalf.', 'jetpack' ) }
+					{ __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) }
 				</p>
 				<Button variant="primary" href="admin.php?page=my-jetpack#/connection">
 					{ __( 'Connect your user account', 'jetpack' ) }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/style.scss
@@ -169,7 +169,7 @@
 		overflow: hidden;
 	}
 
-	// Free-tier upsell rendered when the site has no MCP-capable plan.
+	// Callout card shared by the plan upsell and the connect-account card.
 	// Layout mirrors Activity Log's UpsellCallout: bordered card with copy
 	// on the left and the illustration on the right; stacks on narrow
 	// viewports. The breakpoint is tuned to the AI page's 660px content

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -309,9 +309,8 @@ export default function AiOverview( {
 						{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
 					</Notice.Title>
 					<Notice.Description>
-						{ __( 'Connect your account to see your AI usage.', 'jetpack' ) }{ ' ' }
 						<Link href="admin.php?page=my-jetpack#/connection">
-							{ __( 'Connect account', 'jetpack' ) }
+							{ __( 'Connect your user account to see your AI usage.', 'jetpack' ) }
 						</Link>
 					</Notice.Description>
 				</Notice.Root>

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -296,10 +296,9 @@ describe( 'AiOverview', () => {
 		expect(
 			screen.getByText( 'Your WordPress.com account isn’t connected.', IGNORE_A11Y )
 		).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: 'Connect account' } ) ).toHaveAttribute(
-			'href',
-			'admin.php?page=my-jetpack#/connection'
-		);
+		expect(
+			screen.getByRole( 'link', { name: 'Connect your user account to see your AI usage.' } )
+		).toHaveAttribute( 'href', 'admin.php?page=my-jetpack#/connection' );
 		expect( screen.queryByText( 'Available requests' ) ).not.toBeInTheDocument();
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -301,25 +301,34 @@ describe( 'AI admin page (main.jsx)', () => {
 		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
 	} );
 
-	describe( 'MCP view: connection notices', () => {
-		const CONNECT_TITLE = 'Your WordPress.com account isn’t connected.';
+	describe( 'MCP view: connect card', () => {
+		const CONNECT_CARD_TEXT = 'Connect your account to let agents securely act on your behalf.';
 		const UPSELL_CTA = 'Upgrade plan';
 
 		beforeEach( () => {
 			window.location.hash = '#/mcp';
 		} );
 
-		test( 'site connected, no plan: shows the connect notice instead of the upsell', async () => {
+		test( 'site connected, no plan: shows the connect card instead of the upsell', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
 			mockApiFetch( { mcpGet: { has_mcp_access: false, mcp_abilities: {} } } );
 
 			render( <App /> );
 
-			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
-			expect( screen.getByRole( 'link', { name: 'Connect account' } ) ).toHaveAttribute(
+			await expect(
+				screen.findByText( CONNECT_CARD_TEXT, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'heading', { name: 'Connect AI agents to your site' } )
+			).toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Connect your user account' } ) ).toHaveAttribute(
 				'href',
 				'admin.php?page=my-jetpack#/connection'
 			);
+			// The connect card must not carry the upsell's plan pitch.
+			expect(
+				screen.queryByText( 'Upgrade your plan to give external AI agents access to your site.' )
+			).not.toBeInTheDocument();
 			expect( screen.queryByText( UPSELL_CTA ) ).not.toBeInTheDocument();
 			// The settings fetch is skipped: without a user token it can only fail.
 			expect( apiFetch ).not.toHaveBeenCalledWith(
@@ -327,13 +336,15 @@ describe( 'AI admin page (main.jsx)', () => {
 			);
 		} );
 
-		test( 'site connected, has plan: shows the connect notice and not the hub', async () => {
+		test( 'site connected, has plan: shows the connect card and not the hub', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
 			mockApiFetch( { mcpGet: connectedMcpGet() } );
 
 			render( <App /> );
 
-			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText( CONNECT_CARD_TEXT, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
 			// The skipped fetch keeps hasMcpAccess null, so the hub cannot render.
 			expect(
 				screen.queryByText( 'External AI agent access', IGNORE_A11Y )
@@ -352,7 +363,9 @@ describe( 'AI admin page (main.jsx)', () => {
 
 			render( <App /> );
 
-			await expect( screen.findByText( CONNECT_TITLE, IGNORE_A11Y ) ).resolves.toBeInTheDocument();
+			await expect(
+				screen.findByText( CONNECT_CARD_TEXT, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
 			expect( screen.queryByText( 'No token for user 2', IGNORE_A11Y ) ).not.toBeInTheDocument();
 			expect( apiFetch ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { path: expect.stringContaining( 'mcp-settings' ) } )
@@ -374,7 +387,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			await expect(
 				screen.findByText( 'Something went wrong.', IGNORE_A11Y )
 			).resolves.toBeInTheDocument();
-			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_CARD_TEXT, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'isUserConnected undefined: behaviour unchanged, the upsell still shows', async () => {
@@ -384,7 +397,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			render( <App /> );
 
 			await expect( screen.findByText( UPSELL_CTA ) ).resolves.toBeInTheDocument();
-			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_CARD_TEXT, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'site not connected: the site notice still comes first', async () => {
@@ -409,7 +422,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			expect(
 				screen.queryByText( 'Sorry, something is wrong with your Jetpack connection.', IGNORE_A11Y )
 			).not.toBeInTheDocument();
-			expect( screen.queryByText( CONNECT_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( CONNECT_CARD_TEXT, IGNORE_A11Y ) ).not.toBeInTheDocument();
 			expect( apiFetch ).not.toHaveBeenCalledWith(
 				expect.objectContaining( { path: expect.stringContaining( 'mcp-settings' ) } )
 			);

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -302,7 +302,7 @@ describe( 'AI admin page (main.jsx)', () => {
 	} );
 
 	describe( 'MCP view: connect card', () => {
-		const CONNECT_CARD_TEXT = 'Connect your account to let agents securely act on your behalf.';
+		const CONNECT_CARD_TEXT = 'A user connection lets agents securely act on your behalf.';
 		const UPSELL_CTA = 'Upgrade plan';
 
 		beforeEach( () => {

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -325,7 +325,6 @@ describe( 'AI admin page (main.jsx)', () => {
 				'href',
 				'admin.php?page=my-jetpack#/connection'
 			);
-			// The connect card must not carry the upsell's plan pitch.
 			expect(
 				screen.queryByText( 'Upgrade your plan to give external AI agents access to your site.' )
 			).not.toBeInTheDocument();

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-connect-card
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-connect-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Show a connect-account card on the MCP settings page when the current user is not connected to WordPress.com.


### PR DESCRIPTION
## Proposed changes

An admin who has not connected their own WordPress.com account sees a plain notice on the MCP settings page (from the regression fix #51760, unreleased). This replaces it with the card we already use for the plan upsell, with the action changed to connecting:

* The text is "A user connection lets agents securely act on your behalf."
* The button is **Connect your user account** and opens My Jetpack's connection screen.
* The Overview tab's notice becomes one linked sentence: "Connect your user account to see your AI usage."
* The card announces itself to screen readers, like the notice it replaces.

No analytics events on the card yet — event naming is open.

## Does this pull request change what data or activity we track or use?
No.

## Real-screen before / after

| Before (current trunk, unreleased) | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-mcp-connect-card/before-connect-notice.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-mcp-connect-card/after-connect-card.png) |

## Testing instructions

You need a self-hosted site connected to Jetpack (a Jurassic Ninja site works).

1. Log in as an admin who has not connected their own WordPress.com account — a second admin who never connected, or run `wp jetpack disconnect user` for your own.
2. Open `https://<your-site>/wp-admin/admin.php?page=jetpack-ai#/mcp`.
3. You see the "Connect AI agents to your site" card with a **Connect your user account** button. No "Upgrade plan", no error.
4. Click the button and connect your account.
5. Open the page again. You see the regular view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)