### PR TITLE
Jetpack AI: restore feature settings emptied by a General settings save on Atomic 

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-feature-options-reset
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-feature-options-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: restore the AI feature settings on sites where saving the General settings page had emptied them.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -3027,6 +3027,14 @@ p {
 	const AI_MASTER_OPTOUT_MIGRATED_OPTION = 'jetpack_ai_master_optout_migrated';
 
 	/**
+	 * Option flag that records the repair of emptied Jetpack AI feature options has
+	 * run, so it never runs twice.
+	 *
+	 * @var string
+	 */
+	const AI_EMPTY_OPTIONS_REPAIRED_OPTION = 'jetpack_ai_empty_options_repaired';
+
+	/**
 	 * Register the on-upgrade init hooks whose relative ORDER matters, extracted so
 	 * the ordering can be asserted in tests without invoking plugin_upgrade() (whose
 	 * guards make it unreliable to trigger under test). activate_new_modules()
@@ -3039,6 +3047,7 @@ p {
 	public static function register_upgrade_init_hooks() {
 		add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
 		add_action( 'init', array( __CLASS__, 'reconcile_ai_master_optout' ), 20 );
+		add_action( 'init', array( __CLASS__, 'repair_ai_empty_options' ), 20 );
 	}
 
 	/**
@@ -3084,6 +3093,43 @@ p {
 		}
 
 		update_option( self::AI_MASTER_OPTOUT_MIGRATED_OPTION, true );
+	}
+
+	/**
+	 * Deletes Jetpack AI feature option rows a Settings > General save emptied.
+	 *
+	 * An empty row reads as off, and deleting it restores the registered default where
+	 * writing 1 would record a choice nobody made. Simple is repaired by mu-wpcom.
+	 *
+	 * @return void
+	 */
+	public static function repair_ai_empty_options() {
+		if ( get_option( self::AI_EMPTY_OPTIONS_REPAIRED_OPTION ) ) {
+			return;
+		}
+
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		// The master option is excluded: off Simple it carries the legacy opt-out.
+		$options = array(
+			'jetpack_ai_writing_assistant_enabled',
+			'jetpack_ai_image_editor_enabled',
+			'jetpack_ai_feature_clip_enabled',
+			'jetpack_ai_seo_enabled',
+		);
+
+		foreach ( $options as $option ) {
+			$stored = get_option( $option, 'not-set' );
+
+			// Cast: a same-request write caches the sanitized false, not the stored ''.
+			if ( 'not-set' !== $stored && '' === (string) $stored ) {
+				delete_option( $option );
+			}
+		}
+
+		update_option( self::AI_EMPTY_OPTIONS_REPAIRED_OPTION, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Empty_Options_Repair_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Empty_Options_Repair_Test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for the repair of Jetpack AI feature options a General settings save emptied.
+ *
+ * Until the options moved to their own settings group, submitting Settings > General wrote
+ * null over every one of them, and null stores as an empty string, which reads as the
+ * feature being off. {@see Jetpack::repair_ai_empty_options()} deletes those rows
+ * once so the registered on-by-default value applies again.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Class Jetpack_AI_Empty_Options_Repair_Test
+ *
+ * @covers \Jetpack
+ */
+#[CoversClass( Jetpack::class )]
+class Jetpack_AI_Empty_Options_Repair_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Every option name the repair is responsible for.
+	 *
+	 * @var array
+	 */
+	private const REPAIRED_OPTIONS = array(
+		'jetpack_ai_writing_assistant_enabled',
+		'jetpack_ai_image_editor_enabled',
+		'jetpack_ai_feature_clip_enabled',
+		'jetpack_ai_seo_enabled',
+	);
+
+	/**
+	 * Reset the platform, the repair guard, and every option these tests touch.
+	 */
+	public function tear_down() {
+		delete_option( Jetpack::AI_EMPTY_OPTIONS_REPAIRED_OPTION );
+		delete_option( 'jetpack_ai_enabled' );
+		delete_option( 'jetpack_search_ai_answers_enabled' );
+		foreach ( self::REPAIRED_OPTIONS as $option ) {
+			delete_option( $option );
+		}
+		Constants::clear_single_constant( 'IS_WPCOM' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Leave an option the way a Settings > General save did: the row holding an
+	 * empty string. The flush stands in for the later request that reads it.
+	 *
+	 * @param string $option Option name.
+	 * @return void
+	 */
+	private function empty_option_like_a_general_save( $option ) {
+		update_option( $option, null );
+		wp_cache_flush();
+	}
+
+	/**
+	 * With the row gone the registered default applies, so the feature is on again.
+	 */
+	public function test_repair_deletes_the_emptied_feature_rows() {
+		foreach ( self::REPAIRED_OPTIONS as $option ) {
+			$this->empty_option_like_a_general_save( $option );
+		}
+
+		Jetpack::repair_ai_empty_options();
+
+		foreach ( self::REPAIRED_OPTIONS as $option ) {
+			$this->assertFalse( get_option( $option, false ), "$option should have no stored row after the repair." );
+		}
+	}
+
+	/**
+	 * The repair runs once, so a toggle switched off afterwards stays off.
+	 */
+	public function test_repair_runs_only_once() {
+		Jetpack::repair_ai_empty_options();
+
+		$this->empty_option_like_a_general_save( 'jetpack_ai_image_editor_enabled' );
+		Jetpack::repair_ai_empty_options();
+
+		$this->assertSame( '', get_option( 'jetpack_ai_image_editor_enabled' ) );
+	}
+
+	/**
+	 * Off Simple the `ai` module is the master, and the option carries the legacy
+	 * pre-module opt-out reconcile_ai_master_optout() reads.
+	 */
+	public function test_repair_leaves_the_master_option_alone() {
+		$this->empty_option_like_a_general_save( 'jetpack_ai_enabled' );
+
+		Jetpack::repair_ai_empty_options();
+
+		$this->assertSame( '', get_option( 'jetpack_ai_enabled' ) );
+	}
+
+	/**
+	 * Search owns its option, it was never in the general group, and it is opt-in.
+	 */
+	public function test_repair_leaves_the_search_option_alone() {
+		$this->empty_option_like_a_general_save( 'jetpack_search_ai_answers_enabled' );
+
+		Jetpack::repair_ai_empty_options();
+
+		$this->assertSame( '', get_option( 'jetpack_search_ai_answers_enabled' ) );
+	}
+
+	/**
+	 * Simple is repaired by jetpack-mu-wpcom, which runs before these options are read.
+	 */
+	public function test_repair_is_a_no_op_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->empty_option_like_a_general_save( 'jetpack_ai_image_editor_enabled' );
+
+		Jetpack::repair_ai_empty_options();
+
+		$this->assertSame( '', get_option( 'jetpack_ai_image_editor_enabled' ) );
+		$this->assertFalse( get_option( Jetpack::AI_EMPTY_OPTIONS_REPAIRED_OPTION, false ) );
+	}
+
+	/**
+	 * The repair is wired onto the upgrade path beside the master opt-out migration.
+	 */
+	public function test_repair_is_registered_on_the_upgrade_path() {
+		Jetpack::register_upgrade_init_hooks();
+
+		$this->assertNotFalse( has_action( 'init', array( 'Jetpack', 'repair_ai_empty_options' ) ) );
+	}
+}


### PR DESCRIPTION
## Proposed changes

* On Atomic and self-hosted sites, delete the four Jetpack AI feature option rows that a Settings > General save emptied, so they return to their default-on state.
* Delete the rows rather than storing `1`, so nothing records a choice the site owner never made. Only rows holding an empty string are removed.
* Store `jetpack_ai_empty_options_repaired` after the pass, so the repair runs once per site and a toggle switched off later stays off.
* Run it from `register_upgrade_init_hooks()`, on the existing upgrade path.
* Leave `jetpack_ai_enabled` unchanged. Off Simple the `ai` module is the master and that option carries the legacy pre-module opt-out `reconcile_ai_master_optout()` reads.
* Leave `jetpack_search_ai_answers_enabled`, `reader_chat` and `jetpack_ai_agents_enabled` unchanged.
* Skip WordPress.com Simple, which #51836 repairs earlier in the request.

A toggle somebody switched off by hand stores the same empty string as this bug and is switched back on with it. The controls render for proxied requests only, so this is a small and internal set of choices.

## Related product discussion/links

* #51833 is the permanent prevention fix: it registers the options under the `jetpack_ai` settings group.
* #51836 is the same repair for Simple sites, which this one deliberately skips.
* #51827 is the rollout bridge until #51833 deploys.
* #50287 introduced the affected Jetpack AI settings.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp docker phpunit jetpack -- --filter=Jetpack_AI_Empty_Options_Repair_Test`.
* Run `jp phan plugins/jetpack`.
* On a connected Atomic test site with the marker absent, store empty values for the four feature options and bump the Jetpack version. Confirm the four rows are deleted and `jetpack_ai_empty_options_repaired` is stored.
* Open **Jetpack > AI**, Features tab. Confirm the toggles read as on again.
* Re-empty one option and bump the version again. Confirm it stays empty, because the marker prevents a second pass.
* Confirm `jetpack_ai_enabled`, `jetpack_search_ai_answers_enabled` and `reader_chat` keep their stored values.
