### PR TITLE
Run the four orphaned root-level PHPUnit test files, and fix what that surfaced

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-import-test-not-registered
+++ b/projects/plugins/jetpack/changelog/fix-import-test-not-registered
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Register an existing test file with the PHPUnit suites so it actually runs. Test infrastructure only.
+
+

--- a/projects/plugins/jetpack/changelog/fix-import-test-not-registered
+++ b/projects/plugins/jetpack/changelog/fix-import-test-not-registered
@@ -1,5 +1,0 @@
-Significance: patch
-Type: other
-Comment: Register an existing test file with the PHPUnit suites so it actually runs. Test infrastructure only.
-
-

--- a/projects/plugins/jetpack/changelog/fix-orphaned-tests-not-registered
+++ b/projects/plugins/jetpack/changelog/fix-orphaned-tests-not-registered
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Register four orphaned test files with the PHPUnit suites so they run, and fix what running them surfaced. Test infrastructure plus one invisible whitespace fix in an admin body class.
+
+

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -647,7 +647,7 @@ class Jetpack_Admin {
 	 */
 	public function add_jetpack_admin_body_class( $classes ) {
 		if ( $this->is_jetpack_admin_page() ) {
-			return trim( $classes ) . ' jetpack-admin-page ';
+			return ltrim( trim( $classes ) . ' jetpack-admin-page ' );
 		}
 		return $classes;
 	}

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -147,6 +147,9 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="import">
+			<file>tests/php/Import_Post_Meta_Object_Injection_Test.php</file>
+		</testsuite>
 		<testsuite name="seo-module-migration">
 			<file>tests/php/SEO_Sitemap_Migration_Test.php</file>
 			<file>tests/php/SEO_Canonical_URLs_Migration_Test.php</file>

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -147,6 +147,15 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="block-manifest">
+			<file>tests/php/Block_Manifest_Test.php</file>
+		</testsuite>
+		<testsuite name="jetpack-admin">
+			<file>tests/php/Jetpack_Admin_Test.php</file>
+		</testsuite>
+		<testsuite name="unauth-file-upload">
+			<file>tests/php/Unauth_File_Upload_Test.php</file>
+		</testsuite>
 		<testsuite name="import">
 			<file>tests/php/Import_Post_Meta_Object_Injection_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -138,6 +138,9 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="import">
+			<file>tests/php/Import_Post_Meta_Object_Injection_Test.php</file>
+		</testsuite>
 		<testsuite name="seo-module-migration">
 			<file>tests/php/SEO_Sitemap_Migration_Test.php</file>
 			<file>tests/php/SEO_Canonical_URLs_Migration_Test.php</file>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -138,6 +138,15 @@
 		<testsuite name="autoloaded">
 			<directory suffix="Test.php">tests/php/src</directory>
 		</testsuite>
+		<testsuite name="block-manifest">
+			<file>tests/php/Block_Manifest_Test.php</file>
+		</testsuite>
+		<testsuite name="jetpack-admin">
+			<file>tests/php/Jetpack_Admin_Test.php</file>
+		</testsuite>
+		<testsuite name="unauth-file-upload">
+			<file>tests/php/Unauth_File_Upload_Test.php</file>
+		</testsuite>
 		<testsuite name="import">
 			<file>tests/php/Import_Post_Meta_Object_Injection_Test.php</file>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/Block_Manifest_Test.php
+++ b/projects/plugins/jetpack/tests/php/Block_Manifest_Test.php
@@ -141,8 +141,13 @@ class Block_Manifest_Test extends WP_UnitTestCase {
 		);
 		$this->cleanup_paths[] = $block2_json;
 
-		// Generate manifest.
+		// Generate manifest. The builder reports progress on stdout, which the suite's strict
+		// output check counts against the test, so capture it and assert on it instead.
+		ob_start();
 		$result = build_block_manifest( $this->test_dir );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Found 2 blocks', $output );
 		$this->assertTrue( $result );
 
 		// Track manifest file for cleanup.

--- a/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
+++ b/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
@@ -73,7 +73,7 @@ class Import_Post_Meta_Object_Injection_Test extends WP_UnitTestCase {
 
 		$this->assertNotInstanceOf( stdClass::class, $stored );
 		$this->assertNotInstanceOf( '__PHP_Incomplete_Class', $stored, 'Disallowing classes alone still yields an object.' );
-		$this->assertFalse( is_object( $stored ), 'Imported meta was restored as a live PHP object.' );
+		$this->assertIsNotObject( $stored, 'Imported meta was restored as a live PHP object.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
+++ b/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
@@ -60,11 +60,19 @@ class Import_Post_Meta_Object_Injection_Test extends WP_UnitTestCase {
 	 * rebuilt on every later read.
 	 */
 	public function test_object_payload_is_not_stored_as_object() {
-		$this->import_meta( array( 'evil_meta' => 'O:8:"stdClass":1:{s:8:"filename";s:9:"/tmp/pwned";}' ) );
+		$payload = 'O:8:"stdClass":1:{s:8:"filename";s:10:"/tmp/pwned";}';
+
+		// A payload whose declared string lengths are wrong does not decode at all, which would
+		// make every assertion below pass against unpatched code. Pin that it is really an object.
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- checking the fixture, not untrusted input.
+		$this->assertInstanceOf( stdClass::class, unserialize( $payload ), 'Fixture must decode to an object.' );
+
+		$this->import_meta( array( 'evil_meta' => $payload ) );
 
 		$stored = get_post_meta( $this->post_id, 'evil_meta', true );
 
 		$this->assertNotInstanceOf( stdClass::class, $stored );
+		$this->assertNotInstanceOf( '__PHP_Incomplete_Class', $stored, 'Disallowing classes alone still yields an object.' );
 		$this->assertFalse( is_object( $stored ), 'Imported meta was restored as a live PHP object.' );
 	}
 

--- a/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
+++ b/projects/plugins/jetpack/tests/php/Unauth_File_Upload_Test.php
@@ -226,6 +226,13 @@ class Unauth_File_Upload_Test extends WP_UnitTestCase {
 			return '';
 		};
 
+		// This path leaves an operator breadcrumb via error_log(), which PHPUnit 12 captures and
+		// reports as unexpected output. Older PHPUnit versions do not capture it and have no
+		// such method, hence the guard.
+		if ( method_exists( $this, 'expectErrorLog' ) ) {
+			$this->expectErrorLog();
+		}
+
 		add_filter( 'jetpack_unauth_file_download_signing_key', $callback );
 		try {
 			// Passthrough is the URL handed in (callers omit an empty link) rather than a dead link.

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -23,6 +23,10 @@ if ( getenv( 'DOCKER_PHPUNIT_BASE_DIR' ) ) {
  */
 define( 'TESTING_IN_JETPACK', true );
 
+// tools/build-block-manifest.php builds a manifest on include unless it can see it is
+// under test, which needs a built _inc/blocks that the test suite never produces.
+define( 'DOING_TESTS', true );
+
 // Support for:
 // 1. `WORDPRESS_DEVELOP_DIR` environment variable.
 // 2. Plugin installed inside of WordPress.org developer checkout.


### PR DESCRIPTION
## Proposed changes

Four test files sat at the `tests/php/` root, which no PHPUnit config scans: root-level files are only collected through an explicit `<file>` entry. So none of the four had ever run. This registers them and fixes what running them surfaced.

That matters most for `Import_Post_Meta_Object_Injection_Test`. It's the only coverage anywhere for the import post-meta fix that shipped in 16.1.3, and it had never once executed.

To see the gap before this change:

```bash
cd projects/plugins/jetpack
for f in tests/php/*Test.php; do
  printf '%-56s %s\n' "$f" "$(grep -l "$f" phpunit.9.xml.dist phpunit.11.xml.dist | wc -l)"
done
```

Registered in the 9 and 11 configs; the 12 config is a symlink to the 11. All four stay out of the multisite configs, which take root-level files only when the behavior is multisite-specific.

**Every one of the four failed the first time it ran.**

* **`Import_Post_Meta_Object_Injection_Test`**: the payload declared `s:9` for `/tmp/pwned`, which is 10 characters, so `unserialize()` returned `false` and no object was ever built. Every assertion passed against unpatched code, including the one the test is named for. Corrected the length, added an assertion pinning the fixture so a future typo can't quietly neuter it again, and rejected `__PHP_Incomplete_Class` (what disallowing classes leaves behind without the object stripping).
* **`Block_Manifest_Test`**: couldn't have run at all. It includes `tools/build-block-manifest.php`, which builds a manifest on include unless `DOING_TESTS` is defined, and that constant is defined nowhere in the repo, so the guard its author wrote has never fired. Defined it in the test bootstrap, and captured the builder's progress output, which the suite's strict output check otherwise counts against the test.
* **`Jetpack_Admin_Test`**: a real bug. `add_jetpack_admin_body_class()` returned a leading space for empty input; the test asserts against that, and a sibling test spells out "Result should not start with a space". Fixed the function rather than the expectation.
* **`Unauth_File_Upload_Test`**: the no-signing-key path leaves an operator breadcrumb via `error_log()`. PHPUnit 12 redirects `error_log` into its own capture and reports the contents as unexpected output (`TestCase.php:2429`), which `failOnRisky="true"` then fails. Declared it with PHPUnit's own `expectErrorLog()`, guarded by `method_exists`, since PHPUnit 9 and 11 neither capture it nor define the method and CI runs all three.

### One change here isn't test-only

`class.jetpack-admin.php` is a one-line production fix: an empty `body_class` string came back with a leading space. Invisible to users, which is why the changelog entry is non-user-facing, but it's a behavior change.

## Related product discussion/links

* Follows #51830 and #51831, which backported the Jetpack 16.1.3 fixes. The import test came from that backport; the other three orphans are long-standing.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

All of this was run against a real WordPress 7.1 install rather than checked by inspection.

Confirm the tests are collected. On trunk this returns nothing:

```bash
jetpack docker phpunit jetpack -- --list-tests | grep -E 'Import_Post_Meta|Block_Manifest|Jetpack_Admin_Test|Unauth_File_Upload'
```

Then run the four suites. Each exits 0 on this branch and non-zero on trunk:

```bash
jetpack docker phpunit jetpack -- --testsuite import              # OK (4 tests, 9 assertions)
jetpack docker phpunit jetpack -- --testsuite block-manifest      # OK (4 tests, 14 assertions)
jetpack docker phpunit jetpack -- --testsuite jetpack-admin       # OK (18 tests, 37 assertions)
jetpack docker phpunit jetpack -- --testsuite unauth-file-upload  # OK (41 tests, 58 assertions)
```

To confirm the import test guards something rather than merely passing, revert the fix it covers: change `self::unserialize_no_objects( $meta_value )` back to `maybe_unserialize( $meta_value )` in `projects/packages/import/src/endpoints/class-post.php`, then re-run `--testsuite import`. Two of the four tests should fail, including `test_object_payload_is_not_stored_as_object`, with a live `stdClass` restored from imported meta. Before this branch only one of them failed.

### Known unrelated failure

`Jetpack_Eager_Load_Packages_Test::test_admin_request_does_not_defer_import_to_rest_api_init` fails locally in the `general` suite. It isn't from this branch: it fails identically with trunk's bootstrap, which I verified by stashing the bootstrap change and re-running. That suite already runs in CI, so this looks like a local environment artifact, but flagging it in case it isn't.
