### PR TITLE
Forms: record which check rejected a submission, and fix anonymous Tracks

### DIFF
--- a/projects/packages/forms/changelog/add-forms-spam-verdict-source
+++ b/projects/packages/forms/changelog/add-forms-spam-verdict-source
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Contact Form: record which check rejected a submission, so a blocked response can be told apart from a spam verdict.

--- a/projects/packages/forms/changelog/fix-forms-tracks-anonymous-visitor
+++ b/projects/packages/forms/changelog/fix-forms-tracks-anonymous-visitor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: record Tracks events for submissions from logged-out visitors, which were previously dropped.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -62,6 +62,13 @@ class Contact_Form_Plugin {
 	public static $using_contact_form_field = false;
 
 	/**
+	 * Which built-in check flagged the submission currently being processed.
+	 *
+	 * @var string 'disallowed_list', 'akismet', or '' when neither has flagged it.
+	 */
+	private $spam_verdict_source = '';
+
+	/**
 	 *
 	 * The last Feedback Post ID Erased as part of the Personal Data Eraser.
 	 * Helps with pagination.
@@ -2302,7 +2309,30 @@ class Contact_Form_Plugin {
 			return $is_spam;
 		}
 
-		return $this->is_in_disallowed_list( false, $form );
+		if ( $this->is_in_disallowed_list( false, $form ) ) {
+			$this->spam_verdict_source = 'disallowed_list';
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Which built-in check flagged the submission currently being processed.
+	 *
+	 * @return string 'disallowed_list', 'akismet', or '' when neither has flagged it.
+	 */
+	public function get_spam_verdict_source() {
+		return $this->spam_verdict_source;
+	}
+
+	/**
+	 * Clear the recorded verdict source before a new submission is checked.
+	 *
+	 * @return void
+	 */
+	public function reset_spam_verdict_source() {
+		$this->spam_verdict_source = '';
 	}
 
 	/**
@@ -2434,7 +2464,13 @@ class Contact_Form_Plugin {
 		 * @param WP_Error|bool $result Is the submitted feedback spam.
 		 * @param array|bool $form Submitted feedback.
 		 */
-		return apply_filters( 'contact_form_is_spam_akismet', $result, $form );
+		$result = apply_filters( 'contact_form_is_spam_akismet', $result, $form );
+
+		if ( false !== $result ) {
+			$this->spam_verdict_source = 'akismet';
+		}
+
+		return $result;
 	}
 
 	/**
@@ -3375,16 +3411,23 @@ class Contact_Form_Plugin {
 			require_lib( 'tracks/client' );
 			tracks_record_event( $event_user, $event_name, $event_props );
 		} else {
-			$user_connected = ( new \Automattic\Jetpack\Connection\Manager( 'jetpack-forms' ) )->is_user_connected( get_current_user_id() );
-			if ( ! $user_connected ) {
-				return;
-			}
 			// logged out visitor, record event with Jetpack master user.
 			if ( empty( $event_user->ID ) ) {
 				$master_user_id = Jetpack_Options::get_option( 'master_user' );
 				if ( ! empty( $master_user_id ) ) {
 					$event_user = get_userdata( $master_user_id );
 				}
+			}
+
+			/*
+			 * Check the user the event will be attributed to, not the visitor: a logged-out
+			 * form visitor is never connected, so checking them dropped every anonymous
+			 * submission before the master-user fallback above could be used.
+			 */
+			if ( ! $event_user instanceof \WP_User
+				|| ! ( new \Automattic\Jetpack\Connection\Manager( 'jetpack-forms' ) )->is_user_connected( $event_user->ID )
+			) {
+				return;
 			}
 
 			$tracking = new Tracking();

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3075,6 +3075,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( $is_test_submission ) {
 			$is_spam = false;
 		} else {
+			$plugin->reset_spam_verdict_source();
 			/** This filter is already documented in \Automattic\Jetpack\Forms\ContactForm\Admin */
 			$is_spam = apply_filters( 'jetpack_contact_form_is_spam', false, $akismet_values );
 		}
@@ -3218,6 +3219,25 @@ class Contact_Form extends Contact_Form_Shortcode {
 		}
 		$response->set_status( $feedback_status );
 
+		/*
+		 * Which check rejected the submission. Both checks feed one boolean, and a
+		 * disallowed-list hit is stored as trash while an Akismet hit is stored as spam,
+		 * so neither the boolean nor the status can answer "why" on its own.
+		 */
+		$spam_verdict = '';
+		if ( $in_comment_disallowed_list ) {
+			$spam_verdict = 'disallowed_list';
+		} elseif ( true === $is_spam ) {
+			$spam_verdict = $plugin->get_spam_verdict_source();
+			if ( '' === $spam_verdict ) {
+				$spam_verdict = 'filter';
+			}
+		}
+
+		if ( '' !== $spam_verdict ) {
+			do_action( 'jetpack_forms_log', 'submission_rejected_as_spam', $spam_verdict );
+		}
+
 		foreach ( (array) $akismet_values as $av_key => $av_value ) {
 			$akismet_values[ $av_key ] = Contact_Form_Plugin::strip_tags( $av_value );
 		}
@@ -3269,6 +3289,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		remove_filter( 'wp_insert_post_data', array( $plugin, 'insert_feedback_filter' ), 10 );
 
 		update_post_meta( $post_id, '_feedback_extra_fields', $this->addslashes_deep( $extra_values ) );
+
+		if ( '' !== $spam_verdict ) {
+			update_post_meta( $post_id, '_feedback_spam_verdict', $spam_verdict );
+		}
 
 		if ( 'publish' === $feedback_status ) {
 			Contact_Form_Plugin::recalculate_unread_count();

--- a/projects/packages/forms/tests/php/contact-form/Spam_Verdict_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Spam_Verdict_Test.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Tests for how a rejected submission records which check rejected it.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\Before;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ */
+#[CoversClass( Contact_Form::class )]
+#[CoversClass( Contact_Form_Plugin::class )]
+class Spam_Verdict_Test extends BaseTestCase {
+
+	/**
+	 * The post the form lives on.
+	 *
+	 * @var \WP_Post
+	 */
+	private $post;
+
+	/**
+	 * Arguments each `jetpack_forms_log` call was made with.
+	 *
+	 * @var array
+	 */
+	private $logged = array();
+
+	/**
+	 * @before
+	 */
+	#[Before]
+	public function set_up_spam_verdict_test() {
+		add_filter( 'pre_wp_mail', '__return_true', PHP_INT_MAX );
+
+		$this->logged = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( ...$args ) {
+				$this->logged[] = $args;
+			},
+			10,
+			PHP_INT_MAX
+		);
+
+		$_SERVER['REMOTE_ADDR']     = '203.0.113.9';
+		$_SERVER['HTTP_USER_AGENT'] = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X)';
+
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => 'owner@example.com',
+				'user_login' => 'spam_verdict_owner',
+				'user_pass'  => 'abc123',
+				'role'       => 'author',
+			)
+		);
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title'   => 'Contact',
+				'post_content' => 'Form lives here',
+				'post_status'  => 'draft',
+				'post_author'  => $author_id,
+			),
+			true
+		);
+
+		global $post;
+		$post                     = get_post( $post_id );
+		$this->post               = $post;
+		$_POST['contact-form-id'] = $post_id;
+
+		Contact_Form_Plugin::init()->process_form_submission();
+	}
+
+	/**
+	 * Submit the form and return the feedback post that was created.
+	 *
+	 * @return \stdClass
+	 */
+	private function submit() {
+		$prefix = 'g' . $this->post->ID;
+		$_POST  = array(
+			'contact-form-id'    => $this->post->ID,
+			$prefix . '-name'    => 'Real Customer',
+			$prefix . '-email'   => 'customer@example.com',
+			$prefix . '-message' => 'Please book me an appointment.',
+		);
+
+		$form = new Contact_Form(
+			array( 'to' => 'owner@example.com' ),
+			"[contact-field label='Name' type='name' required='1'/][contact-field label='Email' type='email' required='1'/][contact-field label='Message' type='textarea' required='1'/]"
+		);
+
+		$form->process_submission();
+
+		return end( Posts::init()->posts );
+	}
+
+	/**
+	 * A term in Disallowed Comment Keys matches the user agent, not the message. The
+	 * submission is trashed, and the reason has to survive to say why.
+	 */
+	public function test_disallowed_list_hit_records_its_verdict() {
+		update_option( 'disallowed_keys', "iPhone\n" );
+
+		$feedback = $this->submit();
+
+		$this->assertSame( 'trash', $feedback->post_status );
+		$this->assertSame( 'disallowed_list', get_post_meta( $feedback->ID, '_feedback_spam_verdict', true ) );
+		$this->assertContains(
+			array( 'submission_rejected_as_spam', 'disallowed_list' ),
+			$this->logged
+		);
+	}
+
+	/**
+	 * A verdict from a filter other than the disallowed list is stored as spam and
+	 * recorded separately, so the two cases can be told apart after the fact.
+	 */
+	public function test_filter_verdict_records_separately_from_the_disallowed_list() {
+		add_filter( 'jetpack_contact_form_is_spam', '__return_true', 11 );
+
+		$feedback = $this->submit();
+
+		$this->assertSame( 'spam', $feedback->post_status );
+		$this->assertSame( 'filter', get_post_meta( $feedback->ID, '_feedback_spam_verdict', true ) );
+		$this->assertContains(
+			array( 'submission_rejected_as_spam', 'filter' ),
+			$this->logged
+		);
+
+		remove_all_filters( 'jetpack_contact_form_is_spam' );
+	}
+
+	/**
+	 * An accepted submission records no verdict at all.
+	 */
+	public function test_accepted_submission_records_no_verdict() {
+		$feedback = $this->submit();
+
+		$this->assertSame( 'publish', $feedback->post_status );
+		$this->assertSame( '', get_post_meta( $feedback->ID, '_feedback_spam_verdict', true ) );
+		$this->assertSame( array(), $this->logged );
+	}
+
+	/**
+	 * The verdict source does not leak from one submission into the next.
+	 */
+	public function test_verdict_source_resets_between_submissions() {
+		update_option( 'disallowed_keys', "iPhone\n" );
+		$this->submit();
+
+		update_option( 'disallowed_keys', '' );
+		$feedback = $this->submit();
+
+		$this->assertSame( 'publish', $feedback->post_status );
+		$this->assertSame( '', get_post_meta( $feedback->ID, '_feedback_spam_verdict', true ) );
+	}
+
+	/**
+	 * A logged-out visitor is never a connected user, so the connection check has to run
+	 * against the master user the event is actually attributed to.
+	 */
+	public function test_tracks_event_is_attributed_to_the_master_user_for_a_logged_out_visitor() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_email' => 'master@example.com',
+				'user_login' => 'spam_verdict_master',
+				'user_pass'  => 'abc123',
+				'role'       => 'administrator',
+			)
+		);
+
+		Jetpack_Options::update_option( 'master_user', $owner_id );
+		Jetpack_Options::update_option( 'user_tokens', array( $owner_id => 'token.secret.' . $owner_id ) );
+		Jetpack_Options::update_option( 'id', 1234 );
+		update_option( 'jetpack_tos_agreed', true );
+
+		wp_set_current_user( 0 );
+
+		$recorded = array();
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$recorded ) {
+				$recorded[] = $url;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '',
+				);
+			},
+			10,
+			3
+		);
+
+		Contact_Form_Plugin::init()->record_tracks_event( 'forms_spam_verdict_probe', array() );
+
+		$this->assertNotEmpty(
+			$recorded,
+			'A Tracks event should be recorded for an anonymous visitor when the site has a connected owner.'
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes

Two related gaps that together make a spam-rejected form submission impossible to account for after the fact.

* **`record_tracks_event()` dropped every anonymous submission.** It checked `is_user_connected( get_current_user_id() )` before doing anything. A logged-out form visitor is user ID 0, and `Manager::is_user_connected()` returns false for 0 unconditionally, so the master-user fallback four lines below it was unreachable. On any non-`IS_WPCOM` site, no submission from a logged-out visitor has ever recorded a Tracks event. The check now runs against the user the event is attributed to, after that fallback resolves.
* **The spam verdict was discarded.** Both checks collapse into one boolean via `jetpack_contact_form_is_spam`, so nothing downstream can say which one fired. The post status does not answer it either: a disallowed-list hit is stored as `trash` and an Akismet hit as `spam`. `Contact_Form_Plugin` now records which built-in check produced the verdict, and `process_submission()` writes it to `_feedback_spam_verdict` post meta and fires the existing `jetpack_forms_log` action with it.
* Adds `Spam_Verdict_Test`, five tests. Three of them are proven red without these changes.

No public filter signature changes, and no change to which status a rejected submission gets or whether a notification email is sent. Those are open product decisions, tracked on the Linear issue rather than decided here.

## Related product discussion/links

* FORMS-775, which carries the full investigation and the remaining open decisions: https://linear.app/a8c/issue/FORMS-775
* FORMS-742, prior work on Forms telemetry: https://linear.app/a8c/issue/FORMS-742

## Does this pull request change what data or activity we track or use?

Yes, in two ways, both worth a privacy look.

1. **Tracks events that were silently never sent will now be sent.** `jetpack_forms_message_sent` already existed and was already intended to fire for form submissions; the guard above meant it never did for logged-out visitors on Jetpack sites. Nothing new is collected per event, and the event is still attributed to the site's master user rather than the visitor, exactly as the existing code intended. But in practice the volume of this event goes from zero to non-zero on self-hosted and Atomic sites, so the effect is the same as turning collection on.
2. **A new `jetpack_forms_log` action argument and a new post meta value.** Both carry one of three fixed strings, `disallowed_list`, `akismet`, or `filter`. No visitor data, no message content, no IP, no user agent. The post meta is stored locally on the site alongside the response it describes and is not transmitted anywhere by this change.

Adding the "[Status] Needs Privacy Updates" label so someone confirms item 1 is fine before this merges.

## Testing instructions

Automated, from `projects/packages/forms`:

* `composer phpunit -- --filter Spam_Verdict_Test` passes, 5 tests.
* Revert `src/` and re-run: `test_disallowed_list_hit_records_its_verdict`, `test_filter_verdict_records_separately_from_the_disallowed_list`, and `test_tracks_event_is_attributed_to_the_master_user_for_a_logged_out_visitor` all fail. The last one drives the real `Tracking` stack and asserts on the pixel request, so it is not passing vacuously.
* The full package suite is 1252 tests with one failure, `Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname`, which fails on a clean trunk checkout too and is unrelated.

Manually, on a site with Jetpack Forms:

1. Go to Settings > Discussion and add a term to Disallowed Comment Keys that appears in your browser's user agent, for example `iPhone` on a phone, or `Chrome` on a desktop.
2. Submit a contact form on the front end from that browser.
3. The response lands in Forms > Responses > Trash. Confirm it now carries the reason: `wp post meta get <id> _feedback_spam_verdict` returns `disallowed_list`.
4. Remove the disallowed term, add `add_filter( 'jetpack_contact_form_is_spam', '__return_true', 11 );` in a mu-plugin, and submit again. The response lands in Spam and the meta reads `filter`.
5. Remove both and submit a clean response. No `_feedback_spam_verdict` meta is written.

Note for step 3 and 4: the visitor still sees the normal success message in both cases. That is existing behavior this PR deliberately does not change.
