### PR TITLE
Jetpack AI: land on the Jetpack AI page from My Jetpack's links

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-jetpack-ai-hub-destinations
+++ b/projects/packages/my-jetpack/changelog/update-jetpack-ai-hub-destinations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: Land on the Jetpack AI page from the card's Manage link and after purchase or activation.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -519,17 +519,13 @@ class Jetpack_Ai extends Module_Product {
 	/**
 	 * Get the URL where the user manages the product
 	 *
-	 * Pre-release gate: the Jetpack AI Hub's gated views are limited to
-	 * internal testing environments, so only they land there — everyone else
-	 * keeps the My Jetpack product page. Drop the gate when the views go public.
+	 * The Jetpack plugin registers the Jetpack AI page, so standalone installs
+	 * that ship My Jetpack without it keep the product page.
 	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		if (
-			function_exists( 'jetpack_is_internal_testing_environment' ) &&
-			jetpack_is_internal_testing_environment()
-		) {
+		if ( self::is_plugin_active() ) {
 			return admin_url( 'admin.php?page=jetpack-ai' );
 		}
 

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -177,12 +177,12 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * In internal testing environments the manage URL points at the Jetpack AI
-	 * Hub, whose Overview tab is visible behind the same gate.
+	 * With the Jetpack plugin active the manage URL points at the Jetpack AI page
+	 * for everyone — no proxy, no internal testing hostname.
 	 */
-	public function test_manage_url_points_at_the_jetpack_ai_hub_in_internal_testing() {
+	public function test_manage_url_points_at_the_jetpack_ai_page_for_an_ordinary_visitor() {
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 
 		$manage_url = Jetpack_Ai::get_manage_url();
 
@@ -191,60 +191,29 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * Outside internal testing the Jetpack AI Hub shows only MCP Settings, so
-	 * the manage URL must keep landing on the My Jetpack product page.
+	 * Post-checkout landing is the Jetpack AI page for an ordinary visitor.
 	 */
-	public function test_manage_url_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+	public function test_post_checkout_lands_on_the_jetpack_ai_page_for_an_ordinary_visitor() {
 		activate_plugins( 'jetpack/jetpack.php' );
 		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
-
-		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
-	}
-
-	/**
-	 * Post-checkout landing in internal testing environments is the Jetpack AI Hub.
-	 */
-	public function test_post_checkout_lands_on_the_jetpack_ai_hub_in_internal_testing() {
-		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
 
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
 	}
 
 	/**
-	 * Post-checkout landing outside internal testing stays on the My Jetpack product page.
+	 * Post-activation landing is the Jetpack AI page for an ordinary visitor.
 	 */
-	public function test_post_checkout_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+	public function test_post_activation_lands_on_the_jetpack_ai_page_for_an_ordinary_visitor() {
 		activate_plugins( 'jetpack/jetpack.php' );
 		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
-
-		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
-	}
-
-	/**
-	 * Post-activation landing in internal testing environments is the Jetpack AI Hub.
-	 */
-	public function test_post_activation_lands_on_the_jetpack_ai_hub_in_internal_testing() {
-		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
 
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
 	}
 
 	/**
-	 * Post-activation landing outside internal testing stays on the My Jetpack product page.
-	 */
-	public function test_post_activation_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
-		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
-
-		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
-	}
-
-	/**
-	 * Standalone plugins ship My Jetpack without the Jetpack plugin, so the gate
-	 * helper never exists and the manage URL must fall back to My Jetpack. Separate
-	 * process so no earlier activate_plugins() call has defined the helper.
+	 * Standalone plugins ship My Jetpack without the Jetpack plugin, which is what
+	 * registers the Jetpack AI page, so the manage URL must fall back to My Jetpack.
+	 * Separate process so no earlier activate_plugins() call leaks in.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -252,7 +221,7 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_manage_url_stays_on_the_my_jetpack_product_page_without_the_jetpack_plugin() {
-		$this->assertFalse( function_exists( 'jetpack_is_internal_testing_environment' ) );
+		$this->assertFalse( Jetpack_Ai::is_plugin_active(), 'Precondition: the Jetpack plugin is not active.' );
 		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-destinations
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-destinations
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Land on the Jetpack AI page from My Jetpack's Manage link and after purchase or activation.


### PR DESCRIPTION
Stacked on #51879 — **base is `update/jetpack-ai-hub-gate-lift`, not trunk.**

## Proposed changes

* Land on the Jetpack AI page from the My Jetpack AI card's Manage link, and after purchase or activation. Previously only Automatticians did; everyone else went to the My Jetpack product page.

The old gate did double duty: its `function_exists( 'jetpack_is_internal_testing_environment' )` half was an implicit "is the Jetpack plugin loaded" check. Removing the whole condition would have sent standalone-plugin users (Boost, Protect, Social) to a page those installs never register, so it is replaced with an explicit `self::is_plugin_active()`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On `/wp-admin/admin.php?page=my-jetpack`, click Manage on the Jetpack AI card — it lands on `/wp-admin/admin.php?page=jetpack-ai`. No proxy needed.
2. On a site with a standalone plugin that bundles My Jetpack but not the Jetpack plugin, the same link still goes to the My Jetpack product page.
