### PR TITLE
jetpack-mu-wpcom: fix empty dashboard plan/custom-domain data on Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-dashboard-widgets-site-purchases
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-dashboard-widgets-site-purchases
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard widgets: Prime the site purchases cache on Simple sites so plan and custom-domain data is populated correctly.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -8,6 +8,42 @@
 use Automattic\Jetpack\Connection\Client;
 
 /**
+ * Warm the WordPress.com site-purchases cache early on Simple-site Dashboard loads.
+ *
+ * On Simple sites (IS_WPCOM), wpcom_get_site_purchases() reads the store DB behind
+ * an object-cache lock (see wpcomsh functions-wpcom-features.php). When the cache is
+ * cold and a request loses that build lock, the losing request registers a
+ * 'wpcom_simple_skip_purchase_lookup' filter that forces every *subsequent* purchase
+ * lookup in the same request to return an empty set. The Dashboard resolves several
+ * feature/purchase values while assembling widgets, so a poisoned request leaves the
+ * launch celebration modal (and the other widgets) with sitePlan: null and
+ * hasCustomDomain: false even on paid, custom-domain sites.
+ *
+ * Resolving the purchases here, on 'init' before any of those consumers run, lets this
+ * request be the one that builds and caches them, so the later lookups read warm data.
+ * A no-op on Atomic (purchases come from persistent data there, and this is IS_WPCOM-gated)
+ * and on non-Dashboard requests.
+ *
+ * @return void
+ */
+function wpcom_dashboard_widgets_prime_site_purchases_cache() {
+	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+		return;
+	}
+
+	if ( ! is_admin() || 'index.php' !== ( $GLOBALS['pagenow'] ?? '' ) ) {
+		return;
+	}
+
+	if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+		return;
+	}
+
+	wpcom_get_site_purchases();
+}
+add_action( 'init', 'wpcom_dashboard_widgets_prime_site_purchases_cache', 1 );
+
+/**
  * Load all wpcom dashboard widgets.
  */
 function load_wpcom_dashboard_widgets() {


### PR DESCRIPTION
## Proposed changes

The WordPress.com dashboard widgets localise `sitePlan` and `hasCustomDomain` (`wpcom-dashboard-widgets.php`) from `wpcom_get_site_purchases()` / `wpcom_site_has_feature()`. On **Simple** sites these read the store DB behind an object-cache lock (wpcomsh `functions-wpcom-features.php:262-276`): when the cache is cold and a request loses the build lock, that request registers a `wpcom_simple_skip_purchase_lookup` filter that forces **every subsequent purchase lookup in the same request** to return an empty set.

The observable symptom: on the dashboard, `window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS` comes back with `sitePlan: null` and `hasCustomDomain: false` even on a paid, custom-domain site — while `window.JETPACK_MU_WPCOM_SITE_VISIBILITY` (Reading settings) resolves the same data correctly. Downstream, the site-launch celebration modal then shows the wrong upsell variant.

* Resolve the purchases on `init` — before the widgets and other feature/purchase consumers run — so this request is the one that *builds and caches* them, and the later lookups read warm data instead of racing the lock.
* Gated to Simple-site (`IS_WPCOM`) dashboard (`index.php`) requests; a no-op on Atomic (purchases there come from persistent data) and on every other request. No change to wpcomsh's shared purchase function.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

⚠️ **Needs on-site verification** — the root cause was diagnosed from code; the lock/poison path is partly timing-dependent, so please confirm on an affected Simple site.

1. On a **Simple** WordPress.com site that has a paid plan and a custom domain, open the wp-admin Dashboard.
2. In the console: `console.log( window.JETPACK_MU_WPCOM_DASHBOARD_WIDGETS )` — confirm `sitePlan` is now populated and `hasCustomDomain: true` (before this change they were `null` / `false`).
3. Compare against the Reading settings page (`window.JETPACK_MU_WPCOM_SITE_VISIBILITY`) — they should now agree.
4. To capture the mechanism, temporarily add this mu-plugin and check `error_log` on a dashboard load — `count` should be non-zero and `skip_filter` should read `none`:

```php
add_action( 'wp_dashboard_setup', function () {
	$p = function_exists( 'wpcom_get_site_purchases' ) ? wpcom_get_site_purchases() : 'n/a';
	error_log( sprintf(
		'[purchases-dbg] IS_WPCOM=%s count=%s custom_domain=%s skip_filter=%s',
		defined( 'IS_WPCOM' ) && IS_WPCOM ? '1' : '0',
		is_array( $p ) ? count( $p ) : $p,
		function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'custom-domain' ) ? '1' : '0',
		has_filter( 'wpcom_simple_skip_purchase_lookup' ) ? 'ACTIVE' : 'none'
	) );
}, 99 );
```

### Residual limitation

This makes *this* request build the cache first, which resolves the common intra-request case. It cannot fix a genuine cross-request cold-start race (two fresh requests within the build window) — that would require a change in wpcomsh's shared purchase function, which is intentionally out of scope here.

## Notes

Split out of the site-launch-modals adoption PR (#51716). That PR already neutralises the *custom-domain* half of the symptom client-side (a non-default primary domain suppresses the domain upsell regardless of `hasCustomDomain`); this PR fixes the underlying payload so `sitePlan` is correct too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
