### PR TITLE
Premium Analytics: put Posting activity posts on the site's calendar day

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2065-posting-activity-site-timezone
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2065-posting-activity-site-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Posting activity: Count published posts by the site's calendar day rather than the UTC one.

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -14,7 +14,7 @@
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "PA_TEST_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card || exit 1; done",
+		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card || exit 1; done",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
@@ -1,32 +1,81 @@
+/**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
 import { sanitizeStatsStreakResponse } from '..';
 import { streakFixture } from '../__fixtures__/streak';
 
+/** The package defaults before tests override them. */
+const DEFAULTS = getSettings();
+
+const withTimezone = ( timezone: { offset: number; string: string } ) =>
+	setSettings( {
+		...DEFAULTS,
+		timezone: { ...timezone, offsetFormatted: String( timezone.offset ), abbr: '' },
+	} );
+
 describe( 'Stats streak normalizer', () => {
+	afterEach( () => setSettings( DEFAULTS ) );
+
 	it( 'normalizes timestamp counts into date buckets', () => {
+		withTimezone( { offset: 0, string: 'UTC' } );
+
 		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
 			'2016-04-29': 2,
 			'2016-04-30': 1,
 		} );
 	} );
 
-	it( 'applies the site GMT offset before bucketing counts', () => {
-		expect( sanitizeStatsStreakResponse( streakFixture, { gmtOffset: 10 } ) ).toEqual( {
+	it( 'buckets by the site calendar day, not the UTC one', () => {
+		// The fixture's later timestamps are 23:30 UTC, so an India site has already
+		// turned the page on both of them.
+		withTimezone( { offset: 5.5, string: 'Asia/Kolkata' } );
+
+		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
 			'2016-04-29': 1,
 			'2016-04-30': 1,
 			'2016-05-01': 1,
 		} );
-		expect( sanitizeStatsStreakResponse( streakFixture, { gmtOffset: -10 } ) ).toEqual( {
+
+		withTimezone( { offset: -4, string: 'America/New_York' } );
+
+		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
 			'2016-04-28': 1,
 			'2016-04-29': 1,
 			'2016-04-30': 1,
 		} );
 	} );
 
-	it( 'preserves fractional site GMT offsets', () => {
-		expect(
-			sanitizeStatsStreakResponse( { data: { 1461955500: 1 } }, { gmtOffset: 5.5 } )
-		).toEqual( {
+	it( 'buckets a half-hour zone by its own midnight', () => {
+		// 2016-04-29 18:45 UTC is 00:15 the next day in India.
+		withTimezone( { offset: 5.5, string: 'Asia/Kolkata' } );
+
+		expect( sanitizeStatsStreakResponse( { data: { 1461955500: 1 } } ) ).toEqual( {
 			'2016-04-30': 1,
+		} );
+	} );
+
+	it( 'falls back to the site offset when there is no named timezone', () => {
+		withTimezone( { offset: 5.5, string: '' } );
+
+		expect( sanitizeStatsStreakResponse( { data: { 1461955500: 1 } } ) ).toEqual( {
+			'2016-04-30': 1,
+		} );
+	} );
+
+	it( 'follows the zone across a DST change', () => {
+		// Both timestamps are 04:30 UTC. New York is a day apart on them only because
+		// one is EDT and the other EST, which a fixed offset cannot express.
+		withTimezone( { offset: -4, string: 'America/New_York' } );
+
+		expect( sanitizeStatsStreakResponse( { data: { 1467347400: 1 } } ) ).toEqual( {
+			'2016-07-01': 1,
+		} );
+		expect( sanitizeStatsStreakResponse( { data: { 1451622600: 1 } } ) ).toEqual( {
+			'2015-12-31': 1,
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
@@ -1,14 +1,7 @@
-/**
- * External dependencies
- */
 import { getSettings, setSettings } from '@wordpress/date';
-/**
- * Internal dependencies
- */
 import { sanitizeStatsStreakResponse } from '..';
 import { streakFixture } from '../__fixtures__/streak';
 
-/** The package defaults before tests override them. */
 const DEFAULTS = getSettings();
 
 const withTimezone = ( timezone: { offset: number; string: string } ) =>
@@ -18,6 +11,9 @@ const withTimezone = ( timezone: { offset: number; string: string } ) =>
 	} );
 
 describe( 'Stats streak normalizer', () => {
+	// Group members share one module registry, so neither inherit a previous
+	// suite's settings nor leave ours installed for the next one.
+	beforeEach( () => setSettings( DEFAULTS ) );
 	afterEach( () => setSettings( DEFAULTS ) );
 
 	it( 'normalizes timestamp counts into date buckets', () => {
@@ -67,15 +63,23 @@ describe( 'Stats streak normalizer', () => {
 	} );
 
 	it( 'follows the zone across a DST change', () => {
-		// Both timestamps are 04:30 UTC. New York is a day apart on them only because
-		// one is EDT and the other EST, which a fixed offset cannot express.
+		// New York is a day behind UTC on both, under EDT for the first and EST for
+		// the second: the reported -4 offset puts the second on 2016-01-01.
 		withTimezone( { offset: -4, string: 'America/New_York' } );
 
-		expect( sanitizeStatsStreakResponse( { data: { 1467347400: 1 } } ) ).toEqual( {
-			'2016-07-01': 1,
+		expect( sanitizeStatsStreakResponse( { data: { 1467343800: 1 } } ) ).toEqual( {
+			'2016-06-30': 1,
 		} );
 		expect( sanitizeStatsStreakResponse( { data: { 1451622600: 1 } } ) ).toEqual( {
 			'2015-12-31': 1,
+		} );
+	} );
+
+	it( 'skips keys that are not timestamps', () => {
+		withTimezone( { offset: 0, string: 'UTC' } );
+
+		expect( sanitizeStatsStreakResponse( { data: { total: 5, 1461889800: 1 } } ) ).toEqual( {
+			'2016-04-29': 1,
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
@@ -11,9 +11,6 @@ const withTimezone = ( timezone: { offset: number; string: string } ) =>
 	} );
 
 describe( 'Stats streak normalizer', () => {
-	// Group members share one module registry, so neither inherit a previous
-	// suite's settings nor leave ours installed for the next one.
-	beforeEach( () => setSettings( DEFAULTS ) );
 	afterEach( () => setSettings( DEFAULTS ) );
 
 	it( 'normalizes timestamp counts into date buckets', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
@@ -13,9 +13,8 @@ export type StatsStreakRawResponse = {
 
 export function sanitizeStatsStreakResponse( response: unknown ): StatsStreakResponse {
 	const data = coerceStatsRecord( coerceStatsRecord( response ).data );
-	// Alone among the Stats payloads this one keys by instant, not by day, so the
-	// calendar day has to be resolved here. A named zone rather than the site's
-	// numeric offset, so posts either side of a DST change land on the right day.
+	// Keyed by instant, not by day, so the calendar day is resolved here. By zone
+	// rather than by offset: a fixed offset is a day out either side of a DST change.
 	const zone = tz( siteTimeZone() );
 	const streak: StatsStreakResponse = {};
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
@@ -1,8 +1,8 @@
 import { tz } from '@date-fns/tz';
-import { addHours, format, fromUnixTime } from 'date-fns';
+import { siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { format, fromUnixTime } from 'date-fns';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsRecord } from './utils';
-import type { StatsQueryParams } from '../../utils/stats-params';
 
 export type StatsStreakResponse = Record< string, number >;
 
@@ -11,12 +11,12 @@ export type StatsStreakRawResponse = {
 	data?: Record< string, number >;
 };
 
-export function sanitizeStatsStreakResponse(
-	response: unknown,
-	query?: StatsQueryParams
-): StatsStreakResponse {
+export function sanitizeStatsStreakResponse( response: unknown ): StatsStreakResponse {
 	const data = coerceStatsRecord( coerceStatsRecord( response ).data );
-	const gmtOffset = safeParseFloat( query?.gmtOffset );
+	// Alone among the Stats payloads this one keys by instant, not by day, so the
+	// calendar day has to be resolved here. A named zone rather than the site's
+	// numeric offset, so posts either side of a DST change land on the right day.
+	const zone = tz( siteTimeZone() );
 	const streak: StatsStreakResponse = {};
 
 	for ( const [ timestamp, count ] of Object.entries( data ) ) {
@@ -26,9 +26,7 @@ export function sanitizeStatsStreakResponse(
 			continue;
 		}
 
-		const date = format( addHours( fromUnixTime( seconds ), gmtOffset ), 'yyyy-MM-dd', {
-			in: tz( 'UTC' ),
-		} );
+		const date = format( fromUnixTime( seconds ), 'yyyy-MM-dd', { in: zone } );
 		streak[ date ] = ( streak[ date ] ?? 0 ) + safeParseFloat( count );
 	}
 

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1607,7 +1607,6 @@ describe( 'Stats query factories', () => {
 			from: '2026-06-01',
 			to: '2026-06-30',
 			interval: 'day',
-			gmtOffset: 12,
 			max: 3000,
 		} );
 
@@ -1621,7 +1620,6 @@ describe( 'Stats query factories', () => {
 			{
 				startDate: '2026-06-01',
 				endDate: '2026-06-30',
-				gmtOffset: 12,
 				max: 3000,
 			},
 			undefined,

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-streak-query.ts
@@ -7,7 +7,6 @@ import type { StatsStreakResponse } from '../processing/stats';
 export type StatsStreakParams = StatsReportParams & {
 	startDate?: string;
 	endDate?: string;
-	gmtOffset?: number;
 };
 
 export type { StatsStreakResponse };
@@ -18,7 +17,6 @@ export const statsStreakQuery = (
 	const streakParams: StatsProxyParams = {
 		startDate: params.startDate ?? getDatePart( params.from ) ?? params.start_date,
 		endDate: params.endDate ?? getDatePart( params.to ) ?? params.end_date ?? params.date,
-		...( params.gmtOffset !== undefined ? { gmtOffset: params.gmtOffset } : {} ),
 		...( params.max !== undefined ? { max: params.max } : {} ),
 	};
 

--- a/projects/plugins/jetpack/changelog/wooa7s-2065-posting-activity-site-timezone
+++ b/projects/plugins/jetpack/changelog/wooa7s-2065-posting-activity-site-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Count published posts by the site's calendar day rather than the UTC one in Posting activity.

--- a/projects/plugins/jetpack/changelog/wooa7s-2065-posting-activity-site-timezone
+++ b/projects/plugins/jetpack/changelog/wooa7s-2065-posting-activity-site-timezone
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Count published posts by the site's calendar day rather than the UTC one in Posting activity.
+Premium Analytics: Count posts in Posting activity by the site's calendar day rather than the UTC one.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2065-posting-activity-site-timezone
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2065-posting-activity-site-timezone
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Posting activity: Count published posts by the site's calendar day rather than the UTC one.


### PR DESCRIPTION
## Proposed changes

- Fold `stats/streak` timestamps in the site's timezone instead of UTC, so Posting activity draws each post on the day it was published locally.
- Read the timezone by name rather than as a numeric offset, so the day boundary follows a DST change.
- Drop `gmtOffset` from `StatsStreakParams`: nothing ever supplied it, so the sanitizer always fell back to `0`.
- Drive the sanitizer tests from real site settings via `setSettings()` rather than a hand-passed offset, and add a DST case.

### What was wrong

`stats/streak` is the only Stats payload keyed by instant rather than by day, so the client has to decide which calendar day each timestamp belongs to. It was deciding in UTC. Any post published between local midnight and the site's UTC offset landed on the previous day, and negative-offset sites got the same error running forward.

On a site set to `Asia/Kolkata`, with three known posts:

| Post, in site local time | Before         | After      |
| ------------------------ | -------------- | ---------- |
| **Mon 31 Aug, 02:00**    | **Sun 30 Aug** | Mon 31 Aug |
| Fri 28 Aug, 12:00        | Fri 28 Aug     | Fri 28 Aug |
| Wed 26 Aug, 23:45        | Wed 26 Aug     | Wed 26 Aug |

The affected window is as wide as the offset: 5.5 hours for India, 8 for Taipei, 4 for New York.

### Why it happened

The server was never wrong. It builds each timestamp from `post_date` in the blog's own timezone. The `gmtOffset` param meant to carry that offset back to the client is declared and unit tested, but no caller ever passes it, so `safeParseFloat( undefined )` returned `0` and every timestamp was read as UTC. The tests stayed green because they supply `gmtOffset` themselves, which is exactly the step missing in production.

So trunk was not just picking a worse heuristic, it was disagreeing with the server. The same response's `streak.current` / `streak.long` dates are bucketed by `calculate_streak()` in the blog's IANA zone, and `get_blog_datetimezone()` resolves that zone in the same order `siteTimeZone()` does. This makes both ends read the instants the same way.

Reading the timezone by name rather than passing that number: a fixed offset is an hour out for half the year, so `America/New_York` would still misplace posts either side of a DST transition. The new test covers that case.

## Related product discussion/links

- WOOA7S-2065

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Set the site timezone to `Asia/Kolkata` under Settings > General.
- Publish a post dated between 00:00 and 05:29 site time, within the last few weeks.
- Go to Stats v2 > Insights and hover the matching cell in Posting activity.
- The post sits on the day it was published. On trunk it lands a day early.
- `America/New_York` covers the other direction: a post published after 20:00 local stays on that day instead of moving forward.

