### PR TITLE
Premium Analytics: add an Any feedback? action that reports to Tracks

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4010,6 +4010,9 @@ importers:
       '@automattic/charts':
         specifier: workspace:*
         version: link:../../js-packages/charts
+      '@automattic/jetpack-analytics':
+        specifier: workspace:*
+        version: link:../../js-packages/analytics
       '@automattic/jetpack-connection':
         specifier: workspace:*
         version: link:../../js-packages/connection

--- a/projects/packages/premium-analytics/changelog/stats-v2-feedback-action
+++ b/projects/packages/premium-analytics/changelog/stats-v2-feedback-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an "Any feedback?" action to the dashboard header.

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -40,6 +40,7 @@
 	},
 	"dependencies": {
 		"@automattic/charts": "workspace:*",
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -110,7 +110,7 @@ describe( 'FeedbackAction', () => {
 		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
 		// region on `body`, so an unscoped query matches twice.
 		expect(
-			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you — this helps.' )
+			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you. This helps.' )
 		).toBeInTheDocument();
 		expect( screen.queryByRole( 'radiogroup' ) ).not.toBeInTheDocument();
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -140,46 +140,27 @@ describe( 'FeedbackAction', () => {
 } );
 
 describe( 'the rating scale', () => {
-	it( 'offers the whole scale as one radio group with one tab stop', async () => {
+	it( 'names the group with the question it answers', async () => {
 		await openModal();
 
 		expect( screen.getByRole( 'radiogroup' ) ).toHaveAccessibleName(
 			'Compared with the existing Traffic tab in Stats, the new Traffic tab is:'
 		);
-		expect( screen.getByRole( 'radio', { name: 'Much worse' } ) ).toHaveAttribute(
-			'tabindex',
-			'0'
-		);
-		expect( screen.getByRole( 'radio', { name: 'A bit worse' } ) ).toHaveAttribute(
-			'tabindex',
-			'-1'
-		);
 	} );
 
-	it( 'moves the answer with the arrow keys', async () => {
-		const user = await openModal();
+	it( 'offers the five points worst to best', async () => {
+		await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
-		await user.keyboard( '{ArrowRight}' );
+		const scale = screen.getAllByRole< HTMLInputElement >( 'radio' );
 
-		expect( screen.getByRole( 'radio', { name: 'About the same' } ) ).toBeChecked();
-		expect( screen.getByRole( 'radio', { name: 'About the same' } ) ).toHaveFocus();
-
-		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
-
-		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
-			'jetpack_premium_analytics_feedback_submit',
-			{ rating: 3, comment: '' }
-		);
-	} );
-
-	it( 'wraps from the first answer round to the last', async () => {
-		const user = await openModal();
-
-		await user.click( screen.getByRole( 'radio', { name: 'Much worse' } ) );
-		await user.keyboard( '{ArrowLeft}' );
-
-		expect( screen.getByRole( 'radio', { name: 'Much better' } ) ).toBeChecked();
+		expect( scale.map( point => point.labels?.[ 0 ]?.textContent ) ).toEqual( [
+			'Much worse',
+			'A bit worse',
+			'About the same',
+			'A bit better',
+			'Much better',
+		] );
+		expect( scale.map( point => point.value ) ).toEqual( [ '1', '2', '3', '4', '5' ] );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -110,7 +110,7 @@ describe( 'FeedbackAction', () => {
 		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
 		// region on `body`, so an unscoped query matches twice.
 		expect(
-			within( screen.getByRole( 'dialog' ) ).getByText( 'Thanks — your feedback is on its way.' )
+			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you — this helps.' )
 		).toBeInTheDocument();
 		expect( screen.queryByRole( 'radiogroup' ) ).not.toBeInTheDocument();
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -71,7 +71,7 @@ describe( 'FeedbackAction', () => {
 	it( 'reports the rating and comment as one event', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '4' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'A bit better' } ) );
 		await user.type( screen.getByRole( 'textbox' ), '  Needs a date picker  ' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
@@ -92,7 +92,7 @@ describe( 'FeedbackAction', () => {
 			expect.anything()
 		);
 
-		await user.click( screen.getByRole( 'radio', { name: '1' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Much worse' } ) );
 		await user.click( submit );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
@@ -104,7 +104,7 @@ describe( 'FeedbackAction', () => {
 	it( 'confirms the send rather than just closing', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '3' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
@@ -122,7 +122,7 @@ describe( 'FeedbackAction', () => {
 	it( 'sends nothing when the reader backs out', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '5' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Much better' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 		expect( mockRecordEvent ).not.toHaveBeenCalledWith(
@@ -144,20 +144,26 @@ describe( 'the rating scale', () => {
 		await openModal();
 
 		expect( screen.getByRole( 'radiogroup' ) ).toHaveAccessibleName(
-			'How easy is the new Stats to use?'
+			'Compared with the existing Traffic tab in Stats, the new Traffic tab is:'
 		);
-		expect( screen.getByRole( 'radio', { name: '1' } ) ).toHaveAttribute( 'tabindex', '0' );
-		expect( screen.getByRole( 'radio', { name: '2' } ) ).toHaveAttribute( 'tabindex', '-1' );
+		expect( screen.getByRole( 'radio', { name: 'Much worse' } ) ).toHaveAttribute(
+			'tabindex',
+			'0'
+		);
+		expect( screen.getByRole( 'radio', { name: 'A bit worse' } ) ).toHaveAttribute(
+			'tabindex',
+			'-1'
+		);
 	} );
 
 	it( 'moves the answer with the arrow keys', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '2' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
 		await user.keyboard( '{ArrowRight}' );
 
-		expect( screen.getByRole( 'radio', { name: '3' } ) ).toBeChecked();
-		expect( screen.getByRole( 'radio', { name: '3' } ) ).toHaveFocus();
+		expect( screen.getByRole( 'radio', { name: 'About the same' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'About the same' } ) ).toHaveFocus();
 
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
@@ -170,10 +176,10 @@ describe( 'the rating scale', () => {
 	it( 'wraps from the first answer round to the last', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '1' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Much worse' } ) );
 		await user.keyboard( '{ArrowLeft}' );
 
-		expect( screen.getByRole( 'radio', { name: '5' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Much better' } ) ).toBeChecked();
 	} );
 } );
 
@@ -181,7 +187,7 @@ describe( 'the Tracks identity', () => {
 	it( 'identifies the reader and pins blog_id once, not per event', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: '3' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		expect( mockRecordEvent ).toHaveBeenCalledTimes( 2 );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -1,37 +1,46 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
+import { resetTracksIdentityForTesting } from '../../hooks/use-track-event';
 import { FeedbackAction } from './feedback-action';
 
-const mockInitialize = jest.fn();
+const mockSetUser = jest.fn();
+const mockIdentifyUser = jest.fn();
+const mockAssignSuperProps = jest.fn();
 const mockRecordEvent = jest.fn();
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
 	__esModule: true,
 	default: {
-		initialize: ( ...args: unknown[] ) => mockInitialize( ...args ),
+		setUser: ( ...args: unknown[] ) => mockSetUser( ...args ),
+		identifyUser: () => mockIdentifyUser(),
+		assignSuperProps: ( ...args: unknown[] ) => mockAssignSuperProps( ...args ),
 		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
 	},
 } ) );
 
+const mockGetScriptData = jest.fn();
+
 jest.mock( '@automattic/jetpack-script-data', () => ( {
-	getScriptData: () => ( {
-		site: { wpcom: { blog_id: 42 } },
-		user: { current_user: { wpcom: { ID: 7, login: 'reader' } } },
-	} ),
+	getScriptData: () => mockGetScriptData(),
 } ) );
 
 beforeEach( () => {
 	jest.clearAllMocks();
+	resetTracksIdentityForTesting();
+	mockGetScriptData.mockReturnValue( {
+		site: { wpcom: { blog_id: 42 } },
+		user: { current_user: { wpcom: { ID: 7, login: 'reader' } } },
+	} );
 } );
 
 /**
- * Renders the action and opens the modal, the way every case here starts.
+ * Renders the action and opens the modal, the way most cases here start.
  *
  * @return The `userEvent` session, for the rest of the interaction.
  */
@@ -43,22 +52,32 @@ async function openModal() {
 }
 
 describe( 'FeedbackAction', () => {
-	it( 'records who is answering before the first event', async () => {
+	it( 'stays out of the way until the reader asks for it', () => {
+		render( <FeedbackAction /> );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reports the opening as its own event', async () => {
 		await openModal();
 
-		expect( mockInitialize ).toHaveBeenCalledWith( 7, 'reader' );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_premium_analytics_feedback_open',
+			undefined
+		);
 	} );
 
 	it( 'reports the rating and comment as one event', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'button', { name: '4' } ) );
+		await user.click( screen.getByRole( 'radio', { name: '4' } ) );
 		await user.type( screen.getByRole( 'textbox' ), '  Needs a date picker  ' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
 			'jetpack_premium_analytics_feedback_submit',
-			{ blog_id: 42, rating: 4, comment: 'Needs a date picker' }
+			{ rating: 4, comment: 'Needs a date picker' }
 		);
 	} );
 
@@ -73,19 +92,37 @@ describe( 'FeedbackAction', () => {
 			expect.anything()
 		);
 
-		await user.click( screen.getByRole( 'button', { name: '1' } ) );
+		await user.click( screen.getByRole( 'radio', { name: '1' } ) );
 		await user.click( submit );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
 			'jetpack_premium_analytics_feedback_submit',
-			{ blog_id: 42, rating: 1, comment: '' }
+			{ rating: 1, comment: '' }
 		);
+	} );
+
+	it( 'confirms the send rather than just closing', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: '3' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
+		// region on `body`, so an unscoped query matches twice.
+		expect(
+			within( screen.getByRole( 'dialog' ) ).getByText( 'Thanks — your feedback is on its way.' )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'radiogroup' ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Done' } ) );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'sends nothing when the reader backs out', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'button', { name: '5' } ) );
+		await user.click( screen.getByRole( 'radio', { name: '5' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 		expect( mockRecordEvent ).not.toHaveBeenCalledWith(
@@ -93,5 +130,98 @@ describe( 'FeedbackAction', () => {
 			expect.anything()
 		);
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'caps the comment at the length Tracks will carry', async () => {
+		await openModal();
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveAttribute( 'maxlength', '1000' );
+	} );
+} );
+
+describe( 'the rating scale', () => {
+	it( 'offers the whole scale as one radio group with one tab stop', async () => {
+		await openModal();
+
+		expect( screen.getByRole( 'radiogroup' ) ).toHaveAccessibleName(
+			'How easy is the new Stats to use?'
+		);
+		expect( screen.getByRole( 'radio', { name: '1' } ) ).toHaveAttribute( 'tabindex', '0' );
+		expect( screen.getByRole( 'radio', { name: '2' } ) ).toHaveAttribute( 'tabindex', '-1' );
+	} );
+
+	it( 'moves the answer with the arrow keys', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: '2' } ) );
+		await user.keyboard( '{ArrowRight}' );
+
+		expect( screen.getByRole( 'radio', { name: '3' } ) ).toBeChecked();
+		expect( screen.getByRole( 'radio', { name: '3' } ) ).toHaveFocus();
+
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			{ rating: 3, comment: '' }
+		);
+	} );
+
+	it( 'wraps from the first answer round to the last', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: '1' } ) );
+		await user.keyboard( '{ArrowLeft}' );
+
+		expect( screen.getByRole( 'radio', { name: '5' } ) ).toBeChecked();
+	} );
+} );
+
+describe( 'the Tracks identity', () => {
+	it( 'identifies the reader and pins blog_id once, not per event', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: '3' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 2 );
+		expect( mockSetUser ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetUser ).toHaveBeenCalledWith( 7, 'reader' );
+		expect( mockIdentifyUser ).toHaveBeenCalledTimes( 1 );
+		expect( mockAssignSuperProps ).toHaveBeenCalledTimes( 1 );
+		expect( mockAssignSuperProps ).toHaveBeenCalledWith( { blog_id: 42 } );
+	} );
+
+	it( 'identifies before the first event reaches Tracks', async () => {
+		await openModal();
+
+		expect( mockIdentifyUser.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			mockRecordEvent.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'still records when the site carries no WPCOM identity', async () => {
+		mockGetScriptData.mockReturnValue( {} );
+
+		await openModal();
+
+		expect( mockSetUser ).not.toHaveBeenCalled();
+		expect( mockIdentifyUser ).not.toHaveBeenCalled();
+		expect( mockAssignSuperProps ).not.toHaveBeenCalled();
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_premium_analytics_feedback_open',
+			undefined
+		);
+	} );
+
+	it( 'skips the blog_id super prop when the site is not connected', async () => {
+		mockGetScriptData.mockReturnValue( {
+			user: { current_user: { wpcom: { ID: 7, login: 'reader' } } },
+		} );
+
+		await openModal();
+
+		expect( mockSetUser ).toHaveBeenCalledWith( 7, 'reader' );
+		expect( mockAssignSuperProps ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import { FeedbackAction } from './feedback-action';
+
+const mockInitialize = jest.fn();
+const mockRecordEvent = jest.fn();
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		initialize: ( ...args: unknown[] ) => mockInitialize( ...args ),
+		tracks: { recordEvent: ( ...args: unknown[] ) => mockRecordEvent( ...args ) },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: () => ( {
+		site: { wpcom: { blog_id: 42 } },
+		user: { current_user: { wpcom: { ID: 7, login: 'reader' } } },
+	} ),
+} ) );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+/**
+ * Renders the action and opens the modal, the way every case here starts.
+ *
+ * @return The `userEvent` session, for the rest of the interaction.
+ */
+async function openModal() {
+	const user = userEvent.setup();
+	render( <FeedbackAction /> );
+	await user.click( screen.getByRole( 'button', { name: 'Any feedback?' } ) );
+	return user;
+}
+
+describe( 'FeedbackAction', () => {
+	it( 'records who is answering before the first event', async () => {
+		await openModal();
+
+		expect( mockInitialize ).toHaveBeenCalledWith( 7, 'reader' );
+	} );
+
+	it( 'reports the rating and comment as one event', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'button', { name: '4' } ) );
+		await user.type( screen.getByRole( 'textbox' ), '  Needs a date picker  ' );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			{ blog_id: 42, rating: 4, comment: 'Needs a date picker' }
+		);
+	} );
+
+	it( 'holds the submission until a rating is picked', async () => {
+		const user = await openModal();
+		const submit = screen.getByRole( 'button', { name: 'Send feedback' } );
+
+		await user.click( submit );
+
+		expect( mockRecordEvent ).not.toHaveBeenCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			expect.anything()
+		);
+
+		await user.click( screen.getByRole( 'button', { name: '1' } ) );
+		await user.click( submit );
+
+		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			{ blog_id: 42, rating: 1, comment: '' }
+		);
+	} );
+
+	it( 'sends nothing when the reader backs out', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'button', { name: '5' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( mockRecordEvent ).not.toHaveBeenCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			expect.anything()
+		);
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.tsx
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@jetpack-premium-analytics/externals';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { useTrackEvent } from '../../hooks/use-track-event';
+import { FeedbackModal } from './feedback-modal';
+
+/**
+ * Opt-in entry point for dashboard feedback, sitting beside the dashboard's own actions.
+ *
+ * It belongs in the actions menu next to Customize, but `WidgetDashboard.Actions`
+ * takes no items yet (WOOA7S-2055).
+ *
+ * @return The trigger, and the modal while it is open.
+ */
+export function FeedbackAction() {
+	const trackEvent = useTrackEvent();
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const open = useCallback( () => {
+		trackEvent( 'jetpack_premium_analytics_feedback_open' );
+		setIsOpen( true );
+	}, [ trackEvent ] );
+
+	const close = useCallback( () => setIsOpen( false ), [] );
+
+	return (
+		<>
+			<Button variant="minimal" size="compact" onClick={ open }>
+				{ __( 'Any feedback?', 'jetpack-premium-analytics-pkg' ) }
+			</Button>
+			{ isOpen && <FeedbackModal onClose={ close } /> }
+		</>
+	);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -101,7 +101,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 				<Stack direction="column" gap="lg">
 					<Notice.Root intent="success">
 						<Notice.Description>
-							{ __( 'Thank you — this helps.', 'jetpack-premium-analytics-pkg' ) }
+							{ __( 'Thank you. This helps.', 'jetpack-premium-analytics-pkg' ) }
 						</Notice.Description>
 					</Notice.Root>
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Fieldset, Stack } from '@jetpack-premium-analytics/externals';
+import { Modal, TextareaControl } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { useTrackEvent } from '../../hooks/use-track-event';
+
+const RATINGS = [ 1, 2, 3, 4, 5 ] as const;
+
+// Tracks drops an event whose properties are oversized, so a pasted essay would
+// cost us the rating too.
+const COMMENT_MAX_LENGTH = 1000;
+
+type RatingButtonProps = {
+	value: number;
+	isSelected: boolean;
+	onSelect: ( value: number ) => void;
+};
+
+/**
+ * One point on the ease-of-use scale.
+ *
+ * @param {RatingButtonProps} props            - Component props.
+ * @param {number}            props.value      - The score this button records.
+ * @param {boolean}           props.isSelected - Whether it is the current answer.
+ * @param {Function}          props.onSelect   - Called with `value` when pressed.
+ * @return The button.
+ */
+function RatingButton( { value, isSelected, onSelect }: RatingButtonProps ) {
+	const select = useCallback( () => onSelect( value ), [ onSelect, value ] );
+
+	return (
+		<Button
+			variant={ isSelected ? 'solid' : 'outline' }
+			size="compact"
+			aria-pressed={ isSelected }
+			onClick={ select }
+		>
+			{ value }
+		</Button>
+	);
+}
+
+type FeedbackModalProps = {
+	onClose: () => void;
+};
+
+/**
+ * Ease-of-use rating with an optional comment, recorded as a single Tracks event.
+ *
+ * @param {FeedbackModalProps} props         - Component props.
+ * @param {Function}           props.onClose - Called once the reader submits or dismisses.
+ * @return The modal.
+ */
+export function FeedbackModal( { onClose }: FeedbackModalProps ) {
+	const trackEvent = useTrackEvent();
+	const [ rating, setRating ] = useState< number | null >( null );
+	const [ comment, setComment ] = useState( '' );
+
+	const submit = useCallback( () => {
+		trackEvent( 'jetpack_premium_analytics_feedback_submit', {
+			rating,
+			comment: comment.trim().slice( 0, COMMENT_MAX_LENGTH ),
+		} );
+
+		onClose();
+	}, [ comment, onClose, rating, trackEvent ] );
+
+	return (
+		<Modal
+			title={ __( 'Share your feedback', 'jetpack-premium-analytics-pkg' ) }
+			onRequestClose={ onClose }
+			size="medium"
+		>
+			<Stack direction="column" gap="lg">
+				<Fieldset.Root>
+					<Fieldset.Legend>
+						{ __( 'How easy is the new Stats to use?', 'jetpack-premium-analytics-pkg' ) }
+					</Fieldset.Legend>
+					<Fieldset.Description>
+						{ __( '1 is very hard, 5 is very easy.', 'jetpack-premium-analytics-pkg' ) }
+					</Fieldset.Description>
+
+					<Stack direction="row" gap="sm">
+						{ RATINGS.map( value => (
+							<RatingButton
+								key={ value }
+								value={ value }
+								isSelected={ rating === value }
+								onSelect={ setRating }
+							/>
+						) ) }
+					</Stack>
+				</Fieldset.Root>
+
+				<TextareaControl
+					label={ __( 'What would you change?', 'jetpack-premium-analytics-pkg' ) }
+					value={ comment }
+					maxLength={ COMMENT_MAX_LENGTH }
+					onChange={ setComment }
+				/>
+
+				<Stack direction="row" gap="sm" align="end" justify="end">
+					<Button variant="minimal" size="compact" onClick={ onClose }>
+						{ __( 'Cancel', 'jetpack-premium-analytics-pkg' ) }
+					</Button>
+					<Button variant="solid" size="compact" disabled={ rating === null } onClick={ submit }>
+						{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }
+					</Button>
+				</Stack>
+			</Stack>
+		</Modal>
+	);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,149 +1,50 @@
 /**
  * WordPress dependencies
  */
-import { Button, Fieldset, Notice, Stack } from '@jetpack-premium-analytics/externals';
-import { Modal, TextareaControl } from '@wordpress/components';
-import { useCallback, useId, useState } from '@wordpress/element';
+import { Button, Notice, Stack, Text } from '@jetpack-premium-analytics/externals';
+import { Modal, RadioControl, TextareaControl } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
-/**
- * Types
- */
-import type { KeyboardEvent } from 'react';
 
-const RATINGS = [ 1, 2, 3, 4, 5 ] as const;
-
-type Rating = ( typeof RATINGS )[ number ];
+type Rating = 1 | 2 | 3 | 4 | 5;
 
 // Tracks drops an event whose properties are oversized, so a pasted essay would
 // cost us the rating too.
 const COMMENT_MAX_LENGTH = 1000;
 
-const ARROW_STEPS: Record< string, number | undefined > = {
-	ArrowLeft: -1,
-	ArrowUp: -1,
-	ArrowRight: 1,
-	ArrowDown: 1,
-};
-
 /**
- * Label for every point of the scale, so nobody has to guess what a number means.
+ * The comparison scale, worst to best. `value` is the score that reaches Tracks.
  *
- * @return The labels, keyed by rating.
+ * @return The options, in scale order.
  */
-function ratingLabels(): Record< Rating, string > {
-	return {
-		1: __( 'Much worse', 'jetpack-premium-analytics-pkg' ),
-		2: __( 'A bit worse', 'jetpack-premium-analytics-pkg' ),
-		3: __( 'About the same', 'jetpack-premium-analytics-pkg' ),
-		4: __( 'A bit better', 'jetpack-premium-analytics-pkg' ),
-		5: __( 'Much better', 'jetpack-premium-analytics-pkg' ),
-	};
+function ratingOptions() {
+	return [
+		{ value: '1', label: __( 'Much worse', 'jetpack-premium-analytics-pkg' ) },
+		{ value: '2', label: __( 'A bit worse', 'jetpack-premium-analytics-pkg' ) },
+		{ value: '3', label: __( 'About the same', 'jetpack-premium-analytics-pkg' ) },
+		{ value: '4', label: __( 'A bit better', 'jetpack-premium-analytics-pkg' ) },
+		{ value: '5', label: __( 'Much better', 'jetpack-premium-analytics-pkg' ) },
+	];
 }
 
-type RatingButtonProps = {
-	value: Rating;
-	label: string;
-	isSelected: boolean;
-	isTabStop: boolean;
-	onSelect: ( value: Rating ) => void;
-};
-
 /**
- * One point on the comparison scale.
+ * The question above a control whose own label is hidden.
  *
- * @param {RatingButtonProps} props            - Component props.
- * @param {number}            props.value      - The score this button records.
- * @param {string}            props.label      - What the score means, as the reader reads it.
- * @param {boolean}           props.isSelected - Whether it is the current answer.
- * @param {boolean}           props.isTabStop  - Whether it carries the scale's single tab stop.
- * @param {Function}          props.onSelect   - Called with `value` when pressed.
- * @return The button.
- */
-function RatingButton( { value, label, isSelected, isTabStop, onSelect }: RatingButtonProps ) {
-	const select = useCallback( () => onSelect( value ), [ onSelect, value ] );
-
-	return (
-		<Button
-			role="radio"
-			aria-checked={ isSelected }
-			tabIndex={ isTabStop ? 0 : -1 }
-			variant={ isSelected ? 'solid' : 'outline' }
-			size="compact"
-			onClick={ select }
-		>
-			{ label }
-		</Button>
-	);
-}
-
-type RatingScaleProps = {
-	labelId: string;
-	value: Rating | null;
-	onChange: ( value: Rating ) => void;
-};
-
-/**
- * The five-point scale, as a radio group rather than five toggle buttons.
+ * The control keeps the question as its accessible name, so this copy is for the
+ * eye only and stays out of the accessibility tree rather than being read twice.
+ * The label slot itself is an 11px uppercase caption, which a sentence-long
+ * question reads badly as.
  *
- * @param {RatingScaleProps} props          - Component props.
- * @param {string}           props.labelId  - Id of the element naming the group.
- * @param {number}           props.value    - The current answer, or null.
- * @param {Function}         props.onChange - Called with the newly selected score.
- * @return The scale.
+ * @param {object} props          - Component props.
+ * @param {string} props.children - The question.
+ * @return The question.
  */
-function RatingScale( { labelId, value, onChange }: RatingScaleProps ) {
-	const labels = ratingLabels();
-
-	// Arrow keys move selection and focus together, which is what a radio group owes its
-	// keyboard users; the roving tabindex keeps the whole scale to one tab stop.
-	const onKeyDown = useCallback(
-		( event: KeyboardEvent< HTMLDivElement > ) => {
-			const step = ARROW_STEPS[ event.key ];
-
-			if ( ! step ) {
-				return;
-			}
-
-			event.preventDefault();
-
-			const current = value === null ? 0 : RATINGS.indexOf( value );
-			const nextIndex = ( current + step + RATINGS.length ) % RATINGS.length;
-
-			onChange( RATINGS[ nextIndex ] );
-			event.currentTarget
-				.querySelectorAll< HTMLButtonElement >( '[role="radio"]' )
-				[ nextIndex ]?.focus();
-		},
-		[ onChange, value ]
-	);
-
-	// Stacked rather than in a row: the labels are too long to sit side by side in the modal.
-	return (
-		<Stack
-			direction="column"
-			align="stretch"
-			gap="sm"
-			role="radiogroup"
-			aria-labelledby={ labelId }
-			aria-orientation="vertical"
-			onKeyDown={ onKeyDown }
-		>
-			{ RATINGS.map( ( score, index ) => (
-				<RatingButton
-					key={ score }
-					value={ score }
-					label={ labels[ score ] }
-					isSelected={ value === score }
-					isTabStop={ value === null ? index === 0 : value === score }
-					onSelect={ onChange }
-				/>
-			) ) }
-		</Stack>
-	);
+function Question( { children }: { children: string } ) {
+	return <Text aria-hidden="true">{ children }</Text>;
 }
 
 type FeedbackModalProps = {
@@ -159,10 +60,23 @@ type FeedbackModalProps = {
  */
 export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	const trackEvent = useTrackEvent();
-	const legendId = useId();
 	const [ rating, setRating ] = useState< Rating | null >( null );
 	const [ comment, setComment ] = useState( '' );
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
+
+	const comparisonQuestion = __(
+		'Compared with the existing Traffic tab in Stats, the new Traffic tab is:',
+		'jetpack-premium-analytics-pkg'
+	);
+	const blockerQuestion = __(
+		"What's the one thing we'd need to fix before this replaces the old Stats?",
+		'jetpack-premium-analytics-pkg'
+	);
+
+	const selectRating = useCallback(
+		( value: string ) => setRating( Number( value ) as Rating ),
+		[]
+	);
 
 	const submit = useCallback( () => {
 		if ( rating === null ) {
@@ -198,27 +112,28 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 					</Stack>
 				</Stack>
 			) : (
-				<Stack direction="column" gap="lg">
-					<Fieldset.Root>
-						<Fieldset.Legend id={ legendId }>
-							{ __(
-								'Compared with the existing Traffic tab in Stats, the new Traffic tab is:',
-								'jetpack-premium-analytics-pkg'
-							) }
-						</Fieldset.Legend>
+				<Stack direction="column" gap="xl">
+					<Stack direction="column" gap="sm">
+						<Question>{ comparisonQuestion }</Question>
+						<RadioControl
+							hideLabelFromVision
+							label={ comparisonQuestion }
+							options={ ratingOptions() }
+							selected={ rating === null ? undefined : String( rating ) }
+							onChange={ selectRating }
+						/>
+					</Stack>
 
-						<RatingScale labelId={ legendId } value={ rating } onChange={ setRating } />
-					</Fieldset.Root>
-
-					<TextareaControl
-						label={ __(
-							"What's the one thing we'd need to fix before this replaces the old Stats?",
-							'jetpack-premium-analytics-pkg'
-						) }
-						value={ comment }
-						maxLength={ COMMENT_MAX_LENGTH }
-						onChange={ setComment }
-					/>
+					<Stack direction="column" gap="sm">
+						<Question>{ blockerQuestion }</Question>
+						<TextareaControl
+							hideLabelFromVision
+							label={ blockerQuestion }
+							value={ comment }
+							maxLength={ COMMENT_MAX_LENGTH }
+							onChange={ setComment }
+						/>
+					</Stack>
 
 					<Stack direction="row" gap="sm" justify="end">
 						<Button variant="minimal" size="compact" onClick={ onClose }>

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -29,24 +29,41 @@ const ARROW_STEPS: Record< string, number | undefined > = {
 	ArrowDown: 1,
 };
 
+/**
+ * Label for every point of the scale, so nobody has to guess what a number means.
+ *
+ * @return The labels, keyed by rating.
+ */
+function ratingLabels(): Record< Rating, string > {
+	return {
+		1: __( 'Much worse', 'jetpack-premium-analytics-pkg' ),
+		2: __( 'A bit worse', 'jetpack-premium-analytics-pkg' ),
+		3: __( 'About the same', 'jetpack-premium-analytics-pkg' ),
+		4: __( 'A bit better', 'jetpack-premium-analytics-pkg' ),
+		5: __( 'Much better', 'jetpack-premium-analytics-pkg' ),
+	};
+}
+
 type RatingButtonProps = {
 	value: Rating;
+	label: string;
 	isSelected: boolean;
 	isTabStop: boolean;
 	onSelect: ( value: Rating ) => void;
 };
 
 /**
- * One point on the ease-of-use scale.
+ * One point on the comparison scale.
  *
  * @param {RatingButtonProps} props            - Component props.
  * @param {number}            props.value      - The score this button records.
+ * @param {string}            props.label      - What the score means, as the reader reads it.
  * @param {boolean}           props.isSelected - Whether it is the current answer.
  * @param {boolean}           props.isTabStop  - Whether it carries the scale's single tab stop.
  * @param {Function}          props.onSelect   - Called with `value` when pressed.
  * @return The button.
  */
-function RatingButton( { value, isSelected, isTabStop, onSelect }: RatingButtonProps ) {
+function RatingButton( { value, label, isSelected, isTabStop, onSelect }: RatingButtonProps ) {
 	const select = useCallback( () => onSelect( value ), [ onSelect, value ] );
 
 	return (
@@ -58,7 +75,7 @@ function RatingButton( { value, isSelected, isTabStop, onSelect }: RatingButtonP
 			size="compact"
 			onClick={ select }
 		>
-			{ value }
+			{ label }
 		</Button>
 	);
 }
@@ -70,7 +87,7 @@ type RatingScaleProps = {
 };
 
 /**
- * The 1-5 scale, as a radio group rather than five toggle buttons.
+ * The five-point scale, as a radio group rather than five toggle buttons.
  *
  * @param {RatingScaleProps} props          - Component props.
  * @param {string}           props.labelId  - Id of the element naming the group.
@@ -79,6 +96,8 @@ type RatingScaleProps = {
  * @return The scale.
  */
 function RatingScale( { labelId, value, onChange }: RatingScaleProps ) {
+	const labels = ratingLabels();
+
 	// Arrow keys move selection and focus together, which is what a radio group owes its
 	// keyboard users; the roving tabindex keeps the whole scale to one tab stop.
 	const onKeyDown = useCallback(
@@ -102,18 +121,22 @@ function RatingScale( { labelId, value, onChange }: RatingScaleProps ) {
 		[ onChange, value ]
 	);
 
+	// Stacked rather than in a row: the labels are too long to sit side by side in the modal.
 	return (
 		<Stack
-			direction="row"
+			direction="column"
+			align="stretch"
 			gap="sm"
 			role="radiogroup"
 			aria-labelledby={ labelId }
+			aria-orientation="vertical"
 			onKeyDown={ onKeyDown }
 		>
 			{ RATINGS.map( ( score, index ) => (
 				<RatingButton
 					key={ score }
 					value={ score }
+					label={ labels[ score ] }
 					isSelected={ value === score }
 					isTabStop={ value === null ? index === 0 : value === score }
 					onSelect={ onChange }
@@ -128,7 +151,7 @@ type FeedbackModalProps = {
 };
 
 /**
- * Ease-of-use rating with an optional comment, recorded as a single Tracks event.
+ * Comparison rating with an optional comment, recorded as a single Tracks event.
  *
  * @param {FeedbackModalProps} props         - Component props.
  * @param {Function}           props.onClose - Called once the reader dismisses the modal.
@@ -178,17 +201,20 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 				<Stack direction="column" gap="lg">
 					<Fieldset.Root>
 						<Fieldset.Legend id={ legendId }>
-							{ __( 'How easy is the new Stats to use?', 'jetpack-premium-analytics-pkg' ) }
+							{ __(
+								'Compared with the existing Traffic tab in Stats, the new Traffic tab is:',
+								'jetpack-premium-analytics-pkg'
+							) }
 						</Fieldset.Legend>
-						<Fieldset.Description>
-							{ __( '1 is very hard, 5 is very easy.', 'jetpack-premium-analytics-pkg' ) }
-						</Fieldset.Description>
 
 						<RatingScale labelId={ legendId } value={ rating } onChange={ setRating } />
 					</Fieldset.Root>
 
 					<TextareaControl
-						label={ __( 'What would you change?', 'jetpack-premium-analytics-pkg' ) }
+						label={ __(
+							"What's the one thing we'd need to fix before this replaces the old Stats?",
+							'jetpack-premium-analytics-pkg'
+						) }
 						value={ comment }
 						maxLength={ COMMENT_MAX_LENGTH }
 						onChange={ setComment }

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,25 +1,39 @@
 /**
  * WordPress dependencies
  */
-import { Button, Fieldset, Stack } from '@jetpack-premium-analytics/externals';
+import { Button, Fieldset, Notice, Stack } from '@jetpack-premium-analytics/externals';
 import { Modal, TextareaControl } from '@wordpress/components';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useId, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
+/**
+ * Types
+ */
+import type { KeyboardEvent } from 'react';
 
 const RATINGS = [ 1, 2, 3, 4, 5 ] as const;
+
+type Rating = ( typeof RATINGS )[ number ];
 
 // Tracks drops an event whose properties are oversized, so a pasted essay would
 // cost us the rating too.
 const COMMENT_MAX_LENGTH = 1000;
 
+const ARROW_STEPS: Record< string, number | undefined > = {
+	ArrowLeft: -1,
+	ArrowUp: -1,
+	ArrowRight: 1,
+	ArrowDown: 1,
+};
+
 type RatingButtonProps = {
-	value: number;
+	value: Rating;
 	isSelected: boolean;
-	onSelect: ( value: number ) => void;
+	isTabStop: boolean;
+	onSelect: ( value: Rating ) => void;
 };
 
 /**
@@ -28,21 +42,84 @@ type RatingButtonProps = {
  * @param {RatingButtonProps} props            - Component props.
  * @param {number}            props.value      - The score this button records.
  * @param {boolean}           props.isSelected - Whether it is the current answer.
+ * @param {boolean}           props.isTabStop  - Whether it carries the scale's single tab stop.
  * @param {Function}          props.onSelect   - Called with `value` when pressed.
  * @return The button.
  */
-function RatingButton( { value, isSelected, onSelect }: RatingButtonProps ) {
+function RatingButton( { value, isSelected, isTabStop, onSelect }: RatingButtonProps ) {
 	const select = useCallback( () => onSelect( value ), [ onSelect, value ] );
 
 	return (
 		<Button
+			role="radio"
+			aria-checked={ isSelected }
+			tabIndex={ isTabStop ? 0 : -1 }
 			variant={ isSelected ? 'solid' : 'outline' }
 			size="compact"
-			aria-pressed={ isSelected }
 			onClick={ select }
 		>
 			{ value }
 		</Button>
+	);
+}
+
+type RatingScaleProps = {
+	labelId: string;
+	value: Rating | null;
+	onChange: ( value: Rating ) => void;
+};
+
+/**
+ * The 1-5 scale, as a radio group rather than five toggle buttons.
+ *
+ * @param {RatingScaleProps} props          - Component props.
+ * @param {string}           props.labelId  - Id of the element naming the group.
+ * @param {number}           props.value    - The current answer, or null.
+ * @param {Function}         props.onChange - Called with the newly selected score.
+ * @return The scale.
+ */
+function RatingScale( { labelId, value, onChange }: RatingScaleProps ) {
+	// Arrow keys move selection and focus together, which is what a radio group owes its
+	// keyboard users; the roving tabindex keeps the whole scale to one tab stop.
+	const onKeyDown = useCallback(
+		( event: KeyboardEvent< HTMLDivElement > ) => {
+			const step = ARROW_STEPS[ event.key ];
+
+			if ( ! step ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			const current = value === null ? 0 : RATINGS.indexOf( value );
+			const nextIndex = ( current + step + RATINGS.length ) % RATINGS.length;
+
+			onChange( RATINGS[ nextIndex ] );
+			event.currentTarget
+				.querySelectorAll< HTMLButtonElement >( '[role="radio"]' )
+				[ nextIndex ]?.focus();
+		},
+		[ onChange, value ]
+	);
+
+	return (
+		<Stack
+			direction="row"
+			gap="sm"
+			role="radiogroup"
+			aria-labelledby={ labelId }
+			onKeyDown={ onKeyDown }
+		>
+			{ RATINGS.map( ( score, index ) => (
+				<RatingButton
+					key={ score }
+					value={ score }
+					isSelected={ value === score }
+					isTabStop={ value === null ? index === 0 : value === score }
+					onSelect={ onChange }
+				/>
+			) ) }
+		</Stack>
 	);
 }
 
@@ -54,22 +131,28 @@ type FeedbackModalProps = {
  * Ease-of-use rating with an optional comment, recorded as a single Tracks event.
  *
  * @param {FeedbackModalProps} props         - Component props.
- * @param {Function}           props.onClose - Called once the reader submits or dismisses.
+ * @param {Function}           props.onClose - Called once the reader dismisses the modal.
  * @return The modal.
  */
 export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	const trackEvent = useTrackEvent();
-	const [ rating, setRating ] = useState< number | null >( null );
+	const legendId = useId();
+	const [ rating, setRating ] = useState< Rating | null >( null );
 	const [ comment, setComment ] = useState( '' );
+	const [ hasSubmitted, setHasSubmitted ] = useState( false );
 
 	const submit = useCallback( () => {
+		if ( rating === null ) {
+			return;
+		}
+
 		trackEvent( 'jetpack_premium_analytics_feedback_submit', {
 			rating,
-			comment: comment.trim().slice( 0, COMMENT_MAX_LENGTH ),
+			comment: comment.trim(),
 		} );
 
-		onClose();
-	}, [ comment, onClose, rating, trackEvent ] );
+		setHasSubmitted( true );
+	}, [ comment, rating, trackEvent ] );
 
 	return (
 		<Modal
@@ -77,43 +160,50 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 			onRequestClose={ onClose }
 			size="medium"
 		>
-			<Stack direction="column" gap="lg">
-				<Fieldset.Root>
-					<Fieldset.Legend>
-						{ __( 'How easy is the new Stats to use?', 'jetpack-premium-analytics-pkg' ) }
-					</Fieldset.Legend>
-					<Fieldset.Description>
-						{ __( '1 is very hard, 5 is very easy.', 'jetpack-premium-analytics-pkg' ) }
-					</Fieldset.Description>
+			{ hasSubmitted ? (
+				<Stack direction="column" gap="lg">
+					<Notice.Root intent="success">
+						<Notice.Description>
+							{ __( 'Thanks — your feedback is on its way.', 'jetpack-premium-analytics-pkg' ) }
+						</Notice.Description>
+					</Notice.Root>
 
-					<Stack direction="row" gap="sm">
-						{ RATINGS.map( value => (
-							<RatingButton
-								key={ value }
-								value={ value }
-								isSelected={ rating === value }
-								onSelect={ setRating }
-							/>
-						) ) }
+					<Stack direction="row" gap="sm" justify="end">
+						<Button variant="solid" size="compact" onClick={ onClose }>
+							{ __( 'Done', 'jetpack-premium-analytics-pkg' ) }
+						</Button>
 					</Stack>
-				</Fieldset.Root>
-
-				<TextareaControl
-					label={ __( 'What would you change?', 'jetpack-premium-analytics-pkg' ) }
-					value={ comment }
-					maxLength={ COMMENT_MAX_LENGTH }
-					onChange={ setComment }
-				/>
-
-				<Stack direction="row" gap="sm" align="end" justify="end">
-					<Button variant="minimal" size="compact" onClick={ onClose }>
-						{ __( 'Cancel', 'jetpack-premium-analytics-pkg' ) }
-					</Button>
-					<Button variant="solid" size="compact" disabled={ rating === null } onClick={ submit }>
-						{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }
-					</Button>
 				</Stack>
-			</Stack>
+			) : (
+				<Stack direction="column" gap="lg">
+					<Fieldset.Root>
+						<Fieldset.Legend id={ legendId }>
+							{ __( 'How easy is the new Stats to use?', 'jetpack-premium-analytics-pkg' ) }
+						</Fieldset.Legend>
+						<Fieldset.Description>
+							{ __( '1 is very hard, 5 is very easy.', 'jetpack-premium-analytics-pkg' ) }
+						</Fieldset.Description>
+
+						<RatingScale labelId={ legendId } value={ rating } onChange={ setRating } />
+					</Fieldset.Root>
+
+					<TextareaControl
+						label={ __( 'What would you change?', 'jetpack-premium-analytics-pkg' ) }
+						value={ comment }
+						maxLength={ COMMENT_MAX_LENGTH }
+						onChange={ setComment }
+					/>
+
+					<Stack direction="row" gap="sm" justify="end">
+						<Button variant="minimal" size="compact" onClick={ onClose }>
+							{ __( 'Cancel', 'jetpack-premium-analytics-pkg' ) }
+						</Button>
+						<Button variant="solid" size="compact" disabled={ rating === null } onClick={ submit }>
+							{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }
+						</Button>
+					</Stack>
+				</Stack>
+			) }
 		</Modal>
 	);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -101,7 +101,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 				<Stack direction="column" gap="lg">
 					<Notice.Root intent="success">
 						<Notice.Description>
-							{ __( 'Thanks — your feedback is on its way.', 'jetpack-premium-analytics-pkg' ) }
+							{ __( 'Thank you — this helps.', 'jetpack-premium-analytics-pkg' ) }
 						</Notice.Description>
 					</Notice.Root>
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/index.ts
@@ -1,3 +1,4 @@
 export { DashboardSections } from './dashboard-sections/dashboard-sections';
+export { FeedbackAction } from './feedback/feedback-action';
 export { RefreshFailureNotice } from './refresh-failure-notice/refresh-failure-notice';
 export { SectionSyncNotice } from './section-sync-notice/section-sync-notice';

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-track-event.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-track-event.ts
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { useCallback } from '@wordpress/element';
+
+// The tracker is a module singleton, so identify it once per identity rather than
+// on every consumer's mount.
+let identifiedFor: string | null = null;
+
+/**
+ * Attaches the connected WPCOM identity to the tracker, at most once per identity.
+ */
+function identifyOnce() {
+	const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
+
+	if ( ! wpcomUser?.ID || ! wpcomUser?.login ) {
+		return;
+	}
+
+	const key = `${ wpcomUser.ID }:${ wpcomUser.login }`;
+
+	if ( identifiedFor === key ) {
+		return;
+	}
+
+	jetpackAnalytics.initialize( wpcomUser.ID, wpcomUser.login );
+	identifiedFor = key;
+}
+
+/**
+ * Returns a stable callback for emitting `jetpack_premium_analytics_*` Tracks events,
+ * matching the wrapper Scan and Activity Log use over `@automattic/jetpack-analytics`.
+ *
+ * Events still fire before the WPCOM identity resolves; identifying only fills in
+ * who they belong to.
+ *
+ * @return Callback recording a Tracks event by name, with optional properties.
+ */
+export function useTrackEvent() {
+	return useCallback( ( eventName: string, properties?: Record< string, unknown > ) => {
+		identifyOnce();
+
+		const blogId = getScriptData()?.site?.wpcom?.blog_id;
+
+		jetpackAnalytics.tracks.recordEvent( eventName, {
+			...( blogId ? { blog_id: blogId } : {} ),
+			...properties,
+		} );
+	}, [] );
+}

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-track-event.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-track-event.ts
@@ -5,36 +5,48 @@ import jetpackAnalytics from '@automattic/jetpack-analytics';
 import { getScriptData } from '@automattic/jetpack-script-data';
 import { useCallback } from '@wordpress/element';
 
-// The tracker is a module singleton, so identify it once per identity rather than
-// on every consumer's mount.
-let identifiedFor: string | null = null;
+// The tracker is a page-wide singleton: identify once per page load, not per event
+// and not on every consumer's mount.
+let hasIdentified = false;
 
 /**
- * Attaches the connected WPCOM identity to the tracker, at most once per identity.
+ * Reset the identify latch. Test-only.
+ *
+ * Module state outlives a render/unmount cycle by design, which is the point of the latch,
+ * but it would otherwise leave every test after the first observing nothing.
  */
-function identifyOnce() {
-	const wpcomUser = getScriptData()?.user?.current_user?.wpcom;
-
-	if ( ! wpcomUser?.ID || ! wpcomUser?.login ) {
-		return;
-	}
-
-	const key = `${ wpcomUser.ID }:${ wpcomUser.login }`;
-
-	if ( identifiedFor === key ) {
-		return;
-	}
-
-	jetpackAnalytics.initialize( wpcomUser.ID, wpcomUser.login );
-	identifiedFor = key;
+export function resetTracksIdentityForTesting() {
+	hasIdentified = false;
 }
 
 /**
- * Returns a stable callback for emitting `jetpack_premium_analytics_*` Tracks events,
- * matching the wrapper Scan and Activity Log use over `@automattic/jetpack-analytics`.
- *
- * Events still fire before the WPCOM identity resolves; identifying only fills in
- * who they belong to.
+ * Identify the reader and pin `blog_id` onto every event from this page load.
+ */
+function identifyOnce() {
+	if ( hasIdentified ) {
+		return;
+	}
+	hasIdentified = true;
+
+	const scriptData = getScriptData();
+	const wpcomUser = scriptData?.user?.current_user?.wpcom;
+
+	// Not `initialize()`: it routes through `setSuperProps`, which replaces rather than
+	// merges, so it would wipe whatever another consumer on this page already pinned.
+	if ( wpcomUser?.ID && wpcomUser?.login ) {
+		jetpackAnalytics.setUser( wpcomUser.ID, wpcomUser.login );
+		jetpackAnalytics.identifyUser();
+	}
+
+	const blogId = scriptData?.site?.wpcom?.blog_id;
+
+	if ( blogId ) {
+		jetpackAnalytics.assignSuperProps( { blog_id: blogId } );
+	}
+}
+
+/**
+ * Returns a stable callback for emitting `jetpack_premium_analytics_*` Tracks events.
  *
  * @return Callback recording a Tracks event by name, with optional properties.
  */
@@ -42,11 +54,6 @@ export function useTrackEvent() {
 	return useCallback( ( eventName: string, properties?: Record< string, unknown > ) => {
 		identifyOnce();
 
-		const blogId = getScriptData()?.site?.wpcom?.blog_id;
-
-		jetpackAnalytics.tracks.recordEvent( eventName, {
-			...( blogId ? { blog_id: blogId } : {} ),
-			...properties,
-		} );
+		jetpackAnalytics.tracks.recordEvent( eventName, properties );
 	}, [] );
 }

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -6,6 +6,7 @@
 		"page": "jetpack-premium-analytics"
 	},
 	"dependencies": {
+		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/datetime": "workspace:*",

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -64,7 +64,12 @@ jest.mock( '@jetpack-premium-analytics/ui', () => ( {
 } ) );
 
 jest.mock( '@wordpress/admin-ui', () => ( {
-	Page: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	Page: ( { actions, children }: { actions?: ReactNode; children: ReactNode } ) => (
+		<div>
+			<div data-testid="page-actions">{ actions }</div>
+			{ children }
+		</div>
+	),
 } ) );
 
 jest.mock( '@wordpress/components', () => ( {
@@ -103,7 +108,7 @@ function MockScopeProbe() {
 
 jest.mock( '@wordpress/widget-dashboard', () => {
 	const WidgetDashboard = ( { children }: { children: ReactNode } ) => <div>{ children }</div>;
-	WidgetDashboard.Actions = () => null;
+	WidgetDashboard.Actions = () => <div data-testid="widget-dashboard-actions" />;
 	WidgetDashboard.NoWidgetsState = () => null;
 	WidgetDashboard.Widgets = () => <MockScopeProbe />;
 	WidgetDashboard.Commands = () => null;
@@ -113,7 +118,7 @@ jest.mock( '@wordpress/widget-dashboard', () => {
 
 jest.mock( './components', () => ( {
 	DashboardSections: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
-	FeedbackAction: () => null,
+	FeedbackAction: () => <div data-testid="feedback-action" />,
 	// A marker, not the real notice, which reads a query cache these tests do not
 	// stand up. Covered here: where the stage puts it.
 	RefreshFailureNotice: ( { className }: { className?: string } ) => (
@@ -291,6 +296,24 @@ describe( 'Dashboard refresh-failure notice', () => {
 		expect( notices[ 0 ].previousElementSibling ).toContainElement(
 			screen.getByText( 'header offers comparison' )
 		);
+	} );
+} );
+
+describe( 'Dashboard feedback action', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useActiveSectionMock.mockReturnValue( [ 'traffic', jest.fn() ] );
+		mockActiveSectionSlug = 'traffic';
+		useSectionDateFilterMock.mockReturnValue( DATE_FILTER_RANGE );
+	} );
+
+	it( "sits in the page actions, ahead of the dashboard's own", () => {
+		render( <Dashboard /> );
+
+		const feedback = screen.getByTestId( 'feedback-action' );
+
+		// eslint-disable-next-line testing-library/no-node-access -- order within the actions slot is what this test is for.
+		expect( feedback.nextElementSibling ).toBe( screen.getByTestId( 'widget-dashboard-actions' ) );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -308,6 +308,8 @@ describe( 'Dashboard feedback action', () => {
 	} );
 
 	it( "sits in the page actions, ahead of the dashboard's own", () => {
+		mockSection( { slug: 'traffic', date_filter: DATE_FILTER_RANGE } );
+
 		render( <Dashboard /> );
 
 		const feedback = screen.getByTestId( 'feedback-action' );

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -113,6 +113,7 @@ jest.mock( '@wordpress/widget-dashboard', () => {
 
 jest.mock( './components', () => ( {
 	DashboardSections: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	FeedbackAction: () => null,
 	// A marker, not the real notice, which reads a query cache these tests do not
 	// stand up. Covered here: where the stage puts it.
 	RefreshFailureNotice: ( { className }: { className?: string } ) => (

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -24,7 +24,12 @@ import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { isPremiumAnalyticsInitialSyncFinished } from '../site-readiness';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
-import { DashboardSections, RefreshFailureNotice, SectionSyncNotice } from './components';
+import {
+	DashboardSections,
+	FeedbackAction,
+	RefreshFailureNotice,
+	SectionSyncNotice,
+} from './components';
 import {
 	DATE_FILTER_YEAR,
 	isSectionAwaitingSync,
@@ -220,7 +225,12 @@ function Dashboard(): JSX.Element {
 					<Page
 						visual={ <StatsPageIcon /> }
 						breadcrumbs={ <StatsBreadcrumbs isRoot /> }
-						actions={ <WidgetDashboard.Actions /> }
+						actions={
+							<>
+								<FeedbackAction />
+								<WidgetDashboard.Actions />
+							</>
+						}
 						className={ styles.dashboard }
 					>
 						<DashboardSections

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -7,11 +7,13 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\PremiumAnalytics\Reports\Export\Export;
 use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
 use Automattic\Jetpack\PremiumAnalytics\REST\Notices_Controller;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Configuration as Sync_Configuration;
 use Automattic\Jetpack\PremiumAnalytics\Sync\Sync_Status_Tracker;
+use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 /**
@@ -429,6 +431,8 @@ class Analytics {
 			);
 
 			add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_i18n_loader' ) );
+			add_action( 'admin_enqueue_scripts', array( static::class, 'enqueue_tracks_transport' ) );
+			add_filter( 'jetpack_admin_js_script_data', array( static::class, 'add_tracks_identity_script_data' ), 20 );
 		}
 
 		add_action( 'admin_menu', array( static::class, 'register_admin_menu' ) );
@@ -564,5 +568,57 @@ class Analytics {
 		if ( wp_script_is( 'wp-jp-i18n-loader', 'registered' ) ) {
 			wp_enqueue_script( 'wp-jp-i18n-loader' );
 		}
+	}
+
+	/**
+	 * Load the Tracks transport for the dashboard.
+	 *
+	 * `@automattic/jetpack-analytics` only queues events into `window._tkq` — its own w.js
+	 * loader is disabled — so without this handle no `jetpack_premium_analytics_*` event
+	 * ever flushes. Mirrors Activity Log's `enqueue_initial_state()`.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_tracks_transport() {
+		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+	}
+
+	/**
+	 * Publish the WPCOM identity the dashboard attributes its Tracks events to.
+	 *
+	 * Core's script data carries only the local user. Publicize is the one package that fills
+	 * `current_user.wpcom` in, and the standalone plugin does not bundle it, so without this
+	 * every event would land anonymous there.
+	 *
+	 * @param array $data The script data.
+	 * @return array The script data with the WPCOM identity added.
+	 */
+	public static function add_tracks_identity_script_data( $data ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			$wpcom_user = array(
+				'ID'    => get_current_user_id(),
+				'login' => wp_get_current_user()->user_login,
+			);
+		} else {
+			$connected = ( new Connection_Manager() )->get_connected_user_data();
+
+			if ( empty( $connected['ID'] ) || empty( $connected['login'] ) ) {
+				return $data;
+			}
+
+			// Only the two fields `identifyUser` needs: the rest of the connected-user payload
+			// is profile data the dashboard never reads.
+			$wpcom_user = array(
+				'ID'    => $connected['ID'],
+				'login' => $connected['login'],
+			);
+		}
+
+		$data['user']['current_user']['wpcom'] = array_merge(
+			$data['user']['current_user']['wpcom'] ?? array(),
+			$wpcom_user
+		);
+
+		return $data;
 	}
 }

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -575,11 +575,15 @@ class Analytics {
 	 *
 	 * `@automattic/jetpack-analytics` only queues events into `window._tkq` — its own w.js
 	 * loader is disabled — so without this handle no `jetpack_premium_analytics_*` event
-	 * ever flushes. Mirrors Activity Log's `enqueue_initial_state()`.
+	 * ever flushes. Simple is skipped because stats.php already prints the same script.
 	 *
 	 * @return void
 	 */
 	public static function enqueue_tracks_transport() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
 		wp_enqueue_script( 'jp-tracks', '//stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 	}
 

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -1056,4 +1056,26 @@ class Analytics_Test extends TestCase {
 			'Simple still publishes the VideoPress availability flag.'
 		);
 	}
+	/**
+	 * Without the Tracks transport the dashboard's `@automattic/jetpack-analytics` events
+	 * only pile up in `window._tkq`, so every feedback submission is silently lost.
+	 */
+	public function test_dashboard_enqueues_the_tracks_transport() {
+		Analytics::enqueue_tracks_transport();
+
+		$this->assertTrue( wp_script_is( 'jp-tracks', 'enqueued' ) );
+
+		wp_dequeue_script( 'jp-tracks' );
+		wp_deregister_script( 'jp-tracks' );
+	}
+
+	/**
+	 * The identity filter has to survive a site with no connected user: the dashboard
+	 * still records events there, just anonymously.
+	 */
+	public function test_tracks_identity_is_left_alone_without_a_connected_user() {
+		$data = array( 'user' => array( 'current_user' => array( 'id' => 1 ) ) );
+
+		$this->assertSame( $data, Analytics::add_tracks_identity_script_data( $data ) );
+	}
 }

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -967,7 +967,7 @@ class Analytics_Test extends TestCase {
 
 	/**
 	 * A front-end request registers none of the admin render surface: no menu, no widget
-	 * import map, no CSV export script data.
+	 * import map, no CSV export script data, and no Tracks plumbing.
 	 *
 	 * Isolated because widget-modules.php and csv-exports.php register these filters at file
 	 * scope via require_once, so an earlier test that loaded them would leave them registered
@@ -1007,6 +1007,14 @@ class Analytics_Test extends TestCase {
 				__NAMESPACE__ . '\\inject_videopress_script_data'
 			),
 			'The VideoPress availability flag is not wired on a front-end request.'
+		);
+		$this->assertFalse(
+			has_action( 'admin_enqueue_scripts', array( Analytics::class, 'enqueue_tracks_transport' ) ),
+			'The Tracks transport is not enqueued on a front-end request.'
+		);
+		$this->assertFalse(
+			has_filter( 'jetpack_admin_js_script_data', array( Analytics::class, 'add_tracks_identity_script_data' ) ),
+			'The Tracks identity is not published on a front-end request.'
 		);
 	}
 
@@ -1070,6 +1078,37 @@ class Analytics_Test extends TestCase {
 				__NAMESPACE__ . '\\inject_videopress_script_data'
 			),
 			'Simple still publishes the VideoPress availability flag.'
+		);
+	}
+
+	/**
+	 * Both halves of the Tracks plumbing hang off the dashboard request. The identity filter
+	 * runs at 20 so it merges onto the `current_user` the connection publishes at 10.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_dashboard_request_wires_the_tracks_hooks() {
+		$this->use_fixture_build();
+		$_GET['page'] = self::MENU_SLUG;
+		set_current_screen( self::MENU_HOOKNAME );
+
+		Analytics::init();
+		do_action( 'init' );
+
+		$this->assertNotFalse(
+			has_action( 'admin_enqueue_scripts', array( Analytics::class, 'enqueue_tracks_transport' ) ),
+			'The dashboard enqueues the Tracks transport.'
+		);
+		$this->assertSame(
+			20,
+			has_filter(
+				'jetpack_admin_js_script_data',
+				array( Analytics::class, 'add_tracks_identity_script_data' )
+			),
+			'The Tracks identity is published after the connection fills current_user in.'
 		);
 	}
 

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -81,9 +82,24 @@ class Analytics_Test extends TestCase {
 		remove_all_filters( 'jetpack_stats_post_list_column_url' );
 		remove_all_filters( 'rest_post_dispatch' );
 		remove_all_filters( 'jetpack_stats_transient_cleanup_prefixes' );
+		Constants::clear_constants();
+		$this->reset_tracks_identity_state();
 		Capabilities::unregister();
 		$this->reset_analytics_init_state();
 		parent::tearDown();
+	}
+
+	/**
+	 * Drop the connected-user fixtures the Tracks identity tests set up.
+	 */
+	private function reset_tracks_identity_state() {
+		$user_id = get_current_user_id();
+
+		if ( $user_id ) {
+			delete_transient( "jetpack_connected_user_data_$user_id" );
+			\Jetpack_Options::delete_option( 'user_tokens' );
+			wp_set_current_user( 0 );
+		}
 	}
 
 	/**
@@ -1056,6 +1072,7 @@ class Analytics_Test extends TestCase {
 			'Simple still publishes the VideoPress availability flag.'
 		);
 	}
+
 	/**
 	 * Without the Tracks transport the dashboard's `@automattic/jetpack-analytics` events
 	 * only pile up in `window._tkq`, so every feedback submission is silently lost.
@@ -1077,5 +1094,71 @@ class Analytics_Test extends TestCase {
 		$data = array( 'user' => array( 'current_user' => array( 'id' => 1 ) ) );
 
 		$this->assertSame( $data, Analytics::add_tracks_identity_script_data( $data ) );
+	}
+
+	/**
+	 * On Simple the local user is the WPCOM user, so no connection lookup is involved.
+	 */
+	public function test_tracks_identity_names_the_local_user_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$user_id = self::sign_in_as( 'simple-user' );
+
+		$data = Analytics::add_tracks_identity_script_data( array( 'user' => array( 'current_user' => array() ) ) );
+
+		$this->assertSame(
+			array(
+				'ID'    => $user_id,
+				'login' => 'simple-user',
+			),
+			$data['user']['current_user']['wpcom']
+		);
+	}
+
+	/**
+	 * Off Simple the identity comes from the connection, and carries only the two fields
+	 * `identifyUser` needs: the rest of the connected-user payload is profile data.
+	 */
+	public function test_tracks_identity_names_the_connected_user_elsewhere() {
+		$user_id = self::sign_in_as( 'local-user' );
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => "dummy.usertoken.$user_id" ) );
+		set_transient(
+			"jetpack_connected_user_data_$user_id",
+			array(
+				'ID'    => 777,
+				'login' => 'wpcomuser',
+				'email' => 'wpcomuser@example.com',
+			)
+		);
+
+		$data = Analytics::add_tracks_identity_script_data(
+			array( 'user' => array( 'current_user' => array( 'wpcom' => array( 'colorScheme' => 'default' ) ) ) )
+		);
+
+		$this->assertSame(
+			array(
+				'colorScheme' => 'default',
+				'ID'          => 777,
+				'login'       => 'wpcomuser',
+			),
+			$data['user']['current_user']['wpcom']
+		);
+	}
+
+	/**
+	 * Create a user and make it the current one.
+	 *
+	 * @param string $login User login.
+	 * @return int The new user's ID.
+	 */
+	private static function sign_in_as( $login ) {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => $login,
+				'user_pass'  => 'password',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		return $user_id;
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -1126,6 +1126,18 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
+	 * On Simple stats.php already prints w.js on every wp-admin page, so enqueueing it
+	 * here would only repeat the request.
+	 */
+	public function test_wpcom_simple_skips_the_tracks_transport() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Analytics::enqueue_tracks_transport();
+
+		$this->assertFalse( wp_script_is( 'jp-tracks', 'enqueued' ) );
+	}
+
+	/**
 	 * The identity filter has to survive a site with no connected user: the dashboard
 	 * still records events there, just anonymously.
 	 */

--- a/projects/plugins/jetpack/changelog/stats-v2-feedback-action
+++ b/projects/plugins/jetpack/changelog/stats-v2-feedback-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Add an "Any feedback?" action to the dashboard header.

--- a/projects/plugins/premium-analytics/changelog/stats-v2-feedback-action
+++ b/projects/plugins/premium-analytics/changelog/stats-v2-feedback-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an "Any feedback?" action to the dashboard header.

--- a/projects/plugins/wpcomsh/changelog/stats-v2-feedback-action
+++ b/projects/plugins/wpcomsh/changelog/stats-v2-feedback-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: Add an "Any feedback?" action to the dashboard header.


### PR DESCRIPTION
Fixes STATS-460

## Proposed changes

* Add an "Any feedback?" action to the Premium Analytics dashboard header: a five-point comparison against the existing Traffic tab, plus an optional comment.
* Report the answer as a single `jetpack_premium_analytics_feedback_submit` Tracks event, with `jetpack_premium_analytics_feedback_open` when the modal is opened.
* Add a `useTrackEvent` hook over `@automattic/jetpack-analytics`, identified from `getScriptData()` once per page load.
* Enqueue `jp-tracks` on the dashboard and publish the WPCOM identity in script data, so those events actually reach Tracks rather than queueing in `window._tkq`.
* Present the scale as a radio group with every point labelled, and confirm the send in the modal instead of closing it.

Separately, this makes a fifth near-copy of the same identify-once wrapper (Scan, Activity Log, Backup and Podcast each have one). Consolidating them into `@automattic/jetpack-analytics` is a follow-up, not this PR.

## Related product discussion/links

* STATS-460
* WOOA7S-2055

## Does this pull request change what data or activity we track or use?

Yes. Two new Tracks events, both fired only when someone opens the feedback action themselves:

* `jetpack_premium_analytics_feedback_open`: `blog_id`
* `jetpack_premium_analytics_feedback_submit`: `blog_id`, `rating` (1-5, where 1 is much worse than the existing Traffic tab and 5 much better), `comment` (the reader's own words, trimmed, capped at 1000 characters)

`blog_id` is pinned once as a Tracks super prop rather than added per event, so it rides on both. The dashboard also identifies the connected WPCOM user, which it could not do before: `current_user.wpcom` is filled in by Publicize alone, and the standalone plugin does not bundle it.

The pixel serialises every property, so `rating` lands in Tracks as the string `"4"` rather than a number. Neither event is registered in the Tracks event directory; that only adds a description and owner there, and does not gate collection.

## Testing instructions

1. Build the branch (`jetpack build --deps plugins/premium-analytics`) onto a Jetpack-connected site and open the Premium Analytics dashboard in wp-admin.
2. Open the browser network panel and filter it on `pixel.wp.com`. This is the check that matters: the events are sent by pushing onto `window._tkq`, which succeeds whether or not anything is flushing that queue.
3. Click **Any feedback?** in the page header. The modal opens with the labelled comparison scale and the comment box, and one request goes out with `_en=jetpack_premium_analytics_feedback_open`.
4. Tab to the scale. It takes a single tab stop, and the arrow keys move the answer.
5. Click **Send feedback** without picking a rating. Nothing happens.
6. Pick a rating, type a comment, and click **Send feedback**. The modal confirms the send rather than closing, and a second request goes out with `_en=jetpack_premium_analytics_feedback_submit`, the rating and comment as properties, and `_ui` / `_ul` naming the connected WPCOM user.
7. Click **Done**, reopen the modal, pick a rating, and click **Cancel**. No further request goes out.

Two optional checks:

* `localStorage.setItem( 'debug', 'dops:analytics' )`, then reload, prints each event and its properties to the console. It only proves we called `recordEvent`, so it is a complement to step 2 rather than a substitute.
* A few minutes after step 6, the events are queryable through the `tracks` MCP provider (`user-activity`, filtered on `jetpack_premium_analytics_%`).



https://github.com/user-attachments/assets/e1a6bc6e-4e1f-4b8f-af2a-c5542ea7b439



