### PR TITLE
Jetpack MU WPCOM: Preserve Jetpack AI settings on Simple and Atomic

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-ai-general-settings-reset
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-jetpack-ai-general-settings-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Keep AI feature settings unchanged when saving General Settings.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -340,6 +340,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/font-smoothing-antialiased/font-smoothing-antialiased.php';
 		require_once __DIR__ . '/features/google-analytics/google-analytics.php';
 		require_once __DIR__ . '/features/holiday-snow/class-holiday-snow.php';
+		require_once __DIR__ . '/features/jetpack-ai-settings/jetpack-ai-settings.php';
 		require_once __DIR__ . '/features/launch-button/index.php';
 		require_once __DIR__ . '/features/layout-grid-usage-tracking/layout-grid-usage-tracking.php';
 		require_once __DIR__ . '/features/logo-tool/logo-tool.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-settings/jetpack-ai-settings.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-settings/jetpack-ai-settings.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Protect Jetpack AI settings from General Settings saves.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Settings;
+
+/**
+ * Remove Jetpack AI options from the General Settings allowlist.
+ *
+ * @param array $allowed_options Allowed options grouped by settings page.
+ * @return array
+ */
+function exclude_from_general_options( $allowed_options ) {
+	if ( ! isset( $allowed_options['general'] ) || ! is_array( $allowed_options['general'] ) ) {
+		return $allowed_options;
+	}
+
+	$jetpack_ai_options = array(
+		'jetpack_ai_enabled',
+		'jetpack_ai_writing_assistant_enabled',
+		'jetpack_ai_image_editor_enabled',
+		'jetpack_ai_feature_clip_enabled',
+		'jetpack_ai_seo_enabled',
+	);
+
+	$allowed_options['general'] = array_values( array_diff( $allowed_options['general'], $jetpack_ai_options ) );
+
+	return $allowed_options;
+}
+add_filter( 'allowed_options', __NAMESPACE__ . '\\exclude_from_general_options', 20 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-settings/Jetpack_AI_Settings_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-settings/Jetpack_AI_Settings_Test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for Jetpack AI settings protection.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Settings;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/jetpack-ai-settings/jetpack-ai-settings.php';
+
+/**
+ * Tests for Jetpack AI settings protection.
+ */
+class Jetpack_AI_Settings_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * The filter removes only Jetpack AI options from General Settings.
+	 */
+	public function test_excludes_jetpack_ai_options_from_general_settings() {
+		$this->assertSame( 20, \has_filter( 'allowed_options', __NAMESPACE__ . '\\exclude_from_general_options' ) );
+
+		$allowed_options = array(
+			'general'    => array(
+				'blogname',
+				'jetpack_ai_enabled',
+				'jetpack_ai_writing_assistant_enabled',
+				'jetpack_ai_image_editor_enabled',
+				'jetpack_ai_feature_clip_enabled',
+				'jetpack_ai_seo_enabled',
+				'jetpack_ai_future_option',
+			),
+			'discussion' => array( 'default_ping_status' ),
+		);
+
+		$this->assertSame(
+			array(
+				'general'    => array( 'blogname', 'jetpack_ai_future_option' ),
+				'discussion' => array( 'default_ping_status' ),
+			),
+			exclude_from_general_options( $allowed_options )
+		);
+	}
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-ai-general-settings-reset
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-ai-general-settings-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Keep AI feature settings unchanged when saving General Settings.

--- a/projects/plugins/wpcomsh/changelog/fix-jetpack-ai-general-settings-reset
+++ b/projects/plugins/wpcomsh/changelog/fix-jetpack-ai-general-settings-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Keep AI feature settings unchanged when saving General Settings.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Prevent Settings > General saves on WordPress.com Simple and Atomic sites from updating the five Jetpack AI options that the form does not render.
* Keep the protection in the shared `jetpack-mu-wpcom` package used by both `mu-wpcom-plugin` and Wpcomsh.
* Run the exclusion at priority 20, after WordPress merges registered settings into the General Settings allowlist.
* Leave unrelated settings, direct option updates, and the dedicated Jetpack AI settings endpoint unchanged.

## Related product discussion/links

* #50287 introduced the Jetpack AI settings registry.
* #50386 added the settings UI for the feature toggles.
* Supersedes #51829 by covering both WordPress.com platforms in one shared implementation.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
Atomic
1. Before installing this PR make sure to activate Jetpack AI and toggle all Jetpack AI features
2. Install this PR on your site using Jetpack Beta
3. Go to **Settings > General** and select **Save Changes**.
4. Open a Post and verify that Jetpack AI features are still available (Improve with AI, Generate Image)

Simple
1. Install this PR on your sandbox
2. Go to **Settings > General** and select **Save Changes**.
3. Open a Post and verify that Jetpack AI features are still available (Improve with AI, Generate Image)
