### PR TITLE
Premium Analytics: let Simple sites enable the dashboard with the option

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-premium-analytics-simple-option-gate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-premium-analytics-simple-option-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: Honor the site's own opt-in on WordPress.com Simple, alongside the rollout sticker.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -92,6 +92,10 @@ class Jetpack_Mu_Wpcom {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_comments' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_verbum_moderate' ) );
 			add_action( 'wp_loaded', array( __CLASS__, 'load_verbum_comments_admin' ) );
+			// Registered at mu-plugin scope rather than on plugins_loaded, because
+			// should_load_wpcom_simple_premium_analytics() resolves this filter at plugins_loaded
+			// priority 10.
+			add_filter( 'jetpack_premium_analytics_enabled', array( __CLASS__, 'enable_wpcom_simple_premium_analytics_for_sticker' ) );
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_wpcom_simple_premium_analytics' ) );
 			add_action( 'rest_api_init', array( __CLASS__, 'load_wpcom_simple_premium_analytics_enablement_setting' ) );
 			add_action( 'admin_menu', array( __CLASS__, 'load_wpcom_simple_odyssey_stats' ) );
@@ -822,21 +826,45 @@ class Jetpack_Mu_Wpcom {
 	/**
 	 * Whether Premium Analytics should be loaded on WordPress.com Simple.
 	 *
-	 * @return bool True when the Simple rollout gate is enabled.
+	 * Resolves the same filter over the same option that connected sites use, so one hook answers
+	 * for every platform. The Jetpack plugin, which resolves it everywhere else, does not run on
+	 * Simple, so the question is asked here instead.
+	 *
+	 * @return bool
 	 */
 	public static function should_load_wpcom_simple_premium_analytics() {
-		$blog_id = (int) get_wpcom_blog_id();
-		$enabled = $blog_id > 0 && wpcom_has_blog_sticker( 'jetpack-premium-analytics', $blog_id );
+		/** This filter is documented in projects/plugins/jetpack/class.jetpack.php */
+		return (bool) apply_filters( 'jetpack_premium_analytics_enabled', (bool) get_option( 'jetpack_premium_analytics_enabled' ) );
+	}
 
-		/**
-		 * Filters whether Premium Analytics loads on WordPress.com Simple.
-		 *
-		 * @since $$next-version$$
-		 *
-		 * @param bool $enabled Whether the Simple rollout gate is enabled.
-		 * @param int  $blog_id WPCOM blog ID.
-		 */
-		return (bool) apply_filters( 'jetpack_premium_analytics_wpcom_simple_enabled', $enabled, $blog_id );
+	/**
+	 * Lets the rollout sticker switch the dashboard on, as wpcomsh_enable_premium_analytics() does
+	 * for Atomic.
+	 *
+	 * Answers the shared filter from the sticker alone. Answering it from
+	 * should_load_wpcom_simple_premium_analytics() would recurse, because that resolves this filter.
+	 *
+	 * @todo Retire alongside wpcomsh_enable_premium_analytics(); the opt-in is meant to be the
+	 *       only signal once the rollout no longer needs a lever we control.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $enabled Whether Premium Analytics is already enabled.
+	 * @return bool
+	 */
+	public static function enable_wpcom_simple_premium_analytics_for_sticker( $enabled ) {
+		return $enabled || self::has_wpcom_simple_premium_analytics_sticker();
+	}
+
+	/**
+	 * Whether this Simple site carries the Premium Analytics rollout sticker.
+	 *
+	 * @return bool
+	 */
+	private static function has_wpcom_simple_premium_analytics_sticker() {
+		$blog_id = (int) get_wpcom_blog_id();
+
+		return $blog_id > 0 && wpcom_has_blog_sticker( 'jetpack-premium-analytics', $blog_id );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/premium-analytics/Wpcom_Simple_Premium_Analytics_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/premium-analytics/Wpcom_Simple_Premium_Analytics_Test.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
@@ -18,11 +19,38 @@ class Wpcom_Simple_Premium_Analytics_Test extends \WorDBless\BaseTestCase {
 	 * Tear down.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'jetpack_premium_analytics_wpcom_simple_enabled' );
+		remove_all_filters( 'jetpack_premium_analytics_enabled' );
 		unregister_setting( 'general', 'jetpack_premium_analytics_enabled' );
+		delete_option( 'jetpack_premium_analytics_enabled' );
 		\Mockery::close();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * The package bootstrap has to actually wire the sticker up.
+	 *
+	 * Every other test here registers the filter by hand, so only this one fails if init() stops.
+	 * The bootstrap already ran init() without IS_WPCOM, so this clears the did_action() guard and
+	 * re-runs it with the constant defined, in its own process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_package_bootstrap_wires_the_sticker() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
+
+		unset( $GLOBALS['wp_actions']['jetpack_mu_wpcom_initialized'] );
+		Jetpack_Mu_Wpcom::init();
+
+		$this->assertNotFalse(
+			has_filter( 'jetpack_premium_analytics_enabled', array( Jetpack_Mu_Wpcom::class, 'enable_wpcom_simple_premium_analytics_for_sticker' ) ),
+			'Jetpack_Mu_Wpcom::init() must register the sticker on jetpack_premium_analytics_enabled.'
+		);
 	}
 
 	/**
@@ -30,15 +58,6 @@ class Wpcom_Simple_Premium_Analytics_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_wpcom_simple_premium_analytics_gate_is_off_by_default() {
 		$this->assertFalse( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
-	}
-
-	/**
-	 * The Simple bootstrap gate can be enabled for a staged site.
-	 */
-	public function test_wpcom_simple_premium_analytics_gate_can_be_enabled_by_filter() {
-		add_filter( 'jetpack_premium_analytics_wpcom_simple_enabled', '__return_true' );
-
-		$this->assertTrue( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
 	}
 
 	/**
@@ -59,7 +78,7 @@ class Wpcom_Simple_Premium_Analytics_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_wpcom_simple_premium_analytics_loader_boots_premium_analytics_when_enabled() {
-		add_filter( 'jetpack_premium_analytics_wpcom_simple_enabled', '__return_true' );
+		add_filter( 'jetpack_premium_analytics_enabled', '__return_true' );
 
 		\Mockery::mock( 'alias:' . \Automattic\Jetpack\PremiumAnalytics\Analytics::class )
 			->shouldReceive( 'init_wpcom_simple' )
@@ -82,7 +101,84 @@ class Wpcom_Simple_Premium_Analytics_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The Simple bootstrap gate can be enabled by the rollout sticker.
+	 * The shared filter connected sites use reaches Simple too.
+	 */
+	public function test_wpcom_simple_premium_analytics_gate_can_be_enabled_by_the_shared_filter() {
+		add_filter( 'jetpack_premium_analytics_enabled', '__return_true' );
+
+		$this->assertTrue( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
+	}
+
+	/**
+	 * The Simple bootstrap gate can be enabled by the customer's own opt-in option.
+	 */
+	public function test_wpcom_simple_premium_analytics_gate_can_be_enabled_by_option() {
+		update_option( 'jetpack_premium_analytics_enabled', 1 );
+
+		$this->assertTrue( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
+	}
+
+	/**
+	 * The sticker wins over a site that has opted out, matching Atomic.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_wpcom_simple_premium_analytics_sticker_wins_over_a_falsy_option() {
+		if ( ! defined( 'IS_WPCOM' ) ) {
+			define( 'IS_WPCOM', true );
+		}
+
+		eval( 'function has_blog_sticker( $sticker, $blog_id ) { return $sticker === "jetpack-premium-analytics" && $blog_id > 0; }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		add_filter( 'jetpack_premium_analytics_enabled', array( Jetpack_Mu_Wpcom::class, 'enable_wpcom_simple_premium_analytics_for_sticker' ) );
+		update_option( 'jetpack_premium_analytics_enabled', 0 );
+
+		$this->assertTrue( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
+	}
+
+	/**
+	 * The sticker only ever adds: off-platform the opt-in passes straight through, both ways.
+	 *
+	 * IS_WPCOM and IS_ATOMIC are undefined in this process, so get_wpcom_blog_id() is falsy and the
+	 * blog_id guard returns before any sticker lookup.
+	 */
+	public function test_wpcom_simple_premium_analytics_sticker_filter_passes_the_opt_in_through() {
+		$this->assertFalse( Jetpack_Mu_Wpcom::enable_wpcom_simple_premium_analytics_for_sticker( false ) );
+		$this->assertTrue( Jetpack_Mu_Wpcom::enable_wpcom_simple_premium_analytics_for_sticker( true ) );
+	}
+
+	/**
+	 * The option filter overrides the stored value in either direction.
+	 *
+	 * @param bool $option   Stored option value.
+	 * @param bool $filtered What the filter returns.
+	 * @param bool $expected Expected answer.
+	 * @dataProvider provide_option_filter_overrides
+	 */
+	#[DataProvider( 'provide_option_filter_overrides' )]
+	public function test_wpcom_simple_premium_analytics_gate_option_filter_overrides( $option, $filtered, $expected ) {
+		update_option( 'jetpack_premium_analytics_enabled', $option ? 1 : 0 );
+		add_filter( 'jetpack_premium_analytics_enabled', fn () => $filtered );
+
+		$this->assertSame( $expected, Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
+	}
+
+	/**
+	 * Data for test_wpcom_simple_premium_analytics_gate_option_filter_overrides.
+	 *
+	 * @return array
+	 */
+	public static function provide_option_filter_overrides() {
+		return array(
+			'filter turns it on'  => array( false, true, true ),
+			'filter turns it off' => array( true, false, false ),
+		);
+	}
+
+	/**
+	 * The sticker turns the dashboard on, the way wpcomsh does for Atomic.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -95,6 +191,7 @@ class Wpcom_Simple_Premium_Analytics_Test extends \WorDBless\BaseTestCase {
 		}
 
 		eval( 'function has_blog_sticker( $sticker, $blog_id ) { return $sticker === "jetpack-premium-analytics" && $blog_id > 0; }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		add_filter( 'jetpack_premium_analytics_enabled', array( Jetpack_Mu_Wpcom::class, 'enable_wpcom_simple_premium_analytics_for_sticker' ) );
 
 		$this->assertTrue( Jetpack_Mu_Wpcom::should_load_wpcom_simple_premium_analytics() );
 	}

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -129,7 +129,9 @@ prefixes; Woo `analytics/reports/*` → `proxy/v2/analytics/reports/*`. The dash
 
 Simple has no local proxy, notices, sync, or dashboard support routes — WPCOM serves the dashboard
 and reaches `public-api.wordpress.com` directly. `jetpack-mu-wpcom` boots the package via
-`Analytics::init_wpcom_simple()`, behind the `jetpack-premium-analytics` blog sticker.
+`Analytics::init_wpcom_simple()`, behind the site's own `jetpack_premium_analytics_enabled`
+opt-in or the `jetpack-premium-analytics` blog sticker, whichever says yes. Both answer the
+shared `jetpack_premium_analytics_enabled` filter, as they do on the other platforms.
 
 ### Route guards must use the shared site-readiness helpers
 

--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-simple-option-gate
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-simple-option-gate
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Updates AGENTS.md for the Simple enablement gate. No user-facing change.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/UNI-716/self-serve-enablement-of-the-traffic-tab-preview-on-wpcom-sites

## Proposed changes
* WordPress.com Simple only ever read the `jetpack-premium-analytics` blog sticker, so `jetpack_premium_analytics_enabled` had no effect there. Connected sites already read that option in `Jetpack::is_premium_analytics_enabled()`, and Atomic ORs the sticker on top of it in wpcomsh.
* Honour the option alongside the sticker, so a customer's own opt-in works the same way on Simple as it does on Atomic and self-hosted.
* The blog id guard stays with the sticker lookup, which is the only part that needs it.

Groundwork for the opt-in banner in classic Stats (STATS-461) and the enablement mechanism behind it (UNI-716). The sticker keeps its meaning as the rollout signal we control.

## Related product discussion/links
* STATS-461
* UNI-716

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a Simple sandbox with no `jetpack-premium-analytics` sticker, ensure there is no Stats v2 menu in wp-admin.
* Set the option: `wp option update jetpack_premium_analytics_enabled 1`
* Reload wp-admin and ensure the Stats v2 menu shows up now.
* Set it back to `0` and ensure the menu goes away again.
* Ensure the sticker on its own still works with the option unset.
* `cd projects/packages/jetpack-mu-wpcom && composer phpunit -- --filter Wpcom_Simple_Premium_Analytics_Test`
