### PR TITLE
Premium Analytics: hold the Plan usage widget back from Stats v2

### DIFF
--- a/projects/packages/premium-analytics/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/packages/premium-analytics/changelog/stats-459-hide-plan-usage-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Stats: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.

--- a/projects/packages/premium-analytics/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/packages/premium-analytics/changelog/stats-459-hide-plan-usage-widget
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Stats: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.
+Plan usage: Remove the widget and its upgrade link from the dashboard while the paid plan is revised.

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * Widget type support shared by the registry and default layouts — hard availability only
- * (a feature the site has or doesn't); soft/request-dependent state belongs in the runtime
- * types filter. Persisted layouts keep missing types as removable ghost widgets.
+ * (a feature the site has or doesn't, or a type held back from release); soft/request-dependent
+ * state belongs in the runtime types filter. Persisted layouts keep missing types as removable
+ * ghost widgets.
  *
  * @package automattic/jetpack-premium-analytics
  */

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -27,6 +27,13 @@ const VIDEOPRESS_WIDGET_TYPES = array(
 );
 
 /**
+ * Widget types that surface plan usage and upgrade prompts.
+ */
+const PLAN_USAGE_WIDGET_TYPES = array(
+	'jpa/plan-usage',
+);
+
+/**
  * Returns the current widget support context.
  *
  * @return array{is_wpcom_simple:bool,has_videopress:bool} Widget support context.
@@ -45,7 +52,9 @@ function get_widget_support_context() {
  * @return string[] Unsupported widget type names.
  */
 function get_unsupported_widget_types( $context ) {
-	$unsupported = array();
+	// Usage and upgrade UX stays out of Stats v2 on every site until the paid plan is
+	// settled (STATS-459); it returns through the configurations drawer (WOOA7S-2037).
+	$unsupported = PLAN_USAGE_WIDGET_TYPES;
 
 	// File download tracking is served only on WPCOM Simple. Calypso applies
 	// the same boundary, which excludes self-hosted Jetpack and Atomic sites.

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -374,7 +374,7 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			);
 		}
 
-		// Plan usage is intentionally not a default.
+		// Plan usage is intentionally not a default (and held back entirely while the paid plan is revised).
 		$this->assertNotContains( 'jpa/plan-usage', $layout_types );
 
 		$this->assertSame(

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -267,6 +267,31 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Every held plan-usage type names a real manifest, so a renamed or moved widget
+	 * cannot lift the hold while the absence assertions above stay green.
+	 */
+	public function test_plan_usage_widget_types_match_the_manifest() {
+		$manifests = glob( __DIR__ . '/../../widgets/*/widget.json' );
+		$this->assertNotEmpty( $manifests, 'No widget manifests found — the glob path is wrong.' );
+
+		$names = array();
+		foreach ( $manifests as $manifest ) {
+			$raw = file_get_contents( $manifest ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$this->assertNotFalse( $raw, "Could not read $manifest" );
+
+			$widget = json_decode( $raw, true );
+			$this->assertIsArray( $widget, "Malformed manifest: $manifest" );
+			$this->assertArrayHasKey( 'name', $widget, "Manifest declares no name: $manifest" );
+
+			$names[] = $widget['name'];
+		}
+
+		foreach ( PLAN_USAGE_WIDGET_TYPES as $held ) {
+			$this->assertContains( $held, $names, "$held is held back but no manifest declares it." );
+		}
+	}
+
+	/**
 	 * The registry callback drops the video widgets when VideoPress is absent.
 	 */
 	public function test_registry_callback_removes_video_widgets_without_videopress() {
@@ -584,6 +609,7 @@ class Widget_Availability_Test extends BaseTestCase {
 
 		$this->assertContains( 'jpa/file-downloads', $names );
 		$this->assertContains( 'jpa/shares', $names );
+		$this->assertNotContains( 'jpa/plan-usage', $names, 'The plan-usage hold applies on Simple too.' );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -234,8 +234,8 @@ class Widget_Availability_Test extends BaseTestCase {
 	/**
 	 * Every widget type name declared by a `widgets/*` manifest.
 	 *
-	 * Asserts rather than skips a bad manifest: one silently dropped is absent from both sides
-	 * of a gate-vs-manifest comparison, so the guard would pass while the gate misses a type.
+	 * Asserts rather than skips a malformed manifest, so a dropped one can't quietly narrow
+	 * what the callers compare against.
 	 *
 	 * @return string[] Declared widget type names.
 	 */
@@ -267,13 +267,11 @@ class Widget_Availability_Test extends BaseTestCase {
 	 * "requires" field to key on instead — read that here if one is ever added.
 	 */
 	public function test_videopress_widget_types_match_the_manifest() {
-		$video_names = array_values(
-			array_filter(
-				$this->manifest_widget_names(),
-				static function ( $name ) {
-					return str_contains( $name, 'video' );
-				}
-			)
+		$video_names = array_filter(
+			$this->manifest_widget_names(),
+			static function ( $name ) {
+				return str_contains( $name, 'video' );
+			}
 		);
 
 		$gated = VIDEOPRESS_WIDGET_TYPES;

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -87,6 +87,10 @@ class Widget_Availability_Test extends BaseTestCase {
 				'category' => 'traffic',
 			),
 			array(
+				'name'     => 'jpa/plan-usage',
+				'category' => 'stats',
+			),
+			array(
 				'name'     => 'jpa/hello-world',
 				'category' => 'demo',
 			),
@@ -177,6 +181,14 @@ class Widget_Availability_Test extends BaseTestCase {
 	 */
 	public function test_type_policy_keeps_file_downloads_on_simple() {
 		$this->assertContains( 'jpa/file-downloads', $this->available_names( true ) );
+	}
+
+	/**
+	 * Plan usage is held back regardless of host or features.
+	 */
+	public function test_type_policy_removes_plan_usage_everywhere() {
+		$this->assertNotContains( 'jpa/plan-usage', $this->available_names( false, false ) );
+		$this->assertNotContains( 'jpa/plan-usage', $this->available_names( true, true ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -232,45 +232,14 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The gate and the manifests agree in both directions: a renamed widget can't drop out of the
-	 * gate, and a new video widget can't be added without joining it.
+	 * Every widget type name declared by a `widgets/*` manifest.
 	 *
-	 * The second half rests on a naming heuristic: a VideoPress widget not named with `video` would
-	 * be missed, and an unrelated `video-*` widget wrongly demanded. Widget manifests have no
-	 * "requires" field to key on instead — read that here if one is ever added.
+	 * Asserts rather than skips a bad manifest: one silently dropped is absent from both sides
+	 * of a gate-vs-manifest comparison, so the guard would pass while the gate misses a type.
+	 *
+	 * @return string[] Declared widget type names.
 	 */
-	public function test_videopress_widget_types_match_the_manifest() {
-		$manifests = glob( __DIR__ . '/../../widgets/*/widget.json' );
-		$this->assertNotEmpty( $manifests, 'No widget manifests found — the glob path is wrong.' );
-
-		$video_names = array();
-		foreach ( $manifests as $manifest ) {
-			// Assert rather than skip: a silently dropped manifest is absent from both sides of the
-			// comparison below, so the guard would pass while the gate is missing a type — the failure this test exists to catch.
-			$raw = file_get_contents( $manifest ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$this->assertNotFalse( $raw, "Could not read $manifest" );
-
-			$widget = json_decode( $raw, true );
-			$this->assertIsArray( $widget, "Malformed manifest: $manifest" );
-			$this->assertArrayHasKey( 'name', $widget, "Manifest declares no name: $manifest" );
-
-			if ( str_contains( $widget['name'], 'video' ) ) {
-				$video_names[] = $widget['name'];
-			}
-		}
-
-		$gated = VIDEOPRESS_WIDGET_TYPES;
-		sort( $gated );
-		sort( $video_names );
-
-		$this->assertSame( $gated, $video_names, 'Every video widget must be listed in VIDEOPRESS_WIDGET_TYPES.' );
-	}
-
-	/**
-	 * Every held plan-usage type names a real manifest, so a renamed or moved widget
-	 * cannot lift the hold while the absence assertions above stay green.
-	 */
-	public function test_plan_usage_widget_types_match_the_manifest() {
+	private function manifest_widget_names() {
 		$manifests = glob( __DIR__ . '/../../widgets/*/widget.json' );
 		$this->assertNotEmpty( $manifests, 'No widget manifests found — the glob path is wrong.' );
 
@@ -285,6 +254,41 @@ class Widget_Availability_Test extends BaseTestCase {
 
 			$names[] = $widget['name'];
 		}
+
+		return $names;
+	}
+
+	/**
+	 * The gate and the manifests agree in both directions: a renamed widget can't drop out of the
+	 * gate, and a new video widget can't be added without joining it.
+	 *
+	 * The second half rests on a naming heuristic: a VideoPress widget not named with `video` would
+	 * be missed, and an unrelated `video-*` widget wrongly demanded. Widget manifests have no
+	 * "requires" field to key on instead — read that here if one is ever added.
+	 */
+	public function test_videopress_widget_types_match_the_manifest() {
+		$video_names = array_values(
+			array_filter(
+				$this->manifest_widget_names(),
+				static function ( $name ) {
+					return str_contains( $name, 'video' );
+				}
+			)
+		);
+
+		$gated = VIDEOPRESS_WIDGET_TYPES;
+		sort( $gated );
+		sort( $video_names );
+
+		$this->assertSame( $gated, $video_names, 'Every video widget must be listed in VIDEOPRESS_WIDGET_TYPES.' );
+	}
+
+	/**
+	 * Every held plan-usage type names a real manifest, so a renamed or moved widget
+	 * cannot lift the hold while the absence assertions above stay green.
+	 */
+	public function test_plan_usage_widget_types_match_the_manifest() {
+		$names = $this->manifest_widget_names();
 
 		foreach ( PLAN_USAGE_WIDGET_TYPES as $held ) {
 			$this->assertContains( $held, $names, "$held is held back but no manifest declares it." );

--- a/projects/plugins/jetpack/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/plugins/jetpack/changelog/stats-459-hide-plan-usage-widget
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Stats v2: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.
+Premium Analytics: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.

--- a/projects/plugins/jetpack/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/plugins/jetpack/changelog/stats-459-hide-plan-usage-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Stats v2: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.

--- a/projects/plugins/premium-analytics/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/plugins/premium-analytics/changelog/stats-459-hide-plan-usage-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Stats: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.

--- a/projects/plugins/premium-analytics/changelog/stats-459-hide-plan-usage-widget
+++ b/projects/plugins/premium-analytics/changelog/stats-459-hide-plan-usage-widget
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Stats: Remove the Plan usage widget and its upgrade link from the dashboard while the paid plan is revised.
+Plan usage: Remove the widget and its upgrade link from the dashboard while the paid plan is revised.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/STATS-459/hide-usage-and-upgrade-ux-in-the-preview-traffic-tab

## Why
The Traffic tab of Stats v2 is about to soft-launch as an opt-in preview next to classic Stats, and product asked for the preview to carry no usage or upgrade UX: the paid plan (and whether a view cap survives on it at all) is being revised, so there is nothing settled for a usage meter or an "Upgrade now" prompt to say. The Plan usage widget is the only such surface in the dashboard today, so it is held back until that lands — its designed return, as a panel in the configurations drawer, is tracked in WOOA7S-2037.

## Proposed changes
* Drop `jpa/plan-usage` from the widget type registry on every site, so it no longer appears in the **Add widget** picker or the `widget-modules` REST list.
* Keep the widget's source, tests, stories, data hooks, and proxy endpoints in place: lifting the hold is a one-line change once the plan is settled.
* An instance a user had already added to a layout now renders as the dashboard's "Widget is no longer available." placeholder, which they can remove. It was never part of any default layout.
* No change to billing or to classic Stats, which keeps carrying the plan usage section and tier notices during the preview.

## Verification
The `widget-modules` REST list, queried as an administrator on the local docker site — 72 types on trunk with `jpa/plan-usage` present, 71 on this branch without it.

<details>
<summary>Output</summary>

```text
# trunk
$ wp eval "…rest_do_request( new WP_REST_Request( 'GET', '/wpcom/v2/widget-modules' ) )…"
200 count=72 plan-usage=PRESENT

# this branch
200 count=71 plan-usage=absent
```

</details>

Before/after screenshots of the **Add widget** picker follow in a comment.

## Related product discussion/links
* STATS-459 — this issue; the preview-mode constraint for the Traffic tab soft launch.
* WOOA7S-1984 — the decision to pull the usage surface until the paid plan is updated, and why.
* WOOA7S-2037 — where the plan usage panel returns (configurations drawer), flagged not-for-beta.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build and open Stats v2: `jp build packages/premium-analytics plugins/premium-analytics` (with `packages/my-jetpack` and `plugins/jetpack` built once), then go to **Stats v2** in wp-admin.
* Click **Customize**, then **Add widget**, and search for `usage`.
  - [ ] **Plan usage** is not listed (only the coupon usage widgets, on a WooCommerce site).
  - [ ] The Traffic, Insights, and Subscribers tabs render their default layouts unchanged — Plan usage was never a default.
* Query `GET /wp-json/wpcom/v2/widget-modules` as an administrator.
  - [ ] No entry has `"name": "jpa/plan-usage"`.
* Optional, for the already-added case: on trunk, add **Plan usage** to a tab and click **Done**; switch to this branch and reload.
  - [ ] The tile shows the "Widget is no longer available." placeholder and can be removed in Customize mode.
* `jp test php packages/premium-analytics`
  - [ ] Passes, including the new `Widget_Availability_Test::test_type_policy_removes_plan_usage_everywhere`.
