### PR TITLE
Charts: move the leaderboard gaps and bar radius to CSS

### DIFF
--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -156,6 +156,8 @@ The palette is resolved per provider, so one `ColorCache` and one group-to-color
 | `--a8c-charts-elevation-xs` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003` |
 | `--a8c-charts-elevation-sm` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005` |
 
+`theme.leaderboardChart.rowGap` and `.columnGap` are the deprecated way into the two leaderboard gaps. Both still outrank the role where a consumer sets one, and both are removed in CHARTS-263.
+
 The motion pair carries the one-shot reveal a data mark plays on first paint, across all six charts that animate in. It deliberately does **not** cover interaction motion: hover and transition timings read `--wpds-motion-*` directly, as interface chrome rather than a chart role.
 
 The elevation fallbacks hold the values their removed `--wpds-elevation-*` tokens used to resolve to, until a replacement exists.

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -151,6 +151,8 @@ The palette is resolved per provider, so one `ColorCache` and one group-to-color
 | `--a8c-charts-border-radius-bar` | `--wpds-border-radius-md` | `4px` |
 | `--a8c-charts-border-radius-cell` | `--wpds-border-radius-sm` | `2px` |
 | `--a8c-charts-border-radius-leaderboard-bar` | _(none — pill shape, no WPDS radius fits)_ | `9999px` |
+| `--a8c-charts-dimension-leaderboard-row-gap` | `--wpds-dimension-gap-md` | `12px` |
+| `--a8c-charts-dimension-leaderboard-column-gap` | `--wpds-dimension-gap-xs` | `4px` |
 | `--a8c-charts-elevation-xs` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003` |
 | `--a8c-charts-elevation-sm` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005` |
 

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -156,7 +156,7 @@ The palette is resolved per provider, so one `ColorCache` and one group-to-color
 | `--a8c-charts-elevation-xs` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003` |
 | `--a8c-charts-elevation-sm` | _(none — `--wpds-elevation-*` removed in theme 1.0.0)_ | `0 1px 2px 0 #0000000d, 0 2px 3px 0 #0000000a, 0 6px 6px 0 #00000008, 0 8px 8px 0 #00000005` |
 
-`theme.leaderboardChart.rowGap` and `.columnGap` are the deprecated way into the two leaderboard gaps. Both still outrank the role where a consumer sets one, and both are removed in CHARTS-263.
+`theme.leaderboardChart.rowGap` and `.columnGap` are the deprecated way into the two leaderboard gaps. Both still outrank the role where a consumer sets one, and both are removed in CHARTS-263. Neither carries a default any more — the role does — so both read as `undefined` off `defaultTheme` and `useGlobalChartsTheme()`.
 
 The motion pair carries the one-shot reveal a data mark plays on first paint, across all six charts that animate in. It deliberately does **not** cover interaction motion: hover and transition timings read `--wpds-motion-*` directly, as interface chrome rather than a chart role.
 

--- a/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
+++ b/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-LeaderboardChart: Set the row and column gaps in CSS. Declare `--a8c-charts-dimension-leaderboard-row-gap` or `--a8c-charts-dimension-leaderboard-column-gap` inside the provider tree; they map to `--wpds-dimension-gap-md` and `--wpds-dimension-gap-xs`, so the default spacing now follows the design system. `theme.leaderboardChart.rowGap` and `.columnGap` are deprecated and still win where they are set. `TOKENS.md` lists both roles.
+LeaderboardChart: Set the row and column gaps in CSS. Declare `--a8c-charts-dimension-leaderboard-row-gap` or `--a8c-charts-dimension-leaderboard-column-gap` inside the provider tree; they map to `--wpds-dimension-gap-md` and `--wpds-dimension-gap-xs`, so the default spacing now follows the design system. `theme.leaderboardChart.rowGap` and `.columnGap` are deprecated and still win where they are set, but no longer carry a default, so reading either off `defaultTheme` or `useGlobalChartsTheme()` now gives `undefined` rather than `12` and `4`. `TOKENS.md` lists both roles.

--- a/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
+++ b/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
@@ -1,4 +1,4 @@
-Significance: major
+Significance: minor
 Type: changed
 
-LeaderboardChart: Set the row and column gaps in CSS. Declare `--a8c-charts-dimension-leaderboard-row-gap` or `--a8c-charts-dimension-leaderboard-column-gap` inside the provider tree instead of `theme.leaderboardChart.rowGap` / `.columnGap`, which are no longer read. They map to `--wpds-dimension-gap-md` and `--wpds-dimension-gap-xs`, so the default spacing now follows the design system. `TOKENS.md` lists both roles.
+LeaderboardChart: Set the row and column gaps in CSS. Declare `--a8c-charts-dimension-leaderboard-row-gap` or `--a8c-charts-dimension-leaderboard-column-gap` inside the provider tree; they map to `--wpds-dimension-gap-md` and `--wpds-dimension-gap-xs`, so the default spacing now follows the design system. `theme.leaderboardChart.rowGap` and `.columnGap` are deprecated and still win where they are set. `TOKENS.md` lists both roles.

--- a/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
+++ b/projects/js-packages/charts/changelog/charts-267-leaderboard-gaps-to-css
@@ -1,0 +1,4 @@
+Significance: major
+Type: changed
+
+LeaderboardChart: Set the row and column gaps in CSS. Declare `--a8c-charts-dimension-leaderboard-row-gap` or `--a8c-charts-dimension-leaderboard-column-gap` inside the provider tree instead of `theme.leaderboardChart.rowGap` / `.columnGap`, which are no longer read. They map to `--wpds-dimension-gap-md` and `--wpds-dimension-gap-xs`, so the default spacing now follows the design system. `TOKENS.md` lists both roles.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/hooks/use-fitted-row-count.ts
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/hooks/use-fitted-row-count.ts
@@ -13,8 +13,8 @@ export const SUBPIXEL_TOLERANCE = 0.5;
  * Counts how many leading rows fit inside the content container.
  *
  * Rows are read from the DOM rather than derived from constants: row height
- * depends on the theme's row gap, label wrapping, and whatever a caller renders
- * as a label, so any restated number would drift.
+ * depends on `--a8c-charts-dimension-leaderboard-row-gap`, label wrapping, and
+ * whatever a caller renders as a label, so any restated number would drift.
  *
  * Every row is a direct grid child marked with `data-row-index`; interactive rows
  * use a button wrapper and non-interactive rows use a div wrapper.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -26,6 +26,12 @@ import styles from './leaderboard-chart.module.scss';
 import type { LeaderboardChartProps } from './types';
 import type { LeaderboardEntry } from '../../types';
 
+// Handed to `Grid` as a chain rather than set in this component's stylesheet: `Grid` writes
+// its own gaps through an Emotion class, which a module class of equal specificity would not
+// reliably outrank. The chain lands on the element and resolves there.
+const ROW_GAP = 'var(--a8c-charts-dimension-leaderboard-row-gap, 12px)';
+const COLUMN_GAP = 'var(--a8c-charts-dimension-leaderboard-column-gap, 4px)';
+
 /**
  * Default value formatter using formatMetricValue
  *
@@ -200,8 +206,6 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	const { legendChildren, nonLegendChildren } = useChartChildren( children, 'LeaderboardChart' );
 	const {
 		labelSpacing,
-		rowGap,
-		columnGap,
 		primaryColor: settingsPrimaryColor,
 		secondaryColor: settingsSecondaryColor,
 		deltaColors,
@@ -372,8 +376,8 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					) : (
 						<Grid
 							templateColumns="minmax(0, 1fr) auto"
-							rowGap={ rowGap }
-							columnGap={ columnGap }
+							rowGap={ ROW_GAP }
+							columnGap={ COLUMN_GAP }
 							data-leaderboard-grid
 						>
 							{ data.map( ( entry, rowIndex ) => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -28,7 +28,8 @@ import type { LeaderboardEntry } from '../../types';
 
 // Handed to `Grid` as a chain rather than set in this component's stylesheet: `Grid` writes
 // its own gaps through an Emotion class, which a module class of equal specificity would not
-// reliably outrank. The chain lands on the element and resolves there.
+// reliably outrank. The chain lands on the element and resolves there. The deprecated
+// `theme.leaderboardChart` gaps still win over these, until CHARTS-263 removes them.
 const ROW_GAP = 'var(--a8c-charts-dimension-leaderboard-row-gap, 12px)';
 const COLUMN_GAP = 'var(--a8c-charts-dimension-leaderboard-column-gap, 4px)';
 
@@ -206,6 +207,8 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 	const { legendChildren, nonLegendChildren } = useChartChildren( children, 'LeaderboardChart' );
 	const {
 		labelSpacing,
+		rowGap,
+		columnGap,
 		primaryColor: settingsPrimaryColor,
 		secondaryColor: settingsSecondaryColor,
 		deltaColors,
@@ -376,8 +379,8 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 					) : (
 						<Grid
 							templateColumns="minmax(0, 1fr) auto"
-							rowGap={ ROW_GAP }
-							columnGap={ COLUMN_GAP }
+							rowGap={ rowGap ?? ROW_GAP }
+							columnGap={ columnGap ?? COLUMN_GAP }
 							data-leaderboard-grid
 						>
 							{ data.map( ( entry, rowIndex ) => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -665,4 +665,33 @@ describe( 'LeaderboardChart', () => {
 			expect( screen.getAllByRole( 'button' ) ).toHaveLength( 1 );
 		} );
 	} );
+
+	describe( 'grid gaps', () => {
+		// eslint-disable-next-line testing-library/no-node-access -- The grid is rendered by `Grid` from @wordpress/components, which takes no test id.
+		const grid = () => document.querySelector( '[data-leaderboard-grid]' );
+
+		it( 'hands the catalog role to the grid when the theme sets no gap', () => {
+			render( <LeaderboardChart data={ mockData } /> );
+
+			expect( grid() ).toHaveStyle( {
+				gridRowGap: 'var(--a8c-charts-dimension-leaderboard-row-gap, 12px)',
+				gridColumnGap: 'var(--a8c-charts-dimension-leaderboard-column-gap, 4px)',
+			} );
+		} );
+
+		// The deprecated fields keep working until CHARTS-263 removes them, so a consumer
+		// still setting one is not silently ignored.
+		it( 'lets a theme gap win over the role', () => {
+			render(
+				<GlobalChartsProvider theme={ { leaderboardChart: { rowGap: 20 } } }>
+					<LeaderboardChart data={ mockData } />
+				</GlobalChartsProvider>
+			);
+
+			expect( grid() ).toHaveStyle( {
+				gridRowGap: '20px',
+				gridColumnGap: 'var(--a8c-charts-dimension-leaderboard-column-gap, 4px)',
+			} );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -66,8 +66,6 @@ const defaultTheme: CompleteChartTheme = {
 		featureFillColor: 'var(--a8c-charts-color-surface-secondary, #f4f4f4)',
 	},
 	leaderboardChart: {
-		rowGap: 12,
-		columnGap: 4,
 		labelSpacing: 'xs',
 		// [negative, neutral, positive]
 		deltaColors: [

--- a/projects/js-packages/charts/src/styles/chart-scope.scss
+++ b/projects/js-packages/charts/src/styles/chart-scope.scss
@@ -108,4 +108,7 @@
 	--a8c-charts-border-radius-cell: var(--wpds-border-radius-sm, 2px);
 	// Pill shape; no WPDS radius reaches it.
 	--a8c-charts-border-radius-leaderboard-bar: 9999px;
+
+	--a8c-charts-dimension-leaderboard-row-gap: var(--wpds-dimension-gap-md, 12px);
+	--a8c-charts-dimension-leaderboard-column-gap: var(--wpds-dimension-gap-xs, 4px);
 }

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -451,9 +451,15 @@ export type ChartTheme = {
 	};
 	/** LeaderboardChart specific settings */
 	leaderboardChart?: {
-		/** Gap between rows in the leaderboard grid */
+		/**
+		 * @deprecated Set `--a8c-charts-dimension-leaderboard-row-gap` in CSS. Reading this
+		 * stopped in CHARTS-267; the field is removed in CHARTS-263.
+		 */
 		rowGap?: number;
-		/** Gap between columns in the leaderboard grid */
+		/**
+		 * @deprecated Set `--a8c-charts-dimension-leaderboard-column-gap` in CSS. Reading this
+		 * stopped in CHARTS-267; the field is removed in CHARTS-263.
+		 */
 		columnGap?: number;
 		/** Spacing between label and progress bars */
 		labelSpacing?: GapSize;
@@ -547,9 +553,12 @@ export type ChartTheme = {
 export type CompleteChartTheme = Required< ChartTheme > & {
 	leaderboardChart: Omit<
 		Required< NonNullable< ChartTheme[ 'leaderboardChart' ] > >,
-		'primaryColor' | 'secondaryColor'
+		'primaryColor' | 'secondaryColor' | 'rowGap' | 'columnGap'
 	> &
-		Pick< NonNullable< ChartTheme[ 'leaderboardChart' ] >, 'primaryColor' | 'secondaryColor' >;
+		Pick<
+			NonNullable< ChartTheme[ 'leaderboardChart' ] >,
+			'primaryColor' | 'secondaryColor' | 'rowGap' | 'columnGap'
+		>;
 	conversionFunnelChart: Omit<
 		Required< NonNullable< ChartTheme[ 'conversionFunnelChart' ] > >,
 		'primaryColor'

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -452,13 +452,13 @@ export type ChartTheme = {
 	/** LeaderboardChart specific settings */
 	leaderboardChart?: {
 		/**
-		 * @deprecated Set `--a8c-charts-dimension-leaderboard-row-gap` in CSS. Reading this
-		 * stopped in CHARTS-267; the field is removed in CHARTS-263.
+		 * @deprecated Declare `--a8c-charts-dimension-leaderboard-row-gap` in CSS instead. This
+		 * still wins where it is set, and is removed in the next major.
 		 */
 		rowGap?: number;
 		/**
-		 * @deprecated Set `--a8c-charts-dimension-leaderboard-column-gap` in CSS. Reading this
-		 * stopped in CHARTS-267; the field is removed in CHARTS-263.
+		 * @deprecated Declare `--a8c-charts-dimension-leaderboard-column-gap` in CSS instead. This
+		 * still wins where it is set, and is removed in the next major.
 		 */
 		columnGap?: number;
 		/** Spacing between label and progress bars */

--- a/projects/packages/premium-analytics/changelog/charts-267-leaderboard-gaps-to-css
+++ b/projects/packages/premium-analytics/changelog/charts-267-leaderboard-gaps-to-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Set the dashboard's leaderboard row spacing in CSS rather than on the chart theme. No visible change.

--- a/projects/packages/premium-analytics/changelog/charts-267-leaderboard-gaps-to-css
+++ b/projects/packages/premium-analytics/changelog/charts-267-leaderboard-gaps-to-css
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Set the dashboard's leaderboard row spacing in CSS rather than on the chart theme. No visible change.
+Set the dashboard's leaderboard row spacing and bar radius in CSS rather than on the chart theme. No visible change.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
@@ -18,7 +18,6 @@ import { useMemo } from 'react';
  */
 import { ChartEmptyState } from '../chart-empty-state';
 import styles from './leaderboard-chart.module.scss';
-import type { WooChartTheme } from '../../hooks/use-chart-theme';
 import type { DataFormat } from '../../types';
 import type { ComponentProps, ReactNode } from 'react';
 
@@ -88,7 +87,7 @@ export function LeaderboardChart( {
 	style,
 	fitRows = true,
 }: LeaderboardChartProps ) {
-	const { getElementStyles, theme } = useGlobalChartsContext();
+	const { getElementStyles } = useGlobalChartsContext();
 
 	const valueFormatter = useMemo(
 		() => ( value: number ) => formatMetricValue( value, dataFormat.type, dataFormat.options ),
@@ -104,19 +103,6 @@ export function LeaderboardChart( {
 		const { color: primaryColor } = getElementStyles( { index: 0 } );
 		return lightenHexColor( normalizeColorToHex( primaryColor ), 0.92 );
 	}, [ withOverlayLabel, getElementStyles ] );
-
-	// The `style` prop wins over the theme's bar radius, for per-widget overrides.
-	const chartStyle = useMemo( () => {
-		const wooTheme = theme as WooChartTheme | undefined;
-		const barBorderRadius = wooTheme?.leaderboardChart?.barBorderRadius;
-		if ( ! barBorderRadius && ! style ) {
-			return undefined;
-		}
-		return {
-			'--a8c-charts-border-radius-leaderboard-bar': barBorderRadius,
-			...style,
-		} as React.CSSProperties;
-	}, [ theme, style ] );
 
 	const isEmptyData = ! data || data.length === 0;
 
@@ -141,7 +127,7 @@ export function LeaderboardChart( {
 				withOverlayLabel={ withOverlayLabel }
 				showLegend={ false }
 				fitRows={ fitRows }
-				style={ chartStyle }
+				style={ style }
 				className={ styles.chart }
 			>
 				{ showLegend && (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/chart-roles.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/chart-roles.scss
@@ -3,4 +3,7 @@
 
 	// The dashboard packs leaderboard rows tighter than the package default.
 	--a8c-charts-dimension-leaderboard-row-gap: var(--wpds-dimension-gap-xs);
+
+	// Rounded rather than the package's pill shape.
+	--a8c-charts-border-radius-leaderboard-bar: var(--wpds-border-radius-lg);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/chart-roles.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/chart-roles.scss
@@ -1,0 +1,6 @@
+// On the scope element itself: its own declaration beats an inherited one.
+.a8c-charts-scope {
+
+	// The dashboard packs leaderboard rows tighter than the package default.
+	--a8c-charts-dimension-leaderboard-row-gap: var(--wpds-dimension-gap-xs);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/index.ts
@@ -1,5 +1,5 @@
 export { useAttributesWithSearchFallback } from './use-attributes-with-search-fallback';
-export { useChartTheme, type WooChartTheme } from './use-chart-theme';
+export { useChartTheme } from './use-chart-theme';
 export { useDelayedLoading } from './use-delayed-loading';
 export { useElementSize, type ElementSize } from './use-element-size';
 export { useWidgetNavigationSearch } from './use-widget-navigation-search';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -3,6 +3,11 @@
  */
 import { useMemo } from 'react';
 import type { ChartTheme } from '@jetpack-premium-analytics/externals';
+/**
+ * Internal dependencies
+ */
+// The dashboard's leaderboard spacing. It is set in CSS, not on the theme below.
+import './chart-roles.scss';
 
 /**
  * The `@automattic/charts` theme plus the analytics-specific properties.
@@ -58,8 +63,6 @@ export function useChartTheme(): WooChartTheme {
 				],
 			},
 			leaderboardChart: {
-				rowGap: 4,
-				columnGap: 4,
 				labelSpacing: 'xs',
 				barBorderRadius: 'var(--wpds-border-radius-lg)',
 				deltaColors: [

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -9,9 +9,7 @@ import type { ChartTheme } from '@jetpack-premium-analytics/externals';
 // The dashboard's leaderboard spacing and bar radius. They are set in CSS, not on the theme below.
 import './chart-roles.scss';
 
-export type WooChartTheme = ChartTheme;
-
-export function useChartTheme(): WooChartTheme {
+export function useChartTheme(): ChartTheme {
 	return useMemo( () => {
 		return {
 			backgroundColor: 'var(--wpds-color-background-surface-neutral-strong)',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -6,17 +6,10 @@ import type { ChartTheme } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */
-// The dashboard's leaderboard spacing. It is set in CSS, not on the theme below.
+// The dashboard's leaderboard spacing and bar radius. They are set in CSS, not on the theme below.
 import './chart-roles.scss';
 
-/**
- * The `@automattic/charts` theme plus the analytics-specific properties.
- */
-export type WooChartTheme = ChartTheme & {
-	leaderboardChart: ChartTheme[ 'leaderboardChart' ] & {
-		barBorderRadius: string;
-	};
-};
+export type WooChartTheme = ChartTheme;
 
 export function useChartTheme(): WooChartTheme {
 	return useMemo( () => {
@@ -64,7 +57,6 @@ export function useChartTheme(): WooChartTheme {
 			},
 			leaderboardChart: {
 				labelSpacing: 'xs',
-				barBorderRadius: 'var(--wpds-border-radius-lg)',
 				deltaColors: [
 					'var(--wpds-color-stroke-surface-error-strong)',
 					'var(--wpds-color-foreground-content-neutral-weak)',


### PR DESCRIPTION
Fixes CHARTS-267

## Why

Colors already have one home — a `--a8c-charts-color-*` role set in CSS. Spacing still only had the `theme` prop, so a consumer theming charts reached for CSS for one and a JS object for the other. These two gaps are the only theme fields with an honest design-system match (audited against `@wordpress/theme` 1.2.0; the rejected list is on the issue), so this is not a general "tokenize the theme" change.

## Proposed changes

* Add `--a8c-charts-dimension-leaderboard-row-gap` → `--wpds-dimension-gap-md` and `--a8c-charts-dimension-leaderboard-column-gap` → `--wpds-dimension-gap-xs` to the catalog, and list both in `TOKENS.md`.
* Deprecate `theme.leaderboardChart.rowGap` / `.columnGap`. They are still read and still win where set; CHARTS-263 deletes them.
* Migrate Premium Analytics, the one consumer.

Defaults are unchanged: the roles resolve to the same 12px and 4px the fields held.

## The chain goes through `Grid`'s props, not the stylesheet

The issue said to paint these from `leaderboard-chart.module.scss`. That does not work. `Grid` from `@wordpress/components` writes its gaps through an Emotion class, and a module class targeting the same element is also a single class selector — specificity ties, injection order decides, and Emotion injects at runtime after the static stylesheet. The module rule would lose silently.

Passing the `var()` chain in as the prop value avoids that: `CSSProperties['gridRowGap']` accepts a string, Emotion writes it verbatim, and the chain resolves on the element. Same shape as the `CATALOG_POINTERS` colors — a constant pointer, not something JS resolves.

Units, which decide whether the mapping is right at all: unlike `gap`, these two are **not** scaled by 4px, so `rowGap: 12` is 12px.

## Migration

| Deprecated | Replacement |
| -- | -- |
| `theme.leaderboardChart.rowGap` | `--a8c-charts-dimension-leaderboard-row-gap` |
| `theme.leaderboardChart.columnGap` | `--a8c-charts-dimension-leaderboard-column-gap` |

Read as `rowGap ?? ROW_GAP`, so nothing has to move on this release. An override must be set **inside** the provider tree, or on `.a8c-charts-scope` itself — same rule as the color roles.

One caveat worth knowing before merge, raised by Codex below. The fields lose their defaults, so `CompleteChartTheme` narrows them from `number` to `number | undefined`, and reading either off the exported `defaultTheme` or `useGlobalChartsTheme()` now gives `undefined` rather than `12` and `4`. That is a semver break in a `minor`. Keeping the defaults is not available: `mergeThemes` cannot tell a default `12` from a consumer's explicit `12`, so a retained default would make `??` always take it and leave the CSS role permanently dead. Nothing in the monorepo reads either field — the exposure is the type alone, on a field CHARTS-263 deletes next — so this is recorded in the changelog and `TOKENS.md` rather than fixed.

### Premium Analytics

Migrated here rather than left on the deprecated field. It set `rowGap: 4` against the package default of 12, so the value moves to a new `chart-roles.scss` next to `use-chart-theme.ts`, declared on `.a8c-charts-scope` so it reaches all three of PA's provider sites. `columnGap: 4` was already the default and is dropped.

**`barBorderRadius` goes the same way**, spotted while reviewing the above. It was never a charts field — PA invented it on its own `WooChartTheme` extension, read it back one component later, and wrote it to `--a8c-charts-border-radius-leaderboard-bar` as an inline style. That role has been in the charts catalog all along, so the round trip through JS bought nothing once `chart-roles.scss` existed. With it gone `WooChartTheme` was a bare alias for `ChartTheme` that nothing referenced, so it is deleted too, along with the memo that relayed the radius.

The memo also carried a precedence rule — a `style` prop was meant to beat the theme value. That survives on its own terms: `style` now reaches the chart directly, and a custom property set inline still beats one inherited from the scope wrapper.

Note the fallback asymmetry, which is easy to trip over: charts hand-writes WPDS fallbacks because it has two consumption paths and no build plugin covers both, while PA forbids them (`plugin-wpds/no-token-fallback-values`) because `@wordpress/build` injects them. The same role is written `var(--wpds-dimension-gap-md, 12px)` in charts and `var(--wpds-dimension-gap-xs)` in PA.

## Changelog

`minor` on charts — the roles are additive and the deprecated fields still win, so nothing breaks; CHARTS-263 carries the major when it removes them. `patch` on premium-analytics, no visible change.

No plugin entries: no plugin in the monorepo sets a charts theme, and this is not reachable from one.

## Related product discussion/links

* CHARTS-267, CHARTS-263 (removes the fields), CHARTS-227 (parent)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Run the charts Storybook: `pnpm -C projects/js-packages/storybook run storybook:dev`.

1. Open **Charts Library → Leaderboard Chart → Default**. Row spacing is unchanged from `trunk`.
2. In DevTools, set `--a8c-charts-dimension-leaderboard-row-gap: 30px` on `.a8c-charts-scope`. The rows spread immediately; remove it and they return.
3. Open **Premium Analytics → Widgets Toolkit → Components → LeaderboardChart → Default**. Rows sit 4px apart and the bars keep their 8px radius, as before. The chart element carries no `--a8c-charts-border-radius-leaderboard-bar` inline any more.
4. Confirm your editor marks `theme.leaderboardChart.rowGap` and `.columnGap` deprecated, and still offers `labelSpacing`.
5. Pass `theme={ { leaderboardChart: { rowGap: 20 } } }` to a `GlobalChartsProvider` around a leaderboard. The rows move to 20px — the deprecated field still wins.

### Verified

* `pnpm -C projects/js-packages/charts run test` — 74 suites, 1317 passed. `pnpm -C projects/packages/premium-analytics run test` — 146 suites, 2978 passed. `typecheck` clean on both; `eslint` and `stylelint` clean.
* Two tests added for the gaps: the chain reaching `Grid` when the theme sets nothing, and the theme field outranking it. The second fails if the `?? ROW_GAP` fallback is reverted, so it tests the precedence rather than passing by construction.
* Exercised in Chrome, reading back `getComputedStyle` on the `[data-leaderboard-grid]` element rather than eyeballing:
  * Charts default: `row-gap: 12px`, `column-gap: 4px` — the values the theme fields held.
  * Override on `.a8c-charts-scope`: `30px` / `17px`, then back on removal.
  * Premium Analytics: `row-gap: 4px`, `column-gap: 4px`, role resolving to `4px` at the scope element.
  * Premium Analytics bar radius: `8px`, resolving at the scope element with no inline custom property left on the chart — identical to what the deleted memo produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0147vnw9VyKQkMsknWqyXNc8
