### PR TITLE
Forms: hide the Lead Capture pattern on WordPress.com

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-lead-capture-pattern-wpcom-gate
+++ b/projects/packages/forms/changelog/fix-forms-lead-capture-pattern-wpcom-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: hide the Lead Capture pattern on WordPress.com, matching the block variation that is already hidden there.

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Status\Host;
+
 /**
  * This class serves as a container for what previously were standalone grunion functions.
  * In the long term we should aim to move things to other classes and gradually get rid of this rather than adding more.
@@ -185,6 +187,17 @@ class Util {
 					<!-- /wp:jetpack/contact-form -->',
 			),
 		);
+
+		/*
+		 * The Lead Capture pattern is the twin of the 'lead-capture-form' block variation, which is
+		 * hidden on WordPress.com Simple and WoA sites: there the Subscribe block owns newsletter
+		 * signups, and a form with a Subscribe button subscribes nobody. Drop the pattern on those
+		 * hosts too, so it isn't the last remaining route into a form that looks like a signup and
+		 * silently isn't one.
+		 */
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			unset( $patterns['newsletter-form'] );
+		}
 
 		foreach ( $patterns as $name => $pattern ) {
 			register_block_pattern( $name, $pattern );

--- a/projects/packages/forms/tests/php/contact-form/Util_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Util_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -859,5 +860,61 @@ EOT
 
 		// Cleanup
 		wp_set_current_user( $original_user->ID );
+	}
+
+	/**
+	 * Every form pattern, including Lead Capture, is registered off WordPress.com.
+	 */
+	public function test_register_pattern_registers_lead_capture_off_wpcom() {
+		$this->unregister_form_patterns();
+
+		Util::register_pattern();
+
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+		$this->assertTrue( $registry->is_registered( 'newsletter-form' ), 'Lead Capture should be registered off WordPress.com' );
+		$this->assertTrue( $registry->is_registered( 'contact-form' ) );
+
+		$this->unregister_form_patterns();
+	}
+
+	/**
+	 * On WordPress.com the Subscribe block owns newsletter signups, so the Lead Capture pattern is
+	 * skipped there just like the matching block variation. Every other form pattern still ships.
+	 */
+	public function test_register_pattern_skips_lead_capture_on_wpcom_platform() {
+		$this->unregister_form_patterns();
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Util::register_pattern();
+
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+		$this->assertFalse( $registry->is_registered( 'newsletter-form' ), 'Lead Capture should not be registered on WordPress.com' );
+		$this->assertTrue( $registry->is_registered( 'contact-form' ) );
+		$this->assertTrue( $registry->is_registered( 'rsvp-form' ) );
+
+		Constants::clear_single_constant( 'IS_WPCOM' );
+		$this->unregister_form_patterns();
+	}
+
+	/**
+	 * Clears the form patterns from the global registry so each registration test starts clean.
+	 */
+	private function unregister_form_patterns() {
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+		$names    = array(
+			'contact-form',
+			'newsletter-form',
+			'rsvp-form',
+			'registration-form',
+			'appointment-form',
+			'feedback-form',
+			'salesforce-lead-form',
+		);
+
+		foreach ( $names as $name ) {
+			if ( $registry->is_registered( $name ) ) {
+				unregister_block_pattern( $name );
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Proposed changes

Jetpack Forms ships the same signup-shaped form twice, and only one copy is gated on WordPress.com.

The `lead-capture-form` **block variation** — Name + Email + Consent + a **Subscribe** button — has been hidden on WordPress.com Simple since 2020 (PR 17061) and on WoA since December 2023 (PR 34615). The reasoning both times: on WordPress.com the Subscribe block owns newsletter signups, so this form files responses in Feedback and subscribes nobody. The Aug 2023 rename (PR 32481) said it outright — "rename 'Newsletter Connection' to 'Creative Mail' to avoid confusing with 'Jetpack Newsletters' and subscription block."

The matching `newsletter-form` **block pattern** — titled "Lead Capture Form", shipping the identical Name / Email / Consent / Subscribe markup — was never gated. PR 32481 renamed that pattern's title but left it registered everywhere. On WordPress.com it is now the only remaining route into the form the variation gate was meant to close off.

This gates the pattern on `Host::is_wpcom_platform()` so it tracks the variation. No change off WordPress.com.

Adds two tests in `Util_Test` covering both branches, and a changelog entry.

## Related product discussion/links

* Linear: FORMS-774 — site owners building a "subscribe" form out of the Form block, collecting no subscribers and getting no warning. This PR is one narrow piece of that; the larger product question (should the block detect signup-shaped forms, should Forms offer a subscribe action, or should the Subscribe block grow fields?) is still open there.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a WordPress.com Simple or WoA site:

* Open the post editor and search the inserter's Patterns tab (and the Forms category) for "Lead Capture Form".
* Before this change it is there; after, it is gone — matching the "Lead capture" block variation, which is already absent from the Form block's variation picker on those hosts.
* Confirm the other form patterns (Contact Form, RSVP Form, Registration Form, Appointment Form, Feedback Form, Salesforce Lead Form) are all still present.

On a self-hosted Jetpack site:

* Confirm nothing changed — "Lead Capture Form" is still in the Patterns tab, and the "Lead capture" variation is still offered by the Form block.

PHPUnit:

```
cd projects/packages/forms && composer phpunit -- --filter register_pattern
```
