### PR TITLE
Perf tools: prove the digest mock API's port before handing it to the digest

### DIFF
--- a/tools/performance/scripts/codevitals-digest.test.js
+++ b/tools/performance/scripts/codevitals-digest.test.js
@@ -971,6 +971,12 @@ function buildScenario( scenario ) {
 	};
 }
 
+// Node's fetch rejects the WHATWG "bad port" list before it opens a socket, and listen(0) can
+// hand back one of those ports: the mock API then fails as `fetch failed (bad port)` and reddens
+// a random test. That took out a whole measurement chain once (Tester #865, 2026-08-29). Probe
+// the port rather than hardcode the list, which the runtime owns and may change.
+const PROBE_PATH = '/__probe';
+
 /**
  * Start the mock read API for one scenario on an ephemeral port.
  * Repo-agnostic on purpose: it serves any /api/repos/<repo>/… path and records
@@ -987,6 +993,10 @@ function startMockApi( scenario, { discoFail = false } = {} ) {
 	const requests = [];
 	const server = http.createServer( ( req, res ) => {
 		const u = new URL( req.url, 'http://localhost' );
+		if ( u.pathname === PROBE_PATH ) {
+			res.end( 'ok' ); // deliberately not recorded: tests assert the exact request list
+			return;
+		}
 		requests.push( u.pathname + u.search );
 		if ( /^\/api\/repos\/.+\/metrics$/.test( u.pathname ) ) {
 			if ( discoFail || discoHtml ) {
@@ -1028,15 +1038,40 @@ function startMockApi( scenario, { discoFail = false } = {} ) {
 		res.statusCode = 404;
 		res.end( '{}' );
 	} );
-	return new Promise( resolve => {
-		server.listen( 0, '127.0.0.1', () => {
-			const { port } = server.address();
-			resolve( {
-				url: `http://127.0.0.1:${ port }`,
-				requests,
-				close: () => new Promise( r => server.close( r ) ),
+	return new Promise( ( resolve, reject ) => {
+		let attempts = 0;
+		const bind = () => {
+			server.listen( 0, '127.0.0.1', async () => {
+				const { port } = server.address();
+				const url = `http://127.0.0.1:${ port }`;
+				try {
+					await fetch( url + PROBE_PATH );
+				} catch ( e ) {
+					// Close before rejecting: a live server keeps the runner's event loop alive and
+					// turns a legible failure into a hang.
+					if ( ++attempts > 20 ) {
+						server.close( () =>
+							reject(
+								new Error(
+									`no usable port after 20 tries (last: ${ port }, ${
+										e.cause?.message || e.message
+									})`
+								)
+							)
+						);
+						return;
+					}
+					server.close( bind );
+					return;
+				}
+				resolve( {
+					url,
+					requests,
+					close: () => new Promise( r => server.close( r ) ),
+				} );
 			} );
-		} );
+		};
+		bind();
 	} );
 }
 


### PR DESCRIPTION
Partially addresses [JETPACK-2153: Post Slack alerts for sizable CodeVitals metric changes](https://linear.app/a8c/issue/JETPACK-2153/post-slack-alerts-for-sizable-codevitals-metric-changes)

## Proposed changes

* The digest's test harness serves its mock read API on a `listen(0)` port and points the digest at `http://127.0.0.1:<port>`. Node's `fetch` refuses the WHATWG "bad port" list before it opens a socket, so when the host handed back one of those ports the metrics lookup failed as `fetch failed (bad port)` and reddened whichever test happened to draw it. That message has exactly one source in Node: `requestBadPort()` returning `"blocked"`.
* The harness now fetches the port once before handing it over, and re-binds if that fetch fails. Proving the port beats hardcoding either the blocked list or a cutoff above it: the list belongs to the runtime, and the CI agent's Node is not the build this repo pins. The probe is served on a private path that is never recorded, so the request lists the tests assert are unchanged.
* Giving up closes the server before rejecting. A still-listening server would keep the test runner's event loop alive and turn a legible failure into a hang.

**Why this matters beyond a flaky test.** `tools/performance`'s `test` script is `node --test scripts/*.test.js && node scripts/run-performance-tests.js`, so these unit tests gate the measurement and the CodeVitals POST for the commit under test. The performance measurement build also chains commit-to-commit with a step that only runs on success, so a failure stops the rest of the run too. On 2026-08-29 a build drew a bad port; the chain stopped after 5 of 150 commits, and the following Monday's digest correctly reported no fresh data on any tracked metric.

Test-only change. `codevitals-digest.js` is untouched, so nothing about what the digest reports or what the pipeline measures can change.

No changelog entry: the change is under `tools/`, outside `/projects`.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm --dir tools/performance test:unit` — 244/244 pass.
* Confirm the re-bind path works. In `startMockApi`, temporarily force it: change `await fetch( url + PROBE_PATH );` to also `throw new Error( 'x' )` when `attempts < 3`. The suite should still be 244/244, proving a server can re-bind and still serve correctly.
* Confirm the give-up path fails legibly rather than hanging. Force the probe to always throw. The run should end within a couple of seconds reporting `no usable port after 20 tries (last: <port>, <reason>)`, not stall until the runner is killed.
* Confirm the probe stays out of the recorded requests. Add a temporary test that runs `runDigest( 'clean' )` and asserts no entry of `r.requests` contains `__probe`; the recorded list should hold only the digest's real `/metrics` and `/perf/evolution/...` calls.
* `pnpm exec prettier --check` and `pnpm exec eslint` on the file are clean.
