### PR TITLE
VideoPress: guard the welcome modal against a missing public ThemeProvider

### DIFF
--- a/projects/packages/videopress/changelog/change-fix-vp-onboarding-theme-guard
+++ b/projects/packages/videopress/changelog/change-fix-vp-onboarding-theme-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the dashboard rendering blank on WordPress 7.0.x, where the welcome modal crashed on the missing public ThemeProvider export.

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
@@ -152,6 +152,26 @@ function isWelcomeLoad(): boolean {
 	);
 }
 
+/**
+ * The band's ThemeProvider wrapper, guarded: the `wp-theme` bundled with core
+ * 7.0.x exposes only `privateApis`, so the public `ThemeProvider` import can
+ * resolve to undefined — and rendering it crashed the whole dashboard route,
+ * since this modal's tree is built on every mount. The band keeps its derived
+ * dark scheme where the provider exists and falls back to the stylesheet's
+ * colors where it doesn't.
+ *
+ * @param props          - Component props.
+ * @param props.children - The band's content.
+ * @return The children, re-themed when the environment allows it.
+ */
+function BandTheme( { children }: { children: ReactNode } ): ReactElement {
+	if ( ! ThemeProvider ) {
+		return <>{ children }</>;
+	}
+
+	return <ThemeProvider color={ { background: '#003010' } }>{ children }</ThemeProvider>;
+}
+
 type ValueCard = {
 	icon: ReactNode;
 	title: string;
@@ -355,13 +375,13 @@ export default function OnboardingModal(): ReactElement | null {
 					 * ThemeProvider renders `display: contents`, so the close
 					 * affordance still positions against the band itself.
 					 */ }
-					<ThemeProvider color={ { background: '#003010' } }>
+					<BandTheme>
 						<Dialog.CloseIcon
 							className="vp-onboarding-modal__close"
 							label={ __( 'Close', 'jetpack-videopress-pkg' ) }
 						/>
 						<IntroVideo />
-					</ThemeProvider>
+					</BandTheme>
 				</div>
 
 				<Dialog.Content className="vp-onboarding-modal__body">

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/missing-theme-provider.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/test/missing-theme-provider.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { useOnboardingCounts } from '../../../hooks/use-onboarding-counts';
+import OnboardingModal from '../index';
+
+/*
+ * The `wp-theme` bundled with core 7.0.x exposes only `privateApis`, so the
+ * modal's public `ThemeProvider` import resolves to undefined there. The real
+ * `privateApis` is kept because `@wordpress/ui` unlocks its provider from it —
+ * exactly the environment where the unguarded import blanked the dashboard.
+ */
+jest.mock( '@wordpress/theme', () => {
+	const { privateApis } = jest.requireActual( '@wordpress/theme' );
+	return { __esModule: true, privateApis };
+} );
+
+jest.mock( '../../../hooks/use-onboarding-counts', () => ( {
+	useOnboardingCounts: jest.fn(),
+} ) );
+
+jest.mock( '../../../hooks/use-upload', () => ( {
+	useUpload: () => ( { uploadQueue: [] } ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useNavigate: () => jest.fn(),
+	useSearch: () => ( {} ),
+} ) );
+
+jest.mock( '../intro-video', () => ( {
+	__esModule: true,
+	default: () => null,
+	INTRO_VIDEO_ASPECT: '16 / 9',
+	getAssetUrl: () => undefined,
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: () => ( {
+		site: { wpcom: { blog_id: 123 } },
+		user: { current_user: { id: 7 } },
+	} ),
+	isWoASite: jest.fn( () => false ),
+	isSimpleSite: jest.fn( () => false ),
+} ) );
+
+describe( 'OnboardingModal without a public ThemeProvider', () => {
+	beforeEach( () => {
+		window.localStorage.clear();
+		window.history.replaceState( {}, '', '/wp-admin/admin.php?page=jetpack-videopress' );
+	} );
+
+	it( 'still renders the modal and its close affordance', () => {
+		( useOnboardingCounts as jest.Mock ).mockReturnValue( {
+			videoPressCount: 0,
+			localCount: 0,
+			isSettled: true,
+		} );
+
+		render( <OnboardingModal /> );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Close' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/change-fix-vp-onboarding-theme-guard
+++ b/projects/plugins/jetpack/changelog/change-fix-vp-onboarding-theme-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix the dashboard rendering blank on WordPress 7.0.x, where the welcome modal crashed on the missing public ThemeProvider export.

--- a/projects/plugins/videopress/changelog/change-fix-vp-onboarding-theme-guard
+++ b/projects/plugins/videopress/changelog/change-fix-vp-onboarding-theme-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the dashboard rendering blank on WordPress 7.0.x, where the welcome modal crashed on the missing public ThemeProvider export.


### PR DESCRIPTION
Fixes #51837

## Proposed changes

* Guard the welcome modal's `ThemeProvider` usage: the `wp-theme` script bundled with core 7.0.x exposes only `privateApis`, so the public `ThemeProvider` import resolves to `undefined` there — and rendering it crashed `OnboardingModal` on mount, which the route's error boundary swallowed, leaving every VideoPress dashboard route blank below the header (introduced by #51567).
* The band's children (close affordance and intro video) now render unwrapped when the provider is missing, falling back to the stylesheet's colors; on WP 7.1+ or with a recent Gutenberg active, nothing changes — the derived dark scheme still applies.
* Add a regression test that mocks `@wordpress/theme` down to `privateApis` only — mirroring the WP 7.0.x environment, where `@wordpress/ui` still unlocks its own provider from the private API — and asserts the modal and its close button render.

This intentionally does not replicate `@wordpress/ui`'s `privateApis` unlock for our own usage: private APIs are off-limits to plugin code. The follow-up discussion from the issue (a version-gated force rule for `wp-theme` in `wp-build-polyfills`) is left to its own task.

## Related product discussion/links

* #51837
* #51567 (introduced the regression)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WP 7.0.x site (today's WoA baseline) with the Gutenberg plugin inactive, build VideoPress from this branch and open `admin.php?page=jetpack-videopress`.
* Before this change: the header renders and the content area stays blank, with repeated `React.jsx: type is invalid` warnings in the console. After: the dashboard renders, and the welcome modal opens on a first-run site (or with `&welcome=1`) with its close button working.
* On WP 7.1+ (or with a recent Gutenberg active), verify the modal is unchanged: the close affordance still resolves its colors from the derived dark scheme over the green band.
* `jetpack test js packages/videopress` — passes (the new suite fails against trunk's unguarded render, verified locally).

**What I tested:** the full videopress JS suite, a package build with `--deps`, and ESLint on the touched files, all green; the new regression test reproduces the crash against the unguarded code. **What I did not test:** a live WP 7.0.x site — the fix path is covered by the regression test, but a manual check on a WoA/7.0.x environment is the strongest confirmation.
