### PR TITLE
Backup: show the restore message and percent while progress is pinned at 0

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-restore-progress-message
+++ b/projects/packages/backup/changelog/fix-backup-restore-progress-message
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Restore screen: show the upstream message and a numeric percent while a restore runs, so the file-check preflight that pins the bar at 0% for minutes no longer reads as a hang. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/changelog/fix-backup-restore-progress-message
+++ b/projects/packages/backup/changelog/fix-backup-restore-progress-message
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Restore screen: show the upstream message and a numeric percent while a restore runs, so the file-check preflight that pins the bar at 0% for minutes no longer reads as a hang. No-op when the modernization filter is off.
+Comment: Restore screen: show the upstream message and a numeric percent while a restore runs, so the file-check preflight that pins the bar at 0% for minutes no longer reads as a hang, and announce the running phase to screen readers on both the restore and download screens. No-op when the modernization filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -172,7 +172,11 @@ function deriveState( input: DeriveInput ): RestoreState {
 				message: data.message || __( 'Restore failed.', 'jetpack-backup-pkg' ),
 			};
 		case 'running':
-			return { phase: 'progress', percent: Math.round( data.progress ?? 0 ) };
+			return {
+				phase: 'progress',
+				percent: Math.round( data.progress ?? 0 ),
+				message: data.message,
+			};
 		default:
 			// `queued`, `unknown`, or nothing yet. All the same to the
 			// reader: accepted, nothing to show. Unless it has been that

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -181,7 +181,7 @@ export default function DownloadScreen() {
 					 */ }
 					{ isPreparing && (
 						<Stack direction="column" gap="sm">
-							<Text>{ __( 'Preparing download…', 'jetpack-backup-pkg' ) }</Text>
+							<Text role="status">{ __( 'Preparing download…', 'jetpack-backup-pkg' ) }</Text>
 							{ state.phase === 'progress' ? (
 								<ProgressBar
 									value={ state.percent }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -204,7 +204,11 @@ export default function RestoreScreen() {
 					) }
 					{ state.phase === 'progress' && (
 						<Stack direction="column" gap="sm">
-							<Text>{ __( 'Restoring…', 'jetpack-backup-pkg' ) }</Text>
+							{ /*
+							 * Scoped to this line, not the block: the percentage and message
+							 * below change on every 5s poll and would re-announce with it.
+							 */ }
+							<Text role="status">{ __( 'Restoring…', 'jetpack-backup-pkg' ) }</Text>
 							<ProgressBar
 								value={ state.percent }
 								aria-label={ __( 'Restoring your site', 'jetpack-backup-pkg' ) }

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -209,6 +209,23 @@ export default function RestoreScreen() {
 								value={ state.percent }
 								aria-label={ __( 'Restoring your site', 'jetpack-backup-pkg' ) }
 							/>
+							<Text variant="body-sm" className="jpb-text-muted">
+								{ sprintf(
+									/* translators: %d is a completion percentage, e.g. "50% complete". */
+									__( '%d%% complete', 'jetpack-backup-pkg' ),
+									state.percent
+								) }
+							</Text>
+							{ /*
+							 * The message is the only sign of life while `percent` stays
+							 * pinned at 0 — VaultPress's file-check preflight can run for
+							 * minutes before it moves.
+							 */ }
+							{ state.message && (
+								<Text variant="body-sm" className="jpb-text-muted">
+									{ state.message }
+								</Text>
+							) }
 						</Stack>
 					) }
 					{ state.phase === 'success' && (

--- a/projects/packages/backup/src/dashboard/types/restore.ts
+++ b/projects/packages/backup/src/dashboard/types/restore.ts
@@ -87,7 +87,7 @@ export type RestoreState =
 	| { phase: 'submitting' }
 	| { phase: 'queued' }
 	| { phase: 'unconfirmed'; detail: string | null }
-	| { phase: 'progress'; percent: number }
+	| { phase: 'progress'; percent: number; message: string }
 	| { phase: 'success' }
 	| { phase: 'success-with-errors'; message: string }
 	| { phase: 'lost-track'; detail: string | null }

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -352,6 +352,17 @@ describe( 'Download screen with a file selection', () => {
 		expect( screen.queryByRole( 'button', { name: /Generate download/ } ) ).not.toBeInTheDocument();
 	} );
 
+	// The bare role query is unambiguous: the checklist branch that carries the
+	// screen's other `role="status"` never renders alongside a file selection.
+	it( 'announces that the archive is being prepared, and only that line', async () => {
+		render( <DownloadStage /> );
+
+		// Exact, for the reason given in `restore-progress-message.test.tsx`.
+		await expect( screen.findByRole( 'status', undefined, SETTLE ) ).resolves.toHaveTextContent(
+			/^Preparing download…$/
+		);
+	} );
+
 	it( 'asks WordPress.com for the archive once, without being clicked', async () => {
 		render( <DownloadStage /> );
 

--- a/projects/packages/backup/tests/restore-progress-message.test.tsx
+++ b/projects/packages/backup/tests/restore-progress-message.test.tsx
@@ -1,0 +1,103 @@
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+	useNavigate: () => () => {},
+	useParams: () => ( { rewindId: '1786663613.9425' } ),
+	Link: ( { children, to, ...rest }: { children: React.ReactNode; to: string } ) => (
+		<a href={ to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const RESTORE_ID = 912682;
+const REWIND_ID = '1786663613.9425';
+const SETTLE = { timeout: 10000 };
+
+/**
+ * Answer capabilities and the initiate POST, then let the status poll
+ * report the given progress and message.
+ *
+ * @param progress - The `progress` field the status poll reports.
+ * @param message  - The `message` field the status poll reports.
+ */
+function arrange( progress: number, message: string ) {
+	mockApiFetch.mockImplementation( ( o: { path?: string; method?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( o?.method === 'POST' ) {
+			return Promise.resolve( { id: RESTORE_ID, rewind_id: REWIND_ID } );
+		}
+		if ( path.includes( '/status' ) ) {
+			return Promise.resolve( {
+				id: RESTORE_ID,
+				status: 'running',
+				progress,
+				rewind_id: REWIND_ID,
+				error_code: '',
+				message,
+			} );
+		}
+		return Promise.resolve( [] );
+	} );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+/**
+ * Start a restore with the default six-of-six checklist.
+ */
+async function startRestore() {
+	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+}
+
+describe( 'the Restore screen during a running restore', () => {
+	it( 'shows the upstream message as a sign of life', async () => {
+		arrange( 0, 'Checking remote files: 22396' );
+		render( <RestoreStage /> );
+
+		await startRestore();
+
+		await expect(
+			screen.findByText( 'Checking remote files: 22396', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+
+	// Both figures, so a hardcoded `0%` cannot pass: the preflight pins it at
+	// zero, but the readout has to track the real value once it moves.
+	it.each( [ 0, 42 ] )( 'reports %i%% complete beside the bar', async percent => {
+		arrange( percent, 'Checking remote files: 22396' );
+		render( <RestoreStage /> );
+
+		await startRestore();
+
+		await expect(
+			screen.findByText( `${ percent }% complete`, undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/restore-progress-message.test.tsx
+++ b/projects/packages/backup/tests/restore-progress-message.test.tsx
@@ -88,6 +88,25 @@ describe( 'the Restore screen during a running restore', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
+	it( 'announces that the restore started, and only that line', async () => {
+		arrange( 0, 'Checking remote files: 22396' );
+		render( <RestoreStage /> );
+
+		await startRestore();
+		// Wait for the phase first: the idle branch's own `role="status"` is still
+		// mounted, empty, until the submission settles.
+		await expect(
+			screen.findByText( '0% complete', undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		// Exact, not `toHaveTextContent`: that matches a substring on any ancestor,
+		// so it passes with the role moved onto the whole block — which is the
+		// re-announce-every-poll regression this scoping exists to prevent.
+		await expect( screen.findByRole( 'status', undefined, SETTLE ) ).resolves.toHaveTextContent(
+			/^Restoring…$/
+		);
+	} );
+
 	// Both figures, so a hardcoded `0%` cannot pass: the preflight pins it at
 	// zero, but the readout has to track the real value once it moves.
 	it.each( [ 0, 42 ] )( 'reports %i%% complete beside the bar', async percent => {


### PR DESCRIPTION
Fixes JETPACK-2460

## Proposed changes

VaultPress's file-check preflight reports `percent: 0` for minutes while its `message` counts files. The bridge forwards that message correctly; `use-restore.ts` dropped it when building the `progress` phase, so the screen showed a static "Restoring…" over a determinate bar frozen at 0% — and read as a hang.

Measured against a real restore, polling the bridge every ~10s:

```
status=running progress=0  "Checking remote files: 22396"
status=running progress=0  "Checking remote files: 32315"
status=running progress=0  "Checking remote files: 48984"
status=running progress=0  "Checking remote files: 64786"
```

* `hooks/use-restore.ts` carries `data.message` into the `progress` phase. The sibling branches (`success-with-errors`, `error`) already did; only the phase where it is the sole sign of life discarded it.
* `screens/restore.tsx` renders that message under the bar, plus a numeric `N% complete` readout.
* `types/restore.ts` extends the `progress` phase accordingly.

`restore.tsx` already argued against the old behaviour in its own comments — a determinate bar pinned at 0% "reads as a stall", which is why `queued` uses an indeterminate one. The preflight is minutes, not seconds, so the same reasoning applies with more force.

This is also a parity gap: Calypso's `rewind-flow/progress-bar.tsx` shows the message and a percent figure. **`currentEntry` is deliberately not added** — Calypso renders it, but it is not in the payload this bridge receives, so it would be dead code.

Nothing else changes: no new requests, no change to the status vocabulary, the `queued` phase and the bridge untouched.

## Related product discussion/links

* JETPACK-2460 — found while reviewing #51798, but pre-existing on trunk and unrelated to that PR.

## Does this pull request change what data or activity we track or use?

No. It renders a field the bridge already returned.

## Testing instructions

The dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default, so this is a no-op unless the filter is on.

Automated:

* `jetpack test js packages/backup` — 70 suites / 690 tests. Three are new in `tests/restore-progress-message.test.tsx`, and each was mutation-checked:
  * dropping `data.message` again fails `shows the upstream message as a sign of life`
  * replacing `state.percent` with a literal `0` fails `reports 42% complete beside the bar` (the `0` case alone could not tell the two apart, which is why both figures are asserted)
* `pnpm run typecheck` clean; ESLint clean; a `NODE_ENV=production` build is clean, which is the run that fails on detached `translators:` comments.

By hand, on a site with the filter on and a Backup plan:

1. Go to **Jetpack → VaultPress Backup**, pick a backup, click **Restore to this point**, and confirm.
2. While the restore runs, expect a line such as **`Checking remote files: 48984`** under the bar, with the number climbing, and a **`0% complete`** readout beside it.
3. Before this change the screen showed only "Restoring…" and a bar at 0%, unchanged for minutes.

Not tested: the success and failure ends of a restore were not re-exercised, since neither branch is touched.
