### PR TITLE
Expiry notices: add the plan-expiration modal to wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-expiry-plan-modal-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-expiry-plan-modal-wp-admin
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Expiry notices: add a dismissible modal explaining what changes on a site whose plan has expired.
+Expiry notices: add a dismissible modal explaining what changes on a site whose plan has expired, and point reverted sites at support.

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-expiry-plan-modal-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-expiry-plan-modal-wp-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Expiry notices: add a dismissible modal explaining what changes on a site whose plan has expired.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
@@ -5,6 +5,7 @@
  * @package automattic/jetpack-mu-wpcom
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
 
@@ -262,11 +263,20 @@ function wpcom_expiry_notices_admin_banner_body( array $state ): string {
 	$days       = isset( $state['days_remaining'] ) ? (int) $state['days_remaining'] : 0;
 	$auto_renew = ! empty( $state['auto_renew'] );
 
-	if ( Expiry_Data::STATE_EXPIRED === ( $state['state'] ?? '' ) ) {
+	$stage = $state['state'] ?? '';
+
+	// Past grace by the calendar but still Atomic and un-reverted: none of what
+	// the post-grace copy claims has happened yet, and renewing still prevents
+	// it, so describe it the way the grace period does.
+	if ( Expiry_Data::STATE_EXPIRED === $stage
+		&& ! wpcom_expiry_notices_revert_applies_to_site( $state )
+		&& Constants::is_true( 'IS_ATOMIC' ) ) {
+		$stage = Expiry_Data::STATE_EXPIRED_GRACE;
+	}
+
+	if ( Expiry_Data::STATE_EXPIRED === $stage ) {
 		// A revert takes the site private and deletes what it lists, and buying
 		// the plan again brings none of it back -- so this half asks for support.
-		// Keyed on the revert rather than on `is_atomic`, which is already false
-		// by the time a site has been reverted.
 		if ( wpcom_expiry_notices_revert_applies_to_site( $state ) ) {
 			if ( null === $storage_gb ) {
 				return __( 'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or additional storage. Contact support to get help restoring it.', 'jetpack-mu-wpcom' );
@@ -287,7 +297,7 @@ function wpcom_expiry_notices_admin_banner_body( array $state ): string {
 		);
 	}
 
-	if ( Expiry_Data::STATE_EXPIRED_GRACE === ( $state['state'] ?? '' ) ) {
+	if ( Expiry_Data::STATE_EXPIRED_GRACE === $stage ) {
 		// "If renewal doesn't go through" only makes sense while a renewal
 		// attempt is still scheduled.
 		if ( $auto_renew ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
@@ -46,16 +46,23 @@ function wpcom_expiry_notices_admin_banner_data(): ?array {
 /**
  * CTA URLs for the banner.
  *
- * Once the site has been reverted, renewing no longer undoes anything the
- * notice describes, so the ask becomes support instead.
+ * Only a reverted site is sent to support: one that never carried a transfer
+ * lost plan features and nothing else, and buying the plan again does give those
+ * back. The banner shows on every site, so this has to be asked, not assumed.
  *
  * @param array<string,mixed> $state Expiry state.
  * @return array<string,array>
  */
 function wpcom_expiry_notices_admin_banner_urls( array $state ): array {
 	$urls = Expiry_Data::get_cta_urls( $state, wpcom_expiry_notices_current_admin_url() );
-	if ( Expiry_Data::STATE_EXPIRED === ( $state['state'] ?? '' ) ) {
+	if ( Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
+		return $urls;
+	}
+
+	if ( wpcom_expiry_notices_revert_applies_to_site( $state ) ) {
 		$urls['primary'] = wpcom_expiry_notices_support_cta( $state );
+	} else {
+		$urls['primary']['label'] = __( 'Restore site', 'jetpack-mu-wpcom' );
 	}
 	return $urls;
 }
@@ -256,15 +263,17 @@ function wpcom_expiry_notices_admin_banner_body( array $state ): string {
 	$auto_renew = ! empty( $state['auto_renew'] );
 
 	if ( Expiry_Data::STATE_EXPIRED === ( $state['state'] ?? '' ) ) {
-		// Reverting an Atomic site also takes it private; a Simple site stays
-		// public, so only Atomic mentions it.
-		if ( ! empty( $state['is_atomic'] ) ) {
+		// A revert takes the site private and deletes what it lists, and buying
+		// the plan again brings none of it back -- so this half asks for support.
+		// Keyed on the revert rather than on `is_atomic`, which is already false
+		// by the time a site has been reverted.
+		if ( wpcom_expiry_notices_revert_applies_to_site( $state ) ) {
 			if ( null === $storage_gb ) {
-				return __( 'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or additional storage. Upgrade your plan to restore your site.', 'jetpack-mu-wpcom' );
+				return __( 'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or additional storage. Contact support to get help restoring it.', 'jetpack-mu-wpcom' );
 			}
 			return sprintf(
 				/* translators: %d is a number of gigabytes of storage. */
-				__( 'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or %d GB of storage. Upgrade your plan to restore your site.', 'jetpack-mu-wpcom' ),
+				__( 'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or %d GB of storage. Contact support to get help restoring it.', 'jetpack-mu-wpcom' ),
 				$storage_gb
 			);
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
@@ -46,9 +46,8 @@ function wpcom_expiry_notices_admin_banner_data(): ?array {
 /**
  * CTA URLs for the banner.
  *
- * Once the site has been reverted the ask is no longer "renew" but "put the
- * site back", and wp-admin labels that button "Restore site" where the other
- * surfaces say "Restore my site".
+ * Once the site has been reverted, renewing no longer undoes anything the
+ * notice describes, so the ask becomes support instead.
  *
  * @param array<string,mixed> $state Expiry state.
  * @return array<string,array>
@@ -56,7 +55,7 @@ function wpcom_expiry_notices_admin_banner_data(): ?array {
 function wpcom_expiry_notices_admin_banner_urls( array $state ): array {
 	$urls = Expiry_Data::get_cta_urls( $state, wpcom_expiry_notices_current_admin_url() );
 	if ( Expiry_Data::STATE_EXPIRED === ( $state['state'] ?? '' ) ) {
-		$urls['primary']['label'] = __( 'Restore site', 'jetpack-mu-wpcom' );
+		$urls['primary'] = wpcom_expiry_notices_support_cta( $state );
 	}
 	return $urls;
 }
@@ -138,7 +137,14 @@ function wpcom_expiry_notices_render_admin_banner_html( array $state, array $url
 		<p><strong><?php echo esc_html( wpcom_expiry_notices_admin_banner_heading( $state ) ); ?></strong></p>
 		<p><?php echo esc_html( wpcom_expiry_notices_admin_banner_body( $state ) ); ?></p>
 		<p class="wpcom-expiry-banner__actions">
-			<a class="button button-primary" href="<?php echo esc_url( $urls['primary']['url'] ); ?>">
+			<?php // The message turns this into a Help Center opener; the href stays as what a click falls back to. ?>
+			<a
+				class="button button-primary"
+				href="<?php echo esc_url( $urls['primary']['url'] ); ?>"
+				<?php if ( isset( $urls['primary']['message'] ) ) : ?>
+					data-support-message="<?php echo esc_attr( $urls['primary']['message'] ); ?>"
+				<?php endif; ?>
+			>
 				<?php echo esc_html( $urls['primary']['label'] ); ?>
 			</a>
 			<?php if ( $is_grace ) : ?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
@@ -15,19 +15,8 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
  * @return array{state:array,is_early_warning:bool,is_dismissible:bool,urls:array}|null
  */
 function wpcom_expiry_notices_admin_banner_data(): ?array {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return null;
-	}
-
-	// The Simple notice this replaces excluded VIP sites, and swapping the
-	// notices was never meant to change who sees one. Guarded because
-	// wpcom_is_vip() only exists on wpcom.
-	if ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) {
-		return null;
-	}
-
-	$state = Expiry_Data::get_expiry_state();
-	if ( null === $state || Expiry_Data::STATE_ACTIVE === $state['state'] ) {
+	$state = wpcom_expiry_notices_eligible_state();
+	if ( null === $state ) {
 		return null;
 	}
 
@@ -98,6 +87,10 @@ function wpcom_expiry_notices_enqueue_admin_banner_assets() {
 	}
 
 	$asset_handle = jetpack_mu_wpcom_enqueue_assets( 'expiry-notices-admin-banner', array( 'js', 'css' ) );
+	// Without this the banner's events are recorded on Simple and dropped on
+	// Atomic, where nothing else in wp-admin loads the Tracks transport and
+	// `window._tkq` stays an ordinary array.
+	\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_enqueue_tracking_scripts( $asset_handle );
 	wp_localize_script(
 		$asset_handle,
 		'wpcomExpiryBanner',
@@ -183,14 +176,7 @@ function wpcom_expiry_notices_admin_banner_heading( array $state ): string {
 	);
 
 	if ( $has_expired ) {
-		if ( '' === $plan ) {
-			return __( 'Your plan has expired', 'jetpack-mu-wpcom' );
-		}
-		return sprintf(
-			/* translators: %s is the plan name (e.g. Business). */
-			__( 'Your %s plan has expired', 'jetpack-mu-wpcom' ),
-			$plan
-		);
+		return wpcom_expiry_notices_expired_heading( $state );
 	}
 
 	// A plan that is still expected to renew hasn't failed yet, so it gets a
@@ -382,20 +368,4 @@ function wpcom_expiry_notices_admin_banner_body( array $state ): string {
 		$expiry_date,
 		$storage_gb
 	);
-}
-
-/**
- * Build the full URL of the current admin page so checkout can redirect back.
- * Strips transient query args (`settings-updated`, `_wpnonce`, etc.) so the
- * redirected user doesn't re-trigger one-shot admin notices or hit stale
- * nonces on return.
- */
-function wpcom_expiry_notices_current_admin_url(): string {
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
-	if ( '' === $request_uri ) {
-		return admin_url();
-	}
-	$request_uri = remove_query_arg( wp_removable_query_args(), $request_uri );
-	$admin_path  = preg_replace( '#^/?wp-admin/?#', '', $request_uri );
-	return admin_url( ltrim( $admin_path, '/' ) );
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Wp-admin modal for plans that have expired, in grace or after it.
+ *
+ * Atomic only. Every change the copy lists -- the revert to Free, the themes and
+ * plugins going away, the site turning private -- is what `woa_revert` does to a
+ * transferred site. A Simple site on a lapsed plan loses features, but it is not
+ * reverted and does not go private, so none of this would be true of it.
+ *
+ * All copy lives here rather than in the React that renders it: this package
+ * extracts PHP strings for translation and does not extract JS.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+
+/**
+ * Resolve the data the modal renders from, or null if it shouldn't show.
+ * Shared by the enqueue and render hooks.
+ *
+ * @return array<string,mixed>|null
+ */
+function wpcom_expiry_notices_admin_modal_data(): ?array {
+	// Before resolving any state: deriving it can reach the store, and on Simple
+	// -- where this never shows -- that would be a second such trip per admin
+	// pageview on top of the banner's, for an answer thrown away immediately.
+	if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
+		return null;
+	}
+
+	$state = wpcom_expiry_notices_eligible_state();
+	if ( null === $state ) {
+		return null;
+	}
+
+	if ( ! Expiry_Notice_Dismiss::should_show_modal( $state ) ) {
+		return null;
+	}
+
+	$meta_key = Expiry_Notice_Dismiss::modal_meta_key( $state );
+	if ( null === $meta_key ) {
+		return null;
+	}
+
+	$is_grace = Expiry_Data::STATE_EXPIRED_GRACE === $state['state'];
+	$urls     = Expiry_Data::get_cta_urls( $state, wpcom_expiry_notices_current_admin_url() );
+
+	return array(
+		'state'       => $state,
+		'metaKey'     => $meta_key,
+		'title'       => wpcom_expiry_notices_expired_heading( $state ),
+		'description' => wpcom_expiry_notices_modal_description( $is_grace ),
+		'listIntro'   => $is_grace ? '' : __( 'Here’s what changed:', 'jetpack-mu-wpcom' ),
+		'items'       => wpcom_expiry_notices_modal_items( $is_grace ),
+		'primary'     => wpcom_expiry_notices_modal_primary_cta( $urls, $is_grace ),
+		// Renewing is only one of two things to consider while the site is still
+		// recoverable by paying for the same plan. Once it has been reverted the
+		// only offer is to put it back, so there is nothing to compare.
+		'secondary'   => $is_grace ? $urls['secondary'] : null,
+		'imageUrl'    => plugins_url( 'images/plan-expired.svg', __FILE__ ),
+	);
+}
+
+/**
+ * The paragraph under the title.
+ *
+ * @param bool $is_grace Whether the site is still inside the grace period.
+ */
+function wpcom_expiry_notices_modal_description( bool $is_grace ): string {
+	if ( $is_grace ) {
+		return __( 'Your site will be moved to the Free plan. We will also make these changes to your site:', 'jetpack-mu-wpcom' );
+	}
+	return __( 'Your site has been moved to the Free plan and set to private. Upgrade your plan to restore your site.', 'jetpack-mu-wpcom' );
+}
+
+/**
+ * The listed changes, in the tense the site's state calls for.
+ *
+ * @param bool $is_grace Whether the site is still inside the grace period.
+ * @return array<int,string>
+ */
+function wpcom_expiry_notices_modal_items( bool $is_grace ): array {
+	$domain = Expiry_Domain::get_revert_domain();
+
+	if ( $is_grace ) {
+		$items = array();
+		if ( null !== $domain ) {
+			$items[] = sprintf(
+				/* translators: %s is a WordPress.com domain name (e.g. example.wordpress.com). */
+				__( 'Use %s as your primary domain.', 'jetpack-mu-wpcom' ),
+				$domain
+			);
+		}
+		$items[] = __( 'Remove your installed themes, plugins, and their data.', 'jetpack-mu-wpcom' );
+		$items[] = __( 'Switch to the settings and theme you had before you upgraded.', 'jetpack-mu-wpcom' );
+		$items[] = __( 'Your site will be set to private.', 'jetpack-mu-wpcom' );
+		return $items;
+	}
+
+	$items = array( __( 'Your site is now private.', 'jetpack-mu-wpcom' ) );
+	if ( null !== $domain ) {
+		$items[] = sprintf(
+			/* translators: %s is a WordPress.com domain name (e.g. example.wordpress.com). */
+			__( 'Your primary domain was switched to %s.', 'jetpack-mu-wpcom' ),
+			$domain
+		);
+	}
+	$items[] = __( 'Your installed themes, plugins, and their data were removed from your site.', 'jetpack-mu-wpcom' );
+	$items[] = __( 'Your settings and theme reverted to what you had before upgrading.', 'jetpack-mu-wpcom' );
+	return $items;
+}
+
+/**
+ * The primary CTA. Post-grace the ask is no longer to renew but to put the site
+ * back, so the label changes while the checkout URL doesn't.
+ *
+ * @param array<string,array> $urls     CTA URLs from Expiry_Data::get_cta_urls().
+ * @param bool                $is_grace Whether the site is still inside the grace period.
+ * @return array{label:string,url:string}
+ */
+function wpcom_expiry_notices_modal_primary_cta( array $urls, bool $is_grace ): array {
+	$primary = $urls['primary'];
+	if ( ! $is_grace ) {
+		$primary['label'] = __( 'Restore my site', 'jetpack-mu-wpcom' );
+	}
+	return $primary;
+}
+
+/**
+ * Enqueue + localize the modal's JS/CSS.
+ */
+function wpcom_expiry_notices_enqueue_admin_modal_assets() {
+	$data = wpcom_expiry_notices_admin_modal_data();
+	if ( null === $data ) {
+		return;
+	}
+
+	$asset_handle = jetpack_mu_wpcom_enqueue_assets( 'expiry-notices-admin-modal', array( 'js', 'css' ) );
+	// Atomic wp-admin loads no Tracks transport of its own, so without this the
+	// modal's events would accumulate in a plain array and be dropped on unload.
+	\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_enqueue_tracking_scripts( $asset_handle );
+
+	$state = $data['state'];
+	unset( $data['state'] );
+
+	wp_localize_script(
+		$asset_handle,
+		'wpcomExpiryModal',
+		array_merge(
+			$data,
+			array(
+				'trackProps' => array(
+					'state'          => $state['state'],
+					'days_remaining' => isset( $state['days_remaining'] ) ? (int) $state['days_remaining'] : 0,
+					'product_slug'   => isset( $state['product_slug'] ) ? (string) $state['product_slug'] : '',
+				),
+			)
+		)
+	);
+}
+add_action( 'admin_enqueue_scripts', 'wpcom_expiry_notices_enqueue_admin_modal_assets' );
+
+/**
+ * Render the element the modal mounts into.
+ *
+ * In the footer because the modal is an overlay: it belongs to the page rather
+ * than to any position in it, and mounting late keeps it out of the way of the
+ * admin notice area the banner uses.
+ */
+function wpcom_expiry_notices_render_admin_modal_root() {
+	if ( null === wpcom_expiry_notices_admin_modal_data() ) {
+		return;
+	}
+	echo '<div id="wpcom-expiry-modal-root"></div>';
+}
+add_action( 'admin_footer', 'wpcom_expiry_notices_render_admin_modal_root' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -2,13 +2,9 @@
 /**
  * Wp-admin modal for plans that have expired, in grace or after it.
  *
- * Atomic only. Every change the copy lists -- the revert to Free, the themes and
- * plugins going away, the site turning private -- is what `woa_revert` does to a
- * transferred site. A Simple site on a lapsed plan loses features, but it is not
- * reverted and does not go private, so none of this would be true of it.
- *
- * All copy lives here rather than in the React that renders it: this package
- * extracts PHP strings for translation and does not extract JS.
+ * Atomic only: the copy describes what `woa_revert` does, and a Simple site is
+ * not reverted. Copy lives here rather than in the React that renders it,
+ * because this package extracts PHP strings for translation and not JS.
  *
  * @package automattic/jetpack-mu-wpcom
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -2,9 +2,10 @@
 /**
  * Wp-admin modal for plans that have expired, in grace or after it.
  *
- * Atomic only: the copy describes what `woa_revert` does, and a Simple site is
- * not reverted. Copy lives here rather than in the React that renders it,
- * because this package extracts PHP strings for translation and not JS.
+ * For sites that carry an Atomic transfer, which is not the same as sites that
+ * are Atomic now -- see wpcom_expiry_notices_modal_applies_to_site(). Copy lives
+ * here rather than in the React that renders it, because this package extracts
+ * PHP strings for translation and not JS.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -21,15 +22,12 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
  * @return array<string,mixed>|null
  */
 function wpcom_expiry_notices_admin_modal_data(): ?array {
-	// Before resolving any state: deriving it can reach the store, and on Simple
-	// -- where this never shows -- that would be a second such trip per admin
-	// pageview on top of the banner's, for an answer thrown away immediately.
-	if ( ! Constants::is_true( 'IS_ATOMIC' ) ) {
+	$state = wpcom_expiry_notices_eligible_state();
+	if ( null === $state ) {
 		return null;
 	}
 
-	$state = wpcom_expiry_notices_eligible_state();
-	if ( null === $state ) {
+	if ( ! wpcom_expiry_notices_modal_applies_to_site( $state ) ) {
 		return null;
 	}
 
@@ -59,6 +57,39 @@ function wpcom_expiry_notices_admin_modal_data(): ?array {
 		'secondary'   => $is_grace ? $urls['secondary'] : null,
 		'imageUrl'    => plugins_url( 'images/plan-expired.svg', __FILE__ ),
 	);
+}
+
+/**
+ * Whether this site is one the modal's copy is true of.
+ *
+ * The revert is the whole subject, so the audience is sites that carry a
+ * transfer -- but it cannot simply be "Atomic", because the revert itself is
+ * what ends that. A site is Atomic while the changes are still ahead of it and
+ * Simple once they have happened, which is exactly when the second variant is
+ * due. So Simple counts too, on the sticker wpcom leaves behind.
+ *
+ * @param array<string,mixed> $state Expiry state.
+ */
+function wpcom_expiry_notices_modal_applies_to_site( array $state ): bool {
+	if ( Constants::is_true( 'IS_ATOMIC' ) ) {
+		return true;
+	}
+
+	// Only after the grace period. Before it, a site that has been reverted was
+	// reverted by some earlier lapse, and this one has not reached the changes
+	// the pre-revert variant promises.
+	if ( Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
+		return false;
+	}
+
+	if ( ! wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() ) ) {
+		return false;
+	}
+
+	// The sticker outlives the lapse that earned it. A site reverted years ago
+	// can be lapsing a plan that never carried a transfer, and none of the copy
+	// would be true of that.
+	return Expiry_Data::is_atomic_capable_plan( isset( $state['product_slug'] ) ? (string) $state['product_slug'] : '' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -78,18 +78,16 @@ function wpcom_expiry_notices_modal_applies_to_site( array $state ): bool {
 	// Only after the grace period. Before it, a site that has been reverted was
 	// reverted by some earlier lapse, and this one has not reached the changes
 	// the pre-revert variant promises.
+	//
+	// Not narrowed by plan: Personal and higher carry a transfer, so there is no
+	// tier whose lapse could not have produced this revert. The window does the
+	// narrowing instead -- a state only exists for 60 days past an expiry, and
+	// the revert lands 30 days into it.
 	if ( Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
 		return false;
 	}
 
-	if ( ! wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() ) ) {
-		return false;
-	}
-
-	// The sticker outlives the lapse that earned it. A site reverted years ago
-	// can be lapsing a plan that never carried a transfer, and none of the copy
-	// would be true of that.
-	return Expiry_Data::is_atomic_capable_plan( isset( $state['product_slug'] ) ? (string) $state['product_slug'] : '' );
+	return wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -18,31 +18,48 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
  * Resolve the data the modal renders from, or null if it shouldn't show.
  * Shared by the enqueue and render hooks.
  *
+ * @param bool $flush Drop the memo. For tests, which move the fixture under a
+ *                    process that has already answered once.
  * @return array<string,mixed>|null
  */
-function wpcom_expiry_notices_admin_modal_data(): ?array {
+function wpcom_expiry_notices_admin_modal_data( bool $flush = false ): ?array {
+	// Read twice per pageview -- once to enqueue, once to render -- and each read
+	// costs a sticker lookup and a domain resolution. Distinct from null, which
+	// is a real answer.
+	static $memo = false;
+
+	if ( $flush ) {
+		$memo = false;
+		return null;
+	}
+
+	if ( false !== $memo ) {
+		return $memo;
+	}
+
+	$memo  = null;
 	$state = wpcom_expiry_notices_eligible_state();
 	if ( null === $state ) {
-		return null;
+		return $memo;
 	}
 
 	if ( ! wpcom_expiry_notices_revert_applies_to_site( $state ) ) {
-		return null;
+		return $memo;
 	}
 
 	if ( ! Expiry_Notice_Dismiss::should_show_modal( $state ) ) {
-		return null;
+		return $memo;
 	}
 
 	$meta_key = Expiry_Notice_Dismiss::modal_meta_key( $state );
 	if ( null === $meta_key ) {
-		return null;
+		return $memo;
 	}
 
 	$is_grace = Expiry_Data::STATE_EXPIRED_GRACE === $state['state'];
 	$urls     = Expiry_Data::get_cta_urls( $state, wpcom_expiry_notices_current_admin_url() );
 
-	return array(
+	$memo = array(
 		'state'       => $state,
 		'metaKey'     => $meta_key,
 		'title'       => wpcom_expiry_notices_expired_heading( $state ),
@@ -56,6 +73,8 @@ function wpcom_expiry_notices_admin_modal_data(): ?array {
 		'secondary'   => $is_grace ? $urls['secondary'] : null,
 		'imageUrl'    => plugins_url( 'images/plan-expired.svg', __FILE__ ),
 	);
+
+	return $memo;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -3,14 +3,13 @@
  * Wp-admin modal for plans that have expired, in grace or after it.
  *
  * For sites that carry an Atomic transfer, which is not the same as sites that
- * are Atomic now -- see wpcom_expiry_notices_modal_applies_to_site(). Copy lives
+ * are Atomic now -- see wpcom_expiry_notices_revert_applies_to_site(). Copy lives
  * here rather than in the React that renders it, because this package extracts
  * PHP strings for translation and not JS.
  *
  * @package automattic/jetpack-mu-wpcom
  */
 
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
@@ -27,7 +26,7 @@ function wpcom_expiry_notices_admin_modal_data(): ?array {
 		return null;
 	}
 
-	if ( ! wpcom_expiry_notices_modal_applies_to_site( $state ) ) {
+	if ( ! wpcom_expiry_notices_revert_applies_to_site( $state ) ) {
 		return null;
 	}
 
@@ -60,37 +59,6 @@ function wpcom_expiry_notices_admin_modal_data(): ?array {
 }
 
 /**
- * Whether this site is one the modal's copy is true of.
- *
- * The revert is the whole subject, so the audience is sites that carry a
- * transfer -- but it cannot simply be "Atomic", because the revert itself is
- * what ends that. A site is Atomic while the changes are still ahead of it and
- * Simple once they have happened, which is exactly when the second variant is
- * due. So Simple counts too, on the sticker wpcom leaves behind.
- *
- * @param array<string,mixed> $state Expiry state.
- */
-function wpcom_expiry_notices_modal_applies_to_site( array $state ): bool {
-	if ( Constants::is_true( 'IS_ATOMIC' ) ) {
-		return true;
-	}
-
-	// Only after the grace period. Before it, a site that has been reverted was
-	// reverted by some earlier lapse, and this one has not reached the changes
-	// the pre-revert variant promises.
-	//
-	// Not narrowed by plan: Personal and higher carry a transfer, so there is no
-	// tier whose lapse could not have produced this revert. The window does the
-	// narrowing instead -- a state only exists for 60 days past an expiry, and
-	// the revert lands 30 days into it.
-	if ( Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
-		return false;
-	}
-
-	return wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() );
-}
-
-/**
  * The paragraph under the title.
  *
  * @param bool $is_grace Whether the site is still inside the grace period.
@@ -99,7 +67,9 @@ function wpcom_expiry_notices_modal_description( bool $is_grace ): string {
 	if ( $is_grace ) {
 		return __( 'Your site will be moved to the Free plan. We will also make these changes to your site:', 'jetpack-mu-wpcom' );
 	}
-	return __( 'Your site has been moved to the Free plan and set to private. Upgrade your plan to restore your site.', 'jetpack-mu-wpcom' );
+	// Not "upgrade your plan": buying it again does not bring back what the
+	// revert deleted, which is why the only button here goes to support.
+	return __( 'Your site has been moved to the Free plan and set to private. Contact support to get help restoring it.', 'jetpack-mu-wpcom' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -50,7 +50,7 @@ function wpcom_expiry_notices_admin_modal_data(): ?array {
 		'description' => wpcom_expiry_notices_modal_description( $is_grace ),
 		'listIntro'   => $is_grace ? '' : __( 'Here’s what changed:', 'jetpack-mu-wpcom' ),
 		'items'       => wpcom_expiry_notices_modal_items( $is_grace ),
-		'primary'     => wpcom_expiry_notices_modal_primary_cta( $urls, $is_grace ),
+		'primary'     => wpcom_expiry_notices_modal_primary_cta( $state, $urls, $is_grace ),
 		// Renewing is only one of two things to consider while the site is still
 		// recoverable by paying for the same plan. Once it has been reverted the
 		// only offer is to put it back, so there is nothing to compare.
@@ -140,19 +140,16 @@ function wpcom_expiry_notices_modal_items( bool $is_grace ): array {
 }
 
 /**
- * The primary CTA. Post-grace the ask is no longer to renew but to put the site
- * back, so the label changes while the checkout URL doesn't.
+ * The primary CTA: renew while that still saves the site, support once it
+ * doesn't.
  *
+ * @param array<string,mixed> $state    Expiry state.
  * @param array<string,array> $urls     CTA URLs from Expiry_Data::get_cta_urls().
  * @param bool                $is_grace Whether the site is still inside the grace period.
- * @return array{label:string,url:string}
+ * @return array<string,string>
  */
-function wpcom_expiry_notices_modal_primary_cta( array $urls, bool $is_grace ): array {
-	$primary = $urls['primary'];
-	if ( ! $is_grace ) {
-		$primary['label'] = __( 'Restore my site', 'jetpack-mu-wpcom' );
-	}
-	return $primary;
+function wpcom_expiry_notices_modal_primary_cta( array $state, array $urls, bool $is_grace ): array {
+	return $is_grace ? $urls['primary'] : wpcom_expiry_notices_support_cta( $state );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
@@ -9,6 +9,8 @@ declare( strict_types = 1 );
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices;
 
+use Automattic\Jetpack\Constants;
+
 /**
  * Reads purchases and computes a normalized expiry state for the primary plan.
  */
@@ -112,7 +114,7 @@ class Expiry_Data {
 		// is the effective answer, but it is null until a site is serving the
 		// declared purchase shape, so fall back to the flag there.
 		$raw_auto_renew = ! empty( $purchase->user_allows_auto_renew ?? $purchase->auto_renew ?? null );
-		$is_atomic      = defined( 'IS_ATOMIC' ) && IS_ATOMIC;
+		$is_atomic      = Constants::is_true( 'IS_ATOMIC' );
 
 		// Neither the effective renewal state nor the attempt schedule is a
 		// free read: on a Simple site each one queries the store and pulls in

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
@@ -278,6 +278,19 @@ class Expiry_Data {
 	}
 
 	/**
+	 * Whether a lapse of this plan is what would have taken a site off Atomic.
+	 *
+	 * Only the plans that carry a transfer can be reverted by expiring. Lower
+	 * tiers leave a site Simple throughout, so a lapse of one never produced the
+	 * revert the expiry modal describes.
+	 *
+	 * @param string $slug Product slug.
+	 */
+	public static function is_atomic_capable_plan( string $slug ): bool {
+		return in_array( self::infer_plan_class_from_slug( $slug ), array( 'business', 'commerce', 'pro' ), true );
+	}
+
+	/**
 	 * True if the slug refers to a monthly cadence plan.
 	 *
 	 * @param string $slug Product slug.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
@@ -278,19 +278,6 @@ class Expiry_Data {
 	}
 
 	/**
-	 * Whether a lapse of this plan is what would have taken a site off Atomic.
-	 *
-	 * Only the plans that carry a transfer can be reverted by expiring. Lower
-	 * tiers leave a site Simple throughout, so a lapse of one never produced the
-	 * revert the expiry modal describes.
-	 *
-	 * @param string $slug Product slug.
-	 */
-	public static function is_atomic_capable_plan( string $slug ): bool {
-		return in_array( self::infer_plan_class_from_slug( $slug ), array( 'business', 'commerce', 'pro' ), true );
-	}
-
-	/**
 	 * True if the slug refers to a monthly cadence plan.
 	 *
 	 * @param string $slug Product slug.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
@@ -145,7 +145,12 @@ class Expiry_Domain {
 		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d/domains', (int) $site_id ),
 			'1.2',
-			array( 'method' => 'GET' ),
+			array(
+				'method'  => 'GET',
+				// This runs during an admin page load, so a slow answer must not
+				// become a slow dashboard. Failing here just omits the domain line.
+				'timeout' => 5,
+			),
 			null,
 			'rest'
 		);

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Constants;
 
 /**
  * Resolves the domain the expiry modal names, or null when it should say nothing.
@@ -38,6 +39,14 @@ class Expiry_Domain {
 	 * an answer for. Naming the wrong domain is worse than naming none.
 	 */
 	public static function get_revert_domain(): ?string {
+		// A reverted site is back on Simple, where the blogs table holds the
+		// unmapped address outright. Nothing to ask WordPress.com for -- and
+		// nothing that could ask it, since the blog token the endpoint accepts
+		// belongs to Jetpack-connected sites.
+		if ( Constants::is_true( 'IS_WPCOM' ) ) {
+			return self::simple_revert_domain();
+		}
+
 		$cached = get_transient( self::CACHE_KEY );
 		if ( is_string( $cached ) && '' !== $cached ) {
 			return self::NONE === $cached ? null : $cached;
@@ -53,6 +62,29 @@ class Expiry_Domain {
 		set_transient( self::CACHE_KEY, $domain ?? self::NONE, self::CACHE_TTL );
 
 		return $domain;
+	}
+
+	/**
+	 * The address a reverted Simple site is now on, or null if it kept its own.
+	 *
+	 * `wp_blogs.domain` is the unmapped address itself, so where the site is
+	 * serving from it, that is the switch the copy describes having happened. A
+	 * site still answering on a custom domain kept it through the revert, and
+	 * nothing was switched.
+	 */
+	private static function simple_revert_domain(): ?string {
+		if ( ! function_exists( 'get_blog_details' ) ) {
+			return null;
+		}
+
+		$details  = get_blog_details( get_current_blog_id() );
+		$unmapped = ( is_object( $details ) && ! empty( $details->domain ) ) ? (string) $details->domain : '';
+		if ( '' === $unmapped ) {
+			return null;
+		}
+
+		$serving = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+		return $serving === $unmapped ? $unmapped : null;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
@@ -34,9 +34,8 @@ class Expiry_Domain {
 	 * The WordPress.com address this site would fall back to, or null when the
 	 * modal should leave the domain out.
 	 *
-	 * Null covers two different situations that happen to want the same silence:
-	 * a site whose custom domain survives the revert, and a site we couldn't get
-	 * an answer for. Naming the wrong domain is worse than naming none.
+	 * Null covers both a domain that survives the revert and a lookup that
+	 * failed: naming the wrong one is worse than naming none.
 	 */
 	public static function get_revert_domain(): ?string {
 		// A reverted site is back on Simple, where the blogs table holds the
@@ -67,10 +66,8 @@ class Expiry_Domain {
 	/**
 	 * The address a reverted Simple site is now on, or null if it kept its own.
 	 *
-	 * `wp_blogs.domain` is the unmapped address itself, so where the site is
-	 * serving from it, that is the switch the copy describes having happened. A
-	 * site still answering on a custom domain kept it through the revert, and
-	 * nothing was switched.
+	 * `wp_blogs.domain` is the unmapped address, so serving from it means the
+	 * switch has happened; a custom domain means it never did.
 	 */
 	private static function simple_revert_domain(): ?string {
 		if ( ! function_exists( 'get_blog_details' ) ) {
@@ -90,10 +87,8 @@ class Expiry_Domain {
 	/**
 	 * Pure: pick the fallback address out of a site's domain list.
 	 *
-	 * A custom primary domain is not removed when a plan lapses -- the revert
-	 * keeps it and repoints its A records -- so a site that has one is not going
-	 * to be renamed and has nothing to read here. Only a site sitting on its
-	 * platform-assigned address actually moves, and it moves to the row below.
+	 * The revert keeps a custom primary domain and only repoints it, so a site
+	 * with one is never renamed and gets nothing.
 	 *
 	 * @param array<int,object> $domains Domain objects from /sites/{id}/domains.
 	 * @return string|null

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-domain.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Expiry_Domain: the WordPress.com address a reverted site falls back to.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Resolves the domain the expiry modal names, or null when it should say nothing.
+ */
+class Expiry_Domain {
+
+	const CACHE_KEY = 'wpcom_expiry_notices_revert_domain';
+	const CACHE_TTL = 12 * HOUR_IN_SECONDS;
+
+	// A request that never got an answer is not an answer. Cached only long
+	// enough to stop an outage being re-tried on every admin pageview, where
+	// CACHE_TTL would drop the domain line for half a day over one blip.
+	const FAILURE_TTL = 5 * MINUTE_IN_SECONDS;
+
+	// Stored in place of a domain so a resolved "there is nothing to say here"
+	// is cached too. Without it the common case -- a site keeping its custom
+	// domain -- would re-request the domain list on every admin pageview.
+	const NONE = 'none';
+
+	/**
+	 * The WordPress.com address this site would fall back to, or null when the
+	 * modal should leave the domain out.
+	 *
+	 * Null covers two different situations that happen to want the same silence:
+	 * a site whose custom domain survives the revert, and a site we couldn't get
+	 * an answer for. Naming the wrong domain is worse than naming none.
+	 */
+	public static function get_revert_domain(): ?string {
+		$cached = get_transient( self::CACHE_KEY );
+		if ( is_string( $cached ) && '' !== $cached ) {
+			return self::NONE === $cached ? null : $cached;
+		}
+
+		$domains = self::request_domains();
+		if ( null === $domains ) {
+			set_transient( self::CACHE_KEY, self::NONE, self::FAILURE_TTL );
+			return null;
+		}
+
+		$domain = self::pick_revert_domain( $domains );
+		set_transient( self::CACHE_KEY, $domain ?? self::NONE, self::CACHE_TTL );
+
+		return $domain;
+	}
+
+	/**
+	 * Pure: pick the fallback address out of a site's domain list.
+	 *
+	 * A custom primary domain is not removed when a plan lapses -- the revert
+	 * keeps it and repoints its A records -- so a site that has one is not going
+	 * to be renamed and has nothing to read here. Only a site sitting on its
+	 * platform-assigned address actually moves, and it moves to the row below.
+	 *
+	 * @param array<int,object> $domains Domain objects from /sites/{id}/domains.
+	 * @return string|null
+	 */
+	public static function pick_revert_domain( array $domains ): ?string {
+		$wpcom_domain = null;
+		$primary      = null;
+		$is_assigned  = false;
+
+		foreach ( $domains as $domain ) {
+			if ( empty( $domain->domain ) || ! is_string( $domain->domain ) ) {
+				continue;
+			}
+
+			// The unmapped address, which wpcom synthesizes into every domain
+			// list. Staging is excluded on purpose: `*.wpcomstaging.com` is an
+			// Atomic hosting artifact and the revert deletes its mapping, so it
+			// is never what the site ends up called.
+			if ( ! empty( $domain->wpcom_domain ) && empty( $domain->is_wpcom_staging_domain ) ) {
+				$wpcom_domain = $domain->domain;
+			}
+
+			if ( ! empty( $domain->primary_domain ) ) {
+				$primary     = $domain->domain;
+				$is_assigned = ! empty( $domain->wpcom_domain ) || ! empty( $domain->is_wpcom_staging_domain );
+			}
+		}
+
+		if ( null === $wpcom_domain || null === $primary ) {
+			return null;
+		}
+
+		return $is_assigned ? $wpcom_domain : null;
+	}
+
+	/**
+	 * Fetch the site's domains from WordPress.com.
+	 *
+	 * Version 1.2 of this endpoint accepts a site's own blog token, which is what
+	 * makes it answerable from Atomic at all.
+	 *
+	 * @return array<int,object>|null Null on any failure.
+	 */
+	private static function request_domains(): ?array {
+		if ( ! class_exists( '\Jetpack_Options' ) || ! class_exists( Client::class ) ) {
+			return null;
+		}
+
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return null;
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog(
+			sprintf( '/sites/%d/domains', (int) $site_id ),
+			'1.2',
+			array( 'method' => 'GET' ),
+			null,
+			'rest'
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ) );
+		if ( ! isset( $body->domains ) || ! is_array( $body->domains ) ) {
+			return null;
+		}
+
+		return $body->domains;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
@@ -33,14 +33,30 @@ class Expiry_Notice_Dismiss {
 	const META_BANNER = 'wpcom_plan_expiry_notice_dismiss_wp_admin';
 	// Not scoped: one dismissal of the modal clears it on every surface.
 	const META_MODAL = 'wpcom_plan_expiry_modal_dismiss';
+	// The grace-period modal comes back, so its dismissal can't share a key with
+	// the permanent one: a grace dismissal is stamped after `expiry_ts` and would
+	// otherwise satisfy the post-grace check, burying a modal the user never saw.
+	const META_MODAL_GRACE = 'wpcom_plan_expiry_modal_dismiss_grace';
 
 	const FINAL_WINDOW_DAYS = 7;
+
+	/**
+	 * How long a grace-period modal stays dismissed.
+	 *
+	 * The design asks for "the current browser session, on both wp-admin and
+	 * Calypso". Those are two origins, so no browser-side store can answer for
+	 * both and the dismissal has to live on the server -- where there is no
+	 * session to scope it to. A day is the stand-in: long enough not to nag
+	 * someone working through their site, short enough that the modal keeps
+	 * coming back while the site still has something to lose.
+	 */
+	const MODAL_GRACE_DISMISS_TTL = DAY_IN_SECONDS;
 
 	/**
 	 * Register the banner + modal dismiss meta keys on the `user` object.
 	 */
 	public static function register_user_meta(): void {
-		foreach ( array( self::META_BANNER, self::META_MODAL ) as $meta_key ) {
+		foreach ( array( self::META_BANNER, self::META_MODAL, self::META_MODAL_GRACE ) as $meta_key ) {
 			register_meta(
 				'user',
 				$meta_key,
@@ -88,12 +104,47 @@ class Expiry_Notice_Dismiss {
 	/**
 	 * Should the expired-state modal show for the given user right now?
 	 *
+	 * The modal only speaks to a site that has already lapsed, and the two
+	 * lapsed states dismiss differently: in grace the revert is still ahead, so
+	 * the modal returns after `MODAL_GRACE_DISMISS_TTL`; afterwards it has
+	 * happened and saying so once is enough. Deliberately not routed through
+	 * `is_dismissible()`, which answers for the banner -- where the grace notice
+	 * cannot be dismissed at all.
+	 *
 	 * @param array<string,mixed> $expiry_state State from Expiry_Data::get_expiry_state().
 	 * @param int|null            $user_id      Defaults to current user.
 	 */
 	public static function should_show_modal( array $expiry_state, ?int $user_id = null ): bool {
-		return ! self::is_dismissible( $expiry_state )
-			|| ! self::is_dismissed( $user_id, self::META_MODAL, self::term_expiry_ts( $expiry_state ) );
+		$expiry_ts = self::term_expiry_ts( $expiry_state );
+
+		switch ( $expiry_state['state'] ?? '' ) {
+			case Expiry_Data::STATE_EXPIRED_GRACE:
+				return ! self::is_dismissed( $user_id, self::META_MODAL_GRACE, $expiry_ts, self::MODAL_GRACE_DISMISS_TTL );
+			case Expiry_Data::STATE_EXPIRED:
+				return ! self::is_dismissed( $user_id, self::META_MODAL, $expiry_ts );
+			default:
+				return false;
+		}
+	}
+
+	/**
+	 * The meta key the modal dismisses to in the given state, or null where the
+	 * modal doesn't show at all.
+	 *
+	 * The client has to be told which key to write, and this keeps that choice
+	 * in the same class that reads it back.
+	 *
+	 * @param array<string,mixed> $expiry_state State from Expiry_Data::get_expiry_state().
+	 */
+	public static function modal_meta_key( array $expiry_state ): ?string {
+		switch ( $expiry_state['state'] ?? '' ) {
+			case Expiry_Data::STATE_EXPIRED_GRACE:
+				return self::META_MODAL_GRACE;
+			case Expiry_Data::STATE_EXPIRED:
+				return self::META_MODAL;
+			default:
+				return null;
+		}
 	}
 
 	/**
@@ -109,14 +160,18 @@ class Expiry_Notice_Dismiss {
 	 * later of the two.
 	 *
 	 * @param int|null $user_id   Defaults to current user.
-	 * @param string   $meta_key  One of self::META_BANNER, self::META_MODAL.
+	 * @param string   $meta_key  One of the self::META_* keys.
 	 * @param int|null $expiry_ts Expiry of the term being judged. Null when the
 	 *                            caller has no term in hand, where any stored
 	 *                            dismissal counts.
+	 * @param int|null $ttl       Seconds a dismissal holds for. Null never lapses.
 	 */
-	public static function is_dismissed( ?int $user_id, string $meta_key, ?int $expiry_ts = null ): bool {
+	public static function is_dismissed( ?int $user_id, string $meta_key, ?int $expiry_ts = null, ?int $ttl = null ): bool {
 		$dismissed_at = self::get_dismissed_at( $user_id, $meta_key );
 		if ( null === $dismissed_at ) {
+			return false;
+		}
+		if ( null !== $ttl && $dismissed_at < time() - $ttl ) {
 			return false;
 		}
 		return null === $expiry_ts || $dismissed_at >= $expiry_ts;

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
@@ -41,14 +41,10 @@ class Expiry_Notice_Dismiss {
 	const FINAL_WINDOW_DAYS = 7;
 
 	/**
-	 * How long a grace-period modal stays dismissed.
-	 *
-	 * The design asks for "the current browser session, on both wp-admin and
-	 * Calypso". Those are two origins, so no browser-side store can answer for
-	 * both and the dismissal has to live on the server -- where there is no
-	 * session to scope it to. A day is the stand-in: long enough not to nag
-	 * someone working through their site, short enough that the modal keeps
-	 * coming back while the site still has something to lose.
+	 * Stands in for the "browser session" the design asks this modal to be
+	 * dismissed for: wp-admin and Calypso are two origins, so no browser store
+	 * answers for both and the dismissal lives server-side, where there is no
+	 * session to scope it to.
 	 */
 	const MODAL_GRACE_DISMISS_TTL = DAY_IN_SECONDS;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-notice-dismiss.php
@@ -100,12 +100,9 @@ class Expiry_Notice_Dismiss {
 	/**
 	 * Should the expired-state modal show for the given user right now?
 	 *
-	 * The modal only speaks to a site that has already lapsed, and the two
-	 * lapsed states dismiss differently: in grace the revert is still ahead, so
-	 * the modal returns after `MODAL_GRACE_DISMISS_TTL`; afterwards it has
-	 * happened and saying so once is enough. Deliberately not routed through
-	 * `is_dismissible()`, which answers for the banner -- where the grace notice
-	 * cannot be dismissed at all.
+	 * The two lapsed states dismiss differently: in grace the modal returns after
+	 * `MODAL_GRACE_DISMISS_TTL`, afterwards saying so once is enough. Not routed
+	 * through `is_dismissible()`, which answers for the banner.
 	 *
 	 * @param array<string,mixed> $expiry_state State from Expiry_Data::get_expiry_state().
 	 * @param int|null            $user_id      Defaults to current user.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/css/admin-modal.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/css/admin-modal.scss
@@ -1,0 +1,91 @@
+.wpcom-expiry-modal.components-modal__frame {
+	max-width: 400px;
+	width: calc(100% - 32px);
+	max-height: calc(100% - 32px);
+
+	// Below its own breakpoint the components Modal stops being a centred card
+	// and becomes a sheet pinned to the bottom-left of the overlay, which leaves
+	// this one hanging off-centre and low. Handing position back to the overlay's
+	// flex centring restores the same card at every width, and keeps the vertical
+	// placement proportional to the viewport rather than anchored to its foot.
+	@media (max-width: 599px) {
+		position: relative;
+		inset: auto;
+		margin: auto;
+	}
+
+	.components-modal__content {
+		// The illustration is flush to the frame on three sides, so the padding
+		// that would inset it moves onto the body below.
+		padding: 0;
+		margin-block-start: 0;
+		overflow-x: hidden;
+	}
+
+	// Left holding only the close button, which belongs over the illustration.
+	.components-modal__header {
+		position: absolute;
+		inset-block-start: 0;
+		inset-inline-end: 0;
+		background: none;
+		border-block-end: none;
+		padding: 0;
+		height: auto;
+		z-index: 1;
+	}
+}
+
+.wpcom-expiry-modal__image {
+	display: block;
+	width: 100%;
+	height: auto;
+}
+
+.wpcom-expiry-modal__body {
+	padding: 24px;
+}
+
+.wpcom-expiry-modal__title {
+	margin-block: 0 12px;
+	font-size: 20px;
+	line-height: 1.3;
+}
+
+.wpcom-expiry-modal__list {
+	margin-block: 16px;
+	list-style: none;
+	padding-inline-start: 0;
+
+	li {
+		position: relative;
+		margin-block-end: 8px;
+		padding-inline-start: 28px;
+	}
+
+	// The warning mark against every item. Drawn here rather than shipped as a
+	// per-item icon so the list stays plain translated strings from PHP.
+	li::before {
+		content: "";
+		position: absolute;
+		inset-block-start: 2px;
+		inset-inline-start: 0;
+		width: 16px;
+		height: 16px;
+		background-color: currentColor;
+		color: #d63638;
+		mask-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 3.2A8.8 8.8 0 1 0 20.8 12 8.81 8.81 0 0 0 12 3.2Zm0 16A7.2 7.2 0 1 1 19.2 12 7.21 7.21 0 0 1 12 19.2Zm-.8-11.2h1.6v6h-1.6Zm0 7.2h1.6v1.6h-1.6Z'/%3E%3C/svg%3E");
+		mask-repeat: no-repeat;
+		mask-size: contain;
+	}
+}
+
+.wpcom-expiry-modal__actions {
+	display: flex;
+	gap: 8px;
+	margin-block-start: 24px;
+
+	.components-button {
+		flex: 1;
+		justify-content: center;
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -62,29 +62,46 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 /**
  * The expiry state this user should be shown something about, or null.
  *
- * The audience test the banner and the modal share: someone who could act on
- * the notice, on a site that is in the flow at all. VIP is excluded because the
- * Simple notice this replaces excluded it, and swapping the notices was never
- * meant to change who sees one; the guard exists because `wpcom_is_vip()` is
- * only defined on wpcom.
+ * The audience test the banner and the modal share. Memoized because four hooks
+ * reach it per admin pageview -- each surface enqueues and renders -- and
+ * nothing can change the answer mid-request.
  *
+ * @param bool $flush Drop the memo. For tests, which move the purchase fixture
+ *                    under a process that has already answered once.
  * @return array<string,mixed>|null
  */
-function wpcom_expiry_notices_eligible_state(): ?array {
-	if ( ! current_user_can( 'manage_options' ) ) {
+function wpcom_expiry_notices_eligible_state( bool $flush = false ): ?array {
+	// Distinct from null, which is a real answer worth remembering.
+	static $memo = false;
+
+	if ( $flush ) {
+		$memo = false;
 		return null;
 	}
 
+	if ( false !== $memo ) {
+		return $memo;
+	}
+
+	$memo = null;
+
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return $memo;
+	}
+
+	// Excluded to match the Simple notice this replaces. Guarded because
+	// `wpcom_is_vip()` only exists on wpcom.
 	if ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) {
-		return null;
+		return $memo;
 	}
 
 	$state = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::get_expiry_state();
 	if ( null === $state || \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::STATE_ACTIVE === $state['state'] ) {
-		return null;
+		return $memo;
 	}
 
-	return $state;
+	$memo = $state;
+	return $memo;
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -128,13 +128,9 @@ function wpcom_expiry_notices_expired_heading( array $state ): string {
 /**
  * Whether the revert this feature describes applies to this site, now.
  *
- * Past the grace period the answer waits on the revert having happened, not on
- * the date it was due: the state opens 30 days after expiry, while the revert
- * runs off the subscription-removal record and can lag it. In that gap a site is
- * still Atomic and still renewable, so the past-tense copy would be untrue and
- * support would be the wrong ask. wpcom's sticker marks the event itself.
- *
- * Before then the changes are still ahead, which only an Atomic site faces.
+ * Past the grace period this waits on the sticker rather than the date, because
+ * the revert runs off the subscription-removal record and can lag the state by
+ * days. Before then the changes are still ahead, which only Atomic faces.
  *
  * @param array<string,mixed> $state Expiry state.
  */
@@ -149,13 +145,9 @@ function wpcom_expiry_notices_revert_applies_to_site( array $state ): bool {
 /**
  * The CTA a reverted site gets, pointing at support rather than checkout.
  *
- * Buying the plan again does not undo the revert: the cleanup that follows it
- * deletes the Atomic site outright -- container, tables and tokens -- and a
- * re-transfer starts a fresh one. Plugins, themes and their data are gone, so
- * only support can help with what the notice says was lost.
- *
- * `url` is the fallback for a click the Help Center could not answer; `message`
- * is what its chat opens prefilled with.
+ * Buying the plan again does not undo the revert, so only support can help with
+ * what the notice says was lost. `url` is the fallback for a click the Help
+ * Center could not answer.
  *
  * @param array<string,mixed> $state Expiry state.
  * @return array{label:string,url:string,message:string}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -7,6 +7,7 @@
 
 // @codeCoverageIgnoreStart
 require_once __DIR__ . '/class-expiry-data.php';
+require_once __DIR__ . '/class-expiry-domain.php';
 require_once __DIR__ . '/class-expiry-notice-dismiss.php';
 // @codeCoverageIgnoreEnd
 
@@ -59,15 +60,65 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 }
 
 /**
- * Load the wp-admin banner, unless something has held this site back.
+ * The expiry state this user should be shown something about, or null.
+ *
+ * The audience test the banner and the modal share: someone who could act on
+ * the notice, on a site that is in the flow at all. VIP is excluded because the
+ * Simple notice this replaces excluded it, and swapping the notices was never
+ * meant to change who sees one; the guard exists because `wpcom_is_vip()` is
+ * only defined on wpcom.
+ *
+ * @return array<string,mixed>|null
+ */
+function wpcom_expiry_notices_eligible_state(): ?array {
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return null;
+	}
+
+	if ( function_exists( 'wpcom_is_vip' ) && wpcom_is_vip() ) {
+		return null;
+	}
+
+	$state = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::get_expiry_state();
+	if ( null === $state || \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::STATE_ACTIVE === $state['state'] ) {
+		return null;
+	}
+
+	return $state;
+}
+
+/**
+ * The "Your {plan} plan has expired" heading, shared by the banner and the modal.
+ *
+ * @param array<string,mixed> $state Expiry state.
+ */
+function wpcom_expiry_notices_expired_heading( array $state ): string {
+	$plan = isset( $state['plan_name'] ) && is_string( $state['plan_name'] ) ? $state['plan_name'] : '';
+
+	// Every stage has a variant without the plan name, for the rare purchase
+	// whose slug the Plans package can't resolve to a short name.
+	if ( '' === $plan ) {
+		return __( 'Your plan has expired', 'jetpack-mu-wpcom' );
+	}
+
+	return sprintf(
+		/* translators: %s is the plan name (e.g. Business). */
+		__( 'Your %s plan has expired', 'jetpack-mu-wpcom' ),
+		$plan
+	);
+}
+
+/**
+ * Load the wp-admin banner and modal, unless something has held this site back.
  *
  * On `init` rather than at file load. This file is required on `plugins_loaded`,
- * and both of the banner's own hooks fire later still, so waiting keeps the
- * require off the bootstrap at no cost.
+ * and every hook either surface registers fires later still, so waiting keeps
+ * the requires off the bootstrap at no cost.
  */
 function wpcom_expiry_notices_maybe_load_admin_banner() {
 	if ( is_admin() && wpcom_expiry_notices_is_enabled_for_site() ) {
 		require_once __DIR__ . '/admin-banner.php';
+		require_once __DIR__ . '/admin-modal.php';
 	}
 }
 add_action( 'init', 'wpcom_expiry_notices_maybe_load_admin_banner' ); // @codeCoverageIgnore
@@ -86,3 +137,25 @@ function wpcom_expiry_notices_register_meta() {
 	\Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss::register_user_meta();
 }
 add_action( 'init', 'wpcom_expiry_notices_register_meta' ); // @codeCoverageIgnore
+// `init` alone never registers these on a REST request: WP defines REST_REQUEST
+// in rest_api_loaded() on `parse_request`, which fires after `init`, so the
+// guard above bails and the write silently no-ops -- the endpoint drops an
+// unregistered meta key and still answers 200. Every dismissal arrives over
+// REST, so without this hook none of them persist.
+add_action( 'rest_api_init', 'wpcom_expiry_notices_register_meta' ); // @codeCoverageIgnore
+
+/**
+ * Build the full URL of the current admin page so checkout can redirect back.
+ * Strips transient query args (`settings-updated`, `_wpnonce`, etc.) so the
+ * redirected user doesn't re-trigger one-shot admin notices or hit stale
+ * nonces on return.
+ */
+function wpcom_expiry_notices_current_admin_url(): string {
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+	if ( '' === $request_uri ) {
+		return admin_url();
+	}
+	$request_uri = remove_query_arg( wp_removable_query_args(), $request_uri );
+	$admin_path  = preg_replace( '#^/?wp-admin/?#', '', $request_uri );
+	return admin_url( ltrim( $admin_path, '/' ) );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -126,6 +126,42 @@ function wpcom_expiry_notices_expired_heading( array $state ): string {
 }
 
 /**
+ * The CTA a reverted site gets, pointing at support rather than checkout.
+ *
+ * Buying the plan again does not undo the revert: the cleanup that follows it
+ * deletes the Atomic site outright -- container, tables and tokens -- and a
+ * re-transfer starts a fresh one. Plugins, themes and their data are gone, so
+ * only support can help with what the notice says was lost.
+ *
+ * `url` is the fallback for a click the Help Center could not answer; `message`
+ * is what its chat opens prefilled with.
+ *
+ * @param array<string,mixed> $state Expiry state.
+ * @return array{label:string,url:string,message:string}
+ */
+function wpcom_expiry_notices_support_cta( array $state ): array {
+	$plan = isset( $state['plan_name'] ) && is_string( $state['plan_name'] ) ? $state['plan_name'] : '';
+
+	if ( '' === $plan ) {
+		$message = __( 'My plan expired and I need your help getting it restored.', 'jetpack-mu-wpcom' );
+	} else {
+		$message = sprintf(
+			/* translators: %s is the plan name (e.g. Business). */
+			__( 'My %s plan expired and I need your help getting it restored.', 'jetpack-mu-wpcom' ),
+			$plan
+		);
+	}
+
+	return array(
+		'label'   => __( 'Contact support', 'jetpack-mu-wpcom' ),
+		// Where the Help Center package itself sends people when it cannot open
+		// in place, so a click still lands somewhere useful without its bundle.
+		'url'     => 'https://wordpress.com/help?help-center=home',
+		'message' => $message,
+	);
+}
+
+/**
  * Load the wp-admin banner and modal, unless something has held this site back.
  *
  * On `init` rather than at file load. This file is required on `plugins_loaded`,

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -126,6 +126,28 @@ function wpcom_expiry_notices_expired_heading( array $state ): string {
 }
 
 /**
+ * Whether the revert this feature describes applies to this site, now.
+ *
+ * Not simply "is Atomic": the revert is what ends that, so a site is Atomic
+ * while the changes are ahead of it and Simple once they have happened. wpcom
+ * marks the difference with a sticker, which only counts after the grace period
+ * -- before it, a reverted site was reverted by some earlier lapse.
+ *
+ * @param array<string,mixed> $state Expiry state.
+ */
+function wpcom_expiry_notices_revert_applies_to_site( array $state ): bool {
+	if ( \Automattic\Jetpack\Constants::is_true( 'IS_ATOMIC' ) ) {
+		return true;
+	}
+
+	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
+		return false;
+	}
+
+	return wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() );
+}
+
+/**
  * The CTA a reverted site gets, pointing at support rather than checkout.
  *
  * Buying the plan again does not undo the revert: the cleanup that follows it

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -128,23 +128,22 @@ function wpcom_expiry_notices_expired_heading( array $state ): string {
 /**
  * Whether the revert this feature describes applies to this site, now.
  *
- * Not simply "is Atomic": the revert is what ends that, so a site is Atomic
- * while the changes are ahead of it and Simple once they have happened. wpcom
- * marks the difference with a sticker, which only counts after the grace period
- * -- before it, a reverted site was reverted by some earlier lapse.
+ * Past the grace period the answer waits on the revert having happened, not on
+ * the date it was due: the state opens 30 days after expiry, while the revert
+ * runs off the subscription-removal record and can lag it. In that gap a site is
+ * still Atomic and still renewable, so the past-tense copy would be untrue and
+ * support would be the wrong ask. wpcom's sticker marks the event itself.
+ *
+ * Before then the changes are still ahead, which only an Atomic site faces.
  *
  * @param array<string,mixed> $state Expiry state.
  */
 function wpcom_expiry_notices_revert_applies_to_site( array $state ): bool {
-	if ( \Automattic\Jetpack\Constants::is_true( 'IS_ATOMIC' ) ) {
-		return true;
+	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::STATE_EXPIRED === ( $state['state'] ?? '' ) ) {
+		return wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() );
 	}
 
-	if ( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data::STATE_EXPIRED !== ( $state['state'] ?? '' ) ) {
-		return false;
-	}
-
-	return wpcom_has_blog_sticker( 'blog-transfer-reverted', get_wpcom_blog_id() );
+	return \Automattic\Jetpack\Constants::is_true( 'IS_ATOMIC' );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/images/plan-expired.svg
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/images/plan-expired.svg
@@ -1,0 +1,64 @@
+<svg width="400" height="227" viewBox="0 0 400 227" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g clip-path="url(#clip0_1081_22200)">
+<rect width="400" height="227" fill="#F0F0F0"/>
+<rect width="400" height="227" fill="url(#pattern0_1081_22200)" fill-opacity="0.6"/>
+<path d="M153 -3L153 154" stroke="url(#paint0_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M253 12L253 169" stroke="url(#paint1_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M221 241L221 55" stroke="url(#paint2_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M159 214L159 59" stroke="url(#paint3_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M170 146H398" stroke="url(#paint4_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M261 86L33 86" stroke="url(#paint5_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M271 111H47C35.9543 111 27 119.954 27 131V227" stroke="url(#paint6_linear_1081_22200)" stroke-dasharray="2 2"/>
+<path d="M330 0C330 5.17572 330 57.4938 330 91.0131C330 102.059 321.046 111 310 111H236" stroke="url(#paint7_linear_1081_22200)" stroke-dasharray="2 2"/>
+<rect x="104" y="50" width="192.896" height="126.86" rx="4.61538" fill="#F6F7F7" stroke="#CC1818"/>
+<circle cx="116.05" cy="61.7489" r="2.38948" stroke="#CC1818"/>
+<circle cx="125.391" cy="61.5316" r="2.17226" stroke="#CC1818"/>
+<circle cx="134.95" cy="61.5316" r="2.17226" stroke="#CC1818"/>
+<path d="M196.077 91.2939C197.797 88.2355 202.2 88.2356 203.921 91.2939L225.792 130.175C227.479 133.174 225.311 136.881 221.87 136.881H178.129C174.687 136.881 172.52 133.175 174.207 130.175L196.077 91.2939ZM201.307 92.7646C200.733 91.7452 199.265 91.7452 198.691 92.7646L176.821 131.646C176.259 132.645 176.982 133.881 178.129 133.881H221.87C223.017 133.881 223.739 132.645 223.177 131.646L201.307 92.7646ZM201.499 125.631V128.631H198.499V125.631H201.499ZM201.499 106.131V119.631H198.499V106.131H201.499Z" fill="#CC1818" stroke="#F6F7F7" stroke-width="1.5"/>
+</g>
+<defs>
+<pattern id="pattern0_1081_22200" patternContentUnits="objectBoundingBox" width="0.034" height="0.0599119">
+<use xlink:href="#image0_1081_22200" transform="scale(0.0005 0.000881057)"/>
+</pattern>
+<linearGradient id="paint0_linear_1081_22200" x1="153.5" y1="-3" x2="153" y2="54" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CC1818" stop-opacity="0"/>
+<stop offset="1" stop-color="#CC1818"/>
+</linearGradient>
+<linearGradient id="paint1_linear_1081_22200" x1="253.5" y1="12" x2="253" y2="69" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="1" stop-color="#737373"/>
+</linearGradient>
+<linearGradient id="paint2_linear_1081_22200" x1="220.5" y1="241" x2="220.5" y2="144.598" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CC1818" stop-opacity="0"/>
+<stop offset="1" stop-color="#CC1818"/>
+</linearGradient>
+<linearGradient id="paint3_linear_1081_22200" x1="158.5" y1="214" x2="158.5" y2="133.665" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="1" stop-color="#737373"/>
+</linearGradient>
+<linearGradient id="paint4_linear_1081_22200" x1="370.949" y1="145.5" x2="214.293" y2="145.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#CC1818" stop-opacity="0"/>
+<stop offset="0.7" stop-color="#CC1818"/>
+</linearGradient>
+<linearGradient id="paint5_linear_1081_22200" x1="60.0508" y1="85.5" x2="216.707" y2="85.5" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="0.7" stop-color="#737373"/>
+</linearGradient>
+<linearGradient id="paint6_linear_1081_22200" x1="22.425" y1="221.882" x2="-13.1596" y2="96.7815" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="0.621791" stop-color="#737373"/>
+<stop offset="0.913481" stop-color="#737373"/>
+<stop offset="1" stop-color="#737373" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="paint7_linear_1081_22200" x1="233.62" y1="227.55" x2="309.937" y2="-6.51632" gradientUnits="userSpaceOnUse">
+<stop stop-color="#737373" stop-opacity="0"/>
+<stop offset="0.125009" stop-color="#737373"/>
+<stop offset="0.553464" stop-color="#737373"/>
+<stop offset="1" stop-color="#737373" stop-opacity="0"/>
+</linearGradient>
+<clipPath id="clip0_1081_22200">
+<rect width="400" height="227" fill="white"/>
+</clipPath>
+<image id="image0_1081_22200" width="68" height="68" preserveAspectRatio="none" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEQAAABECAYAAAA4E5OyAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAylpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDkuMC1jMDAxIDc5LmMwMjA0YjJkZWYsIDIwMjMvMDIvMDItMTI6MTQ6MjQgICAgICAgICI+IDxyZGY6UkRGIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyI+IDxyZGY6RGVzY3JpcHRpb24gcmRmOmFib3V0PSIiIHhtbG5zOnhtcD0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bXA6Q3JlYXRvclRvb2w9IkFkb2JlIFBob3Rvc2hvcCAyNC41IChNYWNpbnRvc2gpIiB4bXBNTTpJbnN0YW5jZUlEPSJ4bXAuaWlkOkU4MTBCRTc4NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOkU4MTBCRTc5NkI2QTExRjBCOTI1QjRCNzdDOENGRkMzIj4gPHhtcE1NOkRlcml2ZWRGcm9tIHN0UmVmOmluc3RhbmNlSUQ9InhtcC5paWQ6RTgxMEJFNzY2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiIHN0UmVmOmRvY3VtZW50SUQ9InhtcC5kaWQ6RTgxMEJFNzc2QjZBMTFGMEI5MjVCNEI3N0M4Q0ZGQzMiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz5uSzX6AAAA2UlEQVR42uzaTQ6CMBAGUMaw0FtwET28XoRb6K6OCYk/29aC5n3JBFYd+gIlaRqllEGe2SEAAgQIECBAgAABAgQIECBA/j1j7QARMeXllPXYWLlkzZ3n8Na/lDKv/YYcs/ZZh+XBeqdp/xYg8XK/xvZb0/4tQM5Z16zb8sn0TtP+UbunmmvIphbF2vn4ywABAgQIECBAgAABAgQIECBAgAARIECAAAECBAgQIBvM2GCMadjQ+ZDa/s6HfAHE+ZCPOB/iLwMEiAABAgQIECBAgAABAgTID+cuwADKAy+BgXQl5gAAAABJRU5ErkJggg=="/>
+</defs>
+</svg>

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-banner.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-banner.ts
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { wpcomTrackEvent } from '../../../common/tracks';
+import { openHelpCenterWithMessage } from './help-center.ts';
 
 interface ExpiryBannerData {
 	metaKey: string;
@@ -51,9 +52,19 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		safeSessionSet( impressionKey, '1' );
 	}
 
-	const primaryCta = banner.querySelector( '.button-primary' );
-	primaryCta?.addEventListener( 'click', () => {
-		wpcomTrackEvent( 'jetpack_expiry_banner_cta_click', trackProps );
+	const primaryCta = banner.querySelector< HTMLAnchorElement >( '.button-primary' );
+	primaryCta?.addEventListener( 'click', ( e: Event ) => {
+		const supportMessage = primaryCta.dataset.supportMessage;
+		// Only the reverted state asks for support; everything else is a plain link.
+		const openedHere = supportMessage ? openHelpCenterWithMessage( supportMessage ) : false;
+		if ( openedHere ) {
+			e.preventDefault();
+		}
+
+		wpcomTrackEvent( 'jetpack_expiry_banner_cta_click', {
+			...trackProps,
+			cta: supportMessage ? 'support' : 'renew',
+		} );
 	} );
 
 	const dismissBtn = banner.querySelector( '.wpcom-expiry-banner__dismiss' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
@@ -2,10 +2,15 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, Modal } from '@wordpress/components';
 import { createRoot, useState } from '@wordpress/element';
 import { wpcomTrackEvent } from '../../../common/tracks';
+import { openHelpCenterWithMessage } from './help-center.ts';
+import type { MouseEvent } from 'react';
 
 interface Cta {
 	label: string;
 	url: string;
+	// Present only on the reverted state's CTA, which opens the Help Center with
+	// this typed in rather than following its href.
+	message?: string;
 }
 
 interface ExpiryModalData {
@@ -63,14 +68,24 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 		}
 	};
 
-	// Acting on a CTA settles the modal too: someone on their way to checkout has
-	// answered it, and should not meet it again on the way back. Deliberately not
-	// awaited and the modal is left mounted, so neither delays the navigation the
-	// click has already started. The click is reported as a CTA rather than a
+	// Acting on a CTA settles the modal too: someone who has answered it should
+	// not meet it again on the way back. Reported as a CTA rather than a
 	// dismissal -- one event per thing the user actually did.
-	const onCtaClick = ( cta: string ) => {
-		wpcomTrackEvent( 'jetpack_expiry_modal_cta_click', { ...data.trackProps, cta } );
-		recordDismissal( true ).catch( () => {
+	const onCtaClick = ( cta: string, target: Cta, event: MouseEvent ) => {
+		// The support CTA opens the Help Center over this page rather than
+		// navigating, so the modal has to close itself; its href is only the
+		// fallback for a Help Center that never loaded.
+		const openedHere = target.message ? openHelpCenterWithMessage( target.message ) : false;
+		if ( openedHere ) {
+			event.preventDefault();
+			setIsOpen( false );
+		}
+
+		wpcomTrackEvent( 'jetpack_expiry_modal_cta_click', {
+			...data.trackProps,
+			cta: target.message ? 'support' : cta,
+		} );
+		recordDismissal( ! openedHere ).catch( () => {
 			// Nothing useful to do while the page is leaving; at worst the modal
 			// shows once more.
 		} );
@@ -108,7 +123,7 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 						<Button
 							variant="secondary"
 							href={ data.secondary.url }
-							onClick={ () => onCtaClick( 'secondary' ) }
+							onClick={ event => onCtaClick( 'secondary', data.secondary as Cta, event ) }
 						>
 							{ data.secondary.label }
 						</Button>
@@ -116,7 +131,7 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 					<Button
 						variant="primary"
 						href={ data.primary.url }
-						onClick={ () => onCtaClick( 'primary' ) }
+						onClick={ event => onCtaClick( 'primary', data.primary, event ) }
 					>
 						{ data.primary.label }
 					</Button>

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
@@ -94,10 +94,11 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 	return (
 		// No `title`: the heading belongs under the illustration, so the header is
 		// left holding just the close button, which the stylesheet lifts onto the
-		// image. `aria-label` carries the name the missing title would have given.
+		// image. `contentLabel` names the dialog in its place -- Modal destructures
+		// a fixed prop list, so a bare `aria-label` would be dropped.
 		<Modal
 			className="wpcom-expiry-modal"
-			aria-label={ data.title }
+			contentLabel={ data.title }
 			// A stray click on the overlay shouldn't spend the one dismissal the
 			// user gets, so closing has to be deliberate. Escape still works, and
 			// is left alone on purpose: it is the only way out for someone who

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
@@ -1,0 +1,140 @@
+import apiFetch from '@wordpress/api-fetch';
+import { Button, Modal } from '@wordpress/components';
+import { createRoot, useState } from '@wordpress/element';
+import { wpcomTrackEvent } from '../../../common/tracks';
+
+interface Cta {
+	label: string;
+	url: string;
+}
+
+interface ExpiryModalData {
+	metaKey: string;
+	title: string;
+	description: string;
+	listIntro: string;
+	items: string[];
+	primary: Cta;
+	secondary: Cta | null;
+	imageUrl: string;
+	trackProps: Record< string, string | number >;
+}
+
+declare global {
+	interface Window {
+		wpcomExpiryModal?: ExpiryModalData;
+	}
+}
+
+const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
+	const [ isOpen, setIsOpen ] = useState( true );
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const recordDismissal = ( keepalive: boolean ) =>
+		apiFetch( {
+			path: '/wp/v2/users/me',
+			method: 'POST',
+			data: { meta: { [ data.metaKey ]: 1 } },
+			// Survives the page unload a CTA starts. Without it the browser is
+			// free to cancel the write as it navigates, and the modal returns to
+			// someone who did what it asked.
+			keepalive,
+		} );
+
+	// Closing is the dismissal however it was reached, so the record matches what
+	// the user saw happen. Writing only from the button would let Escape hide a
+	// modal that then came straight back on the next page load.
+	const dismiss = async () => {
+		setIsOpen( false );
+
+		try {
+			await recordDismissal( false );
+			wpcomTrackEvent( 'jetpack_expiry_modal_dismiss', data.trackProps );
+		} catch ( err ) {
+			wpcomTrackEvent( 'jetpack_expiry_modal_dismiss_failed', {
+				...data.trackProps,
+				error_message: err instanceof Error ? err.message : String( err ),
+			} );
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to record expiry modal dismiss', err );
+		}
+	};
+
+	// Acting on a CTA settles the modal too: someone on their way to checkout has
+	// answered it, and should not meet it again on the way back. Deliberately not
+	// awaited and the modal is left mounted, so neither delays the navigation the
+	// click has already started. The click is reported as a CTA rather than a
+	// dismissal -- one event per thing the user actually did.
+	const onCtaClick = ( cta: string ) => {
+		wpcomTrackEvent( 'jetpack_expiry_modal_cta_click', { ...data.trackProps, cta } );
+		recordDismissal( true ).catch( () => {
+			// Nothing useful to do while the page is leaving; at worst the modal
+			// shows once more.
+		} );
+	};
+
+	return (
+		// No `title`: the heading belongs under the illustration, so the header is
+		// left holding just the close button, which the stylesheet lifts onto the
+		// image. `aria-label` carries the name the missing title would have given.
+		<Modal
+			className="wpcom-expiry-modal"
+			aria-label={ data.title }
+			// A stray click on the overlay shouldn't spend the one dismissal the
+			// user gets, so closing has to be deliberate. Escape still works, and
+			// is left alone on purpose: it is the only way out for someone who
+			// can't use a pointer.
+			shouldCloseOnClickOutside={ false }
+			onRequestClose={ dismiss }
+		>
+			<img className="wpcom-expiry-modal__image" src={ data.imageUrl } alt="" />
+
+			<div className="wpcom-expiry-modal__body">
+				<h2 className="wpcom-expiry-modal__title">{ data.title }</h2>
+				<p>{ data.description }</p>
+				{ data.listIntro && <p>{ data.listIntro }</p> }
+
+				<ul className="wpcom-expiry-modal__list">
+					{ data.items.map( item => (
+						<li key={ item }>{ item }</li>
+					) ) }
+				</ul>
+
+				<div className="wpcom-expiry-modal__actions">
+					{ data.secondary && (
+						<Button
+							variant="secondary"
+							href={ data.secondary.url }
+							onClick={ () => onCtaClick( 'secondary' ) }
+						>
+							{ data.secondary.label }
+						</Button>
+					) }
+					<Button
+						variant="primary"
+						href={ data.primary.url }
+						onClick={ () => onCtaClick( 'primary' ) }
+					>
+						{ data.primary.label }
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	);
+};
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	const root = document.getElementById( 'wpcom-expiry-modal-root' );
+	const data = window.wpcomExpiryModal;
+	if ( ! root || ! data ) {
+		return;
+	}
+
+	// No session guard, unlike the banner: the server only serves this markup
+	// when the modal is actually due, so a render is already a unique showing.
+	wpcomTrackEvent( 'jetpack_expiry_modal_impression', data.trackProps );
+	createRoot( root ).render( <ExpiryModal data={ data } /> );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/help-center.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/help-center.ts
@@ -3,15 +3,13 @@ import { dispatch } from '@wordpress/data';
 const HELP_CENTER_STORE = 'automattic/help-center';
 
 /**
- * Open the Help Center's chat with the message already typed in.
+ * Open the Help Center's chat with the message sent.
  *
- * `?query=` fills the input without sending it, so the person still reads and
- * sends their own first message. Mirrors what Calypso's own inline Help Center
- * button does, since there is no URL that opens the panel in this state — the
- * route lives in the Help Center's own router, not the page's.
+ * Dispatched rather than linked because the route lives in the Help Center's own
+ * router, so no URL reaches it.
  *
- * @param message - Text to put in the chat input.
- * @return Whether the Help Center answered. False when its bundle is absent, so the caller can let the click fall through to its href instead.
+ * @param message - Text to send.
+ * @return Whether the Help Center answered. False lets the caller fall through to its href.
  */
 export const openHelpCenterWithMessage = ( message: string ): boolean => {
 	let helpCenter;

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/help-center.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/help-center.ts
@@ -1,0 +1,37 @@
+import { dispatch } from '@wordpress/data';
+
+const HELP_CENTER_STORE = 'automattic/help-center';
+
+/**
+ * Open the Help Center's chat with the message already typed in.
+ *
+ * `?query=` fills the input without sending it, so the person still reads and
+ * sends their own first message. Mirrors what Calypso's own inline Help Center
+ * button does, since there is no URL that opens the panel in this state — the
+ * route lives in the Help Center's own router, not the page's.
+ *
+ * @param message - Text to put in the chat input.
+ * @return Whether the Help Center answered. False when its bundle is absent, so the caller can let the click fall through to its href instead.
+ */
+export const openHelpCenterWithMessage = ( message: string ): boolean => {
+	let helpCenter;
+	try {
+		helpCenter = dispatch( HELP_CENTER_STORE );
+	} catch {
+		return false;
+	}
+
+	// Registered late and asynchronously, and not at all on a screen that never
+	// loaded it, so neither the store nor either action can be assumed.
+	if (
+		typeof helpCenter?.setShowHelpCenter !== 'function' ||
+		typeof helpCenter?.setNavigateToRoute !== 'function'
+	) {
+		return false;
+	}
+
+	helpCenter.setShowHelpCenter( true );
+	helpCenter.setNavigateToRoute( `/odie?query=${ encodeURIComponent( message ) }` );
+
+	return true;
+};

--- a/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
@@ -74,20 +74,6 @@ if ( ! function_exists( 'get_blog_details' ) ) {
 	}
 }
 
-if ( ! function_exists( 'has_blog_sticker' ) ) {
-	/**
-	 * A drop-in for a WordPress.com function. Defaults to no stickers, matching
-	 * a site that has never been transferred.
-	 *
-	 * @param string $sticker Sticker name.
-	 * @param int    $blog_id Blog ID. Unused: tests only ever have one site.
-	 * @return bool
-	 */
-	function has_blog_sticker( $sticker, $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- single-site test env.
-		return in_array( $sticker, $GLOBALS['wpcom_blog_stickers_test_value'] ?? array(), true );
-	}
-}
-
 if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 	/**
 	 * A drop-in for a WordPress.com function.

--- a/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/lib/functions-wordpress.php
@@ -60,6 +60,34 @@ if ( ! function_exists( 'wpcom_is_vip' ) ) {
 	}
 }
 
+if ( ! function_exists( 'get_blog_details' ) ) {
+	/**
+	 * A drop-in for the multisite function WordPress.com keeps the unmapped
+	 * domain in. WorDBless is single-site, so it does not ship one.
+	 *
+	 * @param int $blog_id Blog ID. Unused: tests only ever have one site.
+	 * @return object|false
+	 */
+	function get_blog_details( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- single-site test env.
+		$domain = $GLOBALS['wpcom_blog_details_domain_test_value'] ?? null;
+		return null === $domain ? false : (object) array( 'domain' => $domain );
+	}
+}
+
+if ( ! function_exists( 'has_blog_sticker' ) ) {
+	/**
+	 * A drop-in for a WordPress.com function. Defaults to no stickers, matching
+	 * a site that has never been transferred.
+	 *
+	 * @param string $sticker Sticker name.
+	 * @param int    $blog_id Blog ID. Unused: tests only ever have one site.
+	 * @return bool
+	 */
+	function has_blog_sticker( $sticker, $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- single-site test env.
+		return in_array( $sticker, $GLOBALS['wpcom_blog_stickers_test_value'] ?? array(), true );
+	}
+}
+
 if ( ! function_exists( 'wpcom_rest_api_v2_load_plugin' ) ) {
 	/**
 	 * A drop-in for a WordPress.com function.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -560,5 +560,8 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertStringNotContainsString( 'Contact support', $out );
 		$this->assertStringContainsString( '/checkout/', $out );
+		// And the copy must not claim the changes have already happened.
+		$this->assertStringNotContainsString( 'has been moved to the Free plan', $out );
+		$this->assertStringContainsString( 'will move to the Free plan', $out );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -47,6 +47,7 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
+		wpcom_expiry_notices_eligible_state( true );
 		set_current_screen( 'dashboard' );
 	}
 
@@ -73,6 +74,8 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 				'user_allows_auto_renew' => $auto_renew,
 			),
 		);
+		// The eligible-state memo has already answered for the previous fixture.
+		wpcom_expiry_notices_eligible_state( true );
 	}
 
 	private function render(): string {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -7,6 +7,7 @@
 
 declare( strict_types = 1 );
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
@@ -55,6 +56,7 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
 		unset( $GLOBALS['wpcom_is_vip_test_value'] );
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER );
+		Constants::clear_constants();
 		parent::tear_down();
 	}
 
@@ -153,6 +155,7 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function test_the_two_post_expiry_windows_ask_for_different_things(): void {
+		Constants::set_constant( 'IS_ATOMIC', true );
 		$this->set_purchase( -5 );
 		$grace = $this->render();
 		$this->set_purchase( -45 );
@@ -427,15 +430,17 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function test_body_after_revert_on_atomic_mentions_the_site_going_private(): void {
+		// Keyed on the constant rather than the state's is_atomic, which is
+		// already false by the time a site has been reverted.
+		Constants::set_constant( 'IS_ATOMIC', true );
 		$state = $this->message_state(
 			array(
 				'state'          => Expiry_Data::STATE_EXPIRED,
 				'days_remaining' => -45,
-				'is_atomic'      => true,
 			)
 		);
 		$this->assertSame(
-			'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or 50 GB of storage. Upgrade your plan to restore your site.',
+			'Your site has been moved to the Free plan and set to private. You no longer have access to plugins, custom themes, or 50 GB of storage. Contact support to get help restoring it.',
 			wpcom_expiry_notices_admin_banner_body( $state )
 		);
 	}
@@ -454,6 +459,7 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function test_after_revert_the_cta_points_at_support(): void {
+		Constants::set_constant( 'IS_ATOMIC', true );
 		// Re-purchasing cannot bring back what the revert deleted, so checkout is
 		// the wrong destination once the site is on Free.
 		$this->set_purchase( -45 );
@@ -464,6 +470,7 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function test_the_support_cta_carries_the_message_and_a_fallback(): void {
+		Constants::set_constant( 'IS_ATOMIC', true );
 		// The Help Center has no URL that opens it in this state, so the message
 		// rides on the element and the href is what a click falls back to.
 		$this->set_purchase( -45 );
@@ -485,5 +492,21 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	public function test_body_falls_back_to_additional_storage_for_unknown_slug(): void {
 		$state = $this->message_state( array( 'product_slug' => 'mystery-bundle' ) );
 		$this->assertStringContainsString( 'additional storage', wpcom_expiry_notices_admin_banner_body( $state ) );
+	}
+
+	public function test_a_site_that_was_never_atomic_is_not_sent_to_support(): void {
+		// The banner shows on every site, and one that never carried a transfer
+		// lost plan features and nothing else -- buying the plan again does give
+		// those back, so support is the wrong destination.
+		Constants::set_constant( 'IS_ATOMIC', false );
+		$this->set_purchase( -45 );
+		$out = $this->render();
+
+		$this->assertStringNotContainsString( 'Contact support', $out );
+		$this->assertStringNotContainsString( 'data-support-message', $out );
+		$this->assertStringContainsString( 'Restore site', $out );
+		$this->assertStringContainsString( '/checkout/', $out );
+		// And the copy has to ask for the same thing the button does.
+		$this->assertStringContainsString( 'Upgrade your plan to restore your site.', $out );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -161,8 +161,8 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		// Grace: the site is intact, so the ask is to renew before it isn't.
 		$this->assertStringContainsString( 'Renew now', $grace );
 		$this->assertStringNotContainsString( 'wpcom-expiry-banner__dismiss', $grace );
-		// Reverted: already on Free, so the ask is to restore — and it can be dismissed.
-		$this->assertStringContainsString( 'Restore site', $reverted );
+		// Reverted: renewing no longer undoes any of it, so the ask is support.
+		$this->assertStringContainsString( 'Contact support', $reverted );
 		$this->assertStringContainsString( 'wpcom-expiry-banner__dismiss', $reverted );
 	}
 
@@ -453,18 +453,33 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '50 GB of storage', $body );
 	}
 
-	public function test_after_revert_the_cta_offers_to_restore_the_site(): void {
+	public function test_after_revert_the_cta_points_at_support(): void {
+		// Re-purchasing cannot bring back what the revert deleted, so checkout is
+		// the wrong destination once the site is on Free.
 		$this->set_purchase( -45 );
 		$out = $this->render();
-		$this->assertStringContainsString( 'Restore site', $out );
+		$this->assertStringContainsString( 'Contact support', $out );
 		$this->assertStringNotContainsString( 'Renew now', $out );
+		$this->assertStringNotContainsString( '/checkout/', $out );
+	}
+
+	public function test_the_support_cta_carries_the_message_and_a_fallback(): void {
+		// The Help Center has no URL that opens it in this state, so the message
+		// rides on the element and the href is what a click falls back to.
+		$this->set_purchase( -45 );
+		$out = $this->render();
+		// Plans::get_plan_short_name() is unavailable here, so this is the
+		// no-plan-name variant; wpcom_expiry_notices_support_cta() covers the other.
+		$this->assertStringContainsString( 'data-support-message="My plan expired', $out );
+		$this->assertStringContainsString( 'wordpress.com/help', $out );
 	}
 
 	public function test_before_revert_the_cta_still_asks_for_a_renewal(): void {
 		$this->set_purchase( -5 );
 		$out = $this->render();
 		$this->assertStringContainsString( 'Renew now', $out );
-		$this->assertStringNotContainsString( 'Restore site', $out );
+		$this->assertStringNotContainsString( 'Contact support', $out );
+		$this->assertStringNotContainsString( 'data-support-message', $out );
 	}
 
 	public function test_body_falls_back_to_additional_storage_for_unknown_slug(): void {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-banner.php';
@@ -58,6 +60,20 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER );
 		Constants::clear_constants();
 		parent::tear_down();
+	}
+
+	/**
+	 * A site the revert has already happened to.
+	 *
+	 * `has_blog_sticker` is declared per test because other suites declare their
+	 * own, and a shared definition makes theirs a fatal redeclare -- hence the
+	 * separate process on every caller.
+	 */
+	private function pretend_reverted(): void {
+		Constants::set_constant( 'IS_ATOMIC', false );
+		if ( ! function_exists( 'has_blog_sticker' ) ) {
+			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		}
 	}
 
 	private function set_purchase( int $days_until_expiry, bool $auto_renew = false, string $slug = 'business-bundle' ): void {
@@ -154,8 +170,14 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_the_two_post_expiry_windows_ask_for_different_things(): void {
-		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->pretend_reverted();
 		$this->set_purchase( -5 );
 		$grace = $this->render();
 		$this->set_purchase( -45 );
@@ -429,10 +451,16 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'But it’s not too late.', $body );
 	}
 
-	public function test_body_after_revert_on_atomic_mentions_the_site_going_private(): void {
-		// Keyed on the constant rather than the state's is_atomic, which is
-		// already false by the time a site has been reverted.
-		Constants::set_constant( 'IS_ATOMIC', true );
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_body_after_revert_mentions_the_site_going_private(): void {
+		// Keyed on the revert having happened, not on the state's is_atomic,
+		// which is already false by then.
+		$this->pretend_reverted();
 		$state = $this->message_state(
 			array(
 				'state'          => Expiry_Data::STATE_EXPIRED,
@@ -458,8 +486,14 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '50 GB of storage', $body );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_after_revert_the_cta_points_at_support(): void {
-		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->pretend_reverted();
 		// Re-purchasing cannot bring back what the revert deleted, so checkout is
 		// the wrong destination once the site is on Free.
 		$this->set_purchase( -45 );
@@ -469,8 +503,14 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringNotContainsString( '/checkout/', $out );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_the_support_cta_carries_the_message_and_a_fallback(): void {
-		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->pretend_reverted();
 		// The Help Center has no URL that opens it in this state, so the message
 		// rides on the element and the href is what a click falls back to.
 		$this->set_purchase( -45 );
@@ -508,5 +548,17 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '/checkout/', $out );
 		// And the copy has to ask for the same thing the button does.
 		$this->assertStringContainsString( 'Upgrade your plan to restore your site.', $out );
+	}
+
+	public function test_before_the_revert_runs_the_cta_still_offers_checkout(): void {
+		// Same gap: post-grace by date, but not yet reverted. Renewing still works,
+		// so support would be the wrong ask and the copy must not be past tense
+		// about a revert that has not happened.
+		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->set_purchase( -45 );
+		$out = $this->render();
+
+		$this->assertStringNotContainsString( 'Contact support', $out );
+		$this->assertStringContainsString( '/checkout/', $out );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -47,6 +47,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->admin_id );
+		wpcom_expiry_notices_eligible_state( true );
 		set_current_screen( 'dashboard' );
 		Constants::set_constant( 'IS_ATOMIC', true );
 		// The modal names the domain the site reverts to; resolving it is an HTTP
@@ -88,6 +89,8 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 				'user_allows_auto_renew' => false,
 			),
 		);
+		// The eligible-state memo has already answered for the previous fixture.
+		wpcom_expiry_notices_eligible_state( true );
 	}
 
 	public function test_shows_in_grace_with_the_pre_revert_copy(): void {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -50,6 +50,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		);
 		wp_set_current_user( $this->admin_id );
 		wpcom_expiry_notices_eligible_state( true );
+		wpcom_expiry_notices_admin_modal_data( true );
 		set_current_screen( 'dashboard' );
 		Constants::set_constant( 'IS_ATOMIC', true );
 		// The modal names the domain the site reverts to; resolving it is an HTTP
@@ -95,6 +96,18 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
+	/**
+	 * Record a dismissal and clear the modal memo, which in production could not
+	 * change inside one request.
+	 *
+	 * @param string $meta_key Dismiss meta key.
+	 * @param int    $when     Timestamp to store.
+	 */
+	private function set_dismissed( string $meta_key, int $when ): void {
+		update_user_meta( $this->admin_id, $meta_key, $when );
+		wpcom_expiry_notices_admin_modal_data( true );
+	}
+
 	private function set_purchase( int $days_until_expiry, string $slug = 'business-bundle' ): void {
 		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
 			(object) array(
@@ -107,8 +120,9 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 				'user_allows_auto_renew' => false,
 			),
 		);
-		// The eligible-state memo has already answered for the previous fixture.
+		// Both memos have already answered for the previous fixture.
 		wpcom_expiry_notices_eligible_state( true );
+		wpcom_expiry_notices_admin_modal_data( true );
 	}
 
 	public function test_shows_in_grace_with_the_pre_revert_copy(): void {
@@ -167,25 +181,6 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_shows_after_grace_on_a_reverted_site(): void {
-		// The revert is what moves the site off Atomic, so by the time the
-		// post-grace copy is true the site is Simple. Gating on IS_ATOMIC alone
-		// would make this variant unreachable in production.
-		$this->pretend_reverted_to_simple();
-
-		$this->set_purchase( -45 );
-		$data = wpcom_expiry_notices_admin_modal_data();
-
-		$this->assertNotNull( $data );
-		$this->assertSame( 'Contact support', $data['primary']['label'] );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_does_not_show_in_grace_on_a_reverted_site(): void {
 		// A site already reverted was reverted by an earlier lapse. This one has
 		// not reached the changes the pre-revert variant promises are coming.
@@ -236,10 +231,10 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	public function test_grace_dismissal_lapses_so_the_modal_returns(): void {
 		$this->set_purchase( -5 );
 
-		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() );
+		$this->set_dismissed( Expiry_Notice_Dismiss::META_MODAL_GRACE, time() );
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data(), 'a fresh dismissal should hide the modal' );
 
-		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - ( Expiry_Notice_Dismiss::MODAL_GRACE_DISMISS_TTL + HOUR_IN_SECONDS ) );
+		$this->set_dismissed( Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - ( Expiry_Notice_Dismiss::MODAL_GRACE_DISMISS_TTL + HOUR_IN_SECONDS ) );
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), 'the site is still lapsing, so a stale dismissal should not hold' );
 	}
 
@@ -255,7 +250,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		// Dismissed 10 days ago -- within this term, since the revert it reports
 		// happened at day 30, but far outside the grace TTL, which must not apply
 		// once the revert has actually happened.
-		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL, time() - 10 * DAY_IN_SECONDS );
+		$this->set_dismissed( Expiry_Notice_Dismiss::META_MODAL, time() - 10 * DAY_IN_SECONDS );
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
@@ -271,7 +266,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		// a grace dismissal is stamped after expiry and would otherwise satisfy
 		// the post-grace "belongs to this term" check.
 		$this->set_purchase( -45 );
-		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - DAY_IN_SECONDS );
+		$this->set_dismissed( Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - DAY_IN_SECONDS );
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
@@ -286,16 +281,10 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->set_purchase( -45 );
 		// Dismissed against a purchase that has since been renewed and lapsed
 		// again: this revert is news.
-		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL, time() - YEAR_IN_SECONDS );
+		$this->set_dismissed( Expiry_Notice_Dismiss::META_MODAL, time() - YEAR_IN_SECONDS );
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_names_the_domain_the_site_will_move_to_in_grace(): void {
 		$this->set_revert_domain( 'example.wordpress.com' );
 
@@ -336,25 +325,6 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( $data );
 		$this->assertCount( 3, $data['items'] );
 		$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
-	}
-
-	/**
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_names_the_wpcom_address_a_reverted_site_now_serves_from(): void {
-		$this->pretend_reverted_to_simple();
-		// WorDBless serves example.org, so a blogs-table domain that matches is a
-		// site sitting on its own unmapped address -- the switch already happened.
-		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'example.org';
-
-		$this->set_purchase( -45 );
-		$data = wpcom_expiry_notices_admin_modal_data();
-
-		$this->assertNotNull( $data );
-		$this->assertStringContainsString( 'switched to example.org', implode( "\n", $data['items'] ) );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -10,6 +10,8 @@ declare( strict_types = 1 );
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-modal.php';
@@ -59,7 +61,6 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	public function tear_down() {
 		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
 		unset( $GLOBALS['wpcom_is_vip_test_value'] );
-		unset( $GLOBALS['wpcom_blog_stickers_test_value'] );
 		unset( $GLOBALS['wpcom_blog_details_domain_test_value'] );
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL );
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE );
@@ -82,11 +83,18 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * A site the revert has already moved back to Simple: no longer Atomic, and
 	 * carrying the sticker wpcom leaves behind.
+	 *
+	 * `has_blog_sticker` is declared here rather than in the shared bootstrap
+	 * because other suites in this package declare their own, and a definition
+	 * that is already in place makes theirs a fatal redeclare. Hence the separate
+	 * process on every test that calls this.
 	 */
 	private function pretend_reverted_to_simple(): void {
 		Constants::set_constant( 'IS_ATOMIC', false );
 		Constants::set_constant( 'IS_WPCOM', true );
-		$GLOBALS['wpcom_blog_stickers_test_value'] = array( 'blog-transfer-reverted' );
+		if ( ! function_exists( 'has_blog_sticker' ) ) {
+			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		}
 	}
 
 	private function set_purchase( int $days_until_expiry, string $slug = 'business-bundle' ): void {
@@ -148,6 +156,12 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_shows_after_grace_on_a_reverted_site(): void {
 		// The revert is what moves the site off Atomic, so by the time the
 		// post-grace copy is true the site is Simple. Gating on IS_ATOMIC alone
@@ -161,6 +175,12 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'Restore my site', $data['primary']['label'] );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_does_not_show_in_grace_on_a_reverted_site(): void {
 		// A site already reverted was reverted by an earlier lapse. This one has
 		// not reached the changes the pre-revert variant promises are coming.
@@ -170,6 +190,12 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_shows_for_any_plan_that_could_have_carried_a_transfer(): void {
 		// WPCOM_Features::ATOMIC is granted to Personal and higher, so there is no
 		// paid tier whose lapse could not have produced this revert. Narrowing to
@@ -267,6 +293,12 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_names_the_wpcom_address_a_reverted_site_now_serves_from(): void {
 		$this->pretend_reverted_to_simple();
 		// WorDBless serves example.org, so a blogs-table domain that matches is a
@@ -280,6 +312,12 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( 'switched to example.org', implode( "\n", $data['items'] ) );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_omits_the_domain_when_a_reverted_site_kept_its_own(): void {
 		// Serving from example.org while the blogs table says otherwise: the
 		// custom domain survived the revert, so nothing was switched.

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -81,13 +81,11 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * A site the revert has already moved back to Simple: no longer Atomic, and
-	 * carrying the sticker wpcom leaves behind.
+	 * A site the revert has already moved back to Simple.
 	 *
-	 * `has_blog_sticker` is declared here rather than in the shared bootstrap
-	 * because other suites in this package declare their own, and a definition
-	 * that is already in place makes theirs a fatal redeclare. Hence the separate
-	 * process on every test that calls this.
+	 * `has_blog_sticker` is declared per test because other suites declare their
+	 * own, and a shared definition makes theirs a fatal redeclare -- hence the
+	 * separate process on every caller.
 	 */
 	private function pretend_reverted_to_simple(): void {
 		Constants::set_constant( 'IS_ATOMIC', false );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -59,6 +59,8 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	public function tear_down() {
 		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
 		unset( $GLOBALS['wpcom_is_vip_test_value'] );
+		unset( $GLOBALS['wpcom_blog_stickers_test_value'] );
+		unset( $GLOBALS['wpcom_blog_details_domain_test_value'] );
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL );
 		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE );
 		delete_transient( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::CACHE_KEY );
@@ -75,6 +77,16 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 			$domain ?? \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::NONE,
 			HOUR_IN_SECONDS
 		);
+	}
+
+	/**
+	 * A site the revert has already moved back to Simple: no longer Atomic, and
+	 * carrying the sticker wpcom leaves behind.
+	 */
+	private function pretend_reverted_to_simple(): void {
+		Constants::set_constant( 'IS_ATOMIC', false );
+		Constants::set_constant( 'IS_WPCOM', true );
+		$GLOBALS['wpcom_blog_stickers_test_value'] = array( 'blog-transfer-reverted' );
 	}
 
 	private function set_purchase( int $days_until_expiry, string $slug = 'business-bundle' ): void {
@@ -126,14 +138,46 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		}
 	}
 
-	public function test_does_not_show_on_simple_sites(): void {
-		// Every change the copy lists is something the Atomic revert does. A
-		// Simple site is not reverted, so none of it would be true of one.
+	public function test_does_not_show_on_a_simple_site_that_was_never_atomic(): void {
+		// Every change the copy lists is something the revert does, and a site
+		// that never carried a transfer is never reverted.
 		Constants::set_constant( 'IS_ATOMIC', false );
 		foreach ( array( -5, -45 ) as $days ) {
 			$this->set_purchase( $days );
 			$this->assertNull( wpcom_expiry_notices_admin_modal_data(), "expected no modal on a Simple site {$days} days past expiry" );
 		}
+	}
+
+	public function test_shows_after_grace_on_a_reverted_site(): void {
+		// The revert is what moves the site off Atomic, so by the time the
+		// post-grace copy is true the site is Simple. Gating on IS_ATOMIC alone
+		// would make this variant unreachable in production.
+		$this->pretend_reverted_to_simple();
+
+		$this->set_purchase( -45 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertSame( 'Restore my site', $data['primary']['label'] );
+	}
+
+	public function test_does_not_show_in_grace_on_a_reverted_site(): void {
+		// A site already reverted was reverted by an earlier lapse. This one has
+		// not reached the changes the pre-revert variant promises are coming.
+		$this->pretend_reverted_to_simple();
+
+		$this->set_purchase( -5 );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_does_not_show_for_a_plan_that_never_carried_a_transfer(): void {
+		// The sticker outlives the lapse that earned it: a site reverted long ago
+		// can be lapsing a Personal plan, which never made it Atomic and so never
+		// removed a plugin.
+		$this->pretend_reverted_to_simple();
+
+		$this->set_purchase( -45, 'personal-bundle' );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
 	public function test_does_not_show_for_non_admins(): void {
@@ -219,5 +263,31 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 			$this->assertCount( 3, $data['items'], "expected three items {$days} days past expiry" );
 			$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
 		}
+	}
+
+	public function test_names_the_wpcom_address_a_reverted_site_now_serves_from(): void {
+		$this->pretend_reverted_to_simple();
+		// WorDBless serves example.org, so a blogs-table domain that matches is a
+		// site sitting on its own unmapped address -- the switch already happened.
+		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'example.org';
+
+		$this->set_purchase( -45 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertStringContainsString( 'switched to example.org', implode( "\n", $data['items'] ) );
+	}
+
+	public function test_omits_the_domain_when_a_reverted_site_kept_its_own(): void {
+		// Serving from example.org while the blogs table says otherwise: the
+		// custom domain survived the revert, so nothing was switched.
+		$this->pretend_reverted_to_simple();
+		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'unused.wordpress.com';
+
+		$this->set_purchase( -45 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -170,14 +170,16 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
-	public function test_does_not_show_for_a_plan_that_never_carried_a_transfer(): void {
-		// The sticker outlives the lapse that earned it: a site reverted long ago
-		// can be lapsing a Personal plan, which never made it Atomic and so never
-		// removed a plugin.
+	public function test_shows_for_any_plan_that_could_have_carried_a_transfer(): void {
+		// WPCOM_Features::ATOMIC is granted to Personal and higher, so there is no
+		// paid tier whose lapse could not have produced this revert. Narrowing to
+		// Business would hide the modal from most of the sites it is meant for.
 		$this->pretend_reverted_to_simple();
 
-		$this->set_purchase( -45, 'personal-bundle' );
-		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
+		foreach ( array( 'personal-bundle', 'value_bundle', 'business-bundle' ) as $slug ) {
+			$this->set_purchase( -45, $slug );
+			$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), "expected a modal for {$slug}" );
+		}
 	}
 
 	public function test_does_not_show_for_non_admins(): void {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Admin Modal Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-modal.php';
+
+class Admin_Modal_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	public function set_up() {
+		parent::set_up();
+		// WorDBless resets the users table between tests, so recreate fixture
+		// users here rather than in set_up_before_class.
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'modal_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'modal_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'modal_subscriber',
+				'user_pass'  => 'pass',
+				'user_email' => 'modal_subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
+		set_current_screen( 'dashboard' );
+		Constants::set_constant( 'IS_ATOMIC', true );
+		// The modal names the domain the site reverts to; resolving it is an HTTP
+		// call, so prime the cache the resolver reads. Tests that care about the
+		// domain bullet override this.
+		$this->set_revert_domain( null );
+	}
+
+	public function tear_down() {
+		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
+		unset( $GLOBALS['wpcom_is_vip_test_value'] );
+		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL );
+		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE );
+		delete_transient( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::CACHE_KEY );
+		Constants::clear_constants();
+		parent::tear_down();
+	}
+
+	/**
+	 * @param string|null $domain Domain the site reverts to, or null for none.
+	 */
+	private function set_revert_domain( ?string $domain ): void {
+		set_transient(
+			\Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::CACHE_KEY,
+			$domain ?? \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::NONE,
+			HOUR_IN_SECONDS
+		);
+	}
+
+	private function set_purchase( int $days_until_expiry, string $slug = 'business-bundle' ): void {
+		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
+			(object) array(
+				'product_slug'           => $slug,
+				'product_type'           => 'bundle',
+				// Half a day of slack so a case can't slip into the neighbouring
+				// day bucket between this call and the read. Same reasoning as
+				// Admin_Banner_Test::set_purchase().
+				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
+				'user_allows_auto_renew' => false,
+			),
+		);
+	}
+
+	public function test_shows_in_grace_with_the_pre_revert_copy(): void {
+		$this->set_purchase( -5 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertSame( Expiry_Notice_Dismiss::META_MODAL_GRACE, $data['metaKey'] );
+		$this->assertStringContainsString( 'will be moved to the Free plan', $data['description'] );
+		$this->assertSame( 'Renew now', $data['primary']['label'] );
+		// Renewing is still one of two options while the plan can simply be paid for.
+		$this->assertNotNull( $data['secondary'] );
+		$this->assertStringContainsString( '/plans/', $data['secondary']['url'] );
+	}
+
+	public function test_shows_after_grace_with_the_post_revert_copy(): void {
+		$this->set_purchase( -45 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertSame( Expiry_Notice_Dismiss::META_MODAL, $data['metaKey'] );
+		$this->assertStringContainsString( 'has been moved to the Free plan', $data['description'] );
+		$this->assertSame( 'Restore my site', $data['primary']['label'] );
+		// Nothing left to compare once the site is already on Free.
+		$this->assertNull( $data['secondary'] );
+		$this->assertStringContainsString( 'what changed', $data['listIntro'] );
+	}
+
+	public function test_does_not_show_before_expiry(): void {
+		foreach ( array( 200, 45, 5, 0 ) as $days ) {
+			$this->set_purchase( $days );
+			$this->assertNull( wpcom_expiry_notices_admin_modal_data(), "expected no modal {$days} days before expiry" );
+		}
+	}
+
+	public function test_does_not_show_on_simple_sites(): void {
+		// Every change the copy lists is something the Atomic revert does. A
+		// Simple site is not reverted, so none of it would be true of one.
+		Constants::set_constant( 'IS_ATOMIC', false );
+		foreach ( array( -5, -45 ) as $days ) {
+			$this->set_purchase( $days );
+			$this->assertNull( wpcom_expiry_notices_admin_modal_data(), "expected no modal on a Simple site {$days} days past expiry" );
+		}
+	}
+
+	public function test_does_not_show_for_non_admins(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->set_purchase( -5 );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_does_not_show_on_vip_sites(): void {
+		$GLOBALS['wpcom_is_vip_test_value'] = true;
+		$this->set_purchase( -5 );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_shows_on_every_admin_screen(): void {
+		$this->set_purchase( -5 );
+		foreach ( array( 'dashboard', 'edit-post', 'options-general' ) as $screen ) {
+			set_current_screen( $screen );
+			$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), "expected a modal on {$screen}" );
+		}
+	}
+
+	public function test_grace_dismissal_lapses_so_the_modal_returns(): void {
+		$this->set_purchase( -5 );
+
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data(), 'a fresh dismissal should hide the modal' );
+
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - ( Expiry_Notice_Dismiss::MODAL_GRACE_DISMISS_TTL + HOUR_IN_SECONDS ) );
+		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), 'the site is still lapsing, so a stale dismissal should not hold' );
+	}
+
+	public function test_post_grace_dismissal_does_not_lapse(): void {
+		$this->set_purchase( -45 );
+		// Dismissed 10 days ago -- within this term, since the revert it reports
+		// happened at day 30, but far outside the grace TTL, which must not apply
+		// once the revert has actually happened.
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL, time() - 10 * DAY_IN_SECONDS );
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_a_grace_dismissal_does_not_bury_the_post_grace_modal(): void {
+		// The two states dismiss to separate keys precisely so this can't happen:
+		// a grace dismissal is stamped after expiry and would otherwise satisfy
+		// the post-grace "belongs to this term" check.
+		$this->set_purchase( -45 );
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - DAY_IN_SECONDS );
+		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_dismissal_of_an_earlier_term_shows_again(): void {
+		$this->set_purchase( -45 );
+		// Dismissed against a purchase that has since been renewed and lapsed
+		// again: this revert is news.
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL, time() - YEAR_IN_SECONDS );
+		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
+	}
+
+	public function test_names_the_revert_domain_when_there_is_one(): void {
+		$this->set_revert_domain( 'example.wordpress.com' );
+
+		$this->set_purchase( -5 );
+		$grace = wpcom_expiry_notices_admin_modal_data();
+		$this->assertNotNull( $grace );
+		$this->assertStringContainsString( 'Use example.wordpress.com as your primary domain.', implode( "\n", $grace['items'] ) );
+
+		$this->set_purchase( -45 );
+		$reverted = wpcom_expiry_notices_admin_modal_data();
+		$this->assertNotNull( $reverted );
+		$this->assertStringContainsString( 'switched to example.wordpress.com', implode( "\n", $reverted['items'] ) );
+	}
+
+	public function test_omits_the_domain_line_when_the_site_keeps_its_domain(): void {
+		// A custom primary domain survives the revert, so promising to move the
+		// site off it would be false. The resolver answers null and the bullet
+		// goes away rather than naming the wrong domain.
+		$this->set_revert_domain( null );
+
+		foreach ( array( -5, -45 ) as $days ) {
+			$this->set_purchase( $days );
+			$data = wpcom_expiry_notices_admin_modal_data();
+			$this->assertNotNull( $data, "expected a modal {$days} days past expiry" );
+			$this->assertCount( 3, $data['items'], "expected three items {$days} days past expiry" );
+			$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -133,7 +133,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( $data );
 		$this->assertSame( Expiry_Notice_Dismiss::META_MODAL, $data['metaKey'] );
 		$this->assertStringContainsString( 'has been moved to the Free plan', $data['description'] );
-		$this->assertSame( 'Restore my site', $data['primary']['label'] );
+		$this->assertSame( 'Contact support', $data['primary']['label'] );
 		// Nothing left to compare once the site is already on Free.
 		$this->assertNull( $data['secondary'] );
 		$this->assertStringContainsString( 'what changed', $data['listIntro'] );
@@ -172,7 +172,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$data = wpcom_expiry_notices_admin_modal_data();
 
 		$this->assertNotNull( $data );
-		$this->assertSame( 'Restore my site', $data['primary']['label'] );
+		$this->assertSame( 'Contact support', $data['primary']['label'] );
 	}
 
 	/**
@@ -329,5 +329,39 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertNotNull( $data );
 		$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
+	}
+
+	public function test_the_support_cta_prefills_a_message(): void {
+		$this->set_purchase( -45 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertStringContainsString( 'I need your help getting it restored', $data['primary']['message'] );
+		// A click the Help Center cannot answer still has to land somewhere.
+		$this->assertStringContainsString( 'wordpress.com/help', $data['primary']['url'] );
+	}
+
+	public function test_the_support_message_names_the_plan_when_it_is_known(): void {
+		// Plans::get_plan_short_name() does not resolve in this environment, so
+		// drive the two branches from the state directly.
+		$this->assertSame(
+			'My Business plan expired and I need your help getting it restored.',
+			wpcom_expiry_notices_support_cta( array( 'plan_name' => 'Business' ) )['message']
+		);
+		// A sentence with a hole in it is worse than one without the name.
+		$this->assertSame(
+			'My plan expired and I need your help getting it restored.',
+			wpcom_expiry_notices_support_cta( array( 'plan_name' => null ) )['message']
+		);
+	}
+
+	public function test_the_grace_cta_is_still_checkout(): void {
+		// Renewing still saves the site while the revert is ahead of it.
+		$this->set_purchase( -5 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+
+		$this->assertNotNull( $data );
+		$this->assertStringContainsString( '/checkout/', $data['primary']['url'] );
+		$this->assertArrayNotHasKey( 'message', $data['primary'] );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -124,7 +124,14 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringContainsString( '/plans/', $data['secondary']['url'] );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_shows_after_grace_with_the_post_revert_copy(): void {
+		$this->pretend_reverted_to_simple();
 		$this->set_purchase( -45 );
 		$data = wpcom_expiry_notices_admin_modal_data();
 
@@ -236,7 +243,14 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), 'the site is still lapsing, so a stale dismissal should not hold' );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_post_grace_dismissal_does_not_lapse(): void {
+		$this->pretend_reverted_to_simple();
 		$this->set_purchase( -45 );
 		// Dismissed 10 days ago -- within this term, since the revert it reports
 		// happened at day 30, but far outside the grace TTL, which must not apply
@@ -245,7 +259,14 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_a_grace_dismissal_does_not_bury_the_post_grace_modal(): void {
+		$this->pretend_reverted_to_simple();
 		// The two states dismiss to separate keys precisely so this can't happen:
 		// a grace dismissal is stamped after expiry and would otherwise satisfy
 		// the post-grace "belongs to this term" check.
@@ -254,7 +275,14 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_dismissal_of_an_earlier_term_shows_again(): void {
+		$this->pretend_reverted_to_simple();
 		$this->set_purchase( -45 );
 		// Dismissed against a purchase that has since been renewed and lapsed
 		// again: this revert is news.
@@ -262,18 +290,39 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 
-	public function test_names_the_revert_domain_when_there_is_one(): void {
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_names_the_domain_the_site_will_move_to_in_grace(): void {
 		$this->set_revert_domain( 'example.wordpress.com' );
 
 		$this->set_purchase( -5 );
 		$grace = wpcom_expiry_notices_admin_modal_data();
+
 		$this->assertNotNull( $grace );
 		$this->assertStringContainsString( 'Use example.wordpress.com as your primary domain.', implode( "\n", $grace['items'] ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_names_the_domain_the_site_moved_to_after_the_revert(): void {
+		$this->pretend_reverted_to_simple();
+		// WorDBless serves example.org, so a matching blogs-table domain is a site
+		// sitting on its own unmapped address -- the switch already happened.
+		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'example.org';
 
 		$this->set_purchase( -45 );
 		$reverted = wpcom_expiry_notices_admin_modal_data();
+
 		$this->assertNotNull( $reverted );
-		$this->assertStringContainsString( 'switched to example.wordpress.com', implode( "\n", $reverted['items'] ) );
+		$this->assertStringContainsString( 'switched to example.org', implode( "\n", $reverted['items'] ) );
 	}
 
 	public function test_omits_the_domain_line_when_the_site_keeps_its_domain(): void {
@@ -282,13 +331,11 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		// goes away rather than naming the wrong domain.
 		$this->set_revert_domain( null );
 
-		foreach ( array( -5, -45 ) as $days ) {
-			$this->set_purchase( $days );
-			$data = wpcom_expiry_notices_admin_modal_data();
-			$this->assertNotNull( $data, "expected a modal {$days} days past expiry" );
-			$this->assertCount( 3, $data['items'], "expected three items {$days} days past expiry" );
-			$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
-		}
+		$this->set_purchase( -5 );
+		$data = wpcom_expiry_notices_admin_modal_data();
+		$this->assertNotNull( $data );
+		$this->assertCount( 3, $data['items'] );
+		$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
 	}
 
 	/**
@@ -329,7 +376,14 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertStringNotContainsString( 'primary domain', implode( "\n", $data['items'] ) );
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_the_support_cta_prefills_a_message(): void {
+		$this->pretend_reverted_to_simple();
 		$this->set_purchase( -45 );
 		$data = wpcom_expiry_notices_admin_modal_data();
 
@@ -361,5 +415,15 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( $data );
 		$this->assertStringContainsString( '/checkout/', $data['primary']['url'] );
 		$this->assertArrayNotHasKey( 'message', $data['primary'] );
+	}
+
+	public function test_waits_for_the_revert_rather_than_the_date(): void {
+		// The post-grace state opens 30 days after expiry, but the revert runs off
+		// the subscription-removal record and can lag it. In that gap the site is
+		// still Atomic and still renewable, so past-tense copy would be untrue.
+		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->set_purchase( -45 );
+
+		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Domain_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Domain_Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Expiry_Domain Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/class-expiry-domain.php';
+
+/**
+ * @covers \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain
+ */
+#[CoversClass( Expiry_Domain::class )]
+class Expiry_Domain_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Build a domain row in the shape /sites/{id}/domains returns.
+	 *
+	 * @param string              $domain    Domain name.
+	 * @param array<string,mixed> $overrides Flags to set on the row.
+	 */
+	private function domain( string $domain, array $overrides = array() ): object {
+		return (object) array_merge(
+			array(
+				'domain'                  => $domain,
+				'wpcom_domain'            => false,
+				'is_wpcom_staging_domain' => false,
+				'primary_domain'          => false,
+			),
+			$overrides
+		);
+	}
+
+	public function test_names_the_wpcom_address_for_a_site_on_its_staging_domain(): void {
+		$domains = array(
+			$this->domain( 'example.wordpress.com', array( 'wpcom_domain' => true ) ),
+			$this->domain(
+				'example.wpcomstaging.com',
+				array(
+					'is_wpcom_staging_domain' => true,
+					'primary_domain'          => true,
+				)
+			),
+		);
+
+		$this->assertSame( 'example.wordpress.com', Expiry_Domain::pick_revert_domain( $domains ) );
+	}
+
+	public function test_names_the_wpcom_address_when_it_is_itself_primary(): void {
+		$domains = array(
+			$this->domain(
+				'example.wordpress.com',
+				array(
+					'wpcom_domain'   => true,
+					'primary_domain' => true,
+				)
+			),
+		);
+
+		$this->assertSame( 'example.wordpress.com', Expiry_Domain::pick_revert_domain( $domains ) );
+	}
+
+	public function test_says_nothing_when_a_custom_domain_is_primary(): void {
+		// The revert keeps a real custom domain and only repoints its A records,
+		// so there is no rename to warn about.
+		$domains = array(
+			$this->domain( 'example.wordpress.com', array( 'wpcom_domain' => true ) ),
+			$this->domain( 'example.com', array( 'primary_domain' => true ) ),
+		);
+
+		$this->assertNull( Expiry_Domain::pick_revert_domain( $domains ) );
+	}
+
+	public function test_never_names_the_staging_domain(): void {
+		// `*.wpcomstaging.com` is an Atomic hosting artifact whose mapping the
+		// revert deletes, so it is never what the site ends up called.
+		$domains = array(
+			$this->domain(
+				'example.wpcomstaging.com',
+				array(
+					'wpcom_domain'            => true,
+					'is_wpcom_staging_domain' => true,
+					'primary_domain'          => true,
+				)
+			),
+		);
+
+		$this->assertNull( Expiry_Domain::pick_revert_domain( $domains ) );
+	}
+
+	public function test_handles_a_managed_subdomain_site(): void {
+		// wpcom hides the .wordpress.com row when a managed subdomain (.blog and
+		// friends) is mapped, so the wpcom row is the fallback in both cases and
+		// this needs no special handling -- but it must not regress.
+		$domains = array(
+			$this->domain(
+				'example.home.blog',
+				array(
+					'wpcom_domain'   => true,
+					'primary_domain' => true,
+				)
+			),
+		);
+
+		$this->assertSame( 'example.home.blog', Expiry_Domain::pick_revert_domain( $domains ) );
+	}
+
+	public function test_says_nothing_when_the_list_is_unusable(): void {
+		$this->assertNull( Expiry_Domain::pick_revert_domain( array() ) );
+		// No primary flagged at all: we can't tell whether the site is renaming.
+		$this->assertNull(
+			Expiry_Domain::pick_revert_domain(
+				array( $this->domain( 'example.wordpress.com', array( 'wpcom_domain' => true ) ) )
+			)
+		);
+		// A row with no usable domain string is skipped rather than fatal.
+		$this->assertNull(
+			Expiry_Domain::pick_revert_domain( array( (object) array( 'primary_domain' => true ) ) )
+		);
+	}
+
+	public function test_a_failed_lookup_is_not_cached_as_an_answer(): void {
+		// No connected site id here, so the request can't be made -- the same
+		// path an outage takes. "We couldn't ask" must expire quickly; caching it
+		// for CACHE_TTL would drop the domain line for half a day over one blip.
+		delete_transient( Expiry_Domain::CACHE_KEY );
+
+		$this->assertNull( Expiry_Domain::get_revert_domain() );
+
+		$expires_in = (int) get_option( '_transient_timeout_' . Expiry_Domain::CACHE_KEY ) - time();
+		$this->assertGreaterThan( 0, $expires_in );
+		$this->assertLessThanOrEqual( Expiry_Domain::FAILURE_TTL, $expires_in );
+		$this->assertLessThan( Expiry_Domain::CACHE_TTL, $expires_in );
+
+		delete_transient( Expiry_Domain::CACHE_KEY );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Notice_Dismiss_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Notice_Dismiss_Test.php
@@ -158,6 +158,7 @@ class Expiry_Notice_Dismiss_Test extends \WorDBless\BaseTestCase {
 		$registered = get_registered_meta_keys( 'user' );
 		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_BANNER, $registered );
 		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_MODAL, $registered );
+		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_MODAL_GRACE, $registered );
 		$this->assertTrue( $registered[ Expiry_Notice_Dismiss::META_BANNER ]['show_in_rest'] );
 		$this->assertSame( 'integer', $registered[ Expiry_Notice_Dismiss::META_BANNER ]['type'] );
 	}
@@ -189,5 +190,82 @@ class Expiry_Notice_Dismiss_Test extends \WorDBless\BaseTestCase {
 		$this->assertTrue( Expiry_Notice_Dismiss::should_show_modal( $state, $user_id ) );
 		update_user_meta( $user_id, Expiry_Notice_Dismiss::META_MODAL, self::NOW - DAY_IN_SECONDS );
 		$this->assertFalse( Expiry_Notice_Dismiss::should_show_modal( $state, $user_id ) );
+	}
+
+	private function grace_state( int $expiry_ts ): array {
+		return array(
+			'state'     => Expiry_Data::STATE_EXPIRED_GRACE,
+			'expiry_ts' => $expiry_ts,
+		);
+	}
+
+	public function test_the_modal_only_speaks_to_a_lapsed_site(): void {
+		// The banner carries every stage before expiry; the modal carries none of
+		// them, so `should_show_modal` can't fall through to true the way the
+		// not-yet-dismissible states do for the banner.
+		foreach ( array( Expiry_Data::STATE_ACTIVE, Expiry_Data::STATE_APPROACHING ) as $state ) {
+			$this->assertFalse(
+				Expiry_Notice_Dismiss::should_show_modal( array( 'state' => $state ), 0 ),
+				"expected no modal in {$state}"
+			);
+		}
+	}
+
+	public function test_a_grace_dismissal_lapses_after_the_ttl(): void {
+		$user_id = $this->make_admin( 'grace_ttl' );
+		$state   = $this->grace_state( time() - 5 * DAY_IN_SECONDS );
+
+		update_user_meta( $user_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() );
+		$this->assertFalse( Expiry_Notice_Dismiss::should_show_modal( $state, $user_id ) );
+
+		update_user_meta(
+			$user_id,
+			Expiry_Notice_Dismiss::META_MODAL_GRACE,
+			time() - ( Expiry_Notice_Dismiss::MODAL_GRACE_DISMISS_TTL + HOUR_IN_SECONDS )
+		);
+		$this->assertTrue( Expiry_Notice_Dismiss::should_show_modal( $state, $user_id ) );
+	}
+
+	public function test_a_post_grace_dismissal_never_lapses(): void {
+		$user_id = $this->make_admin( 'post_grace_no_ttl' );
+		$state   = $this->expired_state( time() - 40 * DAY_IN_SECONDS );
+		// Far older than the grace TTL, which must not apply here: the revert has
+		// happened and saying so once is enough.
+		update_user_meta( $user_id, Expiry_Notice_Dismiss::META_MODAL, time() - 30 * DAY_IN_SECONDS );
+		$this->assertFalse( Expiry_Notice_Dismiss::should_show_modal( $state, $user_id ) );
+	}
+
+	public function test_a_grace_dismissal_does_not_bury_the_post_grace_modal(): void {
+		$user_id   = $this->make_admin( 'grace_then_post_grace' );
+		$expiry_ts = time() - 40 * DAY_IN_SECONDS;
+		// Dismissed during grace, so stamped after the term's own expiry -- which
+		// is exactly what the post-grace check looks for. Separate keys are what
+		// stop that from hiding a modal the user has never seen.
+		update_user_meta( $user_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, $expiry_ts + DAY_IN_SECONDS );
+		$this->assertTrue( Expiry_Notice_Dismiss::should_show_modal( $this->expired_state( $expiry_ts ), $user_id ) );
+	}
+
+	public function test_a_grace_dismissal_of_an_earlier_term_does_not_carry_over(): void {
+		$user_id = $this->make_admin( 'grace_earlier_term' );
+		// Recent enough to be inside the TTL, but recorded against a term that has
+		// since renewed and lapsed again.
+		update_user_meta( $user_id, Expiry_Notice_Dismiss::META_MODAL_GRACE, time() - HOUR_IN_SECONDS );
+		$this->assertTrue(
+			Expiry_Notice_Dismiss::should_show_modal( $this->grace_state( time() - 60 ), $user_id )
+		);
+	}
+
+	public function test_modal_meta_key_matches_the_state(): void {
+		$this->assertSame(
+			Expiry_Notice_Dismiss::META_MODAL_GRACE,
+			Expiry_Notice_Dismiss::modal_meta_key( array( 'state' => Expiry_Data::STATE_EXPIRED_GRACE ) )
+		);
+		$this->assertSame(
+			Expiry_Notice_Dismiss::META_MODAL,
+			Expiry_Notice_Dismiss::modal_meta_key( array( 'state' => Expiry_Data::STATE_EXPIRED ) )
+		);
+		$this->assertNull(
+			Expiry_Notice_Dismiss::modal_meta_key( array( 'state' => Expiry_Data::STATE_APPROACHING ) )
+		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Loader_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Loader_Test.php
@@ -26,6 +26,7 @@ class Loader_Test extends \WorDBless\BaseTestCase {
 		delete_option( 'wpcom_expiry_notices_enabled' );
 		unregister_meta_key( 'user', Expiry_Notice_Dismiss::META_BANNER );
 		unregister_meta_key( 'user', Expiry_Notice_Dismiss::META_MODAL );
+		unregister_meta_key( 'user', Expiry_Notice_Dismiss::META_MODAL_GRACE );
 		parent::tear_down();
 	}
 
@@ -38,6 +39,7 @@ class Loader_Test extends \WorDBless\BaseTestCase {
 		$registered = get_registered_meta_keys( 'user' );
 		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_BANNER, $registered );
 		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_MODAL, $registered );
+		$this->assertArrayHasKey( Expiry_Notice_Dismiss::META_MODAL_GRACE, $registered );
 
 		set_current_screen( 'front' );
 	}
@@ -54,5 +56,18 @@ class Loader_Test extends \WorDBless\BaseTestCase {
 		$registered = get_registered_meta_keys( 'user' );
 		$this->assertArrayNotHasKey( Expiry_Notice_Dismiss::META_BANNER, $registered );
 		$this->assertArrayNotHasKey( Expiry_Notice_Dismiss::META_MODAL, $registered );
+		$this->assertArrayNotHasKey( Expiry_Notice_Dismiss::META_MODAL_GRACE, $registered );
+	}
+
+	/**
+	 * Every dismissal is written over REST, and on a REST request `init` runs
+	 * before WP defines REST_REQUEST -- so the `init` hook alone registers
+	 * nothing and the endpoint drops the write while still answering 200.
+	 */
+	public function test_registers_meta_on_rest_api_init(): void {
+		$this->assertNotFalse(
+			has_action( 'rest_api_init', 'wpcom_expiry_notices_register_meta' ),
+			'the meta keys must also register on rest_api_init, or dismissals silently no-op'
+		);
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -23,6 +23,10 @@ module.exports = async () => {
 					'./src/features/expiry-notices/js/admin-banner.ts',
 					'./src/features/expiry-notices/css/admin-banner.scss',
 				],
+				'expiry-notices-admin-modal': [
+					'./src/features/expiry-notices/js/admin-modal.tsx',
+					'./src/features/expiry-notices/css/admin-modal.scss',
+				],
 				'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
 				'html-block-restricted-tags':
 					'./src/features/html-block-restricted-tags/html-block-restricted-tags.tsx',


### PR DESCRIPTION
Fixes DOTCOM-18472

## Proposed changes

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/356b28ca-d4de-4e37-9eb2-12f75d8f010f" />


Adds the dismissible plan-expiration modal to wp-admin, in both designed variants: inside the grace period (changes still ahead) and after it (changes already made). The existing banner stays — it's the standing reminder the modal isn't — so an expired site shows both, and the banner remains once the modal is dismissed.

**Audience: sites that carry an Atomic transfer** — which is deliberately *not* the same as "sites that are Atomic now". The revert is what moves a site off Atomic, so by the time the post-grace copy is true the site is back on Simple. Gating on `IS_ATOMIC` alone made that whole variant unreachable in production. The gate is therefore Atomic, **or** Simple carrying wpcom's `blog-transfer-reverted` sticker — the same pair `woa.php` and `woa-transfer.php` read back as "is Atomic".

The sticker only counts after the grace period — a site already reverted was reverted by an *earlier* lapse, and hasn't reached the changes the pre-revert variant promises are coming. It is deliberately **not** narrowed by plan tier: `WPCOM_Features::ATOMIC` is granted to `WPCOM_PERSONAL_AND_HIGHER_PLANS` (plus the staging product, marketplace plugins and some free plans), so there is no paid tier whose lapse could not have produced the revert. The 60-day state window does the narrowing instead.

**The domain line took some digging.** `unmapped_url` is the obvious source and the wrong one — on Atomic the REST site is a `Jetpack_Shadow_Site` whose `get_unmapped_url()` returns the *current* URL, and Calypso's own docs flag `site.wpcom_url` as incorrect for `.home.blog` sites. `Expiry_Domain` reads the site's domain list instead and takes the row flagged `wpcom_domain` that is **not** the staging domain, since `*.wpcomstaging.com` is a hosting artifact whose mapping the revert deletes.

Because the site is Simple by the post-grace point, the domain lookup follows it: `/sites/{id}/domains` authenticates with a blog token that a Simple site does not have, so on Simple the unmapped address comes from the blogs table instead — free, and the only thing that works there.

**It also omits that line when the site has a real custom domain**, which is a deliberate deviation from the design worth a second opinion. The revert *keeps* a custom domain — `Setup::set_domain_to_wpcom()` only falls back to the WordPress.com address when the primary is absent or is the staging domain. Showing the bullet unconditionally would promise a rename that doesn't happen, to exactly the people most likely to care.

**The post-grace CTA goes to support, not checkout.** Both surfaces previously offered "Restore my site" / "Restore site" pointing at the *same checkout URL as "Renew now"* — only the label differed. Re-purchasing cannot restore anything the notice says was lost: the cleanup that follows a revert deletes the Atomic site outright (container, DB tables, Jetpack tokens), and a re-transfer forces that cleanup first and then starts a fresh one. Plugins, themes and their data are deleted, not archived. So it now reads "Contact support" and opens the Help Center over the page with the ask already made — there is no URL that opens it in that state, so it dispatches to the `automattic/help-center` store the way Calypso's own inline Help Center button does, with the href kept as the fallback. Support is reachable from a reverted site: `WPCOM_Features::SUPPORT` is granted to `WPCOM_ALL_SITES`, and only `priority_support` is plan-gated.

This is scoped to sites the revert actually happened to. The banner shows on every site, so a site that never carried a transfer keeps checkout — it lost plan features and nothing else, and buying the plan again does give those back.

**Two fixes to the shipped banner ride along**, both found while testing this:

* **Dismissals never persisted.** The meta guard tests `defined( 'REST_REQUEST' )` on `init`, but WP defines that constant in `rest_api_loaded()` on `parse_request` — later. So every dismissal wrote an unregistered key, which the endpoint silently drops while still returning `200`. The banner's Dismiss button has never worked. Now also registered on `rest_api_init`, with a regression test, since the failure mode is completely invisible.
* **Tracks was dead in wp-admin on Atomic.** Nothing loaded the transport, so `_tkq` stayed a plain array and every expiry event was discarded on unload. Both surfaces now call `wpcom_enqueue_tracking_scripts()`.

Copy lives in PHP rather than the component: this package extracts PHP strings for translation and does not extract JS, so copy in React would have shipped untranslatable.

**One design compromise to flag.** The grace modal's dismissal is time-boxed (24h) rather than session-scoped. The issue asks for "the current browser session, on both wp-admin and Calypso" — but those are two origins, so no browser store can answer for both, and the state has to live on the server, where there's no session to scope it to.

## Related product discussion/links

* DOTCOM-18471, DOTCOM-18472

## Does this pull request change what data or activity we track or use?

Yes — new Tracks events: `jetpack_expiry_modal_impression`, `jetpack_expiry_modal_cta_click`, `jetpack_expiry_modal_dismiss`, `jetpack_expiry_modal_dismiss_failed`, each carrying `state`, `days_remaining` and `product_slug`.

Note that the existing `jetpack_expiry_banner_*` events will now actually record on Atomic for the first time, as a result of the transport fix above.

## Testing instructions

Needs a test Atomic site whose plan expiration date you can change.

**Inside the grace period** — set the expiration date to between 1 and 30 days ago, then load `/wp-admin`:

* The modal shows "Your {plan} plan has expired", four bullets, and `View other plans` + `Renew now`.
* The domain bullet names the site's `.wordpress.com` address, **not** its `.wpcomstaging.com` one.
* Clicking outside the modal leaves it open — only the X (or Escape) closes it.
* Resize below 600px: the modal stays centred on both axes rather than pinning to the bottom-left.

**After the grace period** — set the expiration date to more than 30 days ago, then load `/wp-admin`:

* Copy switches to past tense, with a single `Contact support` button and no secondary.
* Clicking it opens the Help Center over the page with the message already sent, and does not navigate away.
* The banner's CTA matches, and its closing sentence asks for support rather than an upgrade.

**Dismissal**

* Dismiss with the X and reload: the modal is gone, the banner remains.
* The two states dismiss independently — dismissing the post-grace modal leaves the grace one showing.
* Click a CTA and come back: the modal does not reappear.
* Reset between runs:

```
wp user meta delete <id> wpcom_plan_expiry_modal_dismiss
wp user meta delete <id> wpcom_plan_expiry_modal_dismiss_grace
wp user meta delete <id> wpcom_plan_expiry_notice_dismiss_wp_admin
```

**Reverted sites (post-grace on Simple)** cannot be reached by changing an expiration date alone, because the revert is what moves the site off Atomic. On a Simple site carrying the `blog-transfer-reverted` sticker, an expiration more than 30 days ago shows the post-grace modal; one inside the grace period shows nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
