### PR TITLE
Backup: stop a WordPress.com blip reading as "no Backup plan"

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2309-plan-checks
+++ b/projects/packages/backup/changelog/jetpack-2309-plan-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop a slow or failing WordPress.com from reading as a missing Backup plan.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -133,9 +133,7 @@ class Jetpack_Backup {
 	/**
 	 * Rewind state read from WordPress.com, memoized for the request.
 	 *
-	 * A class property and not a function static so tests can clear it. Only a
-	 * readable response is stored, so nothing a later call could improve on
-	 * sticks for the rest of the request.
+	 * A class property and not a function static so tests can clear it.
 	 *
 	 * @var object|null
 	 */
@@ -569,9 +567,8 @@ class Jetpack_Backup {
 	/**
 	 * Hits the wpcom api to check rewind status.
 	 *
-	 * No timeout override. It used to be 2 seconds, roughly twice a healthy
-	 * round trip, so ordinary latency answered as a failed read; every other
-	 * WordPress.com call in this class takes the default.
+	 * Bounded well clear of a healthy round trip; `Client`'s 10s default is too
+	 * long for the synchronous `authorize_redirect` this sits on.
 	 *
 	 * @return object|WP_Error The decoded rewind state, or a WP_Error if WordPress.com could not be read.
 	 */
@@ -582,7 +579,7 @@ class Jetpack_Backup {
 
 		$site_id = Jetpack_Options::get_option( 'id' );
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array(), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 5 ), null, 'wpcom' );
 
 		// Cast: `wp_remote_retrieve_response_code()` hands back whatever the
 		// transport put there, and a numeric-string `'200'` fails this
@@ -609,10 +606,6 @@ class Jetpack_Backup {
 
 	/**
 	 * Checks whether the current plan (or purchases) of the site already supports the product
-	 *
-	 * Reads rewind *state* with a blog token rather than the capability list
-	 * `REST\Capabilities_Bridge` reads: `/rewind/capabilities` answers 401 to a
-	 * blog token, and every caller here asks before a user connection exists.
 	 *
 	 * @return boolean
 	 */

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -131,6 +131,17 @@ class Jetpack_Backup {
 	const MODERNIZATION_FILTER = 'rsm_jetpack_ui_modernization_backup';
 
 	/**
+	 * Rewind state read from WordPress.com, memoized for the request.
+	 *
+	 * A class property and not a function static so tests can clear it. Only a
+	 * readable response is stored, so nothing a later call could improve on
+	 * sticks for the rest of the request.
+	 *
+	 * @var object|null
+	 */
+	private static $rewind_state = null;
+
+	/**
 	 * Constructor.
 	 */
 	public static function initialize() {
@@ -558,46 +569,61 @@ class Jetpack_Backup {
 	/**
 	 * Hits the wpcom api to check rewind status.
 	 *
-	 * @return Object|WP_Error
+	 * No timeout override. It used to be 2 seconds, roughly twice a healthy
+	 * round trip, so ordinary latency answered as a failed read; every other
+	 * WordPress.com call in this class takes the default.
+	 *
+	 * @return object|WP_Error The decoded rewind state, or a WP_Error if WordPress.com could not be read.
 	 */
 	private static function get_rewind_state_from_wpcom() {
-		static $status = null;
-
-		if ( $status !== null ) {
-			return $status;
+		if ( self::$rewind_state !== null ) {
+			return self::$rewind_state;
 		}
 
 		$site_id = Jetpack_Options::get_option( 'id' );
 
-		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 2 ), null, 'wpcom' );
+		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array(), null, 'wpcom' );
 
 		// Cast: `wp_remote_retrieve_response_code()` hands back whatever the
 		// transport put there, and a numeric-string `'200'` fails this
-		// strict comparison. The result is memoized in `$status` and read by
-		// `has_backup_plan()`, which answers false for a `WP_Error` — so a
-		// site that does have Backup is told, for the rest of the request,
-		// that it does not. That answer is acted on: it backs the
-		// `/has-backup-plan` route and the standalone-license upsell.
+		// strict comparison. `has_backup_plan()` answers false for a
+		// `WP_Error`, so a site that does have Backup would be told it does
+		// not — and that answer is acted on: it backs the `/has-backup-plan`
+		// route and the standalone-license upsell.
 		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error( 'rewind_state_fetch_failed' );
 		}
 
-		$body   = wp_remote_retrieve_body( $response );
-		$status = json_decode( $body );
-		return $status;
+		$state = json_decode( wp_remote_retrieve_body( $response ) );
+
+		// A 200 with no `state` is a read that failed, not a site without a
+		// plan. Caching it would hold that answer for the rest of the request;
+		// refusing lets a later caller ask again and get a real one.
+		if ( ! is_object( $state ) || ! isset( $state->state ) ) {
+			return new WP_Error( 'rewind_state_unreadable' );
+		}
+
+		self::$rewind_state = $state;
+		return self::$rewind_state;
 	}
 
 	/**
 	 * Checks whether the current plan (or purchases) of the site already supports the product
 	 *
+	 * Reads rewind *state* with a blog token rather than the capability list
+	 * `REST\Capabilities_Bridge` reads: `/rewind/capabilities` answers 401 to a
+	 * blog token, and every caller here asks before a user connection exists.
+	 *
 	 * @return boolean
 	 */
 	public static function has_backup_plan() {
 		$rewind_data = static::get_rewind_state_from_wpcom();
+
 		if ( is_wp_error( $rewind_data ) ) {
 			return false;
 		}
-		return is_object( $rewind_data ) && isset( $rewind_data->state ) && 'unavailable' !== $rewind_data->state;
+
+		return 'unavailable' !== $rewind_data->state;
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -64,6 +64,13 @@ class Jetpack_Backup_Test extends TestCase {
 	private $http_requests = 0;
 
 	/**
+	 * Timeout the most recent mocked request was given.
+	 *
+	 * @var int|float|null
+	 */
+	private $captured_timeout = null;
+
+	/**
 	 * Locale reported to the code under test.
 	 *
 	 * @var string
@@ -80,6 +87,7 @@ class Jetpack_Backup_Test extends TestCase {
 	protected function tearDown(): void {
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
 		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
+		remove_filter( 'pre_http_request', array( $this, 'mock_wpcom_response_recording_timeout' ) );
 		remove_filter( 'jetpack_options', array( $this, 'mock_jetpack_connection_options' ) );
 		remove_filter( 'locale', array( $this, 'mock_locale' ) );
 		wp_set_current_user( 0 );
@@ -88,10 +96,13 @@ class Jetpack_Backup_Test extends TestCase {
 			delete_transient( Jetpack_Backup::PROMOTED_PRODUCT_TRANSIENT_PREFIX . sanitize_key( $locale ) );
 		}
 
-		$this->wpcom_status  = 200;
-		$this->wpcom_body    = '{}';
-		$this->http_requests = 0;
-		$this->locale        = 'en_US';
+		$this->wpcom_status     = 200;
+		$this->wpcom_body       = '{}';
+		$this->http_requests    = 0;
+		$this->locale           = 'en_US';
+		$this->captured_timeout = null;
+
+		$this->forget_rewind_state();
 
 		parent::tearDown();
 	}
@@ -295,12 +306,9 @@ class Jetpack_Backup_Test extends TestCase {
 	 * answer is acted on: it backs `GET /jetpack/v4/has-backup-plan` and the
 	 * standalone-license upsell in `jetpack_check_user_licenses()`.
 	 *
-	 * The request count is asserted because that helper memoizes a
-	 * *successful* fetch in a function static, which no test can reset. This
-	 * is the only test in the suite that drives it to a success, so the
-	 * static should still be empty when it runs — and if some later test
-	 * changes that, this assertion says so rather than passing on a cached
-	 * answer that never touched the code under test.
+	 * The request count is asserted because the helper memoizes a readable
+	 * response: without it this would pass on a cached answer left by an
+	 * earlier test rather than on the code under test.
 	 */
 	public function test_has_backup_plan_reads_a_string_status_200() {
 		$this->sign_in_as_connected_admin();
@@ -312,6 +320,66 @@ class Jetpack_Backup_Test extends TestCase {
 
 		$this->assertSame( 1, $this->http_requests );
 		$this->assertTrue( $result );
+	}
+
+	/**
+	 * A 200 that says nothing about the plan does not answer for the rest of
+	 * the request.
+	 *
+	 * It used to be cached as though it were a real read, so one unreadable
+	 * payload told every later caller in that request that the site has no
+	 * Backup plan — and that answer is acted on: it backs
+	 * `GET /jetpack/v4/has-backup-plan` and the standalone-license upsell.
+	 *
+	 * @param string $label Human-readable case name.
+	 * @param string $body  The unreadable body.
+	 * @dataProvider provide_cacheable_unreadable_states
+	 */
+	#[DataProvider( 'provide_cacheable_unreadable_states' )]
+	public function test_has_backup_plan_does_not_cache_an_unreadable_200( $label, $body ) {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_body = $body;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$unreadable = Jetpack_Backup::has_backup_plan();
+
+		$this->wpcom_body = '{"state":"active"}';
+		$recovered        = Jetpack_Backup::has_backup_plan();
+
+		$this->assertFalse( $unreadable, $label );
+		$this->assertSame( 2, $this->http_requests, $label );
+		$this->assertTrue( $recovered, $label );
+	}
+
+	/**
+	 * Bodies a 200 can carry that say nothing about the plan *and* decode to a
+	 * value worth caching. An empty or invalid body decodes to null, which was
+	 * never cached, so it has nothing to prove here.
+	 *
+	 * @return array[]
+	 */
+	public static function provide_cacheable_unreadable_states() {
+		return array(
+			array( 'a JSON list', '[]' ),
+			array( 'a response without a state', '{"last_updated":"2026-09-01T22:10:23.797+00:00"}' ),
+			array( 'a bare number', '123' ),
+			array( 'a bare string', '"active"' ),
+			array( 'a bare boolean', 'true' ),
+		);
+	}
+
+	/**
+	 * The read is no longer bounded by 2 seconds, which is about twice a
+	 * healthy round trip — so ordinary latency answered "no plan".
+	 */
+	public function test_rewind_state_read_is_not_bounded_by_two_seconds() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = 503;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response_recording_timeout' ), 10, 3 );
+
+		Jetpack_Backup::has_backup_plan();
+
+		$this->assertGreaterThan( 2, $this->captured_timeout );
 	}
 
 	public function test_list_backup_events_returns_response_and_pins_backup_actions_on_success() {
@@ -533,6 +601,22 @@ class Jetpack_Backup_Test extends TestCase {
 	}
 
 	/**
+	 * Clear the memoized rewind state, which is otherwise kept for the whole
+	 * process — one readable response would answer every later test without
+	 * reaching the transport.
+	 */
+	private function forget_rewind_state() {
+		$property = new \ReflectionProperty( Jetpack_Backup::class, 'rewind_state' );
+
+		// `setAccessible()` has been a no-op since PHP 8.1 and is deprecated in 8.5.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+
+		$property->setValue( null, null );
+	}
+
+	/**
 	 * Report the configured locale.
 	 *
 	 * @return string
@@ -640,6 +724,19 @@ class Jetpack_Backup_Test extends TestCase {
 		++$this->http_requests;
 
 		return new WP_Error( 'http_request_failed', 'The request failed.' );
+	}
+
+	/**
+	 * Mock a WordPress.com request and record the timeout it was given.
+	 *
+	 * @param false $preempt     Short-circuit value (unused).
+	 * @param array $parsed_args Request args.
+	 * @return array
+	 */
+	public function mock_wpcom_response_recording_timeout( $preempt, $parsed_args ) {
+		$this->captured_timeout = $parsed_args['timeout'] ?? null;
+
+		return $this->mock_wpcom_response();
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -78,6 +78,16 @@ class Jetpack_Backup_Test extends TestCase {
 	private $locale = 'en_US';
 
 	/**
+	 * Clear the memoized rewind state on the way in as well as out, so this
+	 * class starts clean whatever ran before it.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->forget_rewind_state();
+	}
+
+	/**
 	 * Undo the request mocking. Done here rather than after each assertion so
 	 * that a failing assertion cannot leak a filter into the next test.
 	 *
@@ -326,11 +336,6 @@ class Jetpack_Backup_Test extends TestCase {
 	 * A 200 that says nothing about the plan does not answer for the rest of
 	 * the request.
 	 *
-	 * It used to be cached as though it were a real read, so one unreadable
-	 * payload told every later caller in that request that the site has no
-	 * Backup plan — and that answer is acted on: it backs
-	 * `GET /jetpack/v4/has-backup-plan` and the standalone-license upsell.
-	 *
 	 * @param string $label Human-readable case name.
 	 * @param string $body  The unreadable body.
 	 * @dataProvider provide_cacheable_unreadable_states
@@ -362,24 +367,23 @@ class Jetpack_Backup_Test extends TestCase {
 		return array(
 			array( 'a JSON list', '[]' ),
 			array( 'a response without a state', '{"last_updated":"2026-09-01T22:10:23.797+00:00"}' ),
+			array( 'a null state', '{"state":null}' ),
 			array( 'a bare number', '123' ),
-			array( 'a bare string', '"active"' ),
-			array( 'a bare boolean', 'true' ),
 		);
 	}
 
 	/**
-	 * The read is no longer bounded by 2 seconds, which is about twice a
-	 * healthy round trip — so ordinary latency answered "no plan".
+	 * Pinned in both directions: a shorter bound reproduces the bug, and
+	 * `Client`'s 10s default is too long for the redirect this sits on.
 	 */
-	public function test_rewind_state_read_is_not_bounded_by_two_seconds() {
+	public function test_rewind_state_read_is_bounded_at_five_seconds() {
 		$this->sign_in_as_connected_admin();
 		$this->wpcom_status = 503;
 		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response_recording_timeout' ), 10, 3 );
 
 		Jetpack_Backup::has_backup_plan();
 
-		$this->assertGreaterThan( 2, $this->captured_timeout );
+		$this->assertSame( 5, $this->captured_timeout );
 	}
 
 	public function test_list_backup_events_returns_response_and_pins_backup_actions_on_success() {

--- a/projects/plugins/backup/changelog/jetpack-2309-plan-checks
+++ b/projects/plugins/backup/changelog/jetpack-2309-plan-checks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop a slow or failing WordPress.com from reading as a missing Backup plan.


### PR DESCRIPTION
Fixes JETPACK-2309

## Proposed changes

* `Jetpack_Backup::has_backup_plan()` bounded its `/sites/%d/rewind?force=wpcom` read at **2 seconds**. Measured on a connected site that does have a Backup plan, that read takes **780–1174ms**, and one call in six hit the bound. `has_backup_plan()` collapses any `WP_Error` to `false`, so a site that owns Backup was told it does not.
* That answer is acted on. It backs `GET /jetpack/v4/has-backup-plan`, which the connect screen reads to decide whether to send the site owner to checkout — **to buy a plan they already own**.
* **Bounded at 5 seconds instead.** "Drop the override" is not "no bound": the fallback is `Client`'s default of 10s (`class-client.php:123`). This read sits on the synchronous `authorize_redirect`, whose licence read already takes up to 10s, so no bound at all would take that handler's worst case from ~12s to ~20s against a 30s `max_execution_time`. 5s clears the measured round trip four times over, so it cannot reproduce the bug. It does not leave the redirect exactly where it was: `handle_user_connected_redirect()` reads the licence list first and this second, so its worst case goes from ~12s to **~15s** — still half the budget.
* **Refuse a 200 whose body carries no `state`.** It used to be memoized as though it were a real read, so one unreadable payload answered "no plan" for every later caller in that request.
* The memoized state moves from a function static to a private class property so tests can clear it.

### What this deliberately does not do

The issue asks for "a failure reported as a failure rather than silently as no". `has_backup_plan()` still returns a plain `bool` here, because both legacy consumers hand the promise straight on: `src/js/components/Admin/hooks.js` is a bare `.then()` with no rejection path, so `isLoading` would stick true forever, and `src/js/components/backup-connection-screen` passes it to `ConnectScreenRequiredPlan`. Returning `WP_Error` today would trade a wrong answer for a permanent spinner. That change plus the two rejection paths belong together in a follow-up.

The issue's other half — seven legacy routes answering a failure with HTTP 200 — already shipped as JETPACK-2325 in #51625. `/has-backup-plan` was not among the seven, for exactly the reason above.

`REST\Capabilities_Bridge` is untouched. It reads `/rewind/capabilities` as **user**, which answers 401 to a blog token, and every `has_backup_plan()` caller asks before a user connection exists — so the two checks cannot share one read, and the reconciliation the issue's title implies is not available.

## Related product discussion/links

* Linear: JETPACK-2309 (task I3), under the Backup modernization project.
* Its I4 half shipped separately as JETPACK-2325 / #51625.

## Does this pull request change what data or activity we track or use?

No. Same endpoint, same token, same caller. One request is bounded differently, and an unreadable response is no longer cached.

## Testing instructions

This is reachable with the modernization filter **off** — it backs the legacy dashboard and the licence-activation filter — so it is not a no-op the way the dashboard work is.

Automated, from `projects/packages/backup`:

* `composer phpunit` — 401 tests / 1047 assertions.
* Both new tests are mutation-checked. The bound test asserts the value exactly and so catches a retune in either direction: `timeout => 3` fails it (`3 is identical to 5`), and dropping the override for `Client`'s 10s default fails it too (`10 is identical to 5`). An earlier `assertGreaterThan( 2, … )` let 3s through, which would have reinstated the same failure at a lower rate. Removing the unreadable-200 guard fails all four provider cases.
* `composer phpcs:changed` clean, PHPCompatibility at `testVersion 7.4-` clean, `jetpack phan packages/backup` 0 issues.

By hand, on a connected site with a Backup plan:

1. `wp eval 'var_dump( Automattic\Jetpack\Backup\V0005\Jetpack_Backup::has_backup_plan() );'` → `true`.
2. Hit `/wp-json/jetpack/v4/has-backup-plan` as an admin → `true`.
3. Simulate a slow WordPress.com with a mu-plugin that sleeps in `pre_http_request` for 3 seconds and then returns the real response. Before this change the read gave up at 2s and answered `false`; now it waits and answers `true`.
4. Simulate an unreadable 200: return `{"last_updated":"…"}` with no `state`. Expect `false`, and expect a *second* call in the same request to try again rather than reuse that answer.
5. On a site with no plan (`{"state":"unavailable"}`), confirm it still answers a plain `false` — the legitimate negative must be preserved.

