### PR TITLE
Backup: keep the file preview beside the row you opened

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2356-sticky-preview
+++ b/projects/packages/backup/changelog/jetpack-2356-sticky-preview
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: keep the modernized dashboard's file preview beside the row you opened. It rendered at the top of a grid column as tall as the file tree, so on a scrolled tree it was off-screen, and the keyboard focus move then threw the list back to the top. No-op when the modernization filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-browser/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-browser/style.scss
@@ -19,6 +19,18 @@
 		&:has(> .jpb-file-info-card) {
 			grid-template-columns: minmax(0, 1fr) minmax(0, 280px);
 		}
+
+		// `align-self` is load-bearing: grid stretches the card to its row's
+		// height — the tree's — and a stretched card has nowhere to travel.
+		// Silently unsticks if `Card.Root` ever becomes `overflow: hidden`:
+		// that makes `.jpb-backup-detail` the scrollport, not `.jpb-dashboard-body`.
+		> .jpb-file-info-card {
+			position: sticky;
+			align-self: start;
+			// Zero because the scrollport is `.jpb-dashboard-body`; the admin
+			// bar and the sticky `Page` header sit outside it, above its top.
+			inset-block-start: 0;
+		}
 	}
 
 	&__row {

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -211,11 +211,9 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	const { size, hash, lastModified } = usePathInfo( file.period, file.manifestPath );
 	const modified = lastModified ?? file.lastModified;
 
-	// Opening a file mounts this card somewhere else entirely — it is the
-	// second column of a grid as tall as the tree, so on a scrolled tree it
-	// lands well above the row that was clicked. Without a focus move a
-	// keyboard reader has to tab through every remaining row to reach it,
-	// and a screen-reader reader is told nothing happened at all.
+	// Opening a file mounts this card in the tree's sibling column. Without a
+	// focus move a keyboard reader has to tab through every remaining row to
+	// reach it, and a screen-reader reader is told nothing happened at all.
 	//
 	// The preview region is the target rather than the card, because it is
 	// the content the reader asked for, it is already a tab stop, and it is

--- a/projects/packages/backup/tests/file-browser-a11y.test.tsx
+++ b/projects/packages/backup/tests/file-browser-a11y.test.tsx
@@ -116,8 +116,7 @@ describe( 'the preview pane', () => {
 	} );
 
 	// Without this the reader has to tab through every remaining tree row to
-	// reach content they just asked for, and on a scrolled tree the card
-	// renders off-screen entirely.
+	// reach content they just asked for.
 	it( 'takes focus when a file is opened', async () => {
 		await renderBrowser();
 		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );


### PR DESCRIPTION
Fixes JETPACK-2356

## Proposed changes

* The file browser lays the tree and the preview card out as a two-column grid. A grid item starts at the top of its row, and the row is as tall as the tree — so on a scrolled tree the card's content sat far above the scrollport. #51616 then added a focus move for keyboard readers, and `focus()` scrolls its target into view by default, so opening a file threw the file list back toward the top.
* `components/file-browser/style.scss`: the card gets `position: sticky` with `align-self: start`. `align-self` is load-bearing — grid's default `stretch` makes the card as tall as its row, and a stretched card has nowhere to travel.
* `inset-block-start: 0`, not the admin bar's 32px. The scroll container is `.jpb-dashboard-body`; the admin bar and the sticky `Page` header are siblings *above* that scrollport, not inside it. `window.scrollY` never moved in any measurement — the bug was always the inner scroller.

### What is deliberately not here

An earlier revision also passed `preventScroll` to the focus move. Measurement says sticky alone is the fix, and that `preventScroll` makes one case worse:

| | scrolled tree (the bug) | unscrolled, warm reopen |
| -- | -- | -- |
| trunk | 2594 → 166 | 0 → 171, preview 320/320 visible |
| sticky + `preventScroll` | 2594 → 2594 | 0 → 0, preview **149/320** |
| **sticky only (this PR)** | 2594 → 2594 | 0 → 171, preview 320/320 |

Once the card is pinned it is already inside the scrollport when the effect fires, so the default focus scroll cannot do the harmful thing. All `preventScroll` still blocks is the scroll that helps: on a reopen the preview is served from cache at full height, and suppressing it leaves 171px below the fold every time.

### Two things a reviewer should know

* **This depends on `@wordpress/ui` rendering `Card.Root` with `overflow: clip`.** `clip` is not a scroll container, so sticky correctly resolves to `.jpb-dashboard-body`. If that ever becomes `hidden`, `.jpb-backup-detail` becomes the scrollport, never scrolls, and the card silently stops sticking — no error, and jsdom does no layout so no test would catch it.
* **A cold first open still does not reveal the whole preview.** The focus effect fires at mount while the contents fetch is in flight, so the preview is ~49px then grows to 320px with nothing re-checking visibility — 17 of 320px visible at 1280×768. Identical on trunk; not caused or worsened here. Worth its own issue.

## Related product discussion/links

* Linear: JETPACK-2356, under the Backup modernization project.
* Regression source for the second half: #51616 (F6a).

## Does this pull request change what data or activity we track or use?

No. CSS plus the removal of one `focus()` argument.

## Testing instructions

The dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default, so this is a no-op unless the filter is on.

Automated, from `projects/packages/backup`: `pnpm test` — 71 suites / 699 tests. `pnpm run typecheck`, `eslint` and `stylelint` clean. Note jsdom does no layout, so the sticky rule itself is not unit-testable; it was verified by measurement instead.

By hand, on a site with the filter on and a Backup plan:

1. Go to **Jetpack → VaultPress Backup**, pick a backup, open the file browser.
2. Expand a folder deep enough that the tree scrolls — `wp-content/plugins` is usually enough. Scroll to the bottom.
3. Click a file. Expect the preview card to appear pinned at the top of the panel, **beside** the row you clicked, with the list not moving.
4. Before this change the list jumped back toward the top and you had to scroll down again to carry on browsing.
5. Keep clicking files as you scroll. The card should stay in view the whole time.
6. Check RTL too — the columns swap and the card still pins.

Measured on a live site with a real manifest, 140 rows in a 1280×900 window: the scroller offset went 2594 → 166 on click before, and 2594 → 2594 after.
