### PR TITLE
Backup: hide the wp-config.php preview behind a reveal click

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2353-wp-config-gate
+++ b/projects/packages/backup/changelog/jetpack-2353-wp-config-gate
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser now hides wp-config.php's preview behind a Show preview click, so the database password and salts no longer render unprompted. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser now hides any wp-config.php preview behind a Show preview click, at whatever depth it sits in the backup, so the database password and salts no longer render unprompted. No-op when the filter is off.
 
 

--- a/projects/packages/backup/changelog/jetpack-2353-wp-config-gate
+++ b/projects/packages/backup/changelog/jetpack-2353-wp-config-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser now hides wp-config.php's preview behind a Show preview click, so the database password and salts no longer render unprompted. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -81,9 +81,9 @@ const SENSITIVE_PATH = '/wp-config.php';
 /**
  * Whether the given manifest path names the file above.
  *
- * Compared after the volume prefix, and a path without one is compared
- * whole: the `5` in `f5:` is VaultPress's data-type code rather than part
- * of the file's identity, so matching on it would let the gate fail open.
+ * Compared after the volume prefix and lowercased: the `5` in `f5:` is a
+ * data-type code, not part of the file's identity, so matching it would let
+ * the gate fail open.
  *
  * @param manifestPath - The volume-prefixed manifest path, e.g. `f5:/wp-config.php`.
  * @return True when the preview needs a reveal.
@@ -92,7 +92,7 @@ function isSensitivePath( manifestPath: string | undefined ): boolean {
 	if ( ! manifestPath ) {
 		return false;
 	}
-	return manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ) === SENSITIVE_PATH;
+	return manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ).toLowerCase() === SENSITIVE_PATH;
 }
 
 type Props = {
@@ -248,6 +248,7 @@ function PreviewBody( {
  */
 export default function FileInfoCard( { file, onClose }: Props ) {
 	const mimeType = mimeFromName( file.name );
+	const previewRef = useRef< HTMLDivElement >( null );
 	const { tracks } = useAnalytics();
 	const [ revealed, setRevealed ] = useState( false );
 	// Withholding the fetch too, not just the `<pre>`: unrevealed secrets never
@@ -257,6 +258,9 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	const reveal = useCallback( () => {
 		setRevealed( true );
 		tracks.recordEvent( 'jetpack_backup_browser_preview_file_sensitive_click' );
+		// The click unmounts the button holding focus. Same contract the close
+		// button keeps in `file-browser/index.tsx`: move focus, hand it back.
+		previewRef.current?.focus();
 	}, [ tracks ] );
 	const {
 		content,
@@ -281,7 +285,6 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	//
 	// Keyed on `manifestPath` so switching between files re-announces, while
 	// a re-render for any other reason does not steal focus back.
-	const previewRef = useRef< HTMLDivElement >( null );
 	useEffect( () => {
 		// Reset here too: the card is not remounted per file, so without this a
 		// return visit to `wp-config.php` would print it with no second click.

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -72,18 +72,19 @@ function mimeFromName( name: string ): string {
 }
 
 /**
- * The one file whose preview waits for a deliberate second click: the
- * site's root `wp-config.php`, which carries `DB_PASSWORD` and the salts.
- * Same single file Calypso hides, so the two surfaces agree.
+ * The one filename whose preview waits for a deliberate second click:
+ * `wp-config.php`, which carries `DB_PASSWORD` and the salts. Same single
+ * file Calypso hides, so the two surfaces agree.
  */
-const SENSITIVE_PATH = '/wp-config.php';
+const SENSITIVE_NAME = 'wp-config.php';
 
 /**
- * Whether the given manifest path names the file above.
+ * Whether the given manifest path names the file above, at any depth.
  *
- * Compared after the volume prefix and lowercased: the `5` in `f5:` is a
- * data-type code, not part of the file's identity, so matching it would let
- * the gate fail open.
+ * Three ways to fail open, all closed: the volume prefix is dropped (the `5`
+ * in `f5:` is a data-type code, not identity), the compare is lowercased, and
+ * the name matches at any depth, so a second install under `/staging/` is
+ * covered. The `/` in the suffix keeps `mywp-config.php` out.
  *
  * @param manifestPath - The volume-prefixed manifest path, e.g. `f5:/wp-config.php`.
  * @return True when the preview needs a reveal.
@@ -92,7 +93,8 @@ function isSensitivePath( manifestPath: string | undefined ): boolean {
 	if ( ! manifestPath ) {
 		return false;
 	}
-	return manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ).toLowerCase() === SENSITIVE_PATH;
+	const path = manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ).toLowerCase();
+	return path === SENSITIVE_NAME || path.endsWith( `/${ SENSITIVE_NAME }` );
 }
 
 type Props = {
@@ -250,18 +252,28 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	const mimeType = mimeFromName( file.name );
 	const previewRef = useRef< HTMLDivElement >( null );
 	const { tracks } = useAnalytics();
-	const [ revealed, setRevealed ] = useState( false );
+	const previewId = `${ file.period }:${ file.manifestPath }`;
+	const [ revealedFor, setRevealedFor ] = useState< string | null >( null );
+	const [ lastPreviewId, setLastPreviewId ] = useState( previewId );
+	// Cleared during render, not in an effect: `useFileContents` below commits
+	// its query on this same render, so a reveal left over from the previous
+	// file would have fetched the next one's bytes before an effect could run.
+	if ( lastPreviewId !== previewId ) {
+		setLastPreviewId( previewId );
+		setRevealedFor( null );
+	}
+	const revealed = revealedFor === previewId;
 	// Withholding the fetch too, not just the `<pre>`: unrevealed secrets never
 	// reach the browser at all.
 	const awaitingReveal = Boolean( mimeType ) && isSensitivePath( file.manifestPath ) && ! revealed;
 	const showPreview = Boolean( mimeType ) && ! awaitingReveal;
 	const reveal = useCallback( () => {
-		setRevealed( true );
+		setRevealedFor( previewId );
 		tracks.recordEvent( 'jetpack_backup_browser_preview_file_sensitive_click' );
 		// The click unmounts the button holding focus. Same contract the close
 		// button keeps in `file-browser/index.tsx`: move focus, hand it back.
 		previewRef.current?.focus();
-	}, [ tracks ] );
+	}, [ previewId, tracks ] );
 	const {
 		content,
 		isText,
@@ -286,9 +298,6 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	// Keyed on `manifestPath` so switching between files re-announces, while
 	// a re-render for any other reason does not steal focus back.
 	useEffect( () => {
-		// Reset here too: the card is not remounted per file, so without this a
-		// return visit to `wp-config.php` would print it with no second click.
-		setRevealed( false );
 		previewRef.current?.focus();
 	}, [ file.manifestPath ] );
 

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -1,9 +1,10 @@
 import { Spinner, VisuallyHidden } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
-import { useEffect, useRef } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { closeSmall } from '@wordpress/icons';
+import { Icon, closeSmall, unseen } from '@wordpress/icons';
 import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { useAnalytics } from '../../hooks/use-analytics';
 import { useFileContents } from '../../hooks/use-file-contents';
 import { formatFileSize, usePathInfo } from '../../hooks/use-path-info';
 import './style.scss';
@@ -70,6 +71,30 @@ function mimeFromName( name: string ): string {
 	return typeof mime === 'string' ? mime : '';
 }
 
+/**
+ * The one file whose preview waits for a deliberate second click: the
+ * site's root `wp-config.php`, which carries `DB_PASSWORD` and the salts.
+ * Same single file Calypso hides, so the two surfaces agree.
+ */
+const SENSITIVE_PATH = '/wp-config.php';
+
+/**
+ * Whether the given manifest path names the file above.
+ *
+ * Compared after the volume prefix, and a path without one is compared
+ * whole: the `5` in `f5:` is VaultPress's data-type code rather than part
+ * of the file's identity, so matching on it would let the gate fail open.
+ *
+ * @param manifestPath - The volume-prefixed manifest path, e.g. `f5:/wp-config.php`.
+ * @return True when the preview needs a reveal.
+ */
+function isSensitivePath( manifestPath: string | undefined ): boolean {
+	if ( ! manifestPath ) {
+		return false;
+	}
+	return manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ) === SENSITIVE_PATH;
+}
+
 type Props = {
 	file: FileNodeFile;
 	onClose: () => void;
@@ -90,16 +115,20 @@ type Props = {
  * (no nested ternaries) and to give the loading / error / empty branches
  * unique render paths the linter can reason about.
  *
- * @param props             - Component props.
- * @param props.showPreview - Whether the filename's extension is in the previewable map.
- * @param props.isLoading   - Whether the file-contents query is in flight.
- * @param props.content     - The fetched body, or null when not yet resolved.
- * @param props.isText      - Whether the bridge could read the fetched bytes as text.
- * @param props.truncated   - Whether the body stops at the bridge's preview cap.
- * @param props.error       - The fetch error, or null on success.
+ * @param props                - Component props.
+ * @param props.awaitingReveal - Whether the file holds secrets the reader has not asked for yet.
+ * @param props.onReveal       - Called when the reader asks for the hidden preview.
+ * @param props.showPreview    - Whether the filename's extension is in the previewable map.
+ * @param props.isLoading      - Whether the file-contents query is in flight.
+ * @param props.content        - The fetched body, or null when not yet resolved.
+ * @param props.isText         - Whether the bridge could read the fetched bytes as text.
+ * @param props.truncated      - Whether the body stops at the bridge's preview cap.
+ * @param props.error          - The fetch error, or null on success.
  * @return The preview body.
  */
 function PreviewBody( {
+	awaitingReveal,
+	onReveal,
 	showPreview,
 	isLoading,
 	content,
@@ -107,6 +136,8 @@ function PreviewBody( {
 	truncated,
 	error,
 }: {
+	awaitingReveal: boolean;
+	onReveal: () => void;
 	showPreview: boolean;
 	isLoading: boolean;
 	content: string | null;
@@ -114,6 +145,23 @@ function PreviewBody( {
 	truncated: boolean;
 	error: Error | null;
 } ) {
+	// Ahead of `showPreview`, which the gate holds false until the reveal.
+	if ( awaitingReveal ) {
+		return (
+			<Stack direction="column" align="center" gap="xs">
+				<Icon icon={ unseen } />
+				<Text variant="body-sm" render={ <p /> }>
+					{ __(
+						'This preview is hidden because it contains sensitive information.',
+						'jetpack-backup-pkg'
+					) }
+				</Text>
+				<Button variant="outline" size="compact" onClick={ onReveal }>
+					{ __( 'Show preview', 'jetpack-backup-pkg' ) }
+				</Button>
+			</Stack>
+		);
+	}
 	if ( ! showPreview ) {
 		return (
 			<Text variant="body-sm" className="jpb-text-muted">
@@ -200,7 +248,16 @@ function PreviewBody( {
  */
 export default function FileInfoCard( { file, onClose }: Props ) {
 	const mimeType = mimeFromName( file.name );
-	const showPreview = Boolean( mimeType );
+	const { tracks } = useAnalytics();
+	const [ revealed, setRevealed ] = useState( false );
+	// Withholding the fetch too, not just the `<pre>`: unrevealed secrets never
+	// reach the browser at all.
+	const awaitingReveal = Boolean( mimeType ) && isSensitivePath( file.manifestPath ) && ! revealed;
+	const showPreview = Boolean( mimeType ) && ! awaitingReveal;
+	const reveal = useCallback( () => {
+		setRevealed( true );
+		tracks.recordEvent( 'jetpack_backup_browser_preview_file_sensitive_click' );
+	}, [ tracks ] );
 	const {
 		content,
 		isText,
@@ -226,6 +283,9 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 	// a re-render for any other reason does not steal focus back.
 	const previewRef = useRef< HTMLDivElement >( null );
 	useEffect( () => {
+		// Reset here too: the card is not remounted per file, so without this a
+		// return visit to `wp-config.php` would print it with no second click.
+		setRevealed( false );
 		previewRef.current?.focus();
 	}, [ file.manifestPath ] );
 
@@ -296,6 +356,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				) }
 			>
 				<PreviewBody
+					awaitingReveal={ awaitingReveal }
+					onReveal={ reveal }
 					showPreview={ showPreview }
 					isLoading={ contentsLoading }
 					content={ content }

--- a/projects/packages/backup/tests/file-browser-a11y.test.tsx
+++ b/projects/packages/backup/tests/file-browser-a11y.test.tsx
@@ -23,6 +23,9 @@ const noop = () => {};
 const ROOT = {
 	'wp-content': { type: 'dir', has_children: true },
 	'wp-config.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-config.php' },
+	// The busy assertion below needs a file whose preview actually fetches;
+	// `wp-config.php` waits for a reveal click and so never reports busy.
+	'readme.txt': { type: 'file', period: '1786644531', manifest_path: 'f5:/readme.txt' },
 };
 
 /**
@@ -164,9 +167,9 @@ describe( 'the preview while it loads', () => {
 		} );
 
 		await renderBrowser();
-		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: 'File: readme.txt' } ) );
 
-		const preview = await screen.findByRole( 'region', { name: 'Preview of wp-config.php' } );
+		const preview = await screen.findByRole( 'region', { name: 'Preview of readme.txt' } );
 		expect( preview ).toHaveAttribute( 'aria-busy', 'true' );
 		expect( screen.getByText( 'Loading preview…' ) ).toBeInTheDocument();
 

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -20,7 +20,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FileInfoCard from '../src/dashboard/components/file-info-card';
 import { queryClient } from '../src/dashboard/data/query-client';
@@ -213,6 +213,30 @@ describe( 'sensitive preview gate', () => {
 		} );
 
 		await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
+	} );
+	it( 'hands focus to the preview it just revealed', async () => {
+		mockEndpoints( SECRET );
+		renderCard( WP_CONFIG );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+
+		// The click unmounts the button holding focus, so without a handback the
+		// next Tab starts again at the top of the tree.
+		await waitFor( () =>
+			expect( screen.getByRole( 'region', { name: /Preview of wp-config.php/ } ) ).toHaveFocus()
+		);
+	} );
+
+	it( 'gates a differently-cased wp-config.php', async () => {
+		// `mimeFromName` lowercases the extension, so an uppercase name is still
+		// previewable — the gate has to match the same way or it fails open.
+		mockEndpoints( SECRET );
+
+		renderCard( { ...WP_CONFIG, name: 'WP-CONFIG.PHP', manifestPath: 'f5:/WP-CONFIG.PHP' } );
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
 		expect( fetchedContent() ).toBe( false );
 	} );

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -1,0 +1,219 @@
+// JETPACK-2353 — clicking `wp-config.php` printed `DB_PASSWORD` and the salts
+// straight into the `<pre>`. Calypso already hides the same single file behind
+// a "Show preview" click; this is that gate, ported.
+
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: jest.fn(),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileInfoCard from '../src/dashboard/components/file-info-card';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import type { FileNodeFile } from '../src/dashboard/types/file-tree';
+
+/** Closing is irrelevant to these assertions; the card renders regardless. */
+const noop = () => {};
+
+// Not a real credential — a marker whose only job is to be searched for.
+const SECRET = "define( 'DB_PASSWORD', 'hunter2-not-a-real-password' );";
+const PLAIN = 'msgid "Hello"';
+
+const WP_CONFIG: FileNodeFile = {
+	name: 'wp-config.php',
+	path: '/wp-config.php',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/wp-config.php',
+};
+
+const README: FileNodeFile = {
+	name: 'readme.txt',
+	path: '/readme.txt',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/readme.txt',
+};
+
+const HIDDEN = 'This preview is hidden because it contains sensitive information.';
+const UNAVAILABLE = 'Preview unavailable for this file.';
+const SHOW = /show preview/i;
+
+/**
+ * Answer `/file-content` with the given body, and `/path-info` with a size.
+ *
+ * @param content - What the preview fetch returns when it runs.
+ */
+function mockEndpoints( content: string ): void {
+	mockApiFetch.mockImplementation( ( options: { path: string } ) =>
+		Promise.resolve(
+			options.path.includes( '/file-content' )
+				? { content, is_text: true, truncated: false }
+				: { size: 3899 }
+		)
+	);
+}
+
+/**
+ * Whether the preview fetch has gone out at all.
+ *
+ * `/path-info` runs regardless, so "no request" is the wrong assertion.
+ *
+ * @return True when `/file-content` was requested.
+ */
+function fetchedContent(): boolean {
+	return mockApiFetch.mock.calls.some( ( [ opts ] ) =>
+		String( opts?.path ?? '' ).includes( '/file-content' )
+	);
+}
+
+/**
+ * Render one file's card inside the dashboard's query client.
+ *
+ * @param file - The file node to open.
+ * @return The Testing Library render result.
+ */
+function renderCard( file: FileNodeFile ) {
+	return render(
+		<QueryClientProvider>
+			<FileInfoCard file={ file } onClose={ noop } />
+		</QueryClientProvider>
+	);
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	mockApiFetch.mockReset();
+	mockRecordEvent.mockReset();
+} );
+
+describe( 'sensitive preview gate', () => {
+	it( 'hides the root wp-config.php and never fetches it', async () => {
+		mockEndpoints( SECRET );
+
+		renderCard( WP_CONFIG );
+
+		// The heading and the `Type:` row are the positive control: the card
+		// rendered and called the extension previewable, so the absent body
+		// below is this gate and not a tree that threw.
+		await expect(
+			screen.findByRole( 'heading', { name: 'wp-config.php', level: 3 } )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Type:' ) ).toBeInTheDocument();
+		expect( screen.getByText( HIDDEN ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: SHOW } ) ).toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
+	} );
+
+	it( 'shows the contents once the reader asks', async () => {
+		mockEndpoints( SECRET );
+		renderCard( WP_CONFIG );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+
+		await expect( screen.findByText( SECRET ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'records the reveal, and records nothing before it', async () => {
+		mockEndpoints( SECRET );
+		renderCard( WP_CONFIG );
+
+		const button = await screen.findByRole( 'button', { name: SHOW } );
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+
+		await userEvent.click( button );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_backup_browser_preview_file_sensitive_click'
+		);
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	// The card is not remounted per file, so the reveal has to be per-file state
+	// rather than a latch that outlives the file it was granted for.
+	it( 'hides it again after a detour to another file', async () => {
+		mockEndpoints( SECRET );
+		const { rerender } = renderCard( WP_CONFIG );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+		await expect( screen.findByText( SECRET ) ).resolves.toBeInTheDocument();
+
+		// Swapping the prop rather than remounting, which is what the browser does.
+		rerender(
+			<QueryClientProvider>
+				<FileInfoCard file={ README } onClose={ noop } />
+			</QueryClientProvider>
+		);
+		rerender(
+			<QueryClientProvider>
+				<FileInfoCard file={ WP_CONFIG } onClose={ noop } />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+	} );
+
+	// Calypso keys on the whole `f5:/wp-config.php`. The `5` is VaultPress's
+	// data-type code, so a file it typed differently would slip a literal match.
+	it( 'hides it whatever data-type prefix the manifest carries', async () => {
+		mockEndpoints( SECRET );
+
+		renderCard( { ...WP_CONFIG, manifestPath: 'f7:/wp-config.php' } );
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'leaves an ordinary text file alone', async () => {
+		mockEndpoints( PLAIN );
+
+		renderCard( {
+			name: 'jetpack.po',
+			path: '/languages/jetpack.po',
+			type: 'file',
+			period: '1786644531',
+			manifestPath: 'f5:/languages/jetpack.po',
+		} );
+
+		await expect( screen.findByText( PLAIN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: SHOW } ) ).not.toBeInTheDocument();
+	} );
+
+	// Why the gate names one path instead of a family: a stray backup copy is
+	// already unpreviewable, because `bak` is not in the extension map.
+	it( 'needs no entry for a wp-config.php.bak, which never previews at all', async () => {
+		mockEndpoints( SECRET );
+
+		renderCard( {
+			name: 'wp-config.php.bak',
+			path: '/wp-config.php.bak',
+			type: 'file',
+			period: '1786644531',
+			manifestPath: 'f5:/wp-config.php.bak',
+		} );
+
+		await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
+	} );
+} );

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -42,6 +42,14 @@ const WP_CONFIG: FileNodeFile = {
 	manifestPath: 'f5:/wp-config.php',
 };
 
+const STAGING_WP_CONFIG: FileNodeFile = {
+	name: 'wp-config.php',
+	path: '/staging/wp-config.php',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/staging/wp-config.php',
+};
+
 const README: FileNodeFile = {
 	name: 'readme.txt',
 	path: '/readme.txt',
@@ -70,16 +78,25 @@ function mockEndpoints( content: string ): void {
 }
 
 /**
- * Whether the preview fetch has gone out at all.
+ * How many preview fetches have gone out.
  *
- * `/path-info` runs regardless, so "no request" is the wrong assertion.
+ * `/path-info` runs regardless, so counting every request is the wrong measure.
+ *
+ * @return The number of `/file-content` requests.
+ */
+function contentFetches(): number {
+	return mockApiFetch.mock.calls.filter( ( [ opts ] ) =>
+		String( opts?.path ?? '' ).includes( '/file-content' )
+	).length;
+}
+
+/**
+ * Whether the preview fetch has gone out at all.
  *
  * @return True when `/file-content` was requested.
  */
 function fetchedContent(): boolean {
-	return mockApiFetch.mock.calls.some( ( [ opts ] ) =>
-		String( opts?.path ?? '' ).includes( '/file-content' )
-	);
+	return contentFetches() > 0;
 }
 
 /**
@@ -147,8 +164,9 @@ describe( 'sensitive preview gate', () => {
 		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	// The card is not remounted per file, so the reveal has to be per-file state
-	// rather than a latch that outlives the file it was granted for.
+	// The gate is per visit, not per file. Deriving the flag from file identity
+	// alone would leave the reveal sticky for the card's lifetime, because the
+	// identity is unchanged on the way back.
 	it( 'hides it again after a detour to another file', async () => {
 		mockEndpoints( SECRET );
 		const { rerender } = renderCard( WP_CONFIG );
@@ -181,6 +199,56 @@ describe( 'sensitive preview gate', () => {
 
 		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+	} );
+
+	// A second install under the backed-up root — `/staging/`, `/blog/`, a
+	// migration leftover — holds live credentials for a live database.
+	it( 'hides a wp-config.php below the manifest root', async () => {
+		mockEndpoints( SECRET );
+
+		renderCard( STAGING_WP_CONFIG );
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
+	} );
+
+	// The leading `/` in the compare is what stops the basename match
+	// swallowing every name that merely ends in the same letters.
+	it( 'leaves a file whose name only ends in wp-config.php alone', async () => {
+		mockEndpoints( PLAIN );
+
+		renderCard( {
+			name: 'mywp-config.php',
+			path: '/wp-content/mywp-config.php',
+			type: 'file',
+			period: '1786644531',
+			manifestPath: 'f5:/wp-content/mywp-config.php',
+		} );
+
+		await expect( screen.findByText( PLAIN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
+	} );
+
+	// Two gated files in one tree is what makes the stale-reveal render
+	// reachable: the card is not remounted, so on the render that swaps the
+	// prop the old `revealed` is still true and the query commits enabled.
+	it( 'does not carry a reveal from one wp-config.php to another', async () => {
+		mockEndpoints( SECRET );
+		const { rerender } = renderCard( WP_CONFIG );
+
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+		await expect( screen.findByText( SECRET ) ).resolves.toBeInTheDocument();
+		expect( contentFetches() ).toBe( 1 );
+
+		rerender(
+			<QueryClientProvider>
+				<FileInfoCard file={ STAGING_WP_CONFIG } onClose={ noop } />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
+		expect( contentFetches() ).toBe( 1 );
 	} );
 
 	it( 'leaves an ordinary text file alone', async () => {


### PR DESCRIPTION
Fixes JETPACK-2353

## Proposed changes

* Clicking `wp-config.php` in the modernized dashboard's file browser printed the file straight into a `<pre>` — `DB_PASSWORD`, `AUTH_KEY` and the salts, with no interstitial. Confirmed on a live site: a 3,899-character preview containing them.
* Not a privilege escalation. Reaching it needs `manage_options` plus a connected WordPress.com account, i.e. someone who could already read the file over SFTP. What it changes is **exposure surface**: the secrets rendered unprompted, in a browser tab, on a screen someone may be sharing or screenshotting for support. That is the reason Calypso gates the same file.
* `components/file-info-card/index.tsx` gains a sensitivity gate beside `showPreview` — deliberately not inside the extension map, which since JETPACK-2324 doubles as the previewability rule. The card renders Calypso's wording and shape: an `unseen` icon, "This preview is hidden because it contains sensitive information.", and a **Show preview** button.
* **The gate also withholds the fetch.** It feeds `useFileContents`'s `enabled`, so the bytes never leave WordPress.com until the reader asks. Calypso fetches and hides; this does not fetch at all.
* Tracks: `jetpack_backup_browser_preview_file_sensitive_click` on the reveal — Calypso's event name minus its `calypso_jetpack_` prefix, matching this package's `jetpack_backup_*_click` family. It carries no properties.

### Why the match is not Calypso's literal string

Calypso compares `item.manifestPath === 'f5:/wp-config.php'`. This compares the path *after* the volume prefix, lowercased, and matches the filename at any depth. Three ways a literal match fails **open**, which is the wrong direction for an exposure fix:

* The `5` in `f5:` is VaultPress's data-type code rather than part of the file's identity, so a literal match misses a file typed differently. A path with no prefix is compared whole, also fail-closed.
* A `wp-config.php` anywhere other than the manifest root — a second install under `/staging/`, `/blog/` or `/old/`, or a migration leftover — printed in full. Those are live credentials for a live database, not `wp-config-sample.php`. The name now matches at any depth. The `/` in the suffix compare keeps `mywp-config.php` out, and there is a test for that.

Lowercased because `mimeFromName` lowercases the extension: without it, `f5:/WP-CONFIG.PHP` was previewable *and* ungated, and it rendered in full. That is reachable on case-insensitive filesystems, where WordPress still loads the file and the manifest records the on-disk casing.

### Scope, stated as provisional

One filename, at any depth. `wp-config.php.bak` needs no entry — `bak` is not in `PREVIEWABLE_TEXT_TYPES`, and there is a test that fails if anyone adds it. `wp-config-sample.php` ships placeholders.

Not covered: a hand-made copy with a previewable extension (`wp-config-backup.php`, `wp-config.old.php`, `wp-config.php.txt`). And the larger hole is not `wp-config` copies at all — `sql` and `log` are both in the previewable map, so a root `dump.sql` or a `debug.log` prints in full with no gate, and a database dump is a strictly larger secret. Treat "one literal path, because Calypso" as provisional; inverting it to a pattern family is a bigger call than this PR should carry.

### The reveal/fetch identity gap, now closed

An earlier revision left this latent, on the grounds that one gated path yields one gated node. Matching the filename at any depth removes that guarantee: with two `wp-config.php` files in one tree, clicking from one to the other reached the stale render. `FileInfoCard` is not remounted per file, so on the render that swaps the prop the old `revealed` was still true, `useFileContents` committed its query enabled, and the second file's bytes left WordPress.com unasked. A test pins it — two `/file-content` requests before the fix, one after.

An effect cannot close it. `useFileContents` is called before the reset effect, so the query commits and fetches before `setRevealed( false )` runs; the bytes have already gone. The flag has to be right *during* render.

So the reveal is now keyed to `${ period }:${ manifestPath }` and cleared during render, React's documented pattern for adjusting state when a prop changes. React discards that render and re-runs it, so the query never commits enabled. The gate stays per *visit* rather than per file: deriving the flag from identity alone would leave a reveal sticky for the card's lifetime, and `hides it again after a detour to another file` fails if anyone tries it.

The gate no longer depends on `<BackupDetail key={item.rewindId}>` in `screens/overview.tsx`, which nothing asserts.

## Related product discussion/links

* Linear: JETPACK-2353, under the Backup modernization project.
* Reference implementation: Calypso's `client/my-sites/backup/backup-contents-page/file-browser/file-preview.tsx`.

## Does this pull request change what data or activity we track or use?

Yes, in two directions, and both reduce exposure.

* It **removes** a request: the preview of `wp-config.php` is no longer fetched unless the reader asks for it.
* It **adds** one Tracks event, `jetpack_backup_browser_preview_file_sensitive_click`, recorded when the reader takes the reveal. It carries no properties — no path, no filename, no contents.

## Testing instructions

The dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default, so this is a no-op unless the filter is on.

Automated, from `projects/packages/backup`: `pnpm test` — 72 suites / 711 tests. `tests/sensitive-preview-gate.test.tsx` is new: 12 tests, each mutation-checked. Removing the gate fails 9 of them; the 3 survivors are negative controls that other mutants kill. `pnpm run typecheck`, `eslint`, `prettier` clean.

By hand, on a site with the filter on and a Backup plan:

1. Go to **Jetpack → VaultPress Backup**, pick a backup, open the file browser at the site root.
2. Click **wp-config.php**. Expect the "This preview is hidden…" notice and a **Show preview** button, and **no** file contents. In DevTools Network, expect no `/file-content` request.
3. Click **Show preview**. The contents appear, one `/file-content` request goes out, and focus lands on the preview region — Tab from there should continue inside the card, not restart at the top of the tree.
4. Click any ordinary text file (`readme.txt`, a `.po`) — unchanged, previews immediately.
5. Go back to `wp-config.php`. It must be hidden again.
6. On a site with a second install under the backed-up root, click that `wp-config.php` too. It must be hidden, with no `/file-content` request. Clicking straight from one `wp-config.php` to the other must not fetch either.
7. Before this change, step 2 printed `DB_PASSWORD` and the salts with one click.

**Do not paste real values anywhere while testing.** Checking that a key *name* is present is enough.

