### PR TITLE
Backup: offer a way out of the Overview's "Item not found." pane

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2326-item-not-found
+++ b/projects/packages/backup/changelog/jetpack-2326-item-not-found
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the Overview's detail pane now offers a Clear selection button once the activity log has answered and the chosen row is genuinely gone, so a stale ?selected= is no longer a dead end that survives a reload. A log still in flight or one that failed is reported as itself rather than as a missing row, so the button never discards a valid selection. No-op when the filter is off.
+
+

--- a/projects/packages/backup/routes/dashboard/style.scss
+++ b/projects/packages/backup/routes/dashboard/style.scss
@@ -26,6 +26,12 @@
 	gap: 16px;
 	width: 100%;
 
+	// Focused only by script, to catch focus when the empty state unmounts.
+	// Chromium carries `:focus-visible` across that move, ringing the whole grid.
+	&:focus {
+		outline: none;
+	}
+
 	// At desktop widths, switch to the side-by-side activity-list + detail
 	// pane. Below this the two cells stack vertically; the grid's minimums
 	// (360px + 400px + 16px gap) would otherwise overflow the dashboard body

--- a/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-activity-log.test.ts
@@ -262,7 +262,7 @@ describe( 'the default selection on an ascending list', () => {
 				return {
 					list,
 					defaultRewindId,
-					item: useActivityById( defaultRewindId, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+					item: useActivityById( defaultRewindId, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ).item,
 				};
 			},
 			{ wrapper: wrapper() }
@@ -303,7 +303,7 @@ describe( 'the default selection on an ascending list', () => {
 				return {
 					list,
 					defaultRewindId,
-					item: useActivityById( defaultRewindId, 2, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+					item: useActivityById( defaultRewindId, 2, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ).item,
 				};
 			},
 			{ wrapper: wrapper() }
@@ -328,7 +328,7 @@ describe( 'useActivityById', () => {
 					pageSize: ACTIVITY_LOG_DEFAULT_PER_PAGE,
 					sortOrder: 'asc',
 				} ),
-				item: useActivityById( MIDDLE_ID, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ),
+				item: useActivityById( MIDDLE_ID, 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'asc' ).item,
 			} ),
 			{ wrapper: wrapper() }
 		);

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -126,24 +126,29 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
  * selections that are not clicks — a bookmarked `?selected=` on a page nothing
  * has loaded, and the newest-backup default pinned by the hook below.
  *
+ * A null item alone cannot be reported as "no such row": it is equally the
+ * answer while the page query is in flight and after it failed. Callers that
+ * act on the absence — not merely describe it — need `isResolved` and `error`
+ * to tell those three apart.
+ *
  * @param id        - Selection id: `rewindId` for backup items, `activity_id` otherwise.
  * @param page      - The page currently shown in the list.
  * @param pageSize  - The per-page setting currently shown in the list.
  * @param sortOrder - The sort direction currently shown in the list.
- * @return The matching item, or null when nothing in the cached page(s) matches.
+ * @return The matching item or null, whether the page query has answered, and its failure if it did.
  */
 export function useActivityById(
 	id: string | null,
 	page: number,
 	pageSize: number,
 	sortOrder: ActivitySortOrder
-): ActivityItem | null {
+): { item: ActivityItem | null; isResolved: boolean; error: Error | null } {
 	// Follows the list's `sortOrder`: it is part of the cache key, so pinning it
 	// here would open a second query for rows already on screen.
 	const query = useActivityPageQuery( page, pageSize, sortOrder );
 	const queryClient = useQueryClient();
 
-	return useMemo( () => {
+	const item = useMemo( () => {
 		if ( ! id ) {
 			return null;
 		}
@@ -168,6 +173,8 @@ export function useActivityById(
 		// active page query resolves (covered by `query.data`).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ id, query.data ] );
+
+	return { item, isResolved: query.isSuccess, error: query.error };
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { Spinner, VisuallyHidden } from '@wordpress/components';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useSearch } from '@wordpress/route';
-import { Text } from '@wordpress/ui';
+import { Button, Stack, Text } from '@wordpress/ui';
 import ActivityDetail from '../components/activity-detail';
 import ActivityList, { activityQueryArgs } from '../components/activity-list';
 import BackupDetail from '../components/backup-detail';
@@ -177,15 +178,34 @@ function OverviewBody() {
 		isError: restorePointsError,
 	} = useHasRestorePoints();
 
+	const overviewRef = useRef< HTMLDivElement >( null );
+
+	// The updater form, like `clearSelected` below: an object literal replaces the
+	// search wholesale, so every future param would depend on this closure being fresh.
 	const setSelected = useCallback(
 		( id: string ) => {
-			// Merge into existing search so future params (filters, range, etc.) aren't dropped.
 			navigate( {
-				search: { ...search, selected: id },
-			} as unknown as Parameters< typeof navigate >[ 0 ] );
+				search: ( previous: OverviewSearch ) => ( { ...previous, selected: id } ),
+			} as Parameters< typeof navigate >[ 0 ] );
 		},
-		[ navigate, search ]
+		[ navigate ]
 	);
+
+	// The stale id lives in the URL, so the dead end survives a reload without
+	// this; `replace` keeps the Back button from returning to it either.
+	const clearSelected = useCallback( () => {
+		overviewRef.current?.focus();
+		navigate( {
+			search: ( previous: OverviewSearch ) => {
+				const next = { ...previous };
+				delete next.selected;
+				return next;
+			},
+			replace: true,
+			// A single assertion, not `as unknown as`: the updater form stays
+			// comparable, so a typo in `replace` is still a build error.
+		} as Parameters< typeof navigate >[ 0 ] );
+	}, [ navigate ] );
 
 	if (
 		replacesOverview(
@@ -287,7 +307,17 @@ function OverviewBody() {
 			 * a reader whose storage is full needs to read first.
 			 */ }
 			<ReviewRequest />
-			<div className="jpb-overview">
+			{ /*
+			 * Where `clearSelected` puts focus once the empty state unmounts, so the
+			 * next Tab reaches the list rather than the top of the page.
+			 */ }
+			<div
+				className="jpb-overview"
+				ref={ overviewRef }
+				tabIndex={ -1 }
+				role="group"
+				aria-label={ __( 'Backup activity', 'jetpack-backup-pkg' ) }
+			>
 				<ActivityList
 					selectedId={ selectedId }
 					onSelect={ setSelected }
@@ -299,6 +329,7 @@ function OverviewBody() {
 					page={ page }
 					pageSize={ pageSize }
 					sortOrder={ sortOrder }
+					onClearSelected={ clearSelected }
 				/>
 			</div>
 		</>
@@ -310,14 +341,16 @@ function OverviewBody() {
  *
  * Resolves the URL-driven `selectedId` to an activity item and renders the
  * matching detail card: `<BackupDetail>` for backup rows and `<ActivityDetail>`
- * for everything else. Falls back to an empty/not-found state when the
- * selection is missing or doesn't resolve.
+ * for everything else. A selection that resolves to nothing is reported three
+ * ways — the log failed, the log has not answered yet, or the row is gone — and
+ * only the last of those offers to drop the selection.
  *
- * @param props            - Component props.
- * @param props.selectedId - Currently selected row id, or null when nothing is selected.
- * @param props.page       - The page currently shown in the list.
- * @param props.pageSize   - The per-page setting currently shown in the list.
- * @param props.sortOrder  - The sort direction currently shown in the list.
+ * @param props                 - Component props.
+ * @param props.selectedId      - Currently selected row id, or null when nothing is selected.
+ * @param props.page            - The page currently shown in the list.
+ * @param props.pageSize        - The per-page setting currently shown in the list.
+ * @param props.sortOrder       - The sort direction currently shown in the list.
+ * @param props.onClearSelected - Drops `?selected=` from the URL.
  * @return The rendered detail card or an empty-state placeholder.
  */
 function RightPane( {
@@ -325,14 +358,16 @@ function RightPane( {
 	page,
 	pageSize,
 	sortOrder,
+	onClearSelected,
 }: {
 	selectedId: string | null;
 	page: number;
 	pageSize: number;
 	sortOrder: ActivitySortOrder;
+	onClearSelected: () => void;
 } ) {
 	// All four must match the list's arguments — this reads its cache entry.
-	const item = useActivityById( selectedId, page, pageSize, sortOrder );
+	const { item, isResolved, error } = useActivityById( selectedId, page, pageSize, sortOrder );
 	if ( ! selectedId ) {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">
@@ -340,10 +375,36 @@ function RightPane( {
 			</div>
 		);
 	}
+	if ( ! item && error ) {
+		return (
+			<div className="jpb-overview__detail jpb-overview__detail--empty">
+				{ /*
+				 * Neither the upstream reason nor a retry: the list beside this pane
+				 * reports the same failed query with both, and a second copy of each
+				 * is two error notices and two buttons for one thing to fix.
+				 */ }
+				<QueryError title={ __( "We couldn't load this item.", 'jetpack-backup-pkg' ) } />
+			</div>
+		);
+	}
+	if ( ! item && ! isResolved ) {
+		return (
+			<div className="jpb-overview__detail jpb-overview__detail--empty">
+				{ /* `Spinner` is `role="presentation"` with no text, so on its own this branch is silent. */ }
+				<Spinner />
+				<VisuallyHidden>{ __( 'Loading item details…', 'jetpack-backup-pkg' ) }</VisuallyHidden>
+			</div>
+		);
+	}
 	if ( ! item ) {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">
-				<Text>{ __( 'Item not found.', 'jetpack-backup-pkg' ) }</Text>
+				<Stack direction="column" gap="sm" align="center">
+					<Text>{ __( 'That item is no longer in the activity log.', 'jetpack-backup-pkg' ) }</Text>
+					<Button variant="outline" onClick={ onClearSelected }>
+						{ __( 'Clear selection', 'jetpack-backup-pkg' ) }
+					</Button>
+				</Stack>
 			</div>
 		);
 	}

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -1,0 +1,319 @@
+// A `?selected=` pointing at a row the activity log no longer holds rendered
+// "Item not found." and nothing else. The id lives in the URL, so a reload
+// returned the reader to the same dead end — the empty state had to offer a
+// way out of it.
+//
+// That message answered for two other things as well, so the way out is offered
+// only once the log has actually said the row is gone.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => ( {} ),
+	// `search` is folded into the href rather than spread onto the node: React
+	// warns about an object-valued attribute on an `<a>`, and
+	// `@wordpress/jest-console` turns that warning into a suite failure.
+	Link: ( {
+		children,
+		to,
+		search,
+		...rest
+	}: {
+		children: React.ReactNode;
+		to: string;
+		search?: Record< string, string >;
+	} ) => (
+		<a href={ search ? `${ to }?${ new URLSearchParams( search ).toString() }` : to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+
+// Testing Library's default `findBy` window is one second, which these stages
+// have exceeded on a loaded runner under coverage.
+const SETTLE = { timeout: 10000 };
+
+const REWIND_ID = '1786644531.100';
+const STALE_ID = '1700000000.999';
+
+const NOT_FOUND = 'That item is no longer in the activity log.';
+const NO_SELECTION = 'Select an item from the list to see details.';
+const CLEAR = /^Clear selection$/;
+const GROUP_LABEL = 'Backup activity';
+const FAILURE_REASON = 'Service unavailable';
+const LOADING = 'Loading item details…';
+const LOAD_FAILED = "We couldn't load this item.";
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * One completed backup, in WPCOM's rewindable-activity shape.
+ *
+ * @return A raw activity entry.
+ */
+function backupEntry() {
+	return {
+		activity_id: `act-${ REWIND_ID }`,
+		gridicon: 'cloud',
+		summary: 'Backup complete',
+		published: '2026-08-13T18:08:56+00:00',
+		rewind_id: REWIND_ID,
+		actor: { type: 'Application', name: 'Jetpack' },
+		content: { text: '10 plugins, 4 themes' },
+		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * A published post, in the same shape. Carries no `rewind_id`, so a log
+ * holding only this has no default backup for the pane to fall back on.
+ *
+ * @return A raw activity entry.
+ */
+function postEntry() {
+	return {
+		activity_id: 'act-post-1',
+		gridicon: 'posts',
+		summary: 'Post published',
+		published: '2026-08-13T18:10:00+00:00',
+		actor: { type: 'Person', name: 'Bob Sacramento' },
+		content: { text: 'Hello world' },
+		name: 'post__published',
+	};
+}
+
+/**
+ * A finished backup for `/jetpack/v4/backups`. Keeps `summarizeBackups` on
+ * `complete`, which is the one state that never takes the Overview body over.
+ *
+ * @return A raw backup entry.
+ */
+function finishedBackup() {
+	return {
+		id: '1',
+		started: '2026-08-13 18:08:56',
+		last_updated: '2026-08-13 18:54:14',
+		status: 'finished',
+		period: '1786644531',
+		percent: '100',
+		is_backup: '1',
+		is_scan: '0',
+		discarded: '0',
+		stats: { prefix: 'wp_' },
+	};
+}
+
+/** What the activity log does: answer with these rows, never answer, or fail. */
+type ActivityAnswer = ReturnType< typeof backupEntry | typeof postEntry >[] | 'pending' | 'error';
+
+/**
+ * Point every route the Overview reads at a fixed set of answers.
+ *
+ * @param options          - Fixture options.
+ * @param options.activity - Rows the log returns, or how it fails to return any.
+ * @param options.backups  - Raw entries `/jetpack/v4/backups` returns.
+ */
+function mockEndpoints( {
+	activity,
+	backups,
+}: {
+	activity: ActivityAnswer;
+	backups: ReturnType< typeof finishedBackup >[];
+} ) {
+	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
+		const path = o?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			if ( activity === 'pending' ) {
+				return new Promise( () => {} );
+			}
+			if ( activity === 'error' ) {
+				return Promise.reject( { code: 'activity_log_fetch_failed', message: FAILURE_REASON } );
+			}
+			return Promise.resolve( {
+				current: { orderedItems: activity },
+				totalItems: activity.length,
+				totalPages: 1,
+			} );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === '/jetpack/v4/backups' ) {
+			return Promise.resolve( backups );
+		}
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			return Promise.resolve( { contents: {} } );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockSearch.mockReset();
+	mockNavigate.mockReset();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'A selection the activity log cannot resolve', () => {
+	beforeEach( () => {
+		mockEndpoints( { activity: [ backupEntry() ], backups: [] } );
+		mockSearch.mockReturnValue( { selected: STALE_ID } );
+	} );
+
+	it( 'offers a way out beside the message', async () => {
+		render( <OverviewStage /> );
+
+		// The message is the positive: without it the button below could be
+		// missing because the pane never reached this branch — or threw.
+		await expect( screen.findByText( NOT_FOUND, undefined, SETTLE ) ).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: CLEAR } ) ).toBeInTheDocument();
+	} );
+
+	it( 'drops only `selected`, through the router, replacing the entry', async () => {
+		render( <OverviewStage /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+
+		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
+		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {
+			search: ( previous: Record< string, unknown > ) => Record< string, unknown >;
+			replace?: boolean;
+		};
+		// `@wordpress/boot` nests the whole router href inside wp-admin's own
+		// `?p=`, so the param can only be dropped by the router itself.
+		expect( typeof options.search ).toBe( 'function' );
+		expect( options.search( { selected: STALE_ID, page: '3' } ) ).toEqual( { page: '3' } );
+		// Otherwise Back returns to the dead end the reader just left.
+		expect( options.replace ).toBe( true );
+	} );
+
+	it( 'leaves the dead end once the router applies it', async () => {
+		const { rerender } = render( <OverviewStage /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+
+		// The updater's own output, not a hand-written `{}` — otherwise this asserts
+		// the fallback rather than the recovery, and passes with `selected` kept.
+		const applied = mockNavigate.mock.calls[ 0 ][ 0 ] as {
+			search: ( previous: Record< string, unknown > ) => Record< string, unknown >;
+		};
+		mockSearch.mockReturnValue( applied.search( { selected: STALE_ID } ) );
+		rerender( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'heading', { name: 'Backup complete' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hands focus to the two-pane region instead of dropping it', async () => {
+		render( <OverviewStage /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+
+		// The region is the positive: focus cannot be verified as "not lost"
+		// without naming where it went.
+		const region = screen.getByRole( 'group', { name: GROUP_LABEL } );
+		await waitFor( () => expect( region ).toHaveFocus() );
+	} );
+} );
+
+describe( 'Choosing a row', () => {
+	it( 'adds `selected` through the router without dropping the rest of the search', async () => {
+		mockEndpoints( { activity: [ backupEntry(), postEntry() ], backups: [] } );
+		mockSearch.mockReturnValue( { page: '3' } );
+
+		render( <OverviewStage /> );
+		await userEvent.click(
+			await screen.findByRole( 'button', { name: 'Post published' }, SETTLE )
+		);
+
+		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {
+			search: ( previous: Record< string, unknown > ) => Record< string, unknown >;
+		};
+		// The same updater form `clearSelected` uses: an object literal replaces
+		// the search wholesale, so it keeps the rest only while its closure is fresh.
+		expect( typeof options.search ).toBe( 'function' );
+		expect( options.search( { page: '3' } ) ).toEqual( { page: '3', selected: 'act-post-1' } );
+	} );
+} );
+
+describe( 'No selection yet', () => {
+	it( 'still asks the reader to pick a row, with nothing to clear', async () => {
+		mockEndpoints( { activity: [ postEntry() ], backups: [ finishedBackup() ] } );
+		mockSearch.mockReturnValue( {} );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( NO_SELECTION, undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+// The pane reads one nullable item, and null is also the answer while the log
+// is in flight and after it failed. Both of those name a row that is fine, so
+// offering to discard it there throws away a valid selection — and `replace`
+// means Back cannot bring it back.
+describe( 'A selection the activity log has not answered for', () => {
+	beforeEach( () => {
+		// Valid: this id is in the fixture the first suite resolves from, which is
+		// also the control for these two — there the button is offered.
+		mockSearch.mockReturnValue( { selected: REWIND_ID } );
+	} );
+
+	it( 'waits while the log is in flight instead of offering to discard it', async () => {
+		mockEndpoints( { activity: 'pending', backups: [] } );
+
+		render( <OverviewStage /> );
+
+		// The placeholder is the positive: "no button" passes for a pane that
+		// never rendered at all.
+		await expect( screen.findByText( LOADING, undefined, SETTLE ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'reports a failed log instead of offering to discard it', async () => {
+		mockEndpoints( { activity: 'error', backups: [] } );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByText( LOAD_FAILED, undefined, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-2326

## Proposed changes

* A `?selected=` naming a row the activity log cannot resolve rendered `Item not found.` and nothing else — no button, no link, no way to clear the selection. The id lives in the URL, so a reload returned the reader to the same dead end.
* `screens/overview.tsx`: the empty state now carries a **Clear selection** button, and `RightPane` takes an `onClearSelected` prop to drive it.

### Why it goes through the router

`@wordpress/boot` nests the whole router href inside wp-admin's own `?p=` query param (`createPathHistory` / `createHref`), so the path plus its own `?selected=` is URL-encoded into one param. A hand-built `history.replaceState` would have to reimplement both halves and would silently drop wp-admin's `page=`.

Two details that are load-bearing rather than incidental:

* **A functional `search` updater, not an object and not `<Link to="/">`.** In `@tanstack/router-core`, omitting `search` returns `{}` — it wipes *every* param, not just `selected` — and an object literal replaces the search wholesale. Only the function form removes one key and keeps the rest. That matters directly: JETPACK-2312 adds list params to this same search.
* **`replace: true`.** The dead end is a history entry, not just a URL. Without it, Back walks straight back into it.

### Focus

The button removes itself, so focus would drop to `<body>` and send the next Tab to the top of the document — the exact failure `components/file-browser/index.tsx` records for its close button. There is no opener to return to here, so `clearSelected` focuses the two-pane region first. That region gains `role="group"` and an `aria-label` so the focus stop is not an unlabelled mystery, following the precedent `components/file-info-card/index.tsx` already sets for its own programmatic focus target.

### Note on the label

After clearing, `selectedId` falls through to `defaultSelectedId`, so the reader usually lands on the newest backup rather than an empty pane. "Clear selection" names the action truthfully — `?selected=` really is gone — but not that destination. "Show the latest backup" would name the destination and then lie whenever page 1 holds no backup row. Open to a better third option.

## Related product discussion/links

* Linear: JETPACK-2326 (task F8b), under the Backup modernization project. Split out of JETPACK-2312.
* **JETPACK-2312 is stacked on this branch** and must not merge before it — its remembered row would otherwise resurrect the selection this button exists to drop.

## Does this pull request change what data or activity we track or use?

No. One button and a router call; no new requests, no Tracks event.

## Testing instructions

The dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default, so this is a no-op unless the filter is on.

Automated, from `projects/packages/backup`: `pnpm test` — 74 suites / 722 tests. `tests/stale-selection-recovery.test.tsx` is new; every assertion was mutation-checked, including that the button is absent from the *other* empty state and that clearing lands the reader on a real backup rather than the sibling placeholder. `pnpm run typecheck`, `eslint`, `prettier` clean.

By hand, on a site with the filter on and a Backup plan.

**Getting to the dead end.** It needs the URL to name a backup the activity log cannot resolve. Do not hand-build that URL — the router nests its whole href inside wp-admin's own query string, so a reconstructed one silently does nothing and you get the normal screen with the newest backup selected.

1. Go to **Jetpack → VaultPress Backup** and **click any backup row**. The address bar grows a selection carrying that row's rewind id — a number like `1786663613.9425`.
2. In the address bar, **change some digits of that id** so it names nothing (e.g. `1786663613.9425` → `1786663613.0000`). Keep the `<seconds>.<fraction>` shape; the id has to be well-formed, just absent. Press Enter.
3. You should now see **Item not found.** with a **Clear selection** button under it. On trunk this pane is that sentence and nothing else.

**Then check the four behaviours:**

4. **Clear selection** → the selection drops, the detail pane shows a real backup, and the selection disappears from the address.
5. **Back** → you should *not* return to the dead end. (`replace: true`.)
6. Reload step 2's URL without clicking the button → the dead end persists. That is the bug: the id lives in the URL, so it survives a reload.
7. **Keyboard.** Tab to the button and press **Enter**. The next Tab should reach the activity list rather than restarting at the top of the page — and **no focus ring should be drawn around the whole two-pane grid**. Chromium carries `:focus-visible` across the scripted focus move, so that ring is what the `outline: none` in this PR exists to suppress.

Steps 1-4 confirmed on a live site with the modernization filter on. Step 7 is jsdom-only so far and is the part most worth a real screen.
