### PR TITLE
Jetpack AI: Prevent General Settings from resetting feature toggles

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -143,9 +143,12 @@ class Jetpack_AI_Settings {
 			self::FEATURE_OPTIONS['ai_seo']            => __( 'Whether the Jetpack AI SEO features are enabled.', 'jetpack' ),
 		);
 
+		// These settings do not belong to Settings > General. A separate group
+		// prevents options.php from clearing values whose fields are absent from
+		// the General form.
 		foreach ( $options as $option => $description ) {
 			register_setting(
-				'general',
+				'jetpack_ai',
 				$option,
 				array(
 					'type'              => 'boolean',

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-settings-group
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-settings-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Prevent General Settings saves from resetting AI feature settings.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -599,20 +599,33 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The owned options are registered (register_setting on init). The master
-	 * option must stay OUT of core settings REST: off-Simple the module is the
-	 * master (a core-REST write would only clobber the legacy opt-out value),
-	 * and the dedicated feature-settings endpoint is the real writable surface.
+	 * The owned options are registered (register_setting on init) in their own
+	 * group so saving Settings > General cannot clear fields that form does not
+	 * contain. The master option must stay OUT of core settings REST: off-Simple
+	 * the module is the master (a core-REST write would only clobber the legacy
+	 * opt-out value), and the dedicated feature-settings endpoint is the real
+	 * writable surface.
 	 */
 	public function test_options_are_registered() {
+		global $new_allowed_options;
+
 		Jetpack_AI_Settings::register_settings();
 
 		$registered = get_registered_settings();
+		$options    = array( Jetpack_AI_Settings::MASTER_OPTION );
+		foreach ( Jetpack_AI_Settings::OWNED_FEATURES as $feature ) {
+			$options[] = Jetpack_AI_Settings::FEATURE_OPTIONS[ $feature ];
+		}
 
-		$this->assertArrayHasKey( 'jetpack_ai_enabled', $registered );
-		$this->assertArrayHasKey( 'jetpack_ai_writing_assistant_enabled', $registered );
-		$this->assertArrayHasKey( 'jetpack_ai_image_editor_enabled', $registered );
-		$this->assertArrayHasKey( 'jetpack_ai_seo_enabled', $registered );
+		foreach ( $options as $option ) {
+			$this->assertArrayHasKey( $option, $registered );
+			$this->assertSame( 'jetpack_ai', $registered[ $option ]['group'] );
+			$this->assertContains( $option, $new_allowed_options['jetpack_ai'] ?? array() );
+		}
+		$this->assertEmpty(
+			array_intersect( $options, $new_allowed_options['general'] ?? array() ),
+			'Jetpack AI settings must not be submitted with the General Settings form.'
+		);
 		$this->assertArrayNotHasKey( 'jetpack_ai_image_label_enabled', $registered );
 
 		$this->assertFalse( $registered['jetpack_ai_enabled']['show_in_rest'], 'The master option is never exposed over core settings REST.' );


### PR DESCRIPTION
## Proposed changes

* Register the Jetpack AI master setting and its four owned feature settings under a dedicated `jetpack_ai` settings group instead of WordPress's `general` group.
* Prevent Settings > General saves from processing and disabling Jetpack AI options whose fields are absent from that form.
* Keep the existing option names, defaults, sanitization, REST visibility, and sync behavior unchanged.
* Add regression coverage for all five settings.

## Related product discussion/links

* Simple and Atomic rollout bridge: #51827.
* Related Jetpack AI Hub parity work: #51811.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions
Atomic
1. Before installing this PR make sure to activate Jetpack AI and toggle all Jetpack AI features
2. Install this PR on your site using Jetpack Beta
3. Go to **Settings > General** and select **Save Changes**.
4. Open a Post and verify that Jetpack AI features are still available (Improve with AI, Generate Image)

Simple
1. Install this PR on your sandbox
2. Go to **Settings > General** and select **Save Changes**.
3. Open a Post and verify that Jetpack AI features are still available (Improve with AI, Generate Image)
