### PR TITLE
AI: raise the admin test suite's async timeout for instrumented CI runs

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, configure, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select } from '@wordpress/data';
@@ -9,6 +9,13 @@ import App from '../main';
 // main.jsx imports the webpack-aliased 'lib/analytics', which doesn't resolve
 // under jest — provide it virtually. (jest.mock is hoisted above the imports.)
 jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
+
+// This suite renders the whole admin app, whose boot chains several mocked
+// requests through effects. Under coverage instrumentation on a loaded CI
+// runner that settle can exceed testing-library's 1s default async timeout,
+// failing `findBy*`/`waitFor` on timing rather than behavior — seen as
+// repeated Code coverage (JS) failures on otherwise-unrelated PRs.
+configure( { asyncUtilTimeout: 10000 } );
 jest.mock( '@automattic/jetpack-ai-client', () => ( { requestJwt: jest.fn() } ) );
 
 // Both settings hooks fetch through @wordpress/api-fetch; stub it so nothing

--- a/projects/plugins/jetpack/changelog/fix-ai-admin-test-async-timeout
+++ b/projects/plugins/jetpack/changelog/fix-ai-admin-test-async-timeout
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Raise the AI admin test suite's async timeout so coverage-instrumented CI runs don't fail on timing; test-only change
+
+


### PR DESCRIPTION
## Proposed changes

* Raise the AI admin page test suite's async-utility timeout (`configure( { asyncUtilTimeout: 10000 } )`). The suite renders the whole admin app, whose boot chains several mocked requests through effects; under coverage instrumentation on a loaded CI runner that settle can exceed testing-library's 1-second default, so `findBy*`/`waitFor` assertions fail on timing rather than behavior. Observed as repeated `Code coverage (JS)` failures on unrelated PRs (twice consecutively on #51521, e.g. `host-off: shows the host-off notice…` rejecting after the file already ran for ~77s) while trunk's less-contended runs pass.
* Test-only change; no production behavior affected.

## Related product discussion/links

* Surfaced by the Code coverage (JS) failures on #51521.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run test-gui _inc/client/ai/test/main.jsx` from `projects/plugins/jetpack` — all 24 tests pass.
* The timing sensitivity is reproducible in the old code by lowering the default (`configure( { asyncUtilTimeout: 100 } )`): the async assertions fail exactly the way CI's instrumented runs do.
