### PR TITLE
Jetpack AI: lift the proxy gate for ai hub apply its switches on every site

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
@@ -1,4 +1,3 @@
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { JetpackModuleSlug, JetpackProductWithCard } from '../../../types';
 import AntiSpamIcon from '../../products-table-view/icons/anti-spam';
 import BackupIcon from '../../products-table-view/icons/backup';
@@ -116,24 +115,3 @@ export const PRODUCT_MODULES: {
 	'jetpack-forms': 'contact-form',
 	'jetpack-ai': 'ai',
 };
-
-/**
- * The product-to-module map to build cards from.
- *
- * Pre-release gate: outside internal testing environments the AI card is not
- * backed by the 'ai' module, so its cards resolve no module and render exactly
- * as they did before the module existed. Remove when the AI settings page goes
- * public.
- *
- * @return The map, without the AI entry while the gate is on.
- */
-export function getProductModules() {
-	const { showAiModuleToggle = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
-	if ( showAiModuleToggle ) {
-		return PRODUCT_MODULES;
-	}
-
-	const gated = { ...PRODUCT_MODULES };
-	delete gated[ 'jetpack-ai' ];
-	return gated;
-}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
@@ -11,7 +11,6 @@ import useActivatePlugins from '../../../data/products/use-activate-plugins';
 import { useDeactivatePlugins } from '../../../data/products/use-deactivate-plugins';
 import useProduct from '../../../data/products/use-product';
 import { ProductCamelCase } from '../../../data/types';
-import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { useInterstitialsState } from '../../../hooks/use-interstitials-state';
 import { MyJetpackModule } from '../../../types';
 import { PRODUCT_STATUSES } from '../../product-card';
@@ -143,19 +142,13 @@ function ActivationToggle( {
 export function ProductCardAction( { product, module: $module }: ProductCardActionProps ) {
 	const { data: interstitials } = useInterstitialsState();
 	const reloadOnToggle = PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( product.slug );
-	const { showAiModuleToggle = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 
 	// Forms and AI surface the activation toggle directly instead of a "Learn more"
 	// upsell link. Forms is a free module with no interstitial; AI is the site-wide
 	// master switch, and the Content AI settings design shows the card with an inline
 	// Active/off toggle in both states (the AI upsell lives on the AI page, not on
-	// this master control). The AI toggle is limited to internal testing environments
-	// until the AI settings page goes public (pre-release gate); everyone else keeps
-	// the standard card action.
-	if (
-		product.slug === 'jetpack-forms' ||
-		( product.slug === 'jetpack-ai' && showAiModuleToggle )
-	) {
+	// this master control).
+	if ( product.slug === 'jetpack-forms' || product.slug === 'jetpack-ai' ) {
 		// Drive on/off from the module's real activated state, not product.status:
 		// a free product that also has a paid tier (Jetpack AI) reports
 		// "can_upgrade" even when its module is active, which would leave the master

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/mappings.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/mappings.test.ts
@@ -1,24 +1,8 @@
-import { getProductModules, PRODUCT_MODULES } from '../mappings';
+import { PRODUCT_MODULES } from '../mappings';
 
-describe( 'getProductModules', () => {
-	it( 'omits the AI mapping while the pre-release gate is on', () => {
-		window.myJetpackInitialState = {
-			myJetpackFlags: {},
-		} as unknown as Window[ 'myJetpackInitialState' ];
-
-		const map = getProductModules();
-
-		// No AI mapping means AI cards resolve no module, exactly as they did
-		// before AI became a module. Other products keep theirs.
-		expect( map ).not.toHaveProperty( 'jetpack-ai' );
-		expect( map[ 'jetpack-forms' ] ).toBe( 'contact-form' );
-	} );
-
-	it( 'keeps the AI mapping for internal testing environments', () => {
-		window.myJetpackInitialState = {
-			myJetpackFlags: { showAiModuleToggle: true },
-		} as unknown as Window[ 'myJetpackInitialState' ];
-
-		expect( getProductModules() ).toEqual( PRODUCT_MODULES );
+describe( 'PRODUCT_MODULES', () => {
+	it( 'backs the AI card with the ai module for everyone', () => {
+		expect( PRODUCT_MODULES[ 'jetpack-ai' ] ).toBe( 'ai' );
+		expect( PRODUCT_MODULES[ 'jetpack-forms' ] ).toBe( 'contact-form' );
 	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { ProductCamelCase } from '../../../../data/types';
 import { MyJetpackModule } from '../../../../types';
 import { setPendingSuccessNotice } from '../pending-notice';
@@ -154,6 +154,66 @@ describe( 'ProductCardAction', () => {
 		);
 
 		expect( screen.getByRole( 'checkbox' ) ).toBeDisabled();
+	} );
+
+	it( 'routes a product with no paid plan to its Learn more interstitial', async () => {
+		render(
+			<MemoryRouter>
+				<Routes>
+					<Route
+						path="/"
+						element={
+							<ProductCardAction
+								product={ buildProduct( { slug: 'search', name: 'Search', status: 'active' } ) }
+							/>
+						}
+					/>
+					<Route path="/add-search" element={ <div>Search interstitial</div> } />
+				</Routes>
+			</MemoryRouter>
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /learn more/i } ) );
+
+		expect( screen.getByText( 'Search interstitial' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a Learn more link for an inactive product that already has a paid plan', () => {
+		render(
+			<MemoryRouter>
+				<ProductCardAction
+					product={ buildProduct( {
+						slug: 'search',
+						name: 'Search',
+						status: 'inactive',
+						hasPaidPlanForProduct: true,
+					} ) }
+				/>
+			</MemoryRouter>
+		);
+
+		expect( screen.getByRole( 'button', { name: /learn more/i } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the activation toggle for a product whose standalone plugin is installed', () => {
+		// An inactive status would otherwise reach the "Learn more" branch below.
+		render(
+			<MemoryRouter>
+				<ProductCardAction
+					product={ buildProduct( {
+						slug: 'boost',
+						name: 'Boost',
+						status: 'inactive',
+						hasPaidPlanForProduct: true,
+						standalonePluginInfo: { isStandaloneInstalled: true, isStandaloneActive: true },
+					} ) }
+				/>
+			</MemoryRouter>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+		expect( screen.queryByRole( 'button', { name: /learn more/i } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'reloads the page after deactivating Forms so the admin sidebar updates', async () => {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -49,10 +49,8 @@ const formsModule = { available: true, activated: true } as unknown as MyJetpack
 describe( 'ProductCardAction', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		// The suite renders as an internal tester by default so the AI toggle is
-		// visible; the pre-release gate tests below override this per test.
 		window.myJetpackInitialState = {
-			myJetpackFlags: { showAiModuleToggle: true },
+			myJetpackFlags: {},
 		} as unknown as Window[ 'myJetpackInitialState' ];
 	} );
 
@@ -117,13 +115,7 @@ describe( 'ProductCardAction', () => {
 		expect( reloadPage ).toHaveBeenCalled();
 	} );
 
-	it( 'pre-release gate: hides the AI toggle without the showAiModuleToggle flag', () => {
-		// Outside internal testing environments the AI card keeps its standard
-		// action: an inactive free product falls through to "Learn more".
-		window.myJetpackInitialState = {
-			myJetpackFlags: {},
-		} as unknown as Window[ 'myJetpackInitialState' ];
-		// UpgradeAction navigates to the interstitial, so it needs a router.
+	it( 'renders the AI toggle for an ordinary visitor, with no proxy or flag', () => {
 		render(
 			<MemoryRouter>
 				<ProductCardAction
@@ -133,17 +125,11 @@ describe( 'ProductCardAction', () => {
 			</MemoryRouter>
 		);
 
-		expect( screen.getByRole( 'button', { name: /learn more/i } ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /learn more/i } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'pre-release gate: an AI card built without a module renders an inert toggle', () => {
-		// Gated cards are built with no module (see getProductModules), which is
-		// what the card looked like before AI became a module: the generic
-		// branch renders a toggle that cannot be flipped.
-		window.myJetpackInitialState = {
-			myJetpackFlags: {},
-		} as unknown as Window[ 'myJetpackInitialState' ];
+	it( 'renders an inert toggle for an AI card whose module data is missing', () => {
 		render(
 			<ProductCardAction
 				product={ buildProduct( {
@@ -156,15 +142,6 @@ describe( 'ProductCardAction', () => {
 		);
 
 		expect( screen.getByRole( 'checkbox' ) ).toBeDisabled();
-	} );
-
-	it( 'pre-release gate: the Forms toggle is unaffected by the flag', () => {
-		window.myJetpackInitialState = {
-			myJetpackFlags: {},
-		} as unknown as Window[ 'myJetpackInitialState' ];
-		render( <ProductCardAction product={ buildProduct() } module={ formsModule } /> );
-
-		expect( screen.getByRole( 'checkbox' ) ).toBeInTheDocument();
 	} );
 
 	it( 'disables the toggle when the Forms module is unavailable', () => {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
@@ -5,7 +5,7 @@ import { useAllProducts } from '../../../data/products/use-all-products';
 import { WP_Error } from '../../../data/types';
 import useSimpleQuery from '../../../data/use-simple-query';
 import { JetpackProductWithCard } from '../../../types';
-import { getProductModules } from './mappings';
+import { PRODUCT_MODULES } from './mappings';
 import { ProductSection } from './types';
 import { useAllJetpackModules } from './use-all-jetpack-modules';
 import { filterAndSortModules, filterSections } from './utils';
@@ -50,7 +50,7 @@ export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 			id: String( purchase.ID ),
 			title: purchase.product_name,
 			cards: $products.map( ( [ slug, product ] ) => {
-				const moduleSlug = getProductModules()[ slug ] || slug;
+				const moduleSlug = PRODUCT_MODULES[ slug ] || slug;
 
 				return {
 					product,

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useAllProducts } from '../../../data/products/use-all-products';
-import { CATEGORY_CARDS_AND_MODULES, getProductModules } from './mappings';
+import { CATEGORY_CARDS_AND_MODULES, PRODUCT_MODULES } from './mappings';
 import { ProductFilter } from './types';
 import { useAllJetpackModules } from './use-all-jetpack-modules';
 import { buildCards, filterAndSortModules, getSectionTitle, searchAndRankItems } from './utils';
@@ -48,7 +48,7 @@ export function useFilteredProducts( { search, selectedFilter }: UseFilteredProd
 			ALL_CATEGORIES.map( ( [ category, { cards, modules } ] ) => ( {
 				id: category,
 				title: getSectionTitle( category ),
-				cards: buildCards( cards, allProducts, allModules, getProductModules() ),
+				cards: buildCards( cards, allProducts, allModules, PRODUCT_MODULES ),
 				modules: filterAndSortModules( modules.map( slug => allModules[ slug ] ) ),
 			} ) ),
 		[ allProducts, allModules ]

--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-hub-gate-lift
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-hub-gate-lift
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: Show the AI card's on/off control and its real module state to everyone.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -488,7 +488,6 @@ interface Window {
 		loadAddLicenseScreen: string;
 		myJetpackCheckoutUri: string;
 		myJetpackFlags: {
-			showAiModuleToggle: boolean;
 			showFullJetpackStatsCard: boolean;
 			videoPressStats: boolean;
 		};

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -531,11 +531,6 @@ class Initializer {
 			// Only says which destination `manage_url` is: the legacy Stats page
 			// caches its report and wants a `force_refresh` hint the dashboard does not.
 			'premiumAnalyticsEnabled'  => Products\Stats::is_premium_analytics_enabled(),
-			// Pre-release gate: only internal testing environments get the AI
-			// card's module toggle. The helper lives in the Jetpack plugin, so
-			// standalone installs resolve to false. Remove when the AI settings
-			// page goes public.
-			'showAiModuleToggle'       => function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment(),
 		);
 
 		return $flags;

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -578,29 +578,6 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
-	 * Whether the 'ai' module backs this product.
-	 *
-	 * Pre-release gate: the module-backed card is limited to internal testing
-	 * environments. Everywhere else this reports the module as active so the
-	 * product's status and every card built from it match the pre-module
-	 * behavior — the module state never surfaces in My Jetpack.
-	 *
-	 * Remove this override when the AI settings page goes public.
-	 *
-	 * @return bool
-	 */
-	public static function is_module_active() {
-		if (
-			! function_exists( 'jetpack_is_internal_testing_environment' ) ||
-			! jetpack_is_internal_testing_environment()
-		) {
-			return true;
-		}
-
-		return parent::is_module_active();
-	}
-
-	/**
 	 * Get data about the AI Assistant feature
 	 *
 	 * @return array

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -239,16 +239,9 @@ class Initializer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The AI card's pre-release toggle flag follows the Jetpack plugin's
-	 * internal-testing helper.
+	 * The AI card's module toggle is no longer flagged: nothing gates it.
 	 */
-	public function test_my_jetpack_flags_gate_the_ai_module_toggle() {
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
-		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
-
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
-		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
-
-		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
+	public function test_my_jetpack_flags_no_longer_gate_the_ai_module_toggle() {
+		$this->assertArrayNotHasKey( 'showAiModuleToggle', Initializer::get_my_jetpack_flags() );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -157,19 +157,23 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * Pre-release gate: outside internal testing environments the product is not
-	 * module-backed at all, so an inactive module never surfaces — the status is
-	 * what it was before the module existed.
+	 * The real module state surfaces for an ordinary visitor: an inactive module
+	 * reports the product disabled rather than being masked as active.
 	 */
-	public function test_jetpack_ai_ignores_the_module_outside_internal_testing() {
+	public function test_jetpack_ai_follows_the_module_for_an_ordinary_visitor() {
 		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 
+		// Mock a full connection so the module-disabled status is not masked by
+		// site/user connection errors in the parent get_status() flow.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
 		Jetpack_Options::update_option( 'id', 123 );
+
 		activate_plugins( 'jetpack/jetpack.php' );
 		\Jetpack::deactivate_module( 'ai' );
 
-		$this->assertTrue( Jetpack_Ai::is_module_active() );
-		$this->assertNotSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
+		$this->assertFalse( Jetpack_Ai::is_module_active() );
+		$this->assertSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
 	}
 
 	/**

--- a/projects/packages/search/changelog/update-jetpack-ai-hub-gate-lift
+++ b/projects/packages/search/changelog/update-jetpack-ai-hub-gate-lift
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Answers: Apply the site-wide Jetpack AI switch on every site, not only internal testing environments.

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -105,12 +105,6 @@ class AI_Answers {
 	 * @return bool
 	 */
 	public static function is_master_enabled() {
-		// Where enforcement hasn't rolled out, report ungated so no master-off
-		// UI shows before the switch itself does. Remove at public launch.
-		if ( ! self::is_master_rollout_active() ) {
-			return true;
-		}
-
 		// ANDed with the computed predicate so reporting can never be more
 		// permissive than enforcement — e.g. a Simple request where the plugin's
 		// filter never registered, or plugin/package version skew.
@@ -118,23 +112,8 @@ class AI_Answers {
 	}
 
 	/**
-	 * Whether master enforcement has rolled out here — mirrors the Jetpack
-	 * plugin's rollout scoping: Simple keeps its option contract; elsewhere
-	 * the rollout is internal-only for now.
-	 *
-	 * @return bool
-	 */
-	private static function is_master_rollout_active() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
-			return true;
-		}
-
-		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
-	}
-
-	/**
-	 * Whether this package should enforce the master switch — the rollout-scoped
-	 * enforcement predicate behind the block gate.
+	 * Whether this package should enforce the master switch — the enforcement
+	 * predicate behind the block gate.
 	 *
 	 * Mirrors `Jetpack_AI_Settings::is_master_enabled()` in the Jetpack plugin —
 	 * the source of truth, unreferenceable from standalone installs. Computed
@@ -145,10 +124,6 @@ class AI_Answers {
 	 * @return bool True when Jetpack AI is on, or when the site has no master switch.
 	 */
 	public static function should_enforce_master() {
-		if ( ! self::is_master_rollout_active() ) {
-			return true;
-		}
-
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			return (bool) get_option( self::AI_MASTER_OPTION, true );
 		}

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -118,8 +118,7 @@ class AI_Answers_Test extends Search_TestCase {
 	}
 
 	public function test_should_enforce_master_holds_on_wpcom_simple_regardless_of_environment() {
-		// Simple keeps its option contract: enforcement applies there even
-		// outside internal testing environments (is_master_rollout_active()).
+		// Simple keeps its option contract, whatever the environment.
 		Constants::set_constant( 'IS_WPCOM', true );
 		$this->disable_simple_master();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
@@ -137,23 +136,21 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertFalse( AI_Answers::should_enforce_master() );
 	}
 
-	public function test_should_enforce_master_is_true_outside_internal_testing_environments() {
-		// The master switch UI ships internal-only for now, so a public site must not be
-		// gated on a switch its owner cannot see. Module present but inactive, yet ungated.
+	public function test_should_enforce_master_follows_the_module_for_an_ordinary_visitor() {
+		// The master switch is public now, so an inactive module gates the feature
+		// on an ordinary site rather than being waived.
 		$this->turn_ai_module_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::should_enforce_master() );
+		$this->assertFalse( AI_Answers::should_enforce_master() );
 	}
 
-	public function test_is_enabled_ignores_the_module_outside_internal_testing_environments() {
-		// Module-only setup: pins that the package's own enforcement is env-scoped.
-		// (With the Jetpack plugin loaded, its filter gate still applies publicly.)
+	public function test_is_enabled_follows_the_module_for_an_ordinary_visitor() {
 		update_option( 'jetpack_search_ai_answers_enabled', true );
 		$this->turn_ai_module_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::is_enabled() );
+		$this->assertFalse( AI_Answers::is_enabled() );
 	}
 
 	public function test_is_enabled_is_false_when_the_master_is_off() {
@@ -209,19 +206,18 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertTrue( AI_Answers::is_master_enabled() );
 	}
 
-	public function test_is_master_enabled_reports_on_outside_internal_testing_environments() {
-		// The master rollout is a12s-scoped: public sites report ungated even
-		// when the gate is registered, so no master-off UI leaks before the sweep.
+	public function test_is_master_enabled_reports_off_for_an_ordinary_visitor() {
+		// The master switch is public now, so a master-off site reports off
+		// rather than being waived.
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::is_master_enabled() );
+		$this->assertFalse( AI_Answers::is_master_enabled() );
 	}
 
 	public function test_is_master_enabled_reports_the_gate_on_wpcom_simple_regardless_of_environment() {
-		// On Simple the option keeps its contract and the master enforces
-		// publicly (see the plugin's is_master_rollout_active()), so the
-		// reporting must follow it there even outside internal environments.
+		// On Simple the option keeps its contract, so reporting follows it there
+		// whatever the environment.
 		Constants::set_constant( 'IS_WPCOM', true );
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
@@ -239,9 +235,8 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertFalse( AI_Answers::is_master_enabled() );
 	}
 
-	public function test_is_enabled_still_gated_outside_internal_testing_environments() {
-		// Enforcement is the plugin's public filter — only the *reporting* is
-		// scoped. A public master-off site still reports the feature off.
+	public function test_is_enabled_still_gated_for_an_ordinary_visitor() {
+		// A master-off site reports the feature off.
 		update_option( 'jetpack_search_ai_answers_enabled', true );
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -283,18 +283,16 @@ class Ai_Answer_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
 	}
 
-	public function test_renders_when_master_is_off_outside_internal_testing_environments() {
-		// The master switch UI ships internal-only for now, so on a public site
-		// the front-end gate must stay inert: even with the master off, the
-		// block keeps rendering. If the rollout scoping ever moves out of
-		// `should_enforce_master()`, this pin has to change deliberately with it.
+	public function test_renders_nothing_when_master_is_off_for_an_ordinary_visitor() {
+		// The master switch is public now, so the front-end gate applies on an
+		// ordinary site too — no proxy, no internal testing hostname.
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$markup = $this->render();
 
-		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
-		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
 	}
 
 	public function test_renders_when_ai_module_is_not_registered() {

--- a/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
@@ -21,13 +21,13 @@ class Initial_Javascript_State_Test extends Search_TestCase {
 		parent::tearDown();
 	}
 
-	public function test_it_reports_the_master_as_on_outside_internal_testing_environments() {
+	public function test_it_reports_the_master_as_off_for_an_ordinary_visitor() {
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$state = Helper::generate_initial_javascript_state();
 
-		$this->assertTrue( $state['aiMasterEnabled'] );
+		$this->assertFalse( $state['aiMasterEnabled'] );
 	}
 
 	public function test_it_reports_the_ai_master_switch_as_off() {

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -823,25 +823,27 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
-	 * Outside internal testing environments the payload reports the master as
-	 * on and enabling stays allowed — the rollout must not leak publicly.
+	 * The payload reports the real master state for an ordinary visitor, and the
+	 * saved choice can still be written while the master is off.
 	 */
-	public function test_master_reporting_is_scoped_to_internal_testing_environments() {
+	public function test_master_reporting_follows_the_master_for_an_ordinary_visitor() {
 		wp_set_current_user( $this->admin_id );
 		$this->enable_instant_search();
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$get = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
-		$this->assertTrue( $this->server->dispatch( $get )->get_data()['ai_master_enabled'] );
+		$this->assertFalse( $this->server->dispatch( $get )->get_data()['ai_master_enabled'] );
 
+		// The guard that was dead while the master was waived: AI Answers cannot
+		// be turned on while Jetpack AI is off for the site.
 		$post = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$post->set_header( 'content-type', 'application/json' );
 		$post->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
 		$response = $this->server->dispatch( $post );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
 
 		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 	}

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -15,7 +15,7 @@ import { AdminPage, GlobalNotices, useGlobalNotices } from '@automattic/jetpack-
 import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
+import { Notice, Stack, Tabs } from '@wordpress/ui';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
 import McpConnectCallout from './mcp/connect-callout';
@@ -34,10 +34,6 @@ import ScheduledTasks from './scheduled-tasks/index';
 const SETTINGS_REF = 'jetpack-ai-mcp-settings';
 
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
-
-// Views that only exist in internal testing environments. MCP Settings ships
-// publicly, so it is not in here.
-const GATED_VIEWS = [ 'overview', 'features' ];
 
 // Read at call time, not module scope, so the flag reflects the injected page data.
 const getTabViews = () => {
@@ -268,14 +264,6 @@ export default function App() {
 							{ tabViews.map( tab => (
 								<Tabs.Tab key={ tab } value={ tab }>
 									{ VIEW_TITLES[ tab ] }
-									{ /* Overview and Features ship behind the internal-testing gate;
-									     label them so Automatticians don't mistake them for public UI.
-									     Remove with the gate. */ }
-									{ GATED_VIEWS.includes( tab ) && (
-										<Badge intent="medium" className="jetpack-ai-admin__tab-badge">
-											{ __( 'A12s only', 'jetpack' ) }
-										</Badge>
-									) }
 								</Tabs.Tab>
 							) ) }
 						</Tabs.List>

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -228,9 +228,3 @@ body.jetpack_page_jetpack-ai {
 	background: none;
 	cursor: help;
 }
-
-// The tab badge sits inline after the tab label; the Tabs.Tab button provides
-// no gap between its children, so give the badge its own start margin.
-.jetpack-ai-admin__tab-badge {
-	margin-inline-start: 8px;
-}

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -205,17 +205,14 @@ describe( 'AI admin page (main.jsx)', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'internal-testing flag: every gated tab carries an A12s only badge', async () => {
-		// Overview and Features are both gated to internal testing environments;
-		// when the injected flag says we are in one, each tab must say so —
-		// Automatticians should not mistake either view for public UI. MCP
-		// Settings ships publicly, so it must not be labelled.
+	test( 'public views: no tab carries an internal-audience badge', async () => {
 		window.jetpackAiSettings = { showFeaturesView: true };
 		mockApiFetch();
 
 		render( <App /> );
 
-		await expect( screen.findAllByText( 'A12s only' ) ).resolves.toHaveLength( 2 );
+		await expect( screen.findByText( 'Overview' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'A12s only' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'scheduled tasks flag: exposes the gated hash route and Figma empty state', async () => {
@@ -247,9 +244,9 @@ describe( 'AI admin page (main.jsx)', () => {
 		delete window.__agentsManagerActions;
 	} );
 
-	test( 'no internal-testing flag: no A12s only badge renders', async () => {
-		// Without the flag the gate hides the Features view entirely (MCP-only
-		// shape), so the internal-testing label must not appear anywhere.
+	test( 'host closed the views: MCP-only shape, and still no badge', async () => {
+		// A host that closes the gated views (WordPress.com Simple) keeps the
+		// MCP-only shape.
 		window.jetpackAiSettings = {};
 		mockApiFetch();
 
@@ -442,7 +439,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		expect( screen.queryByRole( 'button', { name: 'AI' } ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: without showFeaturesView the page is MCP-only with no tab bar', async () => {
+	test( 'host gate: without showFeaturesView the page is MCP-only with no tab bar', async () => {
 		window.jetpackAiSettings = {};
 		window.location.hash = '';
 		mockApiFetch();
@@ -466,7 +463,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: a #/features deep link falls back to the MCP view when gated', async () => {
+	test( 'host gate: a #/features deep link falls back to the MCP view when closed', async () => {
 		window.jetpackAiSettings = {};
 		window.location.hash = '#/features';
 		mockApiFetch();
@@ -484,7 +481,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: with showFeaturesView the tab bar shows and Overview is the default view', async () => {
+	test( 'host gate: with showFeaturesView the tab bar shows and Overview is the default view', async () => {
 		// Connected, so the Overview usage card renders rather than the
 		// not-connected notice.
 		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -273,10 +273,9 @@ class Jetpack_AI_Page {
 		$config = apply_filters(
 			'jetpack_ai_admin_config',
 			array(
-				// Pre-release gate for the Overview and Features views. When opening
-				// them to everyone, also drop the matching gate in My Jetpack's
-				// Jetpack_Ai::get_manage_url() so its links land here too.
-				'showGatedViews'  => $is_internal_test,
+				// Kept filterable after the views went public so a host can still
+				// close them: WordPress.com Simple serves the MCP view alone.
+				'showGatedViews'  => true,
 				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
 				'mcpSettingsApi'  => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -204,22 +204,7 @@ class Jetpack_AI_Settings {
 	public static function apply_master_gates( $enabled ) {
 		return (bool) $enabled
 			&& self::host_allows_ai()
-			&& ( ! self::should_enforce_ai_controls() || self::is_master_enabled() );
-	}
-
-	/**
-	 * Whether the AI controls — the master switch and the toggles this class owns
-	 * — take effect here. They are not publicly launched, so off Simple they apply
-	 * on internal testing environments only. Remove at public launch.
-	 *
-	 * @return bool
-	 */
-	private static function should_enforce_ai_controls() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
-			return true;
-		}
-
-		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
+			&& self::is_master_enabled();
 	}
 
 	/**
@@ -331,12 +316,10 @@ class Jetpack_AI_Settings {
 			return false;
 		}
 
-		// The toggles this class owns stay on wherever they do not apply: Simple keeps
-		// the existing wp.com settings contract, and elsewhere they are not publicly
-		// launched. The reused Search option ships today with its own settings
-		// surface, so it always honors its stored value.
-		if ( in_array( $feature, self::OWNED_FEATURES, true )
-			&& ( ( new Host() )->is_wpcom_simple() || ! self::should_enforce_ai_controls() ) ) {
+		// The toggles this class owns stay on where they do not apply: Simple keeps the
+		// existing wp.com settings contract. The reused Search option ships with its
+		// own settings surface, so it always honors its stored value.
+		if ( in_array( $feature, self::OWNED_FEATURES, true ) && ( new Host() )->is_wpcom_simple() ) {
 			return true;
 		}
 

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-gate-lift
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-gate-lift
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Make the Overview and WordPress Agent tabs available to everyone, and let the AI switches take effect on every site.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
@@ -68,16 +68,12 @@ class Jetpack_Redux_State_Helper_Test extends WP_UnitTestCase {
 
 	/**
 	 * The initial state reports the effective AI state through the same gate
-	 * chain the editor enforces: waived master outside internal testing
-	 * environments, enforced master (the inactive `ai` module) inside them.
+	 * chain the editor enforces, for every visitor.
 	 */
 	public function test_ai_effectively_enabled_reflects_the_ai_gates() {
 		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
-		$this->assertTrue( $redux_state['isAiEnabled'], 'Outside internal testing envs the master is waived, so AI reads on.' );
 
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		$redux_state                    = Jetpack_Redux_State_Helper::get_initial_state();
-
-		$this->assertFalse( $redux_state['isAiEnabled'], 'On internal testing envs the inactive ai module reads as master off.' );
+		$this->assertFalse( jetpack_is_internal_testing_environment(), 'Precondition: an ordinary environment.' );
+		$this->assertFalse( $redux_state['isAiEnabled'], 'The inactive ai module reads as master off.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -2,10 +2,10 @@
 /**
  * Tests for the Jetpack AI admin page script data.
  *
- * The contract worth locking down: the pre-release a11n gate flag rides the
- * jetpackAiSettings inline script and follows
- * jetpack_is_internal_testing_environment(), so the Features view stays hidden
- * outside internal testing environments while the MCP-only page keeps working.
+ * The contract worth locking down: the Overview and WordPress Agent views render
+ * for every administrator, a host can still close them through
+ * jetpack_ai_admin_config, and the Tracks audience properties keep following
+ * jetpack_is_internal_testing_environment() rather than visibility.
  *
  * @package automattic/jetpack
  */
@@ -266,35 +266,37 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Outside internal testing environments the Features view flag is off.
+	 * The Overview and WordPress Agent views render for everyone: no proxy, no
+	 * Automattician account, no internal testing hostname.
 	 */
-	public function test_features_view_flag_is_off_by_default() {
+	public function test_features_view_flag_is_on_for_an_ordinary_visitor() {
 		$settings = $this->get_injected_settings();
 
 		$this->assertArrayHasKey( 'showFeaturesView', $settings );
-		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertTrue( $settings['showFeaturesView'] );
+		$this->assertFalse( $settings['isA11n'], 'Precondition: not an Automattician.' );
+		$this->assertFalse( $settings['isTest'], 'Precondition: not an internal testing environment.' );
 		$this->assertArrayHasKey( 'featureFlags', $settings );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
 	}
 
 	/**
-	 * A proxied a8c request marks an internal testing environment and turns
-	 * the Features view flag on.
+	 * Visibility is decoupled from the internal-testing predicate, which now
+	 * feeds the Tracks property alone.
 	 */
-	public function test_features_view_flag_follows_internal_testing_environment() {
+	public function test_features_view_flag_no_longer_tracks_the_internal_testing_environment() {
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$settings = $this->get_injected_settings();
 
 		$this->assertTrue( $settings['showFeaturesView'] );
-		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
+		$this->assertTrue( $settings['isTest'], 'The Tracks property still follows the predicate.' );
 	}
 
 	/**
-	 * Hosts can hide pre-release views even in an internal testing environment.
+	 * Hosts can still hide the views: WordPress.com Simple serves the MCP view alone.
 	 */
 	public function test_features_view_flag_can_be_filtered_by_the_host() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter(
 			'jetpack_ai_admin_config',
 			function ( $config ) {
@@ -761,15 +763,35 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The name is only looked up for the gated views, so an ungated page ships
-	 * an empty value rather than paying for the purchase lookup.
+	 * The name is only looked up for the gated views, so a host that closes them
+	 * ships an empty value rather than paying for the purchase lookup.
 	 */
-	public function test_plan_name_is_absent_without_the_gate() {
+	public function test_plan_name_is_absent_when_a_host_closes_the_views() {
+		$this->given_woa( false );
+		$this->given_site( array( $this->jetpack_ai_purchase() ) );
+		add_filter(
+			'jetpack_ai_admin_config',
+			function ( $config ) {
+				$config['showGatedViews'] = false;
+
+				return $config;
+			}
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( '', $settings['planName'] );
+	}
+
+	/**
+	 * And an ordinary visitor now gets it, because the views render for them.
+	 */
+	public function test_plan_name_is_looked_up_for_an_ordinary_visitor() {
 		$this->given_woa( false );
 		$this->given_site( array( $this->jetpack_ai_purchase() ) );
 
 		$settings = $this->get_injected_settings();
 
-		$this->assertSame( '', $settings['planName'] );
+		$this->assertNotSame( '', $settings['planName'] );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -49,15 +49,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Master enforcement only runs on internal testing environments while the
-	 * AI controls are not publicly launched. The predicate treats a proxied
-	 * A8C request as internal, so that is the lever the enforcement tests pull.
-	 */
-	private function force_internal_testing_env() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-	}
-
-	/**
 	 * Reset the options and filters this test touches.
 	 */
 	public function tear_down() {
@@ -111,12 +102,9 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 
 	/**
 	 * Master off (off-Simple: the `ai` module inactive) turns off every AI filter
-	 * the settings class guards — on an internal testing environment, where
-	 * master enforcement is live.
+	 * the settings class guards.
 	 */
 	public function test_master_off_disables_ai_filters() {
-		$this->force_internal_testing_env();
-
 		// Off-Simple, the module is the master and is inactive by default here.
 		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
@@ -126,27 +114,25 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Until the AI controls ship publicly, the master gate is waived outside
-	 * internal testing environments: an inactive `ai` module must not turn AI
-	 * off for the public.
+	 * The master switch takes effect for everyone, with no proxy and no internal
+	 * testing hostname: an inactive `ai` module turns AI off.
 	 */
-	public function test_master_not_enforced_outside_internal_testing_env() {
-		// Plain test env: not internal, module inactive.
+	public function test_master_enforced_for_an_ordinary_visitor() {
+		$this->assertFalse( jetpack_is_internal_testing_environment(), 'Precondition: an ordinary environment.' );
 		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'Precondition: the stored master state reads off.' );
 
-		$this->assertTrue( apply_filters( 'jetpack_ai_enabled', true ) );
-		$this->assertTrue( apply_filters( 'jetpack_search_ai_answers_enabled', true ) );
-		$this->assertTrue( apply_filters( 'jetpack_ai_sidebar_enabled', true ) );
-		$this->assertTrue( apply_filters( 'jetpack_ai_seo_enabled', true ) );
-		$this->assertTrue( Jetpack_AI_Settings::is_ai_enabled() );
-		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled() );
+		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
+		$this->assertFalse( apply_filters( 'jetpack_search_ai_answers_enabled', true ) );
+		$this->assertFalse( apply_filters( 'jetpack_ai_sidebar_enabled', true ) );
+		$this->assertFalse( apply_filters( 'jetpack_ai_seo_enabled', true ) );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_enabled() );
+		$this->assertFalse( Jetpack_AI_Settings::is_ai_seo_enabled() );
 	}
 
 	/**
-	 * The waiver covers only the master gate: the host gate (a server-owner
-	 * decision) keeps enforcing everywhere.
+	 * The host gate (a server-owner decision) keeps enforcing everywhere.
 	 */
-	public function test_host_gate_enforced_outside_internal_testing_env() {
+	public function test_host_gate_enforced_for_an_ordinary_visitor() {
 		if ( ! function_exists( 'wp_supports_ai' ) ) {
 			$this->markTestSkipped( 'wp_supports_ai() is not available in this WordPress version.' );
 		}
@@ -177,7 +163,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * helper's hard AND.
 	 */
 	public function test_is_ai_enabled_master_gate_is_final() {
-		$this->force_internal_testing_env();
 		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
 		add_filter( 'jetpack_ai_enabled', '__return_true', PHP_INT_MAX );
 
@@ -402,28 +387,11 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The controls this class owns are not publicly launched, so a stored-off
-	 * toggle is inert outside internal testing environments: the feature keeps
-	 * the behavior the released version has.
+	 * The WordPress Agent switches take effect for everyone: a stored-off toggle
+	 * turns its feature off with no proxy and no internal testing hostname.
 	 */
-	public function test_owned_toggles_are_inert_outside_internal_testing() {
-		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'jetpack_ai_image_editor_enabled', 0 );
-		update_option( 'jetpack_ai_feature_clip_enabled', 0 );
-		update_option( 'jetpack_ai_seo_enabled', 0 );
-
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) );
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'feature_clip' ) );
-		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_seo' ) );
-	}
-
-	/**
-	 * On an internal testing environment the same stored values apply, so the
-	 * settings page can be exercised end to end there.
-	 */
-	public function test_owned_toggles_apply_on_internal_testing() {
-		$this->force_internal_testing_env();
+	public function test_owned_toggles_apply_for_an_ordinary_visitor() {
+		$this->assertFalse( jetpack_is_internal_testing_environment(), 'Precondition: an ordinary environment.' );
 
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'jetpack_ai_image_editor_enabled', 0 );
@@ -438,10 +406,9 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 
 	/**
 	 * The reused Search option is not one of the controls this class owns: it
-	 * ships today with its own settings surface, so it applies everywhere and
-	 * the rollout scoping must not touch it.
+	 * ships with its own settings surface, so it applies everywhere.
 	 */
-	public function test_reused_toggles_apply_outside_internal_testing() {
+	public function test_reused_toggles_apply_everywhere() {
 		update_option( 'jetpack_search_ai_answers_enabled', 1 );
 
 		$this->assertTrue( Jetpack_AI_Settings::is_feature_enabled( 'ai_search' ) );
@@ -458,7 +425,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 */
 	public function test_seo_feature_follows_its_option() {
 		$this->force_ai_module_active();
-		$this->force_internal_testing_env();
 
 		$this->assertTrue( Jetpack_AI_Settings::is_ai_seo_enabled(), 'Defaults on with every gate open.' );
 
@@ -473,7 +439,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * so the choice returns when the master does.
 	 */
 	public function test_seo_feature_master_off_preserves_saved_value() {
-		$this->force_internal_testing_env();
 
 		// Seed off first so the row exists: a write equal to the registered
 		// default is short-circuited by update_option and stores nothing.
@@ -495,7 +460,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * override the in-chain gate callback, but not the helper's hard AND.
 	 */
 	public function test_seo_feature_late_filter_cannot_beat_master() {
-		$this->force_internal_testing_env();
 		add_filter( 'jetpack_ai_seo_enabled', '__return_true', 999 );
 
 		// Off-Simple the `ai` module is the master and is inactive by default here.
@@ -523,7 +487,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * A feature's option turns it off where the owned toggles apply.
 	 */
 	public function test_feature_option_off() {
-		$this->force_internal_testing_env();
 
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 
@@ -576,7 +539,6 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 */
 	public function test_owned_features_honor_their_option_off_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', false );
-		$this->force_internal_testing_env();
 
 		update_option( 'jetpack_ai_image_editor_enabled', 0 );
 


### PR DESCRIPTION
## Proposed changes

* Show the Jetpack AI page's **Overview** and **WordPress Agent** tabs to every administrator, instead of only Automatticians.
* Remove the "A12s only" badge from those tabs.
* Show the on/off control on the My Jetpack Jetpack AI card to everyone, and let it report the AI module's real state.
* Make the site-wide AI switch and the four WordPress Agent switches actually take effect on self-hosted and Atomic. They previously saved but did nothing outside internal testing environments.

The `jetpack_ai_admin_config` filter is kept, so a host can still close the views — WordPress.com Simple uses it.

## Does this pull request change what data or activity we track or use?

No. The Tracks `is_a11n` / `is_test` properties are unchanged and still follow `jetpack_is_internal_testing_environment()`, with tests pinning that.

## Real-screen before / after

Captured on a live Jurassic Ninja site at `/wp-admin/admin.php?page=jetpack-ai`, unproxied, on a free plan. The only difference between the two is this branch.

| Before — Automatticians only | After — everyone |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-hub-gate-lift/before-overview.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-hub-gate-lift/after-overview.png) |

Both tabs carry an "A12s only" badge before; after, they render for any administrator and the badge is gone.

### The AI switches now take effect

| My Jetpack card | Jetpack AI → WordPress Agent, with AI off |
|---|---|
| ![card](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-hub-gate-lift/after-my-jetpack-ai-card.png) | ![ai off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-hub-gate-lift/after-agent-tab-ai-off.png) |

The AI card gains an on/off control that reports the module's real state. Turning it off puts the WordPress Agent tab into its "Jetpack AI is turned off for this site" state, with the switches greyed out and their saved values kept.

### Verified unproxied on WordPress.com Atomic

A Jurassic Ninja is an internal testing environment by hostname, so it cannot prove the gate on its own. This was also confirmed on an Atomic site with the a8c proxy **off** — a genuine non-Automattician environment, where `jetpack_is_internal_testing_environment()` returns false and the tabs were hidden before this branch.

![atomic unproxied](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-hub-gate-lift/after-atomic-unproxied.png)

With the branch active and the proxy off: all three tabs render, no badge, and the Tracks properties behave correctly and independently — `is_test` **false** (not an internal environment) while `is_a11n` stays **true** (the user is still an Automattician). That separation is the point of keeping those properties out of the lift.

## Testing instructions

No proxy needed — that is the point.

1. Go to `/wp-admin/admin.php?page=jetpack-ai`. The three tabs render and no tab carries an "A12s only" badge.
2. On **WordPress Agent**, turn Writing Assistant off, reload the editor: the AI panel and toolbar button are gone. On trunk this switch does nothing.
3. On `/wp-admin/admin.php?page=my-jetpack`, the Jetpack AI card shows an on/off control. Turn AI off, reload the AI page: it says AI is off and greys the switches.
4. As a non-administrator, `/wp-admin/admin.php?page=jetpack-ai` still refuses access.

### What was deliberately not changed

* **WordPress.com Simple is unaffected.** Its Hub is gated by the `jetpack_mu_wpcom_load_jetpack_ai_hub` filter, which defaults off, and it separately forces the gated views closed. Neither is touched here.
* **The Scheduled tasks tab stays hidden** behind its own default-off feature flag.
* **Tracks identity is unchanged** — see above.
* **Dev-mode signals for other features** (Image Studio, reader chat) and the internal feature-flag screen are untouched.

### One behaviour change worth calling out

With Jetpack AI turned off for a site, the Search REST endpoint now refuses a request that tries to turn AI Answers **on**, returning a 400 with "AI Answers cannot be enabled while Jetpack AI is turned off for this site." That guard was written deliberately but could never fire before, because the master switch was waived outside internal testing environments. Turning AI Answers off is still allowed, so a saved choice can be cleared.
