### PR TITLE
Jetpack MU WPCOM: Preserve Jetpack AI settings on General saves

### DIFF
--- a/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-ai-general-settings-reset
+++ b/projects/plugins/mu-wpcom-plugin/changelog/fix-jetpack-ai-general-settings-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Keep AI feature settings unchanged when saving General Settings.

--- a/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
+++ b/projects/plugins/mu-wpcom-plugin/mu-wpcom-plugin.php
@@ -12,6 +12,36 @@
  */
 
 /**
+ * Prevent General Settings from overwriting Jetpack AI settings it does not render.
+ *
+ * Remove this after Simple sites run a Jetpack version that registers these
+ * options outside the general settings group.
+ *
+ * @param array $allowed_options Allowed options grouped by settings page.
+ * @return array
+ */
+function jetpack_mu_wpcom_exclude_jetpack_ai_settings_from_general_options( $allowed_options ) {
+	if ( ! isset( $allowed_options['general'] ) || ! is_array( $allowed_options['general'] ) ) {
+		return $allowed_options;
+	}
+
+	$jetpack_ai_options = array(
+		'jetpack_ai_enabled',
+		'jetpack_ai_writing_assistant_enabled',
+		'jetpack_ai_image_editor_enabled',
+		'jetpack_ai_feature_clip_enabled',
+		'jetpack_ai_seo_enabled',
+	);
+
+	$allowed_options['general'] = array_values( array_diff( $allowed_options['general'], $jetpack_ai_options ) );
+
+	return $allowed_options;
+}
+if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+	add_filter( 'allowed_options', 'jetpack_mu_wpcom_exclude_jetpack_ai_settings_from_general_options', 20 );
+}
+
+/**
  * Conditionally load the jetpack-mu-wpcom package.
  *
  * JETPACK_MU_WPCOM_LOAD_VIA_BETA_PLUGIN=true will load the package via the Jetpack Beta Tester plugin, not wpcomsh.

--- a/projects/plugins/mu-wpcom-plugin/tests/php/JetpackAISettingsHotfixTest.php
+++ b/projects/plugins/mu-wpcom-plugin/tests/php/JetpackAISettingsHotfixTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Jetpack AI settings hotfix test file.
+ *
+ * @package automattic/jetpack-mu-wpcom-plugin
+ */
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../mu-wpcom-plugin.php';
+
+/**
+ * Test the temporary Jetpack AI settings hotfix.
+ */
+class JetpackAISettingsHotfixTest extends TestCase {
+	/**
+	 * Test that Jetpack AI settings are excluded from General Settings saves.
+	 */
+	public function test_jetpack_ai_settings_are_excluded_from_general_options() {
+		$allowed_options = array(
+			'general'    => array(
+				'blogname',
+				'jetpack_ai_enabled',
+				'jetpack_ai_writing_assistant_enabled',
+				'jetpack_ai_image_editor_enabled',
+				'jetpack_ai_feature_clip_enabled',
+				'jetpack_ai_seo_enabled',
+			),
+			'discussion' => array( 'default_ping_status' ),
+		);
+
+		$this->assertSame(
+			array(
+				'general'    => array( 'blogname' ),
+				'discussion' => array( 'default_ping_status' ),
+			),
+			jetpack_mu_wpcom_exclude_jetpack_ai_settings_from_general_options( $allowed_options )
+		);
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes

* Prevent Settings > General saves on WordPress.com Simple sites from updating the five Jetpack AI options that the form does not render.
* Run the exclusion after WordPress merges registered settings into the General Settings allowlist.
* Leave the Jetpack AI settings endpoint and direct option updates unchanged.
* Treat this as a temporary rollout bridge until Simple sites run a Jetpack version that registers these options in a dedicated settings group.

## Related product discussion/links

* #50287 introduced the Jetpack AI settings registry.
* #50386 added the settings UI for the new toggles.
* #51827 provides the corresponding temporary guard for Atomic sites.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `composer test-php` from `projects/plugins/mu-wpcom-plugin`.
* Confirm `JetpackAISettingsHotfixTest` verifies that the five Jetpack AI options are removed from the `general` group while unrelated General Settings and other settings groups remain unchanged.

