### PR TITLE
Jetpack MU WPCOM: Repair Jetpack AI settings on Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/repair-simple-jetpack-ai-options
+++ b/projects/packages/jetpack-mu-wpcom/changelog/repair-simple-jetpack-ai-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Restore default feature settings on affected WordPress.com Simple sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -87,6 +87,8 @@ class Jetpack_Mu_Wpcom {
 
 		// These features run only on simple sites.
 		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// Repair the options before plugins can read them during loading.
+			require_once __DIR__ . '/features/jetpack-ai-options-repair/jetpack-ai-options-repair.php';
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_simple_jetpack_ai' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_moderate' ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-options-repair/jetpack-ai-options-repair.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/jetpack-ai-options-repair/jetpack-ai-options-repair.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Repair Jetpack AI settings on WordPress.com Simple sites.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Options_Repair;
+
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Jetpack AI options corrupted by General Settings saves.
+ */
+const JETPACK_AI_OPTIONS = array(
+	'jetpack_ai_enabled',
+	'jetpack_ai_writing_assistant_enabled',
+	'jetpack_ai_image_editor_enabled',
+	'jetpack_ai_feature_clip_enabled',
+	'jetpack_ai_seo_enabled',
+);
+
+/**
+ * Records that the Simple-site repair has run.
+ */
+const SIMPLE_REPAIR_MARKER = 'jetpack_mu_wpcom_ai_options_repaired';
+
+/**
+ * Restore Jetpack AI defaults on Simple sites affected by General Settings saves.
+ *
+ * @return void
+ */
+function repair_wpcom_simple_options() {
+	if ( ! ( new Host() )->is_wpcom_simple() || get_option( SIMPLE_REPAIR_MARKER, false ) ) {
+		return;
+	}
+
+	foreach ( JETPACK_AI_OPTIONS as $option ) {
+		delete_option( $option );
+	}
+
+	update_option( SIMPLE_REPAIR_MARKER, true, false );
+}
+repair_wpcom_simple_options();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-options-repair/Jetpack_AI_Options_Repair_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/jetpack-ai-options-repair/Jetpack_AI_Options_Repair_Test.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Tests for the WordPress.com Simple Jetpack AI settings repair.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Jetpack_AI_Options_Repair;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/jetpack-ai-options-repair/jetpack-ai-options-repair.php';
+
+/**
+ * Tests for the WordPress.com Simple Jetpack AI settings repair.
+ */
+class Jetpack_AI_Options_Repair_Test extends \WorDBless\BaseTestCase {
+	const UNRELATED_OPTIONS = array(
+		'reader_chat',
+		'jetpack_ai_agents_enabled',
+		'big_sky_enable',
+	);
+
+	/**
+	 * Reset the options and hosting constants used by each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->reset_test_state();
+	}
+
+	/**
+	 * Clean up options and hosting constants after each test.
+	 */
+	public function tear_down() {
+		$this->reset_test_state();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Remove test options and hosting overrides.
+	 */
+	private function reset_test_state() {
+		Constants::clear_constants();
+
+		foreach ( array_merge( JETPACK_AI_OPTIONS, self::UNRELATED_OPTIONS, array( SIMPLE_REPAIR_MARKER ) ) as $option ) {
+			delete_option( $option );
+		}
+	}
+
+	/**
+	 * The repair deletes only the five corrupted options on Simple sites.
+	 */
+	public function test_repairs_wpcom_simple_options_once() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		foreach ( JETPACK_AI_OPTIONS as $option ) {
+			add_option( $option, '0' );
+		}
+		add_option( 'reader_chat', '1' );
+		add_option( 'jetpack_ai_agents_enabled', '1' );
+		add_option( 'big_sky_enable', '0' );
+
+		repair_wpcom_simple_options();
+
+		foreach ( JETPACK_AI_OPTIONS as $option ) {
+			$this->assertSame( 'missing', get_option( $option, 'missing' ) );
+		}
+		$this->assertTrue( (bool) get_option( SIMPLE_REPAIR_MARKER, false ) );
+		$this->assertSame( '1', get_option( 'reader_chat' ) );
+		$this->assertSame( '1', get_option( 'jetpack_ai_agents_enabled' ) );
+		$this->assertSame( '0', get_option( 'big_sky_enable' ) );
+
+		add_option( JETPACK_AI_OPTIONS[0], '0' );
+		repair_wpcom_simple_options();
+
+		$this->assertSame( '0', get_option( JETPACK_AI_OPTIONS[0] ) );
+	}
+
+	/**
+	 * Atomic sites keep their stored values and never receive the repair marker.
+	 */
+	public function test_does_not_repair_atomic_options() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		Constants::set_constant( 'IS_ATOMIC', true );
+
+		foreach ( JETPACK_AI_OPTIONS as $option ) {
+			add_option( $option, '0' );
+		}
+
+		repair_wpcom_simple_options();
+
+		foreach ( JETPACK_AI_OPTIONS as $option ) {
+			$this->assertSame( '0', get_option( $option ) );
+		}
+		$this->assertSame( 'missing', get_option( SIMPLE_REPAIR_MARKER, 'missing' ) );
+	}
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/repair-simple-jetpack-ai-options
+++ b/projects/plugins/mu-wpcom-plugin/changelog/repair-simple-jetpack-ai-options
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack AI: Restore default feature settings on affected WordPress.com Simple sites.


### PR DESCRIPTION
## Proposed changes

* On WordPress.com Simple sites only, delete the five affected Jetpack AI option rows once so values reset by General Settings return to their default-on state.
* Store `jetpack_mu_wpcom_ai_options_repaired` after the delete pass, with autoload disabled, so the repair runs once per site.
* Leave Atomic values, `reader_chat`, `jetpack_ai_agents_enabled`, and the WordPress Agent option `big_sky_enable` unchanged.
* Run the repair during MU-plugin loading, before plugins can read the affected options.
* Preserve the current Simple default-on contract. Simple does not yet expose these controls, so resetting stored false values is intentional.
* Treat this as a temporary fleet repair and remove it after affected Simple sites have run it and the Simple controls ship.

## Related product discussion/links

* #51833 is the permanent prevention fix: it registers the five options under the dedicated `jetpack_ai` settings group.
* #51827 is the rollout bridge. It can be reverted after #51833 is deployed to the target sites; this repair is independent of that revert.
* #50386 introduced the affected Jetpack AI settings.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp test php packages/jetpack-mu-wpcom -v`.
* Run `jp phan packages/jetpack-mu-wpcom`.
* On a Simple test site with the marker absent, store false values for the five affected options and load a page. Confirm the five rows are deleted and `jetpack_mu_wpcom_ai_options_repaired` is stored with autoload disabled.
* Confirm `reader_chat`, `jetpack_ai_agents_enabled`, and `big_sky_enable` retain their stored values.
* Re-add one affected option as false and load another page. Confirm it remains false because the repair marker prevents a second pass.
* On an Atomic test site, confirm all five values remain unchanged and the repair marker is not created.
