### PR TITLE
Newsletter: email design editor integration shim (do not merge)

### DIFF
--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -351,10 +351,21 @@ export function createDesignSaveMiddleware( id ) {
 			return next( options );
 		}
 
+		// Only the theme.json halves: core-data hands over its whole record, and its `id` is the
+		// sentinel that stands in for a post that does not exist. Sanitizing drops it either way,
+		// but sending it makes every save look like it lost a property to anything comparing what
+		// was sent against what was stored. `version` and `isGlobalStylesUserThemeJSON` are the
+		// store's to set, so they are not ours to send.
+		const { styles, settings } = options.data ?? {};
+		const submitted = {
+			...( undefined === styles ? {} : { styles } ),
+			...( undefined === settings ? {} : { settings } ),
+		};
+
 		const saved = await apiFetch( {
 			path: BOOTSTRAP_PATH,
 			method: 'POST',
-			data: { design: options.data ?? {} },
+			data: { design: submitted },
 		} );
 
 		// The route answers with an envelope — `{ blog_id, design, discarded }` — around a read-back

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -355,10 +355,14 @@ export function createDesignSaveMiddleware( id ) {
 			data: { design: options.data ?? {} },
 		} );
 
-		// The route answers with a read-back rather than an echo: sanitizing drops anything outside
-		// the theme.json schema, so a save can succeed into invisibility. Hand core-data what was
-		// actually stored, so the panel shows what survived.
-		return { id, ...( saved && 'object' === typeof saved ? saved : {} ) };
+		// The route answers with an envelope — `{ blog_id, design, discarded }` — around a read-back
+		// of what was stored, since sanitizing drops anything outside the theme.json schema. Unwrap
+		// it: core-data takes what comes back as the record itself, and the canvas is drawn by
+		// merging that record's `styles` and `settings` over the theme, so handing back the envelope
+		// leaves both undefined and the canvas snaps to its pre-edit design.
+		const design = saved?.design ?? {};
+
+		return { id, settings: design.settings ?? {}, styles: design.styles ?? {} };
 	};
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -31,6 +31,9 @@ const TEMPLATE_POST_TYPE = 'wp_template';
 // and `data:` would execute rather than navigate.
 const NAVIGABLE_PROTOCOLS = [ 'http:', 'https:' ];
 
+// A save arrives as any of these, depending on whether core-data creates or updates.
+const WRITE_METHODS = [ 'POST', 'PUT', 'PATCH' ];
+
 /**
  * Check that a URL the editor will navigate to is one the browser can navigate to.
  *
@@ -322,6 +325,44 @@ export function registerEmailBlocks( bundle ) {
 }
 
 /**
+ * Catch the Styles panel's save and send it to WordPress.com instead.
+ *
+ * The editor writes a core-data `globalStyles` entity, but the design is stored in a WordPress.com
+ * blog option rather than a post, so the write has to be re-addressed to the bootstrap route.
+ *
+ * Matched on this one record's exact path and nothing else. The editor also holds the *site's* own
+ * global-styles record, at edit context, so anything broader would push the site's design through
+ * the email endpoint — and would look correct while doing it on Simple, where the site and the
+ * shadow blog are the same database.
+ *
+ * @param {number} id - The global-styles id the bundle named.
+ * @return {Function} An `apiFetch` middleware.
+ */
+export function createDesignSaveMiddleware( id ) {
+	const target = `/wp/v2/global-styles/${ id }`;
+
+	return async ( options, next ) => {
+		const path = 'string' === typeof options.path ? options.path.split( '?' )[ 0 ] : '';
+		const method = ( options.method || 'GET' ).toUpperCase();
+
+		if ( target !== path || ! WRITE_METHODS.includes( method ) ) {
+			return next( options );
+		}
+
+		const saved = await apiFetch( {
+			path: BOOTSTRAP_PATH,
+			method: 'POST',
+			data: { design: options.data ?? {} },
+		} );
+
+		// The route answers with a read-back rather than an echo: sanitizing drops anything outside
+		// the theme.json schema, so a save can succeed into invisibility. Hand core-data what was
+		// actually stored, so the panel shows what survived.
+		return { id, ...( saved && 'object' === typeof saved ? saved : {} ) };
+	};
+}
+
+/**
  * What the screen shows when it could not load.
  *
  * The design lives on another site, so without this "nothing appeared" and "your
@@ -377,6 +418,10 @@ export async function mountEmailDesignEditor() {
 
 		const postId = getTemplateId( bundle );
 		const preload = buildPreloadMap( bundle, postId );
+
+		if ( config.globalStylesPostId ) {
+			apiFetch.use( createDesignSaveMiddleware( config.globalStylesPostId ) );
+		}
 
 		if ( preload ) {
 			// Registered last so it runs first: api-fetch applies middlewares right to

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -15,8 +15,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { useBlockProps } from '@wordpress/block-editor';
 import { getBlockType, registerBlockType } from '@wordpress/blocks';
 import { Notice } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
 import { createRoot, StrictMode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 
 // Declared by the Jetpack plugin on every platform, answered by WordPress.com, so
@@ -361,6 +363,17 @@ export function createDesignSaveMiddleware( id ) {
 		// merging that record's `styles` and `settings` over the theme, so handing back the envelope
 		// leaves both undefined and the canvas snaps to its pre-edit design.
 		const design = saved?.design ?? {};
+
+		// `discarded` means the save succeeded and kept none of it: sanitizing drops whatever falls
+		// outside the theme.json schema. Without saying so, the panel goes clean and the creator is
+		// told their edit was saved when the stored design no longer contains it.
+		if ( saved?.discarded ) {
+			dispatch( noticesStore ).createNotice(
+				'error',
+				__( 'Those changes could not be saved to your email design.', 'jetpack' ),
+				{ type: 'snackbar', isDismissible: true }
+			);
+		}
 
 		return { id, settings: design.settings ?? {}, styles: design.styles ?? {} };
 	};

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -785,6 +785,60 @@ describe( 'Email design editor entry point', () => {
 			} );
 		} );
 
+		it( 'sends only the design, not the record it came from', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: {
+						// core-data hands over its whole record.
+						id: ourId,
+						title: { rendered: 'Email styles' },
+						_links: { self: [] },
+						version: 3,
+						isGlobalStylesUserThemeJSON: true,
+						styles: { color: { background: '#c0ffee' } },
+						settings: { color: { palette: { custom: [] } } },
+					},
+				},
+				jest.fn()
+			);
+
+			// The sentinel id is not a theme.json key, so it is dropped on the way through — and
+			// sending it makes every save look like it lost a property.
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: {
+						design: {
+							styles: { color: { background: '#c0ffee' } },
+							settings: { color: { palette: { custom: [] } } },
+						},
+					},
+				} )
+			);
+		} );
+
+		it( 'omits a half the panel did not send', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { id: ourId, styles: { color: { text: '#003300' } } },
+				},
+				jest.fn()
+			);
+
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: { design: { styles: { color: { text: '#003300' } } } },
+				} )
+			);
+		} );
+
 		it( 'hands back what was stored, not what was sent', async () => {
 			// Sanitizing drops anything outside the theme.json schema, so the read-back can differ
 			// from the submission. The panel has to show what survived.

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -743,7 +743,12 @@ describe( 'Email design editor entry point', () => {
 
 		it( 'sends the design to WordPress.com rather than to the site', async () => {
 			const next = jest.fn();
-			mockApiFetch.mockResolvedValueOnce( { styles: { color: { background: '#c0ffee' } } } );
+			// The shape WordPress.com actually answers with: a read-back wrapped in an envelope.
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 12345,
+				design: { styles: { color: { background: '#c0ffee' } }, settings: {} },
+				discarded: false,
+			} );
 
 			const result = await createDesignSaveMiddleware( ourId )(
 				{
@@ -761,11 +766,46 @@ describe( 'Email design editor entry point', () => {
 				data: { design: { styles: { color: { background: '#c0ffee' } } } },
 			} );
 
-			// What comes back is a read-back of what was stored, carrying the id core-data expects.
+			// core-data takes this as the record itself, and the canvas is drawn from its `styles`
+			// and `settings`. Handing back the envelope leaves both undefined and the canvas snaps
+			// to its pre-edit design.
 			expect( result ).toEqual( {
 				id: ourId,
+				settings: {},
 				styles: { color: { background: '#c0ffee' } },
 			} );
+		} );
+
+		it( 'hands back what was stored, not what was sent', async () => {
+			// Sanitizing drops anything outside the theme.json schema, so the read-back can differ
+			// from the submission. The panel has to show what survived.
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 12345,
+				design: { styles: { color: { background: '#ffffff' } }, settings: {} },
+				discarded: false,
+			} );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: { color: { background: 'color-mix(in srgb, #fff 50%, #000)' } } },
+				},
+				jest.fn()
+			);
+
+			expect( result.styles ).toEqual( { color: { background: '#ffffff' } } );
+		} );
+
+		it( 'survives an envelope carrying no design', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 12345, design: null, discarded: true } );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				jest.fn()
+			);
+
+			expect( result ).toEqual( { id: ourId, settings: {}, styles: {} } );
 		} );
 
 		it.each( [ 'POST', 'PUT', 'PATCH' ] )( 'catches a %s', async method => {

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -574,7 +574,7 @@ describe( 'Email design editor entry point', () => {
 			expect( preloadedMap() ).not.toHaveProperty( '/wp/v2/templates' );
 		} );
 
-		it( 'installs nothing when the bundle carries neither half', async () => {
+		it( 'preloads nothing when the bundle carries neither half', async () => {
 			mockApiFetch.mockResolvedValue(
 				bootstrapBundle( { templates: undefined, global_styles: undefined } )
 			);
@@ -584,8 +584,12 @@ describe( 'Email design editor entry point', () => {
 
 			// WordPress.com does not send these yet. The editor must still mount rather than
 			// the entry throwing on a key that is not there.
-			expect( mockUse ).not.toHaveBeenCalled();
+			expect( mockCreatePreloadingMiddleware ).not.toHaveBeenCalled();
 			expect( renderedTheErrorState() ).toBe( false );
+
+			// The save middleware still installs: the page named a record even though the
+			// bundle carried none, and a write to it is still ours to catch.
+			expect( mockUse ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		describe( 'the Allow header the preloaded responses carry', () => {
@@ -730,6 +734,100 @@ describe( 'Email design editor entry point', () => {
 			// The template is parsed on first render and resolved against the registry then, so
 			// registering afterwards leaves the same unsupported-block errors.
 			expect( order ).toEqual( [ 'register', 'render' ] );
+		} );
+	} );
+
+	describe( 'when the Styles panel saves', () => {
+		const { createDesignSaveMiddleware } = jest.requireActual( '../src/index' );
+		const ourId = 999999999;
+
+		it( 'sends the design to WordPress.com rather than to the site', async () => {
+			const next = jest.fn();
+			mockApiFetch.mockResolvedValueOnce( { styles: { color: { background: '#c0ffee' } } } );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: { color: { background: '#c0ffee' } } },
+				},
+				next
+			);
+
+			expect( next ).not.toHaveBeenCalled();
+			expect( mockApiFetch ).toHaveBeenCalledWith( {
+				path: '/wpcom/v2/email-editor-bootstrap',
+				method: 'POST',
+				data: { design: { styles: { color: { background: '#c0ffee' } } } },
+			} );
+
+			// What comes back is a read-back of what was stored, carrying the id core-data expects.
+			expect( result ).toEqual( {
+				id: ourId,
+				styles: { color: { background: '#c0ffee' } },
+			} );
+		} );
+
+		it.each( [ 'POST', 'PUT', 'PATCH' ] )( 'catches a %s', async method => {
+			mockApiFetch.mockResolvedValueOnce( {} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method, data: {} },
+				jest.fn()
+			);
+
+			expect( mockApiFetch ).toHaveBeenCalled();
+		} );
+
+		it( "leaves a write to the site's own record alone", async () => {
+			const next = jest.fn( () => 'went to the network' );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: '/wp/v2/global-styles/59', method: 'PUT', data: { styles: {} } },
+				next
+			);
+
+			// The regression this middleware exists to avoid: the site's design must never be
+			// routed through the email endpoint, which would look correct on Simple while doing it.
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( next ).toHaveBeenCalled();
+			expect( result ).toBe( 'went to the network' );
+		} );
+
+		it( 'leaves reads of our own record alone', async () => {
+			const next = jest.fn( () => 'went to the preload' );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }?context=edit`, method: 'GET' },
+				next
+			);
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( result ).toBe( 'went to the preload' );
+		} );
+
+		it( 'catches the write whatever query string it carries', async () => {
+			const next = jest.fn();
+			mockApiFetch.mockResolvedValueOnce( {} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }?_locale=user`, method: 'PUT', data: {} },
+				next
+			);
+
+			expect( next ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not match an id that merely starts the same', async () => {
+			const next = jest.fn();
+
+			await createDesignSaveMiddleware( 99 )(
+				{ path: '/wp/v2/global-styles/991', method: 'PUT', data: {} },
+				next
+			);
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( next ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -44,6 +44,11 @@ jest.mock( '@wordpress/blocks', () => ( {
 
 jest.mock( '@wordpress/block-editor', () => ( { useBlockProps: () => ( {} ) } ) );
 
+// The real stores rather than mocks. Mocking `@wordpress/data` wholesale drops `combineReducers`,
+// which `@wordpress/components` needs at import time by way of `@wordpress/rich-text`.
+const { select, dispatch } = jest.requireActual( '@wordpress/data' );
+const { store: noticesStore } = jest.requireActual( '@wordpress/notices' );
+
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
 /**
@@ -163,6 +168,10 @@ describe( 'Email design editor entry point', () => {
 		mockCreatePreloadingMiddleware.mockClear();
 		mockRegisterBlockType.mockClear();
 		mockGetBlockType.mockReset();
+		// By type: `removeAllNotices()` defaults to the `default` type and would leave the
+		// snackbar the save path creates, so it would leak into the next test.
+		dispatch( noticesStore ).removeAllNotices( 'snackbar' );
+		dispatch( noticesStore ).removeAllNotices( 'default' );
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( bootstrapBundle() );
 		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
@@ -795,6 +804,40 @@ describe( 'Email design editor entry point', () => {
 			);
 
 			expect( result.styles ).toEqual( { color: { background: '#ffffff' } } );
+		} );
+
+		it( 'tells the creator when the save kept nothing', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: null, discarded: true } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
+				jest.fn()
+			);
+
+			// Without this the panel goes clean and the creator is told it saved, while the stored
+			// design no longer holds what they set.
+			expect( select( noticesStore ).getNotices() ).toEqual( [
+				expect.objectContaining( {
+					status: 'error',
+					content: expect.stringContaining( 'could not be saved' ),
+					type: 'snackbar',
+				} ),
+			] );
+		} );
+
+		it( 'stays quiet when the design was kept', async () => {
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 1,
+				design: { styles: { color: { background: '#c0ffee' } }, settings: {} },
+				discarded: false,
+			} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				jest.fn()
+			);
+
+			expect( select( noticesStore ).getNotices() ).toEqual( [] );
 		} );
 
 		it( 'survives an envelope carrying no design', async () => {


### PR DESCRIPTION
> [!IMPORTANT]
> **Not a merge candidate.** This branch is the integration testbed for the email design editor —
> the place both halves are wired together end to end while the work ships in reviewable chunks.
> Rebased onto trunk; it now carries only what has not landed yet.
>
> Shipped so far: #51525 (data layer), #51577 (bundle), #52055 (the screen).
> Still here: the client-side block registration (NL-869) and the save path (NL-873), each going
> up as its own PR with a WordPress.com counterpart.

## Proposed changes

Adds the wp-admin screen that mounts the email design editor, behind a feature flag so it ships off and nothing is user-visible yet.

**Stacked on `add/nl-848-email-design-editor-bundle` (#51577)** — the page enqueues `_inc/build/email-design-editor.*`, which only exists with that PR's webpack entry, so this targets that branch and should be retargeted to trunk once it lands.

**The JavaScript commit is here temporarily.** `src/index.jsx` belongs to #51577's diff, and the save middleware is carried here so the screen can be exercised end to end while both are in review. It is a single isolated commit (`6e7a86b`), touching no file the PHP commits touch, so it can be lifted onto its own branch once #51577 settles.

* **The page.** An `edit_theme_options` page under Appearance — the same capability the bootstrap endpoint already enforces. Everything beyond registration is scoped to `load-{$hook_suffix}`.
* **The flag.** `Feature_Flags::register( 'jetpack-email-design', … )`, default `false`, checked through one `is_enabled()` predicate. Registered at module load rather than on `admin_menu`, so the flag is visible under WP-CLI, REST and cron rather than only in wp-admin. `automattic/jetpack-feature-flags` was already a dependency of this plugin, so there is no lock-file churn.
* **What the page hands the bundle.** `window.JetpackEmailDesignEditor` carries only what describes *this* installation. No WordPress.com ids: the template id and the global-styles id come from the bootstrap response, because they are namespaced to the shadow blog's theme, and a locally computed one is right on Simple and wrong on Atomic and self-hosted.
* **The two iframe-asset settings.** `allowedIframeStyleHandles` plus an `__unstableResolvedAssets` trimmed to those handles, mirroring the package's `Settings_Controller`. WordPress.com strips both from the bundle because they describe the server that computed them; without the first, the canvas paints in the site's own CSS instead of the email's.
* **Block-editor parity.** A custom admin page gets none of this automatically, so the page reproduces what the package's `Assets_Manager` does on WooCommerce's own screen: both `enqueue_block_*_assets` actions, editor styles, block categories, and the server-side block definitions.
* **The Styles panel.** The preloaded `GET` responses now carry an `Allow` header, which is what makes the panel appear at all — see below.
* **The save path.** An `apiFetch` middleware catches writes to this one record and re-addresses them to `POST /wpcom/v2/email-editor-bootstrap`. The editor writes a core-data `globalStyles` entity, but the design is stored in a WordPress.com blog option rather than a post, so left alone the write would go somewhere that cannot answer.
* **Layout.** The editor's frame needs a viewport-sized container — inside the normal admin content column every region stacks into one narrow scrolling strip. WooCommerce avoids this by running on `post.php`, which is already fullscreen.

### Worth a reviewer's attention

* **`wp-interface` is not a registered style handle.** It reads like it belongs beside `wp-editor` and `wp-block-editor` in the stylesheet's dependency list, and naming it drops the whole stylesheet silently — the same failure mode as the `wp-global-styles-engine` script discussion on #51577, on the style side. The list here is deliberately limited to handles WordPress actually registers.
* **The screen is unreachable on a disconnected site,** because the Subscriptions module declares `Requires Connection` and `Jetpack::load_modules()` skips it in offline mode (and returns early entirely when the site is neither connected nor offline). Defensible — there is no design to edit without a connection — but it is a consequence of the file's location rather than a decision, and it is tracked in NL-839.
* **The save middleware matches one exact path, never a pattern.** The editor also holds the *site's own* global-styles record, at edit context. Anything broader would push the site's design through the email endpoint — and would look correct while doing it on Simple, where the site and the shadow blog are the same database. There is a unit test for that regression, and it is checked live below.
* **A preloaded `GET` response carries permissions, not just data.** core-data derives a record's permissions from the `GET` response as well as the `OPTIONS` one, and reads a *missing* `Allow` header as "nothing is permitted" rather than as silence. Our `GET` entries resolved last with no header, so they overwrote the `OPTIONS` answer and the Styles panel never rendered — however editable the design reported itself. Both now carry the header. The template's entry carries an explicit `GET`, since nothing on this screen edits the template and the header is an assertion either way.

## Related product discussion/links

* NL-839

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The screen needs a WordPress.com connection to have anything to show — the design it edits lives on the shadow blog — so test on a Jurassic Ninja site or a Simple site rather than a local disconnected install.

1. Build the plugin on this branch: `jp build plugins/jetpack`. `_inc/build/` should contain `email-design-editor.js`, `.css`, `.rtl.css` and `.asset.php`.
2. **With the flag off (the default):** there should be no **Email Design** item under Appearance, and `/wp-admin/themes.php?page=jetpack-email-design` should return "Sorry, you are not allowed to access this page."
3. Turn the flag on: `wp companion feature-flag enable jetpack-email-design`. Confirm `wp companion feature-flag list` shows `effective` as `1`.
4. **Appearance → Email Design** should now exist and open the editor: header across the top, canvas in the middle, settings sidebar on the right, filling the screen below the admin bar. The admin menu stays visible.
5. The canvas should show the newsletter template, and the title in the header should name it.
6. Check the canvas is not wearing the site's theme CSS — in the console:
   ```js
   [ ...document.querySelector( 'iframe[name="editor-canvas"]' ).contentDocument
       .querySelectorAll( 'link[rel=stylesheet]' ) ].map( l => l.id )
   ```
   Expect only `wp-components-css`, `wp-block-library-css`, `wp-block-editor-content-css` and `wp-edit-blocks-css`, plus any handle from a block that declares email support. The theme's stylesheet should not be among them.
7. Open the **Styles** panel from the header. Typography, Colors, Background and Layout should all be there, and the preview swatch should show the site's stored email design rather than a default. Change a colour and save — expect a `POST` to `/wpcom/v2/email-editor-bootstrap` carrying `{ design: … }`, and **no** request to `/wp/v2/global-styles/<id>`.
8. The same thing from the console, if you would rather not click through the panel:
   ```js
   const id = wp.data.select( 'email-editor/editor' ).getGlobalStylesPostId();
   wp.data.dispatch( 'core' ).editEntityRecord( 'root', 'globalStyles', id, {
       styles: { color: { background: '#c0ffee' } },
   } );
   await wp.data.dispatch( 'core' ).saveEditedEntityRecord( 'root', 'globalStyles', id );
   ```
   In the network panel, expect the same `POST` as above.
9. The regression case, worth doing explicitly: repeat step 7 against the **site's own** global-styles id (the other `global-styles/<n>` the editor loads — take it from the network panel). That one must go straight to `/wp/v2/global-styles/<n>` and never near the WordPress.com route. Note this writes to the site's real global styles, so use a site you don't mind editing.

