### PR TITLE
Drop the repeated client_id check in the WPCC guard

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-duplicate-wpcc-client-id-check
+++ b/projects/plugins/jetpack/changelog/fix-duplicate-wpcc-client-id-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Drop a repeated client_id check when deciding whether WPCC activation was completed.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2365,7 +2365,7 @@ class Jetpack {
 		// Don't activate SSO if they never completed activating WPCC.
 		if ( self::is_module_active( 'wpcc' ) ) {
 			$wpcc_options = Jetpack_Options::get_option( 'wpcc_options' );
-			if ( empty( $wpcc_options ) || empty( $wpcc_options['client_id'] ) || empty( $wpcc_options['client_id'] ) ) {
+			if ( empty( $wpcc_options ) || empty( $wpcc_options['client_id'] ) ) {
 				$deprecated_modules['wpcc'] = null;
 			}
 		}


### PR DESCRIPTION
## Proposed changes

- Remove the repeated `empty( $wpcc_options['client_id'] )` operand from the WPCC activation guard.
- Preserve the guard's current behavior for empty options, a missing or empty `client_id`, and a present `client_id`.
- Add the required Jetpack changelog entry (`patch`, `fixed`).

If the third operand was intended to check another key, `client_secret` is the obvious candidate, but this repository only reads `wpcc_options`; I did not change behavior without evidence.

## Related product discussion/links

- No issue or product discussion; found while reading the guard.

## Does this pull request change what data or activity we track or use?

No. It removes a duplicate boolean operand and does not change data collection, storage, transmission, or behavior.

## Testing instructions

1. Check out this branch.
2. Run `php -l projects/plugins/jetpack/class.jetpack.php`.
3. Review the guard in `Jetpack::handle_deprecated_modules()` and confirm its result is unchanged for:
   - empty `wpcc_options`;
   - a missing or empty `client_id`;
   - a present, non-empty `client_id`.

The removed operand was identical to the preceding one, so the boolean expression has the same truth table before and after the change.
