### PR TITLE
Record the 16.1.3 release in the Jetpack changelog

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -142,6 +142,12 @@
 - Update lock file. [#50855]
 - Update package dependencies. [#50509] [#51008] [#51125] [#51331] [#51399]
 
+## 16.1.3 - 2026-09-01
+### Bug fixes
+- Import: Harden post meta handling so imported values are only restored as plain data.
+- Media API: Check permissions on the target post before attaching a media item to it.
+- Reader: Sanitize repost data taken from the URL before it is inserted into the editor.
+
 ## 16.1.2 - 2026-08-20
 ### Bug fixes
 - Newsletter: Fix a fatal error on the settings page caused by Gutenberg removing a private API that DataViews toggle and radio fields relied on. [#51363]

--- a/projects/plugins/jetpack/changelog/backport-16-1-3
+++ b/projects/plugins/jetpack/changelog/backport-16-1-3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Shipped in 16.1.3 and recorded in that release's changelog block; no separate entry needed for the next release.
+
+

--- a/projects/plugins/jetpack/changelog/fix-jetpack-import-meta-decode
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-import-meta-decode
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Import: Harden post meta handling so imported values are only restored as plain data.

--- a/projects/plugins/jetpack/changelog/fix-reader-repost-sanitize-query-args
+++ b/projects/plugins/jetpack/changelog/fix-reader-repost-sanitize-query-args
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Reader: Sanitize repost data taken from the URL before it is inserted into the editor.

--- a/projects/plugins/jetpack/changelog/jetpack-2092-media-parent-id-target-check
+++ b/projects/plugins/jetpack/changelog/jetpack-2092-media-parent-id-target-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Media API: Check permissions on the target post before attaching a media item to it.

--- a/projects/plugins/jetpack/changelog/jetpack-2228-media-new-parent-id-target-check
+++ b/projects/plugins/jetpack/changelog/jetpack-2228-media-new-parent-id-target-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Media API: Check permissions on the target post before attaching an upload to it.


### PR DESCRIPTION
Stacked on #51830.

## Proposed changes

Records the three fixes from #51830 under a `16.1.3` block in `CHANGELOG.md` rather than leaving them as pending entries that would be listed again under the next version. They already shipped to users in 16.1.3, so reporting them twice would be wrong.

Follows the 16.0.1 backport in #50548, which did the same thing for a fix that shipped out of band:

* **`CHANGELOG.md` only.** No `readme.txt` — that file carries only the current release's section, which is 16.2-a.3. No `jetpack.php` or `composer.json` version bump either; #51435 and #51188 bumped because trunk was still on the 16.1 line at the time, and it has since moved on.
* **The block is inserted in version order**, below 16.2-a.1 and above 16.1.2. Confirmed `changelogger version current` still reports `16.2-a.3` and `version next` still reports `16.2`, so the insertion does not disturb the release tooling.
* **No `[#PR]` links on the entries**, since these came from the release branch rather than from trunk PRs — same as the backported line in the 16.0.1 block.
* **One comment-only entry replaces the three pending ones**, so the changelogger CI gate still passes without producing duplicate lines. `changelogger validate` passes.

The earlier commit on this branch collapses the two near-duplicate Media API entries into one, which is the single Media API line that ends up in the 16.1.3 block.

### The `projects/packages/import` entry stays pending

That one is deliberately untouched. Package changelogs track package versions, and there is no 16.1.3 of `jetpack-import` — the fix reaches package consumers through the next package release, which the release tooling cuts. Nothing to hand-write here.

### One judgment call worth a second opinion

The shipped 16.1.3 `readme.txt` grouped these under a `#### Security:` heading, hand-written at release time. This block uses `### Bug fixes`, matching the 16.0.1 precedent and the `bugfix` type these entries actually carry — `plugins/jetpack` defines no `security` changelogger type. Happy to switch it to `### Security` if you would rather the trunk record match the release's framing; it is a one-word change.

## Related product discussion/links

* Jetpack 16.1.3, released 2026-09-01.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* No code changes — the diff is `CHANGELOG.md` plus changelog entry bookkeeping.
* From `projects/plugins/jetpack`, confirm the tooling still agrees: `changelogger validate`, `changelogger version current` (expect `16.2-a.3`), `changelogger version next` (expect `16.2`).
* Confirm the 16.1.3 block matches what shipped: `git show 16.1.3:readme.txt` in the release repo.
