### PR TITLE
VideoPress: Fix playlist title wrapping and HTML entity decoding

### DIFF
--- a/projects/packages/videopress/changelog/change-fix-vidp-380-playlist-titles
+++ b/projects/packages/videopress/changelog/change-fix-vidp-380-playlist-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Playlist block: Wrap long unbroken video titles and decode HTML entities in titles on the front end.

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/test/view.test.ts
@@ -242,6 +242,25 @@ describe( 'initPlaylistBlock', () => {
 		);
 	} );
 
+	it( 'decodes HTML entities in hydrated titles', async () => {
+		const root = setUpPlaylist();
+		mockLiveMetadata = {
+			aaaaaaaa: { title: 'Sylvie&#039;s Video' },
+			bbbbbbbb: { title: 'Cats &amp; Dogs &lt;3' },
+		};
+
+		await hydratePlaylistMetadata( root );
+
+		const entries = root.querySelectorAll< HTMLButtonElement >( '.videopress-playlist__select' );
+		expect( entries[ 0 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			/^Sylvie's Video$/
+		);
+		expect( entries[ 0 ].dataset.title ).toBe( "Sylvie's Video" );
+		expect( entries[ 1 ].querySelector( '.videopress-playlist__entry-title' ) ).toHaveTextContent(
+			/^Cats & Dogs <3$/
+		);
+	} );
+
 	it( 'retries private videos with a playback token when the token bridge is configured', async () => {
 		window.videopressAjax = { ajaxUrl: '/wp-admin/admin-ajax.php', bridgeUrl: '', post_id: '12' };
 		mockPlaybackToken = 'jwt-token';

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.scss
@@ -279,6 +279,9 @@ $vpp-mono: ui-monospace, menlo, monospace;
 		-webkit-box-orient: vertical;
 		overflow: hidden;
 
+		/* Filename-derived titles can be one long unbreakable word. */
+		overflow-wrap: anywhere;
+
 		/* User-selected theme font preset; inherits when none is chosen. */
 		font-family: var(--vpp-entry-title-font, inherit);
 	}

--- a/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/playlist/view.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
+import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
@@ -124,10 +125,12 @@ export function hydratePlaylistMetadata( root: HTMLElement ): Promise< void[] > 
 			const metadata = result;
 
 			if ( typeof metadata.title === 'string' && metadata.title ) {
-				entry.dataset.title = metadata.title;
+				// The API returns titles HTML-encoded; decode them like the editor does.
+				const title = decodeEntities( metadata.title );
+				entry.dataset.title = title;
 				const titleElement = entry.querySelector( '.videopress-playlist__entry-title' );
 				if ( titleElement ) {
-					titleElement.textContent = metadata.title;
+					titleElement.textContent = title;
 				}
 			}
 

--- a/projects/plugins/jetpack/changelog/change-fix-vidp-380-playlist-titles
+++ b/projects/plugins/jetpack/changelog/change-fix-vidp-380-playlist-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix playlist block video titles overlapping when long, and apostrophes rendering as HTML entities.

--- a/projects/plugins/videopress/changelog/change-fix-vidp-380-playlist-titles
+++ b/projects/plugins/videopress/changelog/change-fix-vidp-380-playlist-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Playlist block: Wrap long unbroken video titles and decode HTML entities in titles on the front end.


### PR DESCRIPTION
Fixes two display bugs in the VideoPress Playlist block reported in VIDP-380.

## Proposed changes
* Playlist block front end: decode HTML entities in video titles hydrated from the videos API (`decodeEntities`), matching what the block editor already does. Previously a title like “Sylvie’s Video” rendered with a literal `&#039;` entity in the playlist.
* Playlist block styles: add `overflow-wrap: anywhere` to the entry title so long unbroken titles (typically auto-generated from filenames with underscores, e.g. `test_video_one_with_underscore`) wrap inside their entry instead of overflowing into the neighboring one. The rule lives in `view.scss`, which is also loaded as the block’s editor style, so both the front end and the editor canvas are covered.
* Add a Jest test covering entity decoding in `hydratePlaylistMetadata`.

Everything else in the render path was audited and already handles user input safely: the server render escapes all output with `esc_html`/`esc_attr`/`esc_url` (titles there are positional fallbacks only), and the front-end hydration writes titles via `textContent`, so no markup injection is possible.

## Related product discussion/links
* VIDP-380

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Connect Jetpack on a site with an active VideoPress plan and upload two or more videos whose filenames are long and contain underscores (e.g. `test_video_one_with_underscore.mp4`), letting VideoPress auto-generate the titles.
* Edit one of the videos and give it a title containing an apostrophe (e.g. “Sylvie’s Video”).
* Create a post with a VideoPress Playlist block containing those videos, choose the “strip” layout, and publish.
* View the post: titles should wrap within their own entry (no overlap with the next entry, in any of the three layouts), and the apostrophe should render as `’`, not `#039;`.
* Check the editor canvas preview of the block as well — titles should wrap there too.

Tested: `jp test js packages/videopress` (18 playlist view tests pass, including a new entity-decoding test), `jp build packages/videopress --deps`, ESLint and Stylelint on the touched files. NOT tested: live rendering on a connected site (requires a VideoPress subscription); the CSS fix was verified against the stylesheet only, so a visual check on a test site is where review should focus.
