### PR TITLE
AI Hub: send standard props on the feature-toggle Tracks event

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -13,7 +13,7 @@ import { ToggleControl } from '@wordpress/components';
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Badge, Card, Link, Notice, Popover, Stack, Text, VisuallyHidden } from '@wordpress/ui';
-import analytics from 'lib/analytics';
+import { EVENTS, recordAiHubEvent } from '../tracks';
 
 // Server-computed target for the AI SEO row: the dedicated Jetpack SEO page
 // where it exists, the Traffic settings card otherwise. Falls back to Traffic
@@ -253,7 +253,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 			onUpdate( { features: { [ key ]: enabled } } ).then( saved => {
 				// Track outcomes, not attempts: a failed save changed nothing.
 				if ( saved ) {
-					analytics.tracks.recordEvent( 'jetpack_ai_feature_toggled', {
+					recordAiHubEvent( EVENTS.FEATURE_TOGGLED, {
 						feature: key,
 						enabled,
 					} );

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -355,6 +355,9 @@ describe( 'AiFeatures rendering', () => {
 		await userEvent.click( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) );
 
 		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_ai_feature_toggled', {
+			site_type: 'jetpack',
+			is_a11n: 'false',
+			is_test: 'false',
 			feature: 'writing_assistant',
 			enabled: false,
 		} );

--- a/projects/plugins/jetpack/_inc/client/ai/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/tracks.js
@@ -10,6 +10,7 @@ import analytics from 'lib/analytics';
 export const EVENTS = {
 	VIEWED: 'jetpack_ai_hub_viewed',
 	LINK_CLICK: 'jetpack_ai_hub_link_click',
+	FEATURE_TOGGLED: 'jetpack_ai_feature_toggled',
 };
 
 /**

--- a/projects/plugins/jetpack/changelog/update-jetpackaihub-feature-events-wrapper
+++ b/projects/plugins/jetpack/changelog/update-jetpackaihub-feature-events-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI: Send the standard site and audience props on the feature-toggle Tracks event.


### PR DESCRIPTION
## Proposed changes

* Route the `jetpack_ai_feature_toggled` event through the AI admin page's shared `recordAiHubEvent` recorder, so it carries the same `site_type`, `is_a11n`, and `is_test` props as the page's other events (`jetpack_ai_hub_viewed`, `jetpack_ai_hub_link_click`). Previously it called the analytics library directly and sent only `feature` and `enabled`.
* Add the event name to the `EVENTS` constant beside its siblings.
* Pin the full payload in the feature-toggle test.

No other behaviour change: same event name, fired from the same place, still only after a successful save.

## Related product discussion/links

* NA

## Does this pull request change what data or activity we track or use?

Yes — the existing `jetpack_ai_feature_toggled` event gains `site_type` (`simple` / `atomic` / `jetpack`) and the `is_a11n` / `is_test` audience flags (as `'true'` / `'false'` strings). No new event, and no content is recorded.

## Testing instructions

* Sync this branch to a test site (Jetpack Beta plugin, or `bin/jetpack-downloader test jetpack update/jetpackaihub-feature-events-wrapper` on a sandboxed Simple site). The relevant tabs show in internal testing environments (e.g. behind the automattic proxy).
* Go to the Jetpack AI admin page, open the **WordPress Agent** tab, and toggle any feature.
* Validate the event fired: set `localStorage.debug = 'dops:analytics'` in the browser console (then reload), or filter the Network tab for `t.gif`.
* The event should carry `feature` and `enabled` plus the new `site_type`, `is_a11n`, and `is_test` props.

Sample event (sanitised), captured on an Atomic test site behind the proxy:

```
site_type=atomic&is_a11n=true&is_test=true&feature=writing_assistant&enabled=true&blog_id=123456789&_en=jetpack_ai_feature_toggled&_ui=12345678&_ut=wpcom%3Auser_id&_ul=exampleuser&...
```

Note: `is_test=true` is expected on a proxied session — this helper counts the A8C proxy as a testing environment.
