### PR TITLE
Launch site: return to the wp-admin page the launch started from

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-site-back-to-wp-admin-page
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-site-back-to-wp-admin-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launch site: point the launch flow back at the wp-admin page it was started from.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -59,6 +59,52 @@ function wpcom_should_show_launch_button(): bool {
 }
 
 /**
+ * The page the launch flow should return to, as a site-relative `ref` value.
+ *
+ * Calypso resolves `ref` against the site's own host, so it doubles as the destination after a
+ * launch and as the target of the flow's Back button. Screens that need query args beyond `page`
+ * (post.php, edit.php filters, and so on) can't be replayed from `ref` alone, so those fall back to
+ * the admin root rather than sending the user to a broken screen.
+ *
+ * @return string
+ */
+function wpcom_get_launch_button_ref(): string {
+	if ( ! is_admin() ) {
+		return 'wp-admin';
+	}
+
+	global $pagenow;
+
+	if ( ! is_string( $pagenow ) || ! preg_match( '/^[a-z0-9_-]+\.php$/', $pagenow ) ) {
+		return 'wp-admin';
+	}
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading the current screen, not a form submission.
+	$query_args = wp_unslash( $_GET );
+
+	if ( ! empty( array_diff_key( $query_args, array( 'page' => '' ) ) ) ) {
+		return 'wp-admin';
+	}
+
+	$page = isset( $query_args['page'] ) && is_string( $query_args['page'] )
+		? sanitize_text_field( $query_args['page'] )
+		: '';
+
+	// admin.php only resolves to a screen together with its `page` arg.
+	if ( 'admin.php' === $pagenow && '' === $page ) {
+		return 'wp-admin';
+	}
+
+	$ref = 'wp-admin/' . $pagenow;
+
+	if ( '' !== $page ) {
+		$ref = add_query_arg( 'page', $page, $ref );
+	}
+
+	return $ref;
+}
+
+/**
  * Adds a "launch site" button to the admin bar.
  *
  * @param WP_Admin_Bar $admin_bar The WordPress admin bar.
@@ -87,7 +133,7 @@ function wpcom_add_launch_button_to_admin_bar( WP_Admin_Bar $admin_bar ) {
 			'href'   => add_query_arg(
 				array(
 					'siteSlug' => $blog_domain,
-					'ref'      => 'wp-admin',
+					'ref'      => wpcom_get_launch_button_ref(),
 				),
 				'https://wordpress.com/start/launch-site'
 			),
@@ -172,6 +218,7 @@ function wpcom_enqueue_launch_button_assets() {
 			'siteDomain'      => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'sitePlan'        => $current_plan,
 			'hasCustomDomain' => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'custom-domain' ),
+			'launchRef'       => wpcom_get_launch_button_ref(),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.jsx
@@ -48,7 +48,7 @@ export function LaunchButton() {
 			// Markup should match what's coming from the back-end.
 			const launchUrl = addQueryArgs( 'https://wordpress.com/start/launch-site', {
 				siteSlug: launchButtonData.siteDomain,
-				ref: 'wp-admin',
+				ref: launchButtonData.launchRef || 'wp-admin',
 			} );
 
 			return (

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launch-button/Launch_Button_Ref_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launch-button/Launch_Button_Ref_Test.php
@@ -23,23 +23,48 @@ class Launch_Button_Ref_Test extends \WorDBless\BaseTestCase {
 	private $original_pagenow;
 
 	/**
+	 * Original $GLOBALS['current_screen'] value, restored after each test.
+	 *
+	 * @var WP_Screen|null
+	 */
+	private $original_current_screen;
+
+	/**
+	 * Original $_GET value, restored after each test.
+	 *
+	 * @var array
+	 */
+	private $original_get;
+
+	/**
 	 * Set up test fixtures.
 	 */
 	public function set_up() {
 		parent::set_up();
 
 		global $pagenow;
-		$this->original_pagenow = $pagenow;
-		$_GET                   = array();
+		$this->original_pagenow        = $pagenow;
+		$this->original_current_screen = $GLOBALS['current_screen'] ?? null;
+		$this->original_get            = $_GET;
+		$_GET                          = array();
 	}
 
 	/**
 	 * Restore globals touched by the tests.
+	 *
+	 * Calling set_current_screen() decides is_admin() for everything that runs afterwards, so
+	 * leaving it set here would put unrelated suites in an admin context they never asked for.
 	 */
 	public function tear_down() {
 		global $pagenow;
 		$pagenow = $this->original_pagenow;
-		$_GET    = array();
+		$_GET    = $this->original_get;
+
+		if ( $this->original_current_screen === null ) {
+			unset( $GLOBALS['current_screen'] );
+		} else {
+			$GLOBALS['current_screen'] = $this->original_current_screen;
+		}
 
 		parent::tear_down();
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launch-button/Launch_Button_Ref_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launch-button/Launch_Button_Ref_Test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for the launch button's `ref` value.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launch-button/index.php';
+
+/**
+ * Exercises wpcom_get_launch_button_ref(), which tells Calypso the page the launch flow should
+ * return to.
+ */
+class Launch_Button_Ref_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Original $pagenow global value, restored after each test.
+	 *
+	 * @var string|null
+	 */
+	private $original_pagenow;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		global $pagenow;
+		$this->original_pagenow = $pagenow;
+		$_GET                   = array();
+	}
+
+	/**
+	 * Restore globals touched by the tests.
+	 */
+	public function tear_down() {
+		global $pagenow;
+		$pagenow = $this->original_pagenow;
+		$_GET    = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * On the front end there is no admin screen to return to.
+	 */
+	public function test_returns_admin_root_on_the_front_end() {
+		set_current_screen( 'front' );
+
+		global $pagenow;
+		$pagenow = 'index.php';
+
+		$this->assertSame( 'wp-admin', wpcom_get_launch_button_ref() );
+	}
+
+	/**
+	 * A menu page keeps its `page` arg, so Back lands on the same screen.
+	 */
+	public function test_keeps_the_page_arg_for_a_menu_screen() {
+		set_current_screen( 'dashboard' );
+
+		global $pagenow;
+		$pagenow      = 'admin.php';
+		$_GET['page'] = 'stats';
+
+		$this->assertSame( 'wp-admin/admin.php?page=stats', wpcom_get_launch_button_ref() );
+	}
+
+	/**
+	 * An argument-less admin screen resolves to its own file.
+	 */
+	public function test_resolves_an_argument_less_admin_screen() {
+		set_current_screen( 'options-reading' );
+
+		global $pagenow;
+		$pagenow = 'options-reading.php';
+
+		$this->assertSame( 'wp-admin/options-reading.php', wpcom_get_launch_button_ref() );
+	}
+
+	/**
+	 * Screens that need query args we don't replay fall back to the admin root, rather than sending
+	 * the user to a screen that errors without them.
+	 */
+	public function test_falls_back_for_screens_needing_other_query_args() {
+		set_current_screen( 'post' );
+
+		global $pagenow;
+		$pagenow        = 'post.php';
+		$_GET['post']   = '123';
+		$_GET['action'] = 'edit';
+
+		$this->assertSame( 'wp-admin', wpcom_get_launch_button_ref() );
+	}
+
+	/**
+	 * The admin.php file without its `page` arg isn't a screen, so it falls back to the admin root.
+	 */
+	public function test_falls_back_for_admin_php_without_a_page_arg() {
+		set_current_screen( 'dashboard' );
+
+		global $pagenow;
+		$pagenow = 'admin.php';
+
+		$this->assertSame( 'wp-admin', wpcom_get_launch_button_ref() );
+	}
+
+	/**
+	 * A $pagenow that isn't a plain PHP filename is never interpolated into the ref.
+	 */
+	public function test_rejects_an_unexpected_pagenow() {
+		set_current_screen( 'dashboard' );
+
+		global $pagenow;
+		$pagenow = '../../evil';
+
+		$this->assertSame( 'wp-admin', wpcom_get_launch_button_ref() );
+	}
+}


### PR DESCRIPTION
Follow-up for [DOTOBRD-606](https://linear.app/a8c/issue/DOTOBRD-606)

## Proposed changes

* The admin bar's "Launch site" button sent `ref=wp-admin`, which can only point back at the admin root. It now carries the screen the user is actually on, e.g. `ref=wp-admin/admin.php?page=stats`.
* Adds `wpcom_get_launch_button_ref()`, which builds that value from `$pagenow` plus the `page` query arg, and hands it to the JS button through `JETPACK_LAUNCH_BUTTON_DATA` so the PHP-rendered and JS-rendered markup stay in sync.
* Adds PHP unit tests covering the front end, menu screens, argument-less screens, and the fallbacks.

This follows the pattern the site visibility settings already use (`ref=wp-admin/options-reading.php` in `replace-site-visibility/launch-site/index.tsx`).

Calypso resolves `ref` as `https://{siteSlug}/{ref}`, so the host is always the site's own — a crafted `ref` cannot redirect off-site. Screens that need query args beyond `page` (`post.php`, `edit.php` filters) can't be replayed from `ref` alone, so those keep today's admin-root fallback instead of landing the user on a screen that errors without them. `admin.php` without a `page` arg falls back for the same reason.

Companion Calypso PR: Automattic/wp-calypso#114002 — that side makes the launch flow's Back button honour the `ref` this PR sends. Both are needed for the full fix; this PR alone improves the post-launch destination, and is harmless without it.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On an unlaunched Simple or Atomic site, go to `/wp-admin/admin.php?page=stats`.
* Hover the "Launch site" button in the admin bar and check the URL — it should now read `…/start/launch-site?siteSlug=<site>&ref=wp-admin%2Fadmin.php%3Fpage%3Dstats` instead of `&ref=wp-admin`.
* Repeat on Settings → Reading (`options-reading.php`) and on the post editor (`post.php?post=…&action=edit`). The editor should still fall back to plain `ref=wp-admin`, since that screen can't be restored from `ref` alone.
* Complete a launch from the Stats page and confirm you land back on Stats rather than the admin root.
* With the companion Calypso PR applied, press "Back" in the launch flow and confirm it returns to Stats.
