### PR TITLE
Backport the Jetpack 16.1.3 fixes to trunk

### DIFF
--- a/projects/packages/import/changelog/import-harden-post-meta
+++ b/projects/packages/import/changelog/import-harden-post-meta
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Harden post meta handling so imported values are only restored as plain data.

--- a/projects/packages/import/src/endpoints/class-post.php
+++ b/projects/packages/import/src/endpoints/class-post.php
@@ -167,7 +167,7 @@ class Post extends \WP_REST_Posts_Controller {
 		if ( is_array( $metas ) ) {
 			foreach ( $metas as $meta_key => $meta_value ) {
 
-				$meta_value = maybe_unserialize( $meta_value );
+				$meta_value = self::unserialize_no_objects( $meta_value );
 				if ( $meta_key === '_edit_last' ) {
 					update_post_meta( $post_id, $meta_key, $meta_value );
 				} else {
@@ -178,6 +178,50 @@ class Post extends \WP_REST_Posts_Controller {
 				do_action( 'import_post_meta', $post_id, $meta_key, $meta_value );
 			}
 		}
+	}
+
+	/**
+	 * Restore an imported meta value as plain data.
+	 *
+	 * Imported meta is plain data (scalars and arrays), so serialized values are decoded without
+	 * class instantiation and any residual objects are dropped. This matches maybe_unserialize()
+	 * for non-serialized and object-free serialized values.
+	 *
+	 * @param mixed $value The raw meta value.
+	 * @return mixed A plain (object-free) value.
+	 */
+	private static function unserialize_no_objects( $value ) {
+		if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+			return $value;
+		}
+
+		// maybe_unserialize() decodes with no `allowed_classes`; call unserialize() directly with classes
+		// disallowed so meta is only ever restored as plain data. The is_serialized() guard above and the
+		// @ (warnings on malformed input) mirror maybe_unserialize()'s own behavior.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- allowed_classes => false makes this decode safe.
+		$decoded = @unserialize( trim( $value ), array( 'allowed_classes' => false ) );
+
+		return self::strip_objects( $decoded );
+	}
+
+	/**
+	 * Recursively replace any objects in a decoded value with null.
+	 *
+	 * @param mixed $value Decoded value.
+	 * @return mixed The value with any objects removed.
+	 */
+	private static function strip_objects( $value ) {
+		if ( is_object( $value ) ) {
+			return null;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = self::strip_objects( $item );
+			}
+		}
+
+		return $value;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-jetpack-import-meta-decode
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-import-meta-decode
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Import: Harden post meta handling so imported values are only restored as plain data.

--- a/projects/plugins/jetpack/changelog/fix-reader-repost-sanitize-query-args
+++ b/projects/plugins/jetpack/changelog/fix-reader-repost-sanitize-query-args
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Reader: Sanitize repost data taken from the URL before it is inserted into the editor.

--- a/projects/plugins/jetpack/changelog/jetpack-2092-media-parent-id-target-check
+++ b/projects/plugins/jetpack/changelog/jetpack-2092-media-parent-id-target-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Media API: Check permissions on the target post before attaching a media item to it.

--- a/projects/plugins/jetpack/changelog/jetpack-2228-media-new-parent-id-target-check
+++ b/projects/plugins/jetpack/changelog/jetpack-2228-media-new-parent-id-target-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Media API: Check permissions on the target post before attaching an upload to it.

--- a/projects/plugins/jetpack/extensions/shared/reader-repost.js
+++ b/projects/plugins/jetpack/extensions/shared/reader-repost.js
@@ -1,13 +1,191 @@
 import { createBlock } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
+import { escapeAttribute, escapeHTML } from '@wordpress/escape-html';
 import { getQueryArgs } from '@wordpress/url';
 import { waitForEditor } from './wait-for-editor';
 
-const { url, title, text, comment_content, comment_author } = getQueryArgs( window.location.href );
+const queryArgs = getQueryArgs( window.location.href );
+
+/**
+ * Reads a query arg, treating anything that is not a string as absent.
+ *
+ * `getQueryArgs()` parses bracket syntax (`?title[]=a&title[]=b`) into arrays and objects, so
+ * none of these values is guaranteed to be a string just because it came from a query string.
+ *
+ * @param {string} name - Query arg name.
+ * @return {string} The value when it is a string, otherwise an empty string.
+ */
+function getStringArg( name ) {
+	const value = queryArgs[ name ];
+	return typeof value === 'string' ? value : '';
+}
+
+const url = getStringArg( 'url' );
+const title = getStringArg( 'title' );
+const text = getStringArg( 'text' );
+const commentContent = getStringArg( 'comment_content' );
+const commentAuthor = getStringArg( 'comment_author' );
+
+/**
+ * Protocols we are willing to emit into an `href` or hand to `core/embed`.
+ *
+ * Everything reaching this file comes from the query string, so a bare
+ * `javascript:` or `data:` URL would otherwise become a click-to-execute link.
+ */
+const ALLOWED_PROTOCOLS = [ 'http:', 'https:' ];
+
+/**
+ * Normalizes an untrusted URL, rejecting anything that is not an absolute http(s) URL.
+ *
+ * @param {unknown} candidate - The URL to check.
+ * @return {?string} The normalized URL, or null when it is not safe to use.
+ */
+function getSafeUrl( candidate ) {
+	if ( typeof candidate !== 'string' || ! candidate ) {
+		return null;
+	}
+
+	try {
+		const parsed = new URL( candidate );
+		return ALLOWED_PROTOCOLS.includes( parsed.protocol ) ? parsed.href : null;
+	} catch {
+		// Not a parseable absolute URL.
+		return null;
+	}
+}
+
+/**
+ * Tags and attributes kept as-is in reposted comment content.
+ *
+ * Mirrors WordPress's own comment allowlist — the `$allowedtags` global that `wp_kses()`
+ * applies to comments, in `wp-includes/kses.php` — so anything a commenter could legitimately
+ * submit survives the round trip, and nothing they could not is permitted here. `p` and `br`
+ * are the two additions: the Reader sends *rendered* comment HTML, which has already been
+ * through `wpautop()`.
+ *
+ * Everything absent from this map — every `on*` handler, `srcdoc`, `style` — is dropped.
+ * Attribute *values* are validated separately; an allowlisted `href` can still carry a
+ * `javascript:` URL.
+ */
+const ALLOWED_ATTRIBUTES = {
+	A: [ 'href', 'title' ],
+	ABBR: [ 'title' ],
+	ACRONYM: [ 'title' ],
+	B: [],
+	BLOCKQUOTE: [ 'cite' ],
+	BR: [],
+	CITE: [],
+	CODE: [],
+	DEL: [ 'datetime' ],
+	EM: [],
+	I: [],
+	P: [],
+	Q: [ 'cite' ],
+	S: [],
+	STRIKE: [],
+	STRONG: [],
+};
+
+const ALLOWED_TAGS = Object.keys( ALLOWED_ATTRIBUTES );
+
+/** Allowlisted attributes whose value is a URL, and so needs checking beyond its name. */
+const URL_ATTRIBUTES = [ 'href', 'cite' ];
+
+/**
+ * Tags dropped along with their contents, rather than unwrapped.
+ *
+ * Their text is markup or code rather than prose, so surfacing it in the quote would be
+ * noise. Unwrapping them would be safe, just ugly.
+ */
+const DISCARDED_TAGS = [ 'SCRIPT', 'STYLE', 'TEMPLATE', 'NOSCRIPT' ];
+
+/**
+ * Sanitizes rendered comment HTML down to a safe subset.
+ *
+ * Unknown tags are unwrapped, so their text survives while the element and its attributes
+ * are dropped — `<iframe srcdoc="…">x</iframe>` becomes the bare text `x`. HTML comments are
+ * removed outright: the allowlist above describes elements, and a comment is the one node type
+ * whose danger here comes from the destination rather than from its content.
+ *
+ * @param {unknown} html - Untrusted comment HTML.
+ * @return {string} Sanitized HTML.
+ */
+function sanitizeCommentContent( html ) {
+	if ( typeof html !== 'string' || ! html ) {
+		return '';
+	}
+
+	// An inert document: assigning innerHTML here never executes scripts or loads subresources.
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = html;
+
+	// `querySelectorAll` returns a static list in document order, so unwrapping a parent still
+	// leaves its children queued for their own pass.
+	doc.body.querySelectorAll( '*' ).forEach( element => {
+		// HTML elements report an uppercase tagName, but foreign content (SVG, MathML) keeps its
+		// original case — an SVG-namespaced `<script>` reports `script`, not `SCRIPT`.
+		const tag = element.tagName.toUpperCase();
+
+		if ( DISCARDED_TAGS.includes( tag ) ) {
+			element.remove();
+			return;
+		}
+
+		if ( ! ALLOWED_TAGS.includes( tag ) ) {
+			element.replaceWith( ...element.childNodes );
+			return;
+		}
+
+		const allowedAttributes = ALLOWED_ATTRIBUTES[ tag ] || [];
+		Array.from( element.attributes ).forEach( ( { name, value } ) => {
+			if ( ! allowedAttributes.includes( name ) ) {
+				element.removeAttribute( name );
+				return;
+			}
+
+			// An allowlisted `href` or `cite` is still an untrusted URL. Keep the *normalized*
+			// form rather than the raw one: it percent-encodes the angle brackets that the raw
+			// value would otherwise carry into the markup.
+			if ( URL_ATTRIBUTES.includes( name ) ) {
+				const safeValue = getSafeUrl( value );
+
+				if ( safeValue ) {
+					element.setAttribute( name, safeValue );
+				} else {
+					element.removeAttribute( name );
+				}
+				return;
+			}
+
+			// Serialization escapes `&` and `"` inside an attribute value, but not `<` or `>`, and
+			// the block parser scans post content as text rather than as a DOM — so a `<!-- wp:… -->`
+			// sequence left in an attribute is read as a real block delimiter, exactly as a loose
+			// comment node would be. Neither character carries meaning in the values kept here.
+			if ( /[<>]/.test( value ) ) {
+				element.setAttribute( name, value.replace( /[<>]/g, '' ) );
+			}
+		} );
+	} );
+
+	// `querySelectorAll` matches elements only, so comment nodes reach `innerHTML` untouched. In
+	// this destination that is not inert punctuation: a quote's value is serialized into post
+	// content, where `<!-- wp:html -->` is a block delimiter. Left in place, an injected delimiter
+	// ends the quote early and opens a block of the attacker's choosing when the victim saves.
+	const walker = doc.createTreeWalker( doc.body, NodeFilter.SHOW_COMMENT );
+	const comments = [];
+	while ( walker.nextNode() ) {
+		comments.push( walker.currentNode );
+	}
+	comments.forEach( comment => comment.remove() );
+
+	return doc.body.innerHTML;
+}
+
+const safeUrl = getSafeUrl( url );
 
 // This enables functionality to "repost" from the reader, adding context like an embed of the
 // original post, and any extra comment or text data if applicable.
-if ( url ) {
+if ( safeUrl ) {
 	( async () => {
 		// Wait for the editor to be initialized and the core blocks registered.
 		await waitForEditor();
@@ -15,21 +193,24 @@ if ( url ) {
 		const blocks = [];
 
 		if ( text && text !== title ) {
-			const link = `<a href="${ url }">${ title }</a>`;
+			const link = `<a href="${ escapeAttribute( safeUrl ) }">${ escapeHTML( title ) }</a>`;
 			blocks.push(
 				createBlock( 'core/quote', {
-					value: `<p>${ text }</p>`,
+					value: `<p>${ escapeHTML( text ) }</p>`,
 					citation: link,
 				} )
 			);
 		}
 
-		if ( comment_content ) {
+		if ( commentContent ) {
 			blocks.push(
-				createBlock( 'core/quote', { value: comment_content, citation: comment_author } )
+				createBlock( 'core/quote', {
+					value: sanitizeCommentContent( commentContent ),
+					citation: escapeHTML( commentAuthor ),
+				} )
 			);
 		}
-		blocks.push( createBlock( 'core/embed', { url, type: 'wp-embed' } ) );
+		blocks.push( createBlock( 'core/embed', { url: safeUrl, type: 'wp-embed' } ) );
 
 		dispatch( 'core/editor' ).resetEditorBlocks( blocks );
 	} )();

--- a/projects/plugins/jetpack/extensions/shared/test/reader-repost.test.js
+++ b/projects/plugins/jetpack/extensions/shared/test/reader-repost.test.js
@@ -1,0 +1,418 @@
+/**
+ * Tests for the Reader repost editor extension.
+ *
+ * Every value this module consumes arrives from the query string of an editor URL that an
+ * attacker can hand to a logged-in user, so each one is treated as untrusted input.
+ */
+
+const mockResetEditorBlocks = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: () => ( { resetEditorBlocks: mockResetEditorBlocks } ),
+} ) );
+
+jest.mock( '@wordpress/blocks', () => ( {
+	createBlock: ( name, attributes ) => ( { name, attributes } ),
+} ) );
+
+jest.mock( '../wait-for-editor', () => ( {
+	waitForEditor: () => Promise.resolve(),
+} ) );
+
+/**
+ * Loads the module against a real editor URL and returns the blocks it produced.
+ *
+ * `@wordpress/url` is deliberately left unmocked so the query string is parsed exactly as it
+ * would be in the browser — the attack arrives as a URL, so the URL parsing is part of what
+ * needs testing. The module runs its work in an async IIFE at import time, so this re-imports
+ * it in isolation per case and flushes the task queue before reading the result.
+ *
+ * @param {string} queryString - Raw query string, without the leading `?`.
+ * @return {Promise<Array|null>} The blocks passed to resetEditorBlocks, or null if never called.
+ */
+async function loadWithQueryString( queryString ) {
+	mockResetEditorBlocks.mockClear();
+	window.history.replaceState( {}, '', `/wp-admin/post-new.php?${ queryString }` );
+
+	await jest.isolateModulesAsync( async () => {
+		require( '../reader-repost' );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+	} );
+
+	return mockResetEditorBlocks.mock.calls.length
+		? mockResetEditorBlocks.mock.calls[ 0 ][ 0 ]
+		: null;
+}
+
+/**
+ * Loads the module with the given query args, encoding them into a real URL first.
+ *
+ * Use `loadWithQueryString` directly for shapes `URLSearchParams` cannot express, such as the
+ * bracket syntax that produces array values.
+ *
+ * @param {object} queryArgs - Query args to encode into the editor URL.
+ * @return {Promise<Array|null>} The blocks passed to resetEditorBlocks, or null if never called.
+ */
+function loadWithQueryArgs( queryArgs ) {
+	return loadWithQueryString( new URLSearchParams( queryArgs ).toString() );
+}
+
+const getQuoteBlocks = blocks => blocks.filter( block => block.name === 'core/quote' );
+const getEmbedBlock = blocks => blocks.find( block => block.name === 'core/embed' );
+
+/**
+ * Parses HTML and returns the tag names of every element it actually creates.
+ *
+ * Escaped markup yields an empty list, which is the property that matters here: the payload
+ * is inert text rather than live DOM.
+ *
+ * @param {string} html - The HTML to parse.
+ * @return {string[]} Tag names, uppercased.
+ */
+function getRenderedTagNames( html ) {
+	const doc = document.implementation.createHTMLDocument( '' );
+	doc.body.innerHTML = html;
+	return Array.from( doc.body.querySelectorAll( '*' ) ).map( element => element.tagName );
+}
+
+describe( 'reader-repost', () => {
+	describe( 'end to end', () => {
+		it( 'produces no executable markup anywhere in the resulting blocks', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: 'safe',
+				comment_author:
+					'<iframe srcdoc="<script>top.alert(top.document.domain)</script>">x</iframe>',
+			} );
+
+			// No value from the URL may become a live element in any attribute of any block.
+			const renderedTags = blocks
+				.flatMap( block => Object.values( block.attributes ) )
+				.filter( attribute => typeof attribute === 'string' )
+				.flatMap( getRenderedTagNames );
+
+			expect( renderedTags ).not.toContain( 'IFRAME' );
+			expect( renderedTags ).not.toContain( 'SCRIPT' );
+		} );
+	} );
+
+	describe( 'comment_author', () => {
+		it( 'neutralizes an iframe srcdoc payload', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: 'safe',
+				comment_author:
+					'<iframe srcdoc="<script>top.alert(top.document.domain)</script>">x</iframe>',
+			} );
+
+			const { citation } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			// The payload survives only as inert text: escaping it means no element is built,
+			// so there is no frame to load and no script to run.
+			expect( getRenderedTagNames( citation ) ).toEqual( [] );
+			expect( citation ).toContain( '&lt;iframe' );
+		} );
+
+		it( 'escapes the display name rather than treating it as markup', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: 'safe',
+				comment_author: 'Ada & <b>Grace</b>',
+			} );
+
+			// escapeHTML() escapes `&` and `<`; `>` is harmless once `<` cannot start a tag.
+			expect( getQuoteBlocks( blocks )[ 0 ].attributes.citation ).toBe(
+				'Ada &amp; &lt;b>Grace&lt;/b>'
+			);
+		} );
+	} );
+
+	describe( 'comment_content', () => {
+		it( 'preserves the formatting the Reader actually sends', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content:
+					'<p>First <strong>bold</strong> and <em>italic</em>.</p><p>Second with a <a href="https://example.com/x">link</a>.</p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).toContain( '<strong>bold</strong>' );
+			expect( value ).toContain( '<em>italic</em>' );
+			expect( value ).toContain( '<a href="https://example.com/x">link</a>' );
+			expect( value.match( /<p>/g ) ).toHaveLength( 2 );
+		} );
+
+		it( 'strips dangerous elements while keeping their text', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content:
+					'<p>before</p><iframe srcdoc="<script>alert(1)</script>">x</iframe><p>after</p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			// Here the content IS parsed as markup, so assert the iframe is gone from the DOM
+			// the value produces — not merely absent from the string.
+			expect( getRenderedTagNames( value ) ).toEqual( [ 'P', 'P' ] );
+			expect( value ).not.toContain( 'srcdoc' );
+			expect( value ).toContain( '<p>before</p>' );
+			expect( value ).toContain( '<p>after</p>' );
+		} );
+
+		it( 'strips script in foreign content, where tag names keep their case', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<p>before</p><svg><script>alert(1)</script></svg><p>after</p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( getRenderedTagNames( value ) ).toEqual( [ 'P', 'P' ] );
+			expect( value ).not.toContain( 'alert(1)' );
+		} );
+
+		it( 'strips event handler attributes from allowed elements', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<p onmouseover="alert(1)">hover me</p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).toBe( '<p>hover me</p>' );
+		} );
+
+		it( 'strips HTML comments, which are block delimiters in this destination', async () => {
+			// A quote's value is serialized into post content, where `<!-- wp:html -->` is not
+			// inert punctuation but a block delimiter: left in place it ends the quote early and
+			// opens a block of the attacker's choosing once the victim saves.
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<p>before</p><!-- /wp:quote --><!-- wp:html --><p>after</p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).toBe( '<p>before</p><p>after</p>' );
+			expect( value ).not.toContain( '<!--' );
+		} );
+
+		it( 'strips HTML comments nested inside an element that is itself unwrapped', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<div><p>text<!-- wp:html --></p></div>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).toBe( '<p>text</p>' );
+			expect( value ).not.toContain( 'wp:html' );
+		} );
+
+		it( 'strips angle brackets from free-text attributes, which serialize unescaped', async () => {
+			// The same delimiter problem one level down: attribute values are serialized without
+			// escaping `<` or `>`, so a delimiter parked in `title` survives a comment-node sweep.
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<abbr title="<!-- /wp:quote --><!-- wp:html -->">x</abbr>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).not.toContain( '<!--' );
+			expect( value ).toBe( '<abbr title="!-- /wp:quote --!-- wp:html --">x</abbr>' );
+		} );
+
+		it( 'strips angle brackets from datetime as well as title', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<del datetime="<!-- wp:html -->">x</del>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).not.toContain( '<!--' );
+		} );
+
+		it( 'keeps the normalized URL, not the raw one, so href cannot smuggle a delimiter', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<a href="https://example.com/?a=<!-- wp:html -->">x</a>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).not.toContain( '<!--' );
+			expect( value ).toContain( '%3C!--' );
+		} );
+
+		it( 'keeps the formatting WordPress itself allows in a comment', async () => {
+			// The tags in WordPress's $allowedtags (wp-includes/kses.php), which is the set a
+			// commenter can actually submit, so all of it must survive the repost round trip.
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content:
+					'<p><a href="https://example.com" title="t">a</a> <abbr title="t">ab</abbr> ' +
+					'<acronym title="t">ac</acronym> <b>b</b> <cite>ci</cite> <code>co</code> ' +
+					'<del datetime="2026-01-01">d</del> <em>e</em> <i>i</i> ' +
+					'<q cite="https://example.com">q</q> <s>s</s> <strike>st</strike> ' +
+					'<strong>sr</strong></p><blockquote cite="https://example.com">bq</blockquote>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( getRenderedTagNames( value ).sort() ).toEqual(
+				[
+					'A',
+					'ABBR',
+					'ACRONYM',
+					'B',
+					'BLOCKQUOTE',
+					'CITE',
+					'CODE',
+					'DEL',
+					'EM',
+					'I',
+					'P',
+					'Q',
+					'S',
+					'STRIKE',
+					'STRONG',
+				].sort()
+			);
+
+			// Allowlisted attributes survive alongside their tags.
+			expect( value ).toContain( 'title="t"' );
+			expect( value ).toContain( 'datetime="2026-01-01"' );
+			// Normalized rather than preserved verbatim: keeping the parsed form is what stops a
+			// raw value from carrying angle brackets into the markup, at the cost of cosmetic
+			// rewrites like this added trailing slash.
+			expect( value ).toContain( 'cite="https://example.com/"' );
+		} );
+
+		it( 'drops javascript: URLs from cite as well as href', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<blockquote cite="javascript:alert(1)">quoted</blockquote>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).not.toContain( 'javascript:' );
+			expect( value ).toContain( 'quoted' );
+		} );
+
+		it( 'drops javascript: hrefs that the tag allowlist alone would keep', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				comment_content: '<p><a href="javascript:alert(1)">click</a></p>',
+			} );
+
+			const { value } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).not.toContain( 'javascript:' );
+			expect( value ).toContain( 'click' );
+		} );
+	} );
+
+	describe( 'malformed query args', () => {
+		it( 'still builds blocks when a value arrives as an array rather than a string', async () => {
+			// `getQueryArgs()` parses `?text[]=a&text[]=b` into an array, so the values are not
+			// guaranteed to be strings. Treating one as a string would throw and abandon the
+			// repost entirely.
+			const blocks = await loadWithQueryString(
+				'url=https%3A%2F%2Fexample.com%2Fa&text[]=x&text[]=y&title[k]=v'
+			);
+
+			expect( blocks ).not.toBeNull();
+			expect( getEmbedBlock( blocks ).attributes.url ).toBe( 'https://example.com/a' );
+		} );
+
+		it( 'ignores a non-string comment_content instead of throwing', async () => {
+			const blocks = await loadWithQueryString(
+				'url=https%3A%2F%2Fexample.com%2Fa&comment_content[]=x'
+			);
+
+			expect( blocks ).not.toBeNull();
+			expect( getQuoteBlocks( blocks ) ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'url', () => {
+		it( 'round-trips a multi-parameter URL through the citation href', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/post?a=1&b=2',
+				title: 'Title',
+				text: 'Some text',
+			} );
+
+			const { citation } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			// The `&` must be escaped in the source so the attribute is well-formed, and must
+			// decode back to a single `&` when parsed — not to `&amp;` or a dropped parameter.
+			expect( citation ).toContain( '&amp;b=2' );
+
+			// Parsed in this document rather than a detached one, so jest-dom's element check
+			// passes; `innerHTML` still never executes scripts.
+			const container = document.createElement( 'div' );
+			container.innerHTML = citation;
+			expect( container.querySelector( 'a' ) ).toHaveAttribute(
+				'href',
+				'https://example.com/post?a=1&b=2'
+			);
+		} );
+
+		it( 'refuses to build any blocks for a javascript: URL', async () => {
+			const blocks = await loadWithQueryArgs( { url: 'javascript:alert(1)' } );
+
+			expect( blocks ).toBeNull();
+		} );
+
+		it( 'refuses to build any blocks for a data: URL', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'data:text/html,<script>alert(1)</script>',
+			} );
+
+			expect( blocks ).toBeNull();
+		} );
+
+		it( 'passes a normalized http(s) URL through to the embed', async () => {
+			const blocks = await loadWithQueryArgs( { url: 'https://example.com/post' } );
+
+			expect( getEmbedBlock( blocks ).attributes.url ).toBe( 'https://example.com/post' );
+		} );
+
+		it( 'prevents a quote from breaking out of the citation href attribute', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/?a="><img src=x onerror=alert(1)>',
+				title: 'Title',
+				text: 'Some text',
+			} );
+
+			const { citation } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			// URL normalization percent-encodes the quote before escapeAttribute() sees it,
+			// so the attribute cannot be closed early either way.
+			expect( citation ).not.toContain( '<img' );
+			expect( citation ).not.toMatch( /href="[^"]*"[^>]/ );
+			expect( citation ).toContain( '%22' );
+		} );
+	} );
+
+	describe( 'title and text', () => {
+		it( 'escapes both instead of interpolating them as markup', async () => {
+			const blocks = await loadWithQueryArgs( {
+				url: 'https://example.com/source',
+				title: '<img src=x onerror=alert(1)>',
+				text: '<script>alert(1)</script>',
+			} );
+
+			const { value, citation } = getQuoteBlocks( blocks )[ 0 ].attributes;
+
+			expect( value ).toBe( '<p>&lt;script>alert(1)&lt;/script></p>' );
+			expect( citation ).toContain( '&lt;img src=x onerror=alert(1)>' );
+			expect( citation ).not.toContain( '<img' );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -167,7 +167,21 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 		}
 
 		if ( isset( $input['parent_id'] ) ) {
-			$insert['post_parent'] = $input['parent_id'];
+			$parent_id = (int) $input['parent_id'];
+
+			/*
+			 * Attaching media to a post is an edit of that post, so it takes `edit_post` on
+			 * the target, as core's WP_REST_Attachments_Controller does for the same field.
+			 * Without this a caller attaches their own media to any post on the site.
+			 *
+			 * Zero is exempt: it detaches the item rather than naming a target, and
+			 * `edit_post` fails closed on 0, which would make detaching impossible.
+			 */
+			if ( $parent_id && ! current_user_can( 'edit_post', $parent_id ) ) {
+				return new WP_Error( 'unauthorized', 'User cannot edit the parent post', 403 );
+			}
+
+			$insert['post_parent'] = $parent_id;
 		}
 
 		if ( isset( $input['alt'] ) ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-upload-media-v1-1-endpoint.php
@@ -84,6 +84,50 @@ class WPCOM_JSON_API_Upload_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			return new WP_Error( 'invalid_input', 'No media provided in input.' );
 		}
 
+		/*
+		 * Attaching an upload to a post is an edit of that post, so a caller-supplied
+		 * `parent_id` takes `edit_post` on the target. `upload_files` above says only that
+		 * the caller may upload something, never where they may put it.
+		 *
+		 * Every target is checked here, before the first file is written. Refusing from
+		 * inside `handle_media_creation_v1_1()` would leave the items it already created
+		 * on disk and in the database, and a retry would upload them again.
+		 *
+		 * An upload-token request drops `parent_id` instead of being refused. Such a request
+		 * runs with no logged-in user by construction -- `is_authorized_with_upload_token()`
+		 * fails as soon as `get_current_user_id()` is non-zero -- so it can never
+		 * demonstrate `edit_post` on any target, and refusing would break any client that
+		 * pairs a token with `parent_id` for no security gain. Dropping lands the item at
+		 * `post_parent` 0, the same place `absint()` already puts unusable input. The token
+		 * is not treated as trusted here: it is an opaque bearer credential mintable by any
+		 * logged-in user via `/sites/%s/media/token`, so it must not buy an attach.
+		 *
+		 * Zero is exempt: it names no target, and `edit_post` fails closed on 0.
+		 */
+		if ( $this->api->is_authorized_with_upload_token() ) {
+			foreach ( $media_attrs as $i => $media_attr ) {
+				$media_attr = (array) $media_attr;
+				unset( $media_attr['parent_id'] );
+				$media_attrs[ $i ] = $media_attr;
+			}
+		} else {
+			foreach ( $media_attrs as $media_attr ) {
+				// An entry may arrive as an object or as something that is neither; casting
+				// keeps a string entry from being indexed as an array.
+				$media_attr = (array) $media_attr;
+
+				if ( empty( $media_attr['parent_id'] ) ) {
+					continue;
+				}
+
+				$parent_id = absint( $media_attr['parent_id'] );
+
+				if ( $parent_id && ! current_user_can( 'edit_post', $parent_id ) ) {
+					return new WP_Error( 'unauthorized', 'User cannot edit the parent post', 403 );
+				}
+			}
+		}
+
 		$jetpack_sync    = null;
 		$is_jetpack_site = false;
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {

--- a/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
+++ b/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Regression tests for post meta handling in the Import package's post endpoint.
+ *
+ * These live here rather than in projects/packages/import because that package's suite runs
+ * without WordPress, and a meta round trip needs a real one.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Import\Endpoints\Post as Import_Post_Endpoint;
+
+/**
+ * Verifies that imported post meta can never be restored as a PHP object.
+ */
+class Import_Post_Meta_Object_Injection_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Post the meta gets attached to.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Skip when the import package is not loaded, and set up an importing user.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! class_exists( Import_Post_Endpoint::class ) ) {
+			$this->markTestSkipped( 'The jetpack-import package is not loaded in this build.' );
+		}
+
+		// process_post_meta() itself does no capability check -- the route's permission_callback
+		// does -- but run as an administrator so the test mirrors the real caller.
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->post_id = self::factory()->post->create();
+	}
+
+	/**
+	 * Runs a meta payload through the real endpoint method.
+	 *
+	 * @param array $meta Meta key => value map, exactly as it arrives in the REST body.
+	 * @return void
+	 */
+	private function import_meta( array $meta ) {
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/import/posts' );
+		$request->set_param( 'meta', $meta );
+
+		( new Import_Post_Endpoint() )->process_post_meta( $this->post_id, $request );
+	}
+
+	/**
+	 * A serialized object in a meta value must not survive as an object.
+	 *
+	 * Asserted after a full storage round trip, since an object handed to add_post_meta() is
+	 * rebuilt on every later read.
+	 */
+	public function test_object_payload_is_not_stored_as_object() {
+		$this->import_meta( array( 'evil_meta' => 'O:8:"stdClass":1:{s:8:"filename";s:9:"/tmp/pwned";}' ) );
+
+		$stored = get_post_meta( $this->post_id, 'evil_meta', true );
+
+		$this->assertNotInstanceOf( stdClass::class, $stored );
+		$this->assertFalse( is_object( $stored ), 'Imported meta was restored as a live PHP object.' );
+	}
+
+	/**
+	 * An object nested inside an otherwise legitimate array must be dropped, siblings kept.
+	 */
+	public function test_nested_object_is_dropped_but_siblings_survive() {
+		$payload = 'a:2:{s:4:"safe";s:2:"ok";s:3:"bad";O:8:"stdClass":0:{}}';
+
+		$this->import_meta( array( 'mixed_meta' => $payload ) );
+
+		$stored = get_post_meta( $this->post_id, 'mixed_meta', true );
+
+		$this->assertIsArray( $stored );
+		$this->assertSame( 'ok', $stored['safe'] );
+		$this->assertFalse( is_object( $stored['bad'] ), 'A nested object survived the import.' );
+	}
+
+	/**
+	 * The regression guard: a legitimately serialized array must round-trip unchanged.
+	 *
+	 * Shaped like _wp_attachment_metadata, which is the most common serialized meta an import
+	 * actually carries.
+	 */
+	public function test_legitimate_serialized_array_round_trips_unchanged() {
+		$original = array(
+			'width'  => 1200,
+			'height' => 800,
+			'file'   => '2026/08/example.jpg',
+			'sizes'  => array(
+				'thumbnail' => array(
+					'file'   => 'example-150x150.jpg',
+					'width'  => 150,
+					'height' => 150,
+				),
+			),
+		);
+
+		$this->import_meta( array( '_wp_attachment_metadata' => serialize( $original ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize -- building test input.
+
+		$this->assertSame( $original, get_post_meta( $this->post_id, '_wp_attachment_metadata', true ) );
+	}
+
+	/**
+	 * A plain, non-serialized scalar must pass through untouched.
+	 */
+	public function test_plain_scalar_passes_through() {
+		$this->import_meta( array( 'plain_meta' => 'just a string' ) );
+
+		$this->assertSame( 'just a string', get_post_meta( $this->post_id, 'plain_meta', true ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Media_Endpoints_Authorization_Test.php
@@ -715,6 +715,182 @@ class WPCOM_JSON_API_Media_Endpoints_Authorization_Test extends WP_UnitTestCase 
 	}
 
 	/**
+	 * V1.1: `parent_id` names a post to attach the media to, which is an edit of that post.
+	 * A caller who may edit their own attachment must not be able to hang it off a post they
+	 * cannot edit.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_rejects_parent_id_the_user_cannot_edit() {
+		global $blog_id;
+
+		$attachment_id = $this->create_attachment( self::$owner_id );
+		$target_id     = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		wp_set_current_user( self::$owner_id );
+
+		$this->assertTrue( current_user_can( 'edit_post', $attachment_id ), 'The caller owns the attachment.' );
+		$this->assertFalse( current_user_can( 'edit_post', $target_id ), 'The caller must not be able to edit the target.' );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input(
+			array(
+				'title'     => 'Renamed',
+				'parent_id' => $target_id,
+			)
+		);
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data() );
+
+		// The whole update is refused, not just the parent field.
+		$this->assertSame( 0, (int) get_post( $attachment_id )->post_parent );
+		$this->assertSame( 'Original title', get_post( $attachment_id )->post_title );
+	}
+
+	/**
+	 * V1.2 reaches the same `parent_id` handling through `parent::callback()`, so pin it
+	 * there too — the v1.2 route is registered from v1 up to v1.2.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_2_callback_rejects_parent_id_the_user_cannot_edit() {
+		global $blog_id;
+
+		$attachment_id = $this->create_attachment( self::$owner_id );
+		$target_id     = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		wp_set_current_user( self::$owner_id );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Edit_Media_v1_2_Endpoint::class );
+		$this->set_input( array( 'parent_id' => $target_id ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d/edit', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 0, (int) get_post( $attachment_id )->post_parent );
+	}
+
+	/**
+	 * V1.1: attaching media to a post the caller may edit still works.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_allows_parent_id_the_user_can_edit() {
+		global $blog_id;
+
+		$attachment_id = $this->create_attachment( self::$owner_id );
+		$target_id     = self::factory()->post->create( array( 'post_author' => self::$owner_id ) );
+
+		wp_set_current_user( self::$owner_id );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input( array( 'parent_id' => $target_id ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( $target_id, (int) get_post( $attachment_id )->post_parent );
+	}
+
+	/**
+	 * V1.1: a `parent_id` naming a post that does not exist is refused, for every role.
+	 * `edit_post` maps to `do_not_allow` on a missing post, so this 403s administrators
+	 * too. Intended: trunk wrote the dangling `post_parent` instead. A trashed target
+	 * still passes, since the post is there to check.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_rejects_a_parent_id_that_does_not_exist() {
+		global $blog_id;
+
+		$attachment_id = $this->create_attachment( self::$owner_id );
+		$missing_id    = 999999;
+
+		$this->assertNull( get_post( $missing_id ), 'Fixture ID must not exist.' );
+
+		wp_set_current_user( self::$editor_id );
+		$this->assertFalse( current_user_can( 'edit_post', $missing_id ), 'edit_post fails closed on a missing post.' );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input( array( 'parent_id' => $missing_id ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data() );
+		$this->assertSame( 0, (int) get_post( $attachment_id )->post_parent );
+	}
+
+	/**
+	 * V1.1: a trashed target is still a post the caller may edit, so re-parenting to it
+	 * keeps working. Pins the boundary of the missing-post rejection above.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_allows_a_trashed_parent_id() {
+		global $blog_id;
+
+		$attachment_id = $this->create_attachment( self::$owner_id );
+		$target_id     = self::factory()->post->create( array( 'post_author' => self::$owner_id ) );
+		wp_trash_post( $target_id );
+
+		wp_set_current_user( self::$owner_id );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input( array( 'parent_id' => $target_id ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( $target_id, (int) get_post( $attachment_id )->post_parent );
+	}
+
+	/**
+	 * V1.1: `parent_id` 0 detaches the item. It names no target, and `edit_post` fails
+	 * closed on 0, so it must stay exempt from the target check or detaching becomes
+	 * impossible.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_v1_1_callback_allows_detaching_media() {
+		global $blog_id;
+
+		$target_id     = self::factory()->post->create( array( 'post_author' => self::$owner_id ) );
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'image.jpg',
+				'post_parent'    => $target_id,
+				'post_title'     => 'Original title',
+				'post_mime_type' => 'image/jpeg',
+				'post_type'      => 'attachment',
+				'post_author'    => self::$owner_id,
+			)
+		);
+
+		wp_set_current_user( self::$owner_id );
+
+		$endpoint = $this->make_endpoint( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class );
+		$this->set_input( array( 'parent_id' => 0 ) );
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/%d', $blog_id, $attachment_id ), $blog_id, $attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( 0, (int) get_post( $attachment_id )->post_parent );
+	}
+
+	/**
 	 * V1.1: editors can still rename media uploaded by someone else.
 	 *
 	 * @group json-api

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Upload_Media_Authorization_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Upload_Media_Authorization_Test.php
@@ -1,0 +1,399 @@
+<?php
+/**
+ * Per-target authorization tests for the media upload JSON API endpoint.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api.php';
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Per-target authorization tests for `POST /sites/%s/media/new`.
+ *
+ * The endpoint gates on `upload_files`, which says the caller may upload something but
+ * never where they may put it. `attrs[i]['parent_id']` names the post an upload is
+ * attached to, and attaching is an edit of that post.
+ *
+ * These live in their own file rather than in
+ * `WPCOM_JSON_API_Media_Endpoints_Authorization_Test`: this is a different endpoint class
+ * with a different `request_format` and a callback that takes no media ID, so the fixtures
+ * there do not fit.
+ *
+ * @covers \WPCOM_JSON_API_Upload_Media_v1_1_Endpoint
+ */
+#[CoversClass( WPCOM_JSON_API_Upload_Media_v1_1_Endpoint::class )]
+class WPCOM_JSON_API_Upload_Media_Authorization_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Author doing the uploading.
+	 *
+	 * @var int
+	 */
+	private static $uploader_id;
+
+	/**
+	 * A second author, whose posts the uploader may not edit.
+	 *
+	 * @var int
+	 */
+	private static $other_author_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	private static $editor_id;
+
+	/**
+	 * URLs the endpoint was asked to fetch during the test.
+	 *
+	 * @var string[]
+	 */
+	private $fetched = array();
+
+	/**
+	 * Create fixtures once, before any tests in the class have run.
+	 *
+	 * @param object $factory A factory object needed for creating fixtures.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$uploader_id     = $factory->user->create( array( 'role' => 'author' ) );
+		self::$other_author_id = $factory->user->create( array( 'role' => 'author' ) );
+		self::$editor_id       = $factory->user->create( array( 'role' => 'editor' ) );
+	}
+
+	/**
+	 * Prepare the environment for the test.
+	 */
+	public function set_up() {
+		global $blog_id;
+
+		parent::set_up();
+
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+
+		add_filter( 'pre_http_request', array( $this, 'serve_image' ), 10, 3 );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'serve_image' ) );
+
+		WPCOM_JSON_API::init()->token_details = array();
+		WPCOM_JSON_API::init()->post_body     = null;
+		WPCOM_JSON_API::init()->content_type  = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Serve real image bytes for any sideload, and record that the fetch happened.
+	 *
+	 * `download_url()` streams to `$parsed_args['filename']`, so a short-circuited request
+	 * has to write the file itself. The bytes must be a real image: `handle_media_sideload()`
+	 * runs the result through `file_is_displayable_image()`, so junk fails for the wrong
+	 * reason and the assertions stop discriminating.
+	 *
+	 * @param bool   $preempt     Whether to preempt the request.
+	 * @param array  $parsed_args Request arguments.
+	 * @param string $url         The request URL.
+	 * @return array
+	 */
+	public function serve_image( $preempt, $parsed_args, $url ) {
+		$this->fetched[] = $url;
+
+		if ( ! empty( $parsed_args['filename'] ) ) {
+			file_put_contents( $parsed_args['filename'], file_get_contents( __DIR__ . '/../files/jetpack.jpg' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		}
+
+		return array(
+			'headers'  => array(),
+			'body'     => '',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => $parsed_args['filename'] ?? null,
+		);
+	}
+
+	/**
+	 * Build the upload endpoint, declaring the fields the callback reads.
+	 *
+	 * `input()` runs the body through `cast_and_filter()` against `request_format`, so a
+	 * field the fixture does not declare never reaches the callback.
+	 *
+	 * @return WPCOM_JSON_API_Upload_Media_v1_1_Endpoint
+	 */
+	private function make_endpoint() {
+		return new WPCOM_JSON_API_Upload_Media_v1_1_Endpoint(
+			array(
+				'description'    => '',
+				'group'          => '__do_not_document',
+				'stat'           => 'test',
+				'method'         => 'POST',
+				'path'           => '/sites/%s/media/new',
+				'path_labels'    => array(
+					'$site' => '(int|string) Site ID or domain',
+				),
+				'request_format' => array(
+					'media_urls' => '(array) An array of URLs to upload.',
+					'attrs'      => '(array) An array of attributes to assign.',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Set the request input for the API endpoint.
+	 *
+	 * @param array $input Input data.
+	 */
+	private function set_input( $input ) {
+		WPCOM_JSON_API::init()->post_body    = wp_json_encode( $input, JSON_UNESCAPED_SLASHES );
+		WPCOM_JSON_API::init()->content_type = 'application/json';
+	}
+
+	/**
+	 * Invoke the endpoint with the given media URLs and attributes.
+	 *
+	 * @param array $media_urls Media URLs.
+	 * @param array $attrs      Per-item attributes.
+	 * @return mixed
+	 */
+	private function upload( $media_urls, $attrs ) {
+		global $blog_id;
+
+		$this->set_input(
+			array(
+				'media_urls' => $media_urls,
+				'attrs'      => $attrs,
+			)
+		);
+
+		return $this->make_endpoint()->callback( sprintf( '/sites/%d/media/new', $blog_id ), $blog_id );
+	}
+
+	/**
+	 * Count the attachments on the site, to prove a refusal created nothing.
+	 *
+	 * @return int
+	 */
+	private function attachment_count() {
+		return count(
+			get_posts(
+				array(
+					'post_type'   => 'attachment',
+					'post_status' => 'any',
+					'fields'      => 'ids',
+					'numberposts' => -1,
+				)
+			)
+		);
+	}
+
+	/**
+	 * `upload_files` does not authorize attaching an upload to someone else's post.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_upload_rejects_a_parent_id_the_user_cannot_edit() {
+		$target_id = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		wp_set_current_user( self::$uploader_id );
+
+		$this->assertTrue( current_user_can( 'upload_files' ), 'The caller must pass the endpoint gate.' );
+		$this->assertFalse( current_user_can( 'edit_post', $target_id ), 'The caller must not be able to edit the target.' );
+
+		$before   = $this->attachment_count();
+		$response = $this->upload( array( 'https://example.com/one.jpg' ), array( array( 'parent_id' => $target_id ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( 403, $response->get_error_data() );
+
+		// The refusal has to come before any work: nothing fetched, nothing created.
+		$this->assertSame( array(), $this->fetched, 'The gate must reject before any remote fetch.' );
+		$this->assertSame( $before, $this->attachment_count(), 'No attachment may be created.' );
+	}
+
+	/**
+	 * A batch is refused whole. One unauthorized target rejects the request rather than
+	 * uploading the rest, because the endpoint creates items one at a time and a partial
+	 * batch would leave the earlier ones behind with no way to retry cleanly.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_upload_refuses_the_whole_batch_when_one_target_is_unauthorized() {
+		$own_id   = self::factory()->post->create( array( 'post_author' => self::$uploader_id ) );
+		$other_id = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		wp_set_current_user( self::$uploader_id );
+
+		$before   = $this->attachment_count();
+		$response = $this->upload(
+			array( 'https://example.com/one.jpg', 'https://example.com/two.jpg' ),
+			array(
+				array( 'parent_id' => $own_id ),
+				array( 'parent_id' => $other_id ),
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unauthorized', $response->get_error_code() );
+		$this->assertSame( array(), $this->fetched, 'The authorized item must not be uploaded either.' );
+		$this->assertSame( $before, $this->attachment_count(), 'No attachment may be created.' );
+	}
+
+	/**
+	 * Uploading onto a post the caller may edit still works.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_upload_allows_a_parent_id_the_user_can_edit() {
+		$target_id = self::factory()->post->create( array( 'post_author' => self::$uploader_id ) );
+
+		wp_set_current_user( self::$uploader_id );
+
+		$response = $this->upload( array( 'https://example.com/one.jpg' ), array( array( 'parent_id' => $target_id ) ) );
+
+		$this->assertNotWPError( $response );
+		$this->assertCount( 1, $this->fetched );
+
+		$media = get_posts(
+			array(
+				'post_type'   => 'attachment',
+				'post_status' => 'any',
+				'post_parent' => $target_id,
+				'fields'      => 'ids',
+				'numberposts' => -1,
+			)
+		);
+
+		$this->assertCount( 1, $media, 'The upload must be attached to the target.' );
+	}
+
+	/**
+	 * An upload with no `parent_id` is unaffected: it names no target, so there is nothing
+	 * to authorize.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_upload_without_a_parent_id_still_works() {
+		wp_set_current_user( self::$uploader_id );
+
+		$before   = $this->attachment_count();
+		$response = $this->upload( array( 'https://example.com/one.jpg' ), array() );
+
+		$this->assertNotWPError( $response );
+		$this->assertSame( $before + 1, $this->attachment_count() );
+	}
+
+	/**
+	 * An upload-token request has `parent_id` dropped, not refused: the upload succeeds and
+	 * the item lands unattached.
+	 *
+	 * Such a request runs with no logged-in user by construction — WPCOM's
+	 * `is_authorized_with_upload_token()` returns false as soon as `get_current_user_id()`
+	 * is non-zero — so it can never demonstrate `edit_post` on any target. Refusing would
+	 * break any client pairing a token with `parent_id` and buy nothing: dropping reaches
+	 * the same `post_parent` 0 the check already treats as safe.
+	 *
+	 * The token is not trusted here. It is an opaque bearer credential mintable by any
+	 * logged-in user via `/sites/%s/media/token`, so it must not buy an attach.
+	 *
+	 * The monorepo stub always returns false, so the token arm has to be forced to reach
+	 * this at all.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_upload_token_request_drops_the_parent_id() {
+		global $blog_id;
+
+		$target_id = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		// No logged-in user, exactly as an upload-token request runs.
+		wp_set_current_user( 0 );
+		$this->assertFalse( current_user_can( 'edit_post', $target_id ), 'A userless request can never pass edit_post.' );
+
+		$endpoint      = $this->make_endpoint();
+		$endpoint->api = new class() extends WPCOM_JSON_API {
+			/**
+			 * Stand in for the WPCOM implementation, which the monorepo stubs to false.
+			 *
+			 * @return bool
+			 */
+			public function is_authorized_with_upload_token() {
+				return true;
+			}
+		};
+
+		// The endpoint reads its body from its own API object, not from the singleton.
+		$endpoint->api->token_details = array( 'blog_id' => $blog_id );
+		$endpoint->api->post_body     = wp_json_encode(
+			array(
+				'media_urls' => array( 'https://example.com/one.jpg' ),
+				'attrs'      => array( array( 'parent_id' => $target_id ) ),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+		$endpoint->api->content_type  = 'application/json';
+
+		$response = $endpoint->callback( sprintf( '/sites/%d/media/new', $blog_id ), $blog_id );
+
+		$this->assertNotWPError( $response, 'A token upload must not be refused.' );
+		$this->assertCount( 1, $this->fetched, 'The upload must proceed.' );
+
+		$attached = get_posts(
+			array(
+				'post_type'   => 'attachment',
+				'post_status' => 'any',
+				'post_parent' => $target_id,
+				'fields'      => 'ids',
+				'numberposts' => -1,
+			)
+		);
+
+		$this->assertSame( array(), $attached, 'The token must not buy an attach to the target.' );
+	}
+
+	/**
+	 * Editors may attach uploads to other users' posts, because they may edit those posts.
+	 * Pins that the check follows `edit_post` rather than authorship.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_editor_may_upload_onto_another_users_post() {
+		$target_id = self::factory()->post->create( array( 'post_author' => self::$other_author_id ) );
+
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->upload( array( 'https://example.com/one.jpg' ), array( array( 'parent_id' => $target_id ) ) );
+
+		$this->assertNotWPError( $response );
+		$this->assertCount( 1, $this->fetched );
+	}
+}


### PR DESCRIPTION
## Proposed changes

* Backports the fixes that shipped in Jetpack 16.1.3 into trunk, so they are not lost when the next version is cut.
* One commit per patch applied to the 16.1.3 tag, each carrying its tests and changelog entry. The non-test code is identical to what shipped, so there is no functional difference from 16.1.3.

## Related product discussion/links

* Jetpack 16.1.3, released 2026-09-01.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing to click through — the four changes are covered by unit tests that run in CI. To run them locally:

* JS: `cd projects/plugins/jetpack && TZ=UTC pnpm exec jest --config=tests/jest.config.extensions.js --testPathPatterns 'shared/test/reader-repost'`
* PHP: `jp docker phpunit jetpack -- --filter 'WPCOM_JSON_API_Media_Endpoints_Authorization_Test|WPCOM_JSON_API_Upload_Media_Authorization_Test|Import_Post_Meta_Object_Injection_Test'`

The media endpoint tests were merged by hand against the post-type checks already on trunk, so that file is the one worth a close read.

To sanity check against the release itself, diff a 16.1.3 build of the plugin against a build of this branch: the only differences should be the version number and changelog.
