### PR TITLE
Private sites: expose a minimal REST API index for auth discovery

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-private-site-rest-index-discovery
+++ b/projects/plugins/wpcomsh/changelog/add-private-site-rest-index-discovery
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Private sites: Expose a minimal REST API index so clients can discover how to authenticate.

--- a/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-coming-soon-template.php
@@ -23,6 +23,8 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 	<title><?php bloginfo( 'name' ); ?></title>
 
 	<?php
+	print_rest_api_discovery_link();
+
 	wp_enqueue_style( 'recoleta-font', '//s1.wp.com/i/fonts/recoleta/css/400.min.css', array(), WPCOMSH_VERSION );
 	wp_enqueue_style( 'wpcomsh-coming-soon-style', plugins_url( 'style.css', __FILE__ ), array(), WPCOMSH_VERSION );
 	do_action( 'login_enqueue_scripts' );

--- a/projects/plugins/wpcomsh/private-site/access-denied-private-site-template.php
+++ b/projects/plugins/wpcomsh/private-site/access-denied-private-site-template.php
@@ -22,6 +22,8 @@ header( 'Content-Type: ' . get_bloginfo( 'html_type' ) . '; charset=' . get_blog
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title><?php bloginfo( 'name' ); ?></title>
 	<?php
+	print_rest_api_discovery_link();
+
 	// Use styles from wp-login.
 	wp_enqueue_style( 'login' );
 	do_action( 'login_enqueue_scripts' );

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -602,6 +602,11 @@ function rest_index( $response ) {
 
 	$data = $response->get_data();
 
+	// `authentication` and `routes` are maps: an empty PHP array would serialize as [], so coerce
+	// each to an object so clients that read them as objects (or validate a schema) don't break. A
+	// populated `authentication` stays an array -- non-empty string-keyed arrays already encode as {}.
+	$authentication = empty( $data['authentication'] ) ? (object) array() : $data['authentication'];
+
 	// Allowlist. Anything not named here is intentionally withheld.
 	return new WP_REST_Response(
 		array(
@@ -611,8 +616,8 @@ function rest_index( $response ) {
 			'home'           => home_url(),
 			'gmt_offset'     => 0,
 			'namespaces'     => array(),
-			'authentication' => $data['authentication'] ?? array(),
-			'routes'         => array(),
+			'authentication' => $authentication,
+			'routes'         => (object) array(),
 		)
 	);
 }

--- a/projects/plugins/wpcomsh/private-site/private-site.php
+++ b/projects/plugins/wpcomsh/private-site/private-site.php
@@ -12,6 +12,8 @@ use Automattic\Jetpack\Connection\Rest_Authentication;
 use Jetpack;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
 use function esc_html_e;
 use function get_current_blog_id;
 use function get_option;
@@ -101,6 +103,9 @@ function init() {
 
 	// Scrutinize REST API requests.
 	add_filter( 'rest_dispatch_request', '\Private_Site\rest_dispatch_request', 10, 3 );
+
+	// Reduce the REST index to the minimum an unauthenticated client needs to authenticate.
+	add_filter( 'rest_index', '\Private_Site\rest_index', PHP_INT_MAX );
 
 	// Prevent Pinterest pinning.
 	add_action( 'wp_head', '\Private_Site\private_no_pinning' );
@@ -431,8 +436,32 @@ function send_access_denied_error_response() {
 		);
 	}
 
+	/*
+	 * Advertise the REST API root so clients can discover how to authenticate. We set only the
+	 * `https://api.w.org/` link, not core's `rest_output_link_header()`, which also emits an
+	 * `alternate` link exposing the requested resource's REST route.
+	 */
+	if ( ! headers_sent() ) {
+		$api_root = get_rest_url();
+		if ( ! empty( $api_root ) ) {
+			header( sprintf( 'Link: <%s>; rel="https://api.w.org/"', sanitize_url( $api_root ) ), false );
+		}
+	}
+
 	require access_denied_template_path();
 	exit( 0 );
+}
+
+/**
+ * Print the WordPress REST API discovery `<link>` tag for the access-denied templates — the
+ * HTML `<head>` counterpart to the `Link:` header in `send_access_denied_error_response()`,
+ * which explains why we emit only the `https://api.w.org/` link.
+ */
+function print_rest_api_discovery_link() {
+	$api_root = get_rest_url();
+	if ( ! empty( $api_root ) ) {
+		printf( '<link rel="https://api.w.org/" href="%s" />', esc_url( $api_root ) );
+	}
 }
 
 /**
@@ -540,11 +569,52 @@ function rest_dispatch_request( $dispatch_result, $request, $route ) {
 		return null;
 	}
 
+	/*
+	 * Allow a read of the REST index so clients can discover how to authenticate.
+	 * `\Private_Site\rest_index()` strips the payload down to just that.
+	 */
+	if ( '/' === $route && WP_REST_Server::READABLE === $request->get_method() ) {
+		return null;
+	}
+
 	if ( should_prevent_site_access() ) {
 		return new WP_Error( 'private_site', __( 'This site is private.', 'wpcomsh' ), array( 'status' => 403 ) );
 	}
 
 	return null;
+}
+
+/**
+ * Reduce the REST index to the minimum an unauthenticated visitor needs to discover
+ * how to authenticate.
+ *
+ * Built from an allowlist rather than by unsetting fields, so anything core or a plugin
+ * adds to the index later stays hidden until allowlisted here. Runs at `PHP_INT_MAX` so
+ * core has already populated `authentication` (hooked at the default priority) first.
+ *
+ * @param WP_REST_Response $response REST index response.
+ * @return WP_REST_Response
+ */
+function rest_index( $response ) {
+	if ( ! should_prevent_site_access() ) {
+		return $response;
+	}
+
+	$data = $response->get_data();
+
+	// Allowlist. Anything not named here is intentionally withheld.
+	return new WP_REST_Response(
+		array(
+			'name'           => get_bloginfo( 'name', 'display' ), // 'display' routes through `mask_site_name`; a raw read would leak the real name.
+			'description'    => '',
+			'url'            => get_option( 'siteurl' ),
+			'home'           => home_url(),
+			'gmt_offset'     => 0,
+			'namespaces'     => array(),
+			'authentication' => $data['authentication'] ?? array(),
+			'routes'         => array(),
+		)
+	);
 }
 
 /**

--- a/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
@@ -185,7 +185,7 @@ class PrivateSiteTest extends WP_UnitTestCase {
 		$this->assertSame( '', $data['description'] );
 		$this->assertSame( 0, $data['gmt_offset'] );
 		$this->assertSame( array(), $data['namespaces'] );
-		$this->assertSame( array(), $data['routes'] );
+		$this->assertEquals( new \stdClass(), $data['routes'], 'routes is a map: empty must be {} (an object), not []' );
 		// The raw site name and _links (help, active-theme) must not survive the trim.
 		$this->assertNotSame( 'Secret Site Name', $data['name'] );
 		$this->assertSame( array(), $result->get_links() );
@@ -204,6 +204,19 @@ class PrivateSiteTest extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $data['authentication'] );
 		$this->assertArrayHasKey( 'application-passwords', $data['authentication'] );
+	}
+
+	/**
+	 * `authentication` is a map, so an empty one (no SSL, no auth plugins) must still serialize as an
+	 * object, not `[]` -- core seeds it as an empty array, which would otherwise encode as `[]`.
+	 */
+	public function test_rest_index_serializes_empty_authentication_as_an_object() {
+		wp_set_current_user( 0 );
+		$response = new WP_REST_Response( array( 'authentication' => array() ) );
+
+		$auth = \Private_Site\rest_index( $response )->get_data()['authentication'];
+
+		$this->assertEquals( new \stdClass(), $auth, 'empty authentication must be {} (an object), not []' );
 	}
 
 	/**
@@ -232,7 +245,7 @@ class PrivateSiteTest extends WP_UnitTestCase {
 			'authorize-application.php',
 			$data['authentication']['application-passwords']['endpoints']['authorization']
 		);
-		$this->assertSame( array(), $data['routes'], 'the index is still stripped for unauthenticated visitors' );
+		$this->assertEquals( new \stdClass(), $data['routes'], 'the index is still stripped for unauthenticated visitors' );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
+++ b/projects/plugins/wpcomsh/tests/PrivateSiteTest.php
@@ -109,4 +109,207 @@ class PrivateSiteTest extends WP_UnitTestCase {
 
 		$this->assertFalse( \Private_Site\is_private_blog_user() );
 	}
+
+	/**
+	 * The REST index is readable so unauthenticated clients can discover how to authenticate.
+	 */
+	public function test_rest_dispatch_request_allows_reading_the_index() {
+		wp_set_current_user( 0 );
+
+		$result = \Private_Site\rest_dispatch_request( null, new WP_REST_Request( 'GET', '/' ), '/' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Only reads of the index are allowed; writes to it are still denied.
+	 */
+	public function test_rest_dispatch_request_denies_writing_the_index() {
+		wp_set_current_user( 0 );
+
+		$result = \Private_Site\rest_dispatch_request( null, new WP_REST_Request( 'POST', '/' ), '/' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'private_site', $result->get_error_code() );
+	}
+
+	/**
+	 * Content endpoints remain denied for unauthenticated visitors.
+	 */
+	public function test_rest_dispatch_request_denies_content_endpoints() {
+		wp_set_current_user( 0 );
+
+		$result = \Private_Site\rest_dispatch_request( null, new WP_REST_Request( 'GET', '/wp/v2/posts' ), '/wp/v2/posts' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'private_site', $result->get_error_code() );
+	}
+
+	/**
+	 * The batch endpoint is not the index and stays denied.
+	 */
+	public function test_rest_dispatch_request_denies_the_batch_endpoint() {
+		wp_set_current_user( 0 );
+
+		$result = \Private_Site\rest_dispatch_request( null, new WP_REST_Request( 'GET', '/batch/v1' ), '/batch/v1' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'private_site', $result->get_error_code() );
+	}
+
+	/**
+	 * A dispatch result from another plugin is left untouched.
+	 */
+	public function test_rest_dispatch_request_preserves_a_prior_dispatch_result() {
+		wp_set_current_user( 0 );
+
+		$prior  = new WP_REST_Response( 'handled elsewhere' );
+		$result = \Private_Site\rest_dispatch_request( $prior, new WP_REST_Request( 'GET', '/wp/v2/posts' ), '/wp/v2/posts' );
+
+		$this->assertSame( $prior, $result );
+	}
+
+	/**
+	 * The trimmed index exposes only the allowlisted keys; everything else is withheld.
+	 */
+	public function test_rest_index_returns_only_allowlisted_keys() {
+		wp_set_current_user( 0 );
+
+		$result = \Private_Site\rest_index( $this->full_rest_index_response() );
+		$data   = $result->get_data();
+
+		$this->assertSame(
+			array( 'name', 'description', 'url', 'home', 'gmt_offset', 'namespaces', 'authentication', 'routes' ),
+			array_keys( $data )
+		);
+		$this->assertSame( '', $data['description'] );
+		$this->assertSame( 0, $data['gmt_offset'] );
+		$this->assertSame( array(), $data['namespaces'] );
+		$this->assertSame( array(), $data['routes'] );
+		// The raw site name and _links (help, active-theme) must not survive the trim.
+		$this->assertNotSame( 'Secret Site Name', $data['name'] );
+		$this->assertSame( array(), $result->get_links() );
+	}
+
+	/**
+	 * The authentication block is the payload clients need, so it is copied through verbatim.
+	 */
+	public function test_rest_index_preserves_the_authentication_block() {
+		wp_set_current_user( 0 );
+
+		$response = $this->full_rest_index_response();
+		$expected = $response->get_data()['authentication'];
+
+		$data = \Private_Site\rest_index( $response )->get_data();
+
+		$this->assertSame( $expected, $data['authentication'] );
+		$this->assertArrayHasKey( 'application-passwords', $data['authentication'] );
+	}
+
+	/**
+	 * End-to-end: the Application Passwords authorization URL — the whole point of exposing the
+	 * index — survives the trim. This only holds because the filter runs after core populates
+	 * `authentication` (both hook `rest_index`, ours at PHP_INT_MAX); a lower priority would drop it.
+	 */
+	public function test_rest_index_keeps_the_application_passwords_authorization_url() {
+		wp_set_current_user( 0 );
+		// Atomic sites have SSL, so core advertises Application Passwords; force that in the test env.
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
+		// Core hooks this on rest_api_init; re-add it explicitly since the suite's hook backup +
+		// the REST-server singleton can leave it detached by the time this test runs.
+		add_filter( 'rest_index', 'rest_add_application_passwords_to_index' );
+		// Register the filter exactly as init() does on a live private site.
+		add_filter( 'rest_index', '\Private_Site\rest_index', PHP_INT_MAX );
+
+		$data = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/' ) )->get_data();
+
+		remove_filter( 'rest_index', '\Private_Site\rest_index', PHP_INT_MAX );
+		remove_filter( 'rest_index', 'rest_add_application_passwords_to_index' );
+		remove_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+		$this->assertArrayHasKey( 'application-passwords', $data['authentication'] );
+		$this->assertStringContainsString(
+			'authorize-application.php',
+			$data['authentication']['application-passwords']['endpoints']['authorization']
+		);
+		$this->assertSame( array(), $data['routes'], 'the index is still stripped for unauthenticated visitors' );
+	}
+
+	/**
+	 * Running last (PHP_INT_MAX) means we snapshot every provider's contribution, so a third-party
+	 * auth plugin that follows core's convention -- adding its method under `authentication` -- is
+	 * kept alongside core's Application Passwords rather than clobbered.
+	 */
+	public function test_rest_index_preserves_other_plugins_authentication_methods() {
+		wp_set_current_user( 0 );
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
+		add_filter( 'rest_index', 'rest_add_application_passwords_to_index' );
+		// A third-party auth plugin registering at a normal priority, i.e. before ours.
+		$acme = function ( $response ) {
+			$response->data['authentication']['acme-oauth'] = array(
+				'endpoints' => array( 'authorization' => 'https://example.com/acme/authorize' ),
+			);
+			return $response;
+		};
+		add_filter( 'rest_index', $acme, 20 );
+		add_filter( 'rest_index', '\Private_Site\rest_index', PHP_INT_MAX );
+
+		$auth = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/' ) )->get_data()['authentication'];
+
+		remove_filter( 'rest_index', '\Private_Site\rest_index', PHP_INT_MAX );
+		remove_filter( 'rest_index', $acme, 20 );
+		remove_filter( 'rest_index', 'rest_add_application_passwords_to_index' );
+		remove_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+		$this->assertArrayHasKey( 'application-passwords', $auth );
+		$this->assertArrayHasKey( 'acme-oauth', $auth );
+	}
+
+	/**
+	 * The index name is routed through the site-name mask rather than the raw option.
+	 */
+	public function test_rest_index_masks_the_site_name() {
+		wp_set_current_user( 0 );
+		update_option( 'blogname', 'Secret Site Name' );
+		add_filter( 'bloginfo', '\Private_Site\mask_site_name', 3, 2 );
+
+		$data = \Private_Site\rest_index( $this->full_rest_index_response() )->get_data();
+
+		$this->assertSame( 'Private Site', $data['name'] );
+
+		remove_filter( 'bloginfo', '\Private_Site\mask_site_name', 3 );
+	}
+
+	/**
+	 * Builds a response shaped like core's full REST index, including fields a private site must not leak.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function full_rest_index_response() {
+		$response = new WP_REST_Response(
+			array(
+				'name'            => 'Secret Site Name',
+				'description'     => 'Secret tagline',
+				'url'             => 'https://example.com',
+				'home'            => 'https://example.com',
+				'gmt_offset'      => '5',
+				'timezone_string' => 'America/New_York',
+				'namespaces'      => array( 'wp/v2', 'secret-plugin/v1' ),
+				'authentication'  => array(
+					'application-passwords' => array(
+						'endpoints' => array(
+							'authorization' => 'https://example.com/wp-admin/authorize-application.php',
+						),
+					),
+				),
+				'site_icon'       => 42,
+				'routes'          => array(
+					'/secret-plugin/v1/secrets' => array( 'namespace' => 'secret-plugin/v1' ),
+				),
+			)
+		);
+		$response->add_link( 'help', 'https://developer.wordpress.org/rest-api/' );
+
+		return $response;
+	}
 }

--- a/projects/plugins/wpcomsh/tests/e2e/specs/private-site-access.test.js
+++ b/projects/plugins/wpcomsh/tests/e2e/specs/private-site-access.test.js
@@ -77,8 +77,9 @@ describe( 'Private Site -- Logged out Access', () => {
 		expect( index.name ).toBe( 'Private Site' );
 		expect( index.description ).toBe( '' );
 		expect( index.namespaces ).toStrictEqual( [] );
-		expect( index.routes ).toStrictEqual( [] );
+		expect( index.routes ).toStrictEqual( {} );
 		expect( index ).toHaveProperty( 'authentication' );
+		expect( Array.isArray( index.authentication ) ).toBe( false ); // a map, an object even when empty
 		expect( index ).not.toHaveProperty( '_links' );
 		expect( index ).not.toHaveProperty( 'site_icon' );
 		expect( index ).not.toHaveProperty( 'timezone_string' );

--- a/projects/plugins/wpcomsh/tests/e2e/specs/private-site-access.test.js
+++ b/projects/plugins/wpcomsh/tests/e2e/specs/private-site-access.test.js
@@ -67,6 +67,37 @@ describe( 'Private Site -- Logged out Access', () => {
 		} );
 	} );
 
+	it( 'Should expose a minimal REST API index for logged out user', async () => {
+		const res = await fetchPath( '/wp-json/' );
+		expect( res.status ).toBe( 200 );
+
+		const index = await res.json();
+
+		// Discovery-only payload -- nothing that fingerprints the site.
+		expect( index.name ).toBe( 'Private Site' );
+		expect( index.description ).toBe( '' );
+		expect( index.namespaces ).toStrictEqual( [] );
+		expect( index.routes ).toStrictEqual( [] );
+		expect( index ).toHaveProperty( 'authentication' );
+		expect( index ).not.toHaveProperty( '_links' );
+		expect( index ).not.toHaveProperty( 'site_icon' );
+		expect( index ).not.toHaveProperty( 'timezone_string' );
+
+		// The real site name and route table must not leak.
+		const serialized = JSON.stringify( index );
+		expect( serialized ).not.toMatch( /wpcomsh test/ );
+		expect( serialized ).not.toMatch( /wp\/v2/ );
+	} );
+
+	it( 'Should advertise the REST API root on the access denied page for logged out user', async () => {
+		const res = await fetchPath();
+
+		expect( res.headers.get( 'link' ) ).toMatch( /rel="https:\/\/api\.w\.org\/"/ );
+
+		const homePage = await res.text();
+		expect( homePage ).toMatch( /<link rel="https:\/\/api\.w\.org\/" href="[^"]+" \/>/ );
+	} );
+
 	it( 'Should not show REST API posts for logged out user with nonce', async () => {
 		const res = await fetchPathLoggedOutWithRestApiNonce( '/wp-json/wp/v2/posts' );
 		const posts = await res.json();
@@ -145,6 +176,18 @@ describe( 'Private Site -- Logged in Access', () => {
 		const loggedIn = await res.json();
 
 		expect( loggedIn ).toBe( 1 );
+	} );
+
+	it( 'Should show the full REST API index for logged in user with nonce', async () => {
+		const res = await fetchPathLoggedInWithRestApiNonce( '/wp-json/' );
+		expect( res.status ).toBe( 200 );
+
+		const index = await res.json();
+
+		// Authenticated members see the unmodified index.
+		expect( index.namespaces ).toContain( 'wp/v2' );
+		expect( Object.keys( index.routes ).length ).toBeGreaterThan( 1 );
+		expect( index.name ).not.toBe( 'Private Site' );
 	} );
 
 	it( 'Should not show REST API posts for logged in user without nonce', async () => {


### PR DESCRIPTION
## Proposed changes

A private Atomic site answers `403 {"code":"private_site"}` at its JSON root (`/wp-json/`) to any unauthenticated caller. That breaks WordPress's REST **autodiscovery** protocol: a client learns how to authenticate by reading the index *before* it has credentials, so the existing approach gives no supported way for a well-behaved app to connect to a private site.

This PR exposes a deliberately minimal API root instead:

* **Allow `GET /` only** — exact-match on the route, `READABLE` only.  Everything else still returns `403`.
* **Strip the index to an allowlist** via a `rest_index` filter. The response is *rebuilt* from named fields rather than filtered down, so nothing — a future core field, another plugin's addition — can leak incidentally. `namespaces`/`routes` are emptied (the route table is a precise plugin fingerprint), the name is masked, and `description`/`gmt_offset` return empty values.
* **Preserve `authentication` verbatim.** This is the whole point: it carries the Application Passwords **authorization URL** (`…/wp-admin/authorize-application.php`), the page an app sends the user to in order to mint credentials. The filter runs at `PHP_INT_MAX` so it runs *after* core — and any auth plugin — has populated that authorization mechanisms.
* **Advertise the API root on the interstitial** — the `Link: rel="https://api.w.org/"` header plus the matching `<link>` tag. The private-site interstitial short-circuits `template_redirect`, so core's discovery link never fires. We emit only the `api.w.org` link, not core's helper, which would also add an `alternate` link exposing the requested resource's REST route.

Everything is gated on `should_prevent_site_access()`, so authenticated members — and Jetpack blog-token / WP-CLI requests — still get the full, unmodified index. Coming-soon sites get the same treatment (they run the same code path and are, if anything, more likely to be set up by app users).

## Related product discussion/links

<!-- Driven by an internal report; the discussion is on an internal p2. -->

## Does this pull request change what data or activity we track or use?

No. Previously an unauthenticated request to `/wp-json/` on a private site returned only a `403` error; it now returns a deliberately minimal, allowlisted payload — a masked name, the `url`/`home` the caller already fetched, and the `authentication` block that points at the login/authorize URL. None of that is private, and the content, config, and full namespace/route table a private site protects stay exactly as unreadable as before. No private data is exposed either way.

## Testing instructions

Automated (from the monorepo root):

* `jp docker phpunit wpcomsh -- --filter PrivateSiteTest` — 18 cases: the dispatch allow/deny matrix, allowlist exactness, name masking, the app-passwords authorization URL surviving the trim, a second auth plugin's method being preserved alongside core's, and the empty `routes`/`authentication` maps serializing as `{}`.

**A private Atomic staging site is already running this branch** — hit it directly with `curl https://jeremyseriousbusinessdev.wpcomstaging.com/wp-json` and you get the minimal index: `"name":"Private Site"`, `"namespaces":[]`, `"routes":{}`, and `authentication.application-passwords.endpoints.authorization` pointing at `…/wp-admin/authorize-application.php`.

By hand, on your own site marked private and running this code (Atomic: **Settings → Privacy → Private**):

* `curl -s 'https://<site>/wp-json/'` logged out → `200`, body has only `name`/`description`/`url`/`home`/`gmt_offset`/`namespaces`/`authentication`/`routes`; `name` is `"Private Site"`; `namespaces` and `routes` are empty; and `authentication.application-passwords.endpoints.authorization` points at `authorize-application.php`.
* `curl -s 'https://<site>/wp-json/wp/v2/posts'` logged out → still `403 private_site`.
* `curl -sI 'https://<site>/'` logged out → carries `Link: <…>; rel="https://api.w.org/"`, and the interstitial HTML has the matching `<link>` tag.
* Logged in as a member → `/wp-json/` returns the full, unmodified index.

- [x] **Confirmed on a real private Atomic site** (the staging site above): `/wp-json/` returns `200` with `authentication.application-passwords.endpoints.authorization` present — `is_ssl()` is true on Atomic, so core advertises Application Passwords and the filter passes the URL through. 