### PR TITLE
WOOA7S-2032: Premium Analytics: display the dashboard on a three-column grid and rearrange the Traffic defaults

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2032-three-column-layout
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2032-three-column-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Display the dashboard on a three-column grid and rearrange the default Traffic widgets.

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { ROW_HEIGHT_PRESETS, WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
+import { ROW_HEIGHT_PRESETS } from '@wordpress/widget-dashboard';
 import { DASHBOARD_GRID_SETTINGS_KEY, DASHBOARD_PREFERENCES_SCOPE } from '../constants';
 import { useDashboardGridSettings } from './use-dashboard-grid-settings';
 
@@ -14,7 +14,7 @@ describe( 'useDashboardGridSettings', () => {
 		);
 	} );
 
-	it( 'pins the column count whatever the stored preference says', () => {
+	it( 'pins the count to three columns whatever the stored preference says', () => {
 		dispatch( preferencesStore ).set( DASHBOARD_PREFERENCES_SCOPE, DASHBOARD_GRID_SETTINGS_KEY, {
 			model: 'grid',
 			rowHeight: ROW_HEIGHT_PRESETS.medium,
@@ -24,12 +24,12 @@ describe( 'useDashboardGridSettings', () => {
 		const { result } = renderHook( () => useDashboardGridSettings() );
 
 		expect( result.current[ 0 ] ).toMatchObject( {
-			columns: WIDGET_DASHBOARD_COLUMN_COUNT,
+			columns: 3,
 			rowHeight: ROW_HEIGHT_PRESETS.medium,
 		} );
 	} );
 
-	it( 'keeps the pinned count after a write', () => {
+	it( 'keeps three columns after a write', () => {
 		const { result } = renderHook( () => useDashboardGridSettings() );
 
 		act( () =>
@@ -37,7 +37,7 @@ describe( 'useDashboardGridSettings', () => {
 		);
 
 		expect( result.current[ 0 ] ).toMatchObject( {
-			columns: WIDGET_DASHBOARD_COLUMN_COUNT,
+			columns: 3,
 			rowHeight: ROW_HEIGHT_PRESETS.large,
 		} );
 	} );

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -6,7 +6,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import {
 	DEFAULT_GRID,
 	ROW_HEIGHT_PRESETS,
-	WIDGET_DASHBOARD_COLUMN_COUNT,
 	normalizeGridSettings,
 } from '@wordpress/widget-dashboard';
 import fastDeepEqual from 'fast-deep-equal/es6/index.js';
@@ -20,10 +19,20 @@ import type { WidgetGridSettings } from '@wordpress/widget-dashboard';
  * and only this small default is persisted as a cleared preference.
  */
 const PA_DEFAULT_ROW_HEIGHT = ROW_HEIGHT_PRESETS.small;
+
+/**
+ * The analytics dashboards are designed on three columns, one fewer than the
+ * package default.
+ */
+const PA_COLUMN_COUNT = 3;
 // DEFAULT_GRID is the 2D grid model, so it carries `rowHeight`; keep the spread
 // unannotated so the override type-checks against the grid variant rather than
 // the `rowHeight`-less masonry member of the settings union.
-const PA_DEFAULT_GRID = { ...DEFAULT_GRID, rowHeight: PA_DEFAULT_ROW_HEIGHT };
+const PA_DEFAULT_GRID = {
+	...DEFAULT_GRID,
+	columns: PA_COLUMN_COUNT,
+	rowHeight: PA_DEFAULT_ROW_HEIGHT,
+};
 
 /**
  * Hook for managing dashboard grid-settings preferences.
@@ -50,9 +59,9 @@ export function useDashboardGridSettings(): [
 		 ).get( DASHBOARD_PREFERENCES_SCOPE, DASHBOARD_GRID_SETTINGS_KEY );
 		return {
 			...normalizeGridSettings( stored ?? PA_DEFAULT_GRID, PA_DEFAULT_ROW_HEIGHT ),
-			// Placements are authored for four columns, and preferences written by the
-			// removed Columns control may still carry another count: pin it on read.
-			columns: WIDGET_DASHBOARD_COLUMN_COUNT,
+			// Preferences written by the removed Columns control may still carry
+			// another count, so pin it on read.
+			columns: PA_COLUMN_COUNT,
 		};
 	}, [] );
 

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-grid-settings/use-dashboard-grid-settings.ts
@@ -21,7 +21,7 @@ import type { WidgetGridSettings } from '@wordpress/widget-dashboard';
 const PA_DEFAULT_ROW_HEIGHT = ROW_HEIGHT_PRESETS.small;
 
 /**
- * The analytics dashboards are designed on three columns, one fewer than the
+ * The main analytics dashboard is designed on three columns, one fewer than the
  * package default.
  */
 const PA_COLUMN_COUNT = 3;

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -187,14 +187,15 @@ function get_dashboard_default_widget_instance(
 function get_dashboard_default_section_layouts() {
 	return array(
 		DASHBOARD_TRAFFIC_SECTION_ID     => array(
-			// Rows fill the four-column grid. Plan usage is intentionally not a
-			// default; it stays available from the widget picker.
+			// Rows fill the three-column grid in the prototype's order. Plan usage
+			// is intentionally not a default; it stays available from the widget
+			// picker.
 			// Row 1: traffic chart.
 			get_dashboard_default_widget_instance(
 				'default-traffic-chart-widget-instance',
 				'jpa/traffic-chart',
 				0,
-				4,
+				3,
 				2
 			),
 			// Row 2: most-viewed posts + referrers + devices.
@@ -202,7 +203,7 @@ function get_dashboard_default_section_layouts() {
 				'default-stats-top-posts-widget-instance',
 				'jpa/stats-top-posts',
 				1,
-				2,
+				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
@@ -224,7 +225,7 @@ function get_dashboard_default_section_layouts() {
 				'default-locations-widget-instance',
 				'jpa/locations',
 				4,
-				3,
+				2,
 				2
 			),
 			get_dashboard_default_widget_instance(
@@ -234,13 +235,16 @@ function get_dashboard_default_section_layouts() {
 				1,
 				2
 			),
-			// Row 4: VideoPress (sites running VideoPress only) + clicks + authors.
+			// Row 4: UTM insights + clicks + VideoPress (sites running VideoPress only).
 			get_dashboard_default_widget_instance(
-				'default-videopress-widget-instance',
-				'jpa/videopress',
+				'default-utm-insights-widget-instance',
+				'jpa/utm-insights',
 				6,
 				1,
-				2
+				2,
+				array(
+					'utmDimension' => 'utm_source,utm_medium',
+				)
 			),
 			get_dashboard_default_widget_instance(
 				'default-clicks-widget-instance',
@@ -250,22 +254,19 @@ function get_dashboard_default_section_layouts() {
 				2
 			),
 			get_dashboard_default_widget_instance(
-				'default-authors-widget-instance',
-				'jpa/authors',
+				'default-videopress-widget-instance',
+				'jpa/videopress',
 				8,
-				2,
+				1,
 				2
 			),
-			// Row 5: UTM insights + search terms + file downloads (Simple only).
+			// Row 5: authors + search terms + file downloads (Simple only).
 			get_dashboard_default_widget_instance(
-				'default-utm-insights-widget-instance',
-				'jpa/utm-insights',
+				'default-authors-widget-instance',
+				'jpa/authors',
 				9,
-				2,
-				2,
-				array(
-					'utmDimension' => 'utm_source,utm_medium',
-				)
+				1,
+				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-search-terms-widget-instance',

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -423,8 +423,8 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_types   = array_column( $layout, 'type' );
 
 		// uuid => [ type, width, height, order ]. The at-a-glance cards share row 2
-		// as the design pairs them; WOOA7S-2009 settles the final widths. Every row
-		// fills the four-column grid.
+		// as the design pairs them; WOOA7S-2009 settles the final widths. Widths are
+		// still authored for four columns; the grid is now three.
 		$expected = array(
 			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 4, 1, 0 ),
 			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 2, 1 ),
@@ -496,7 +496,7 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		// uuid => [ type, width, order ]; widths fill the four-column grid.
+		// uuid => [ type, width, order ]; widths are still authored for four columns.
 		$expected = array(
 			'default-subscribers-chart-widget-instance'  => array( 'jpa/subscribers-chart', 4, 0 ),
 			'default-subscribers-list-widget-instance'   => array( 'jpa/subscribers-list', 2, 1 ),
@@ -560,7 +560,7 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout         = seed_default_dashboard_layout( array(), DASHBOARD_ADS_SECTION_ID );
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 
-		// uuid => [ type, width, height, order ]; widths fill the four-column grid.
+		// uuid => [ type, width, height, order ]; widths are still authored for four columns.
 		$expected = array(
 			'default-wordads-highlights-widget-instance' => array( 'jpa/wordads-highlights', 4, 1, 0 ),
 			'default-wordads-chart-tabs-widget-instance' => array( 'jpa/wordads-chart-tabs', 4, 2, 1 ),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -370,18 +370,18 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_types    = array_column( $layout, 'type' );
 		$utm_widget_uuid = 'default-utm-insights-widget-instance';
 
-		// uuid => [ type, width, order ]; widths fill the four-column grid.
+		// uuid => [ type, width, order ]; widths fill the three-column grid.
 		$expected = array(
-			'default-traffic-chart-widget-instance'   => array( 'jpa/traffic-chart', 4, 0 ),
-			'default-stats-top-posts-widget-instance' => array( 'jpa/stats-top-posts', 2, 1 ),
+			'default-traffic-chart-widget-instance'   => array( 'jpa/traffic-chart', 3, 0 ),
+			'default-stats-top-posts-widget-instance' => array( 'jpa/stats-top-posts', 1, 1 ),
 			'default-referrers-widget-instance'       => array( 'jpa/referrers', 1, 2 ),
 			'default-devices-widget-instance'         => array( 'jpa/devices', 1, 3 ),
-			'default-locations-widget-instance'       => array( 'jpa/locations', 3, 4 ),
+			'default-locations-widget-instance'       => array( 'jpa/locations', 2, 4 ),
 			'default-top-platforms-widget-instance'   => array( 'jpa/top-platforms', 1, 5 ),
-			'default-videopress-widget-instance'      => array( 'jpa/videopress', 1, 6 ),
+			'default-utm-insights-widget-instance'    => array( 'jpa/utm-insights', 1, 6 ),
 			'default-clicks-widget-instance'          => array( 'jpa/clicks', 1, 7 ),
-			'default-authors-widget-instance'         => array( 'jpa/authors', 2, 8 ),
-			'default-utm-insights-widget-instance'    => array( 'jpa/utm-insights', 2, 9 ),
+			'default-videopress-widget-instance'      => array( 'jpa/videopress', 1, 8 ),
+			'default-authors-widget-instance'         => array( 'jpa/authors', 1, 9 ),
 			'default-search-terms-widget-instance'    => array( 'jpa/search-terms', 1, 10 ),
 			'default-file-downloads-widget-instance'  => array( 'jpa/file-downloads', 1, 11 ),
 		);

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -134,7 +134,7 @@ export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetContr
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		// The placement the dashboard seeds this widget at, where the tiles sit in
 		// one row above the report link.
-		widgetWidth: 4,
+		widgetWidth: 3,
 		widgetHeight: 1,
 	},
 	argTypes: {

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
@@ -213,7 +213,7 @@ export const WidgetDashboardWithWidget: StoryObj< PostDetailHighlightsDashboardS
 	render: args => <PostDetailHighlightsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		widgetWidth: 4,
+		widgetWidth: 3,
 		widgetHeight: 1,
 		withComparison: true,
 		hasPostScope: true,

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -210,7 +210,7 @@ export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardSt
 	render: args => <PostTrafficActivityDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		widgetWidth: 4,
+		widgetWidth: 3,
 		widgetHeight: 2,
 		hasPostScope: true,
 		preset: 'last-30-days',

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -25,17 +25,15 @@ import type {
 import { StoryRouterProvider } from './with-story-router';
 
 const DASHBOARD_ROW_HEIGHT = ROW_HEIGHT_PRESETS.small;
-// Mirrors the route stages' `--wp-grid-gap` override, so edit-mode track guides and the
-// four-column canvas width below match production. Keep the two forms in sync.
+const DASHBOARD_COLUMN_COUNT = 3;
+// Mirrors the route stages' `--wp-grid-gap` override, so edit-mode track guides match production.
 const DASHBOARD_GRID_GAP_TOKEN = 'var(--wpds-dimension-gap-lg)';
-const DASHBOARD_GRID_GAP = 16;
-const DASHBOARD_ONE_COLUMN_WIDTH = 381;
-const DASHBOARD_PAGE_INLINE_PADDING = 48;
+// A desktop wp-admin content area. The dashboard is fluid, so DASHBOARD_COLUMN_COUNT divides
+// this width rather than setting it.
+const DASHBOARD_DESKTOP_CANVAS_WIDTH = 1620;
 
 export const WIDGET_DASHBOARD_STORY_WIDTHS = {
-	desktop: `${
-		DASHBOARD_ONE_COLUMN_WIDTH * 4 + DASHBOARD_GRID_GAP * 3 + DASHBOARD_PAGE_INLINE_PADDING
-	}px`,
+	desktop: `${ DASHBOARD_DESKTOP_CANVAS_WIDTH }px`,
 	narrow: '640px',
 	mobile: '370px',
 } as const;
@@ -71,7 +69,7 @@ export const widgetDashboardWithWidgetArgTypes = {
 		options: Object.values( WIDGET_DASHBOARD_STORY_WIDTHS ),
 	},
 	widgetWidth: {
-		control: { type: 'number', min: 1, max: 4, step: 1 },
+		control: { type: 'number', min: 1, max: DASHBOARD_COLUMN_COUNT, step: 1 },
 	},
 	widgetHeight: {
 		control: { type: 'number', min: 1, max: 4, step: 1 },
@@ -243,7 +241,7 @@ export function WidgetDashboardWithWidget( {
 								onLayoutChange={ setLayout }
 								widgetTypes={ [ storyWidgetType ] }
 								resolveWidgetModule={ resolveWidgetModule }
-								gridSettings={ { model: 'grid', rowHeight } }
+								gridSettings={ { model: 'grid', columns: DASHBOARD_COLUMN_COUNT, rowHeight } }
 								editMode={ currentEditMode }
 								onEditChange={ setCurrentEditMode }
 							>

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/stories/traffic-views-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/stories/traffic-views-activity-widget.stories.tsx
@@ -136,7 +136,7 @@ export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetContr
 	render: args => <TrafficViewsActivityDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		widgetWidth: 4,
+		widgetWidth: 3,
 		widgetHeight: 1,
 		rowHeight: 200,
 	},

--- a/projects/plugins/jetpack/changelog/wooa7s-2032-three-column-layout
+++ b/projects/plugins/jetpack/changelog/wooa7s-2032-three-column-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Display the dashboard on a three-column grid and rearrange the default Traffic widgets.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2032-three-column-layout
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2032-three-column-layout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Display the dashboard on a three-column grid and rearrange the default Traffic widgets.


### PR DESCRIPTION
Fixes WOOA7S-2032

## Proposed changes

The dashboard design lays widgets out on three columns, but `@wordpress/widget-dashboard` used to hard-code the grid to four via `WIDGET_DASHBOARD_COLUMN_COUNT`.
WordPress/gutenberg#82204 made `gridSettings.columns` a host decision, and the `0.7.1-next.v.202609031004.0` bump now on trunk carries it, so this PR sets ours:

* Pin the grid to three columns in `useDashboardGridSettings`, for both the default grid and stored layouts, so an existing customized layout also renders on three columns.
* Rearrange the default Traffic layout to the design: the traffic chart spans the full first row, Locations spans two columns, and the remaining widgets take one column each in the design's order.
* Update `Dashboard_Layout_Test` to the new order and widths.

## Related product discussion/links

* WOOA7S-2032
* WordPress/gutenberg#82173 is the proposal, WordPress/gutenberg#82204 the implementation.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the branch (`jp build plugins/premium-analytics --deps`) and open Stats v2 → Traffic as a user without a saved layout customization.
* The dashboard renders on three columns in the new default order: Traffic chart (full row), Top posts & pages, Referrers, Devices, Locations (double width), Top platforms, UTM insights, Clicks, VideoPress, Authors, Search terms, File downloads. VideoPress only renders on a site running VideoPress and File downloads only on Simple, so a plain test site shows ten widgets under the chart.
* Narrow the window: the grid steps down to two columns under 960px of container width and one under 600px.
* `jp test php packages/premium-analytics` covers the same default map in `Dashboard_Layout_Test`.

| Before (main checkout, trunk) | After (this branch) |
| --- | --- |
| ![Four-column grid: Traffic summary spans three columns with Top pages beside it, then Top referrers, Devices and Top locations](https://github.com/user-attachments/assets/a29019c5-9759-4884-9e19-e46897f48a51) | ![Three-column grid: Traffic summary spans the full first row, then Top pages, Top referrers and Devices, with Top locations two columns wide](https://github.com/user-attachments/assets/4c06895b-1056-44b9-8f73-a0ade815075e) |
| Traffic summary spans three of the four columns, so Top pages sits beside it and Top locations lands in the third row. | Traffic summary spans the full first row, Top pages, Top referrers and Devices fill the second, and Top locations is two columns wide. |

Verified on a local site at 1600px: three columns in the order above, and `Dashboard_Layout_Test` passes. Not checked: a site that already has a saved layout customization, and the narrow breakpoints on a real device.


