### PR TITLE
Jetpack Search: Preserve Site Chat and WordPress Agent settings

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-ai-settings-group
+++ b/projects/plugins/jetpack/changelog/fix-related-ai-settings-group
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack Search: Prevent General Settings from disabling Site Chat and WordPress Agent access.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
@@ -76,7 +76,7 @@ function register_ai_agents_setting() {
 	$show_in_rest = ! ( new Host() )->is_wpcom_simple();
 
 	register_setting(
-		'general',
+		'jetpack_search',
 		'jetpack_ai_agents_enabled',
 		array(
 			'type'              => 'boolean',

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/reader-chat/class-jetpack-reader-chat.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/reader-chat/class-jetpack-reader-chat.php
@@ -82,7 +82,7 @@ class Jetpack_Reader_Chat {
 	 */
 	public static function register_settings(): void {
 		register_setting(
-			'general',
+			'jetpack_search',
 			'reader_chat',
 			array(
 				'type'              => 'boolean',

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
@@ -39,7 +39,7 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		$this->deactivate_ai_module_for_test();
 		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
-		unregister_setting( 'general', 'jetpack_ai_agents_enabled' );
+		unregister_setting( 'jetpack_search', 'jetpack_ai_agents_enabled' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
 
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
@@ -55,7 +55,7 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	 * Test that the AI Agent Access setting is exposed as a REST-writable boolean.
 	 */
 	public function test_register_ai_agents_setting_registers_rest_boolean_option() {
-		global $wp_registered_settings;
+		global $new_allowed_options, $wp_registered_settings;
 
 		AiAssistantPlugin\register_ai_agents_setting();
 
@@ -68,6 +68,9 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 		$this->assertSame( 'rest_sanitize_boolean', $setting['sanitize_callback'] );
 		$this->assertTrue( $setting['show_in_rest'] );
 		$this->assertFalse( $setting['default'] );
+		$this->assertSame( 'jetpack_search', $setting['group'] );
+		$this->assertContains( 'jetpack_ai_agents_enabled', $new_allowed_options['jetpack_search'] ?? array() );
+		$this->assertNotContains( 'jetpack_ai_agents_enabled', $new_allowed_options['general'] ?? array() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
@@ -76,7 +76,7 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
 		delete_option( 'launch-status' );
-		unregister_setting( 'general', 'reader_chat' );
+		unregister_setting( 'jetpack_search', 'reader_chat' );
 		$GLOBALS['wp_scripts'] = $this->saved_wp_scripts;
 		$GLOBALS['wp_styles']  = $this->saved_wp_styles;
 		\Automattic\Jetpack\Status\Cache::clear();
@@ -289,6 +289,8 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 	 * Test that register_settings() registers reader_chat without a proxied rollout gate.
 	 */
 	public function test_register_settings_registers_reader_chat_setting() {
+		global $new_allowed_options;
+
 		Jetpack_Reader_Chat::register_settings();
 		$registered_settings = get_registered_settings();
 
@@ -306,6 +308,9 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 			$registered_settings['reader_chat']['description'] ?? '',
 			'reader_chat description should use the Site Chat name.'
 		);
+		$this->assertSame( 'jetpack_search', $registered_settings['reader_chat']['group'] );
+		$this->assertContains( 'reader_chat', $new_allowed_options['jetpack_search'] ?? array() );
+		$this->assertNotContains( 'reader_chat', $new_allowed_options['general'] ?? array() );
 	}
 
 	// ──────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #

## Proposed changes

* Move `reader_chat` and `jetpack_ai_agents_enabled` from the `general` settings group to a dedicated `jetpack_search` group.
* Keep these two Jetpack Search dashboard controls grouped with their owning settings surface.
* Prevent General Settings saves from resetting the options when their controls are absent.
* Preserve the existing option names, values, defaults, REST/update paths, and Sync behavior; no migration or repair runs.
* Add regression coverage for the new group and removal from the `general` allowed-options list.

## Related product discussion/links

* Follows the settings-group isolation pattern from #51833, using a Search-owned group for these two Search dashboard controls.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp docker phpunit jetpack -- --filter="AI_Assistant_Plugin_Test|Jetpack_Reader_Chat_Test"`.
* Confirm the suite passes.
* Save General Settings and confirm the existing `reader_chat` and `jetpack_ai_agents_enabled` option values are unchanged.
* Use the dedicated Site Chat and AI Agent Access controls and confirm each option can still be enabled and disabled.
