### PR TITLE
Sync: sync the jetpack_premium_analytics_enabled option

### DIFF
--- a/projects/packages/sync/changelog/add-sync-premium-analytics-enabled-option
+++ b/projects/packages/sync/changelog/add-sync-premium-analytics-enabled-option
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync the jetpack_premium_analytics_enabled option, so WordPress.com can see whether a site has the Premium Analytics dashboard turned on.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -84,6 +84,7 @@ class Defaults {
 		'jetpack_options',
 		'jetpack_portfolio',
 		'jetpack_portfolio_posts_per_page',
+		'jetpack_premium_analytics_enabled',
 		'jetpack_protect_global_whitelist',
 		'jetpack_protect_key',
 		'jetpack_publicize_options',

--- a/projects/plugins/jetpack/changelog/add-sync-premium-analytics-enabled-option
+++ b/projects/plugins/jetpack/changelog/add-sync-premium-analytics-enabled-option
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Sync tests: cover the newly synced jetpack_premium_analytics_enabled option.

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -170,6 +170,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_holiday_snow_enabled'                 => false,
 			'jetpack_portfolio'                            => 'pineapple',
 			'jetpack_portfolio_posts_per_page'             => 'pineapple',
+			'jetpack_premium_analytics_enabled'            => '1',
 			'jetpack_testimonial'                          => 'pineapple',
 			'jetpack_testimonial_posts_per_page'           => 'pineapple',
 			'tiled_galleries'                              => 'pineapple',


### PR DESCRIPTION
## Proposed changes
* Adds `jetpack_premium_analytics_enabled` to the Sync options allowlist.

The option decides whether a site runs the Premium Analytics dashboard, and it's written locally - either by the site's own opt-in (#51864) or by an Automattician. Without it in the allowlist WordPress.com has no way to see which sites are on, which we need for the rollout targeting behind STATS-461 and for reporting on how many people enable it.

## Related product discussion/links
* STATS-461
* UNI-716

## Does this pull request change what data or activity we track or use?
Yes - it syncs one more site option, `jetpack_premium_analytics_enabled`, a boolean saying whether the site has the Premium Analytics dashboard turned on. No personal data.

## Testing instructions
* On a connected site, ensure `Automattic\Jetpack\Sync\Defaults::get_options_whitelist()` includes `jetpack_premium_analytics_enabled`.
* Run `wp option update jetpack_premium_analytics_enabled 1` and ensure a `jetpack_sync_save_option` action is queued for it (e.g. via `wp jetpack sync status` or by watching the queue).
* Ensure the value shows up on the WordPress.com side for that blog once sync drains.
* `cd projects/packages/sync && composer phpunit`
