### PR TITLE
Backup: keep the reader's place in the list across Download and Restore

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2125,6 +2125,9 @@ importers:
       '@babel/runtime':
         specifier: 7.29.7
         version: 7.29.7
+      '@tanstack/react-router':
+        specifier: ^1.167.1
+        version: 1.167.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/dom':
         specifier: 10.4.1
         version: 10.4.1

--- a/projects/packages/backup/changelog/jetpack-2312-f8a-preserve-list-state
+++ b/projects/packages/backup/changelog/jetpack-2312-f8a-preserve-list-state
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the Overview now remembers the list page, page size and selected row for the trip out to Download or Restore, so coming back returns the reader where they were instead of the top of the list. A remembered page the log has since outgrown is clamped to the last page that exists, so a log that shrank while they were away no longer leaves them with no rows and no pagination. No-op when the filter is off.

--- a/projects/packages/backup/package.json
+++ b/projects/packages/backup/package.json
@@ -66,6 +66,7 @@
 		"@automattic/jetpack-wp-build-polyfills": "workspace:*",
 		"@babel/core": "7.29.7",
 		"@babel/runtime": "7.29.7",
+		"@tanstack/react-router": "^1.167.1",
 		"@testing-library/dom": "10.4.1",
 		"@testing-library/react": "16.3.2",
 		"@testing-library/user-event": "14.6.1",

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -142,11 +142,10 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		[ onChangeView, sortOrder ]
 	);
 
-	// A remembered page can outlive the log that had it, and DataViews hides its
-	// footer entirely at one page — so nothing on screen would offer a way back.
-	// `totalPages` falls back to 1, so a request that is in flight, paused offline
-	// or failed reads as a one-page log. A literal `totalPages: 0` survives that
-	// fallback's `??`, though, so `>= 1` is what stops it from clamping to page 0.
+	// A remembered page can outlive its log, and DataViews hides the footer at one
+	// page — so nothing on screen would offer a way back. `totalPages` falls back to
+	// 1, so in flight, paused offline and failed all read as a one-page log; a
+	// literal 0 survives that `??`, which is what `>= 1` guards against.
 	useEffect( () => {
 		if ( ! isFetching && ! isPaused && ! error && totalPages >= 1 && page > totalPages ) {
 			onChangeView( { ...view, page: totalPages } );

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -145,7 +145,8 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 	// A remembered page can outlive the log that had it, and DataViews hides its
 	// footer entirely at one page — so nothing on screen would offer a way back.
 	// `totalPages` falls back to 1, so a request that is in flight, paused offline
-	// or failed reads as a one-page log; `>= 1` rejects a literal `totalPages: 0`.
+	// or failed reads as a one-page log. A literal `totalPages: 0` survives that
+	// fallback's `??`, though, so `>= 1` is what stops it from clamping to page 0.
 	useEffect( () => {
 		if ( ! isFetching && ! isPaused && ! error && totalPages >= 1 && page > totalPages ) {
 			onChangeView( { ...view, page: totalPages } );

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -1,6 +1,6 @@
 import { DataViews } from '@wordpress/dataviews';
 import { dateI18n } from '@wordpress/date';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, cloud, image, post, plugins as pluginsIcon, color, info } from '@wordpress/icons';
 import { Card, Stack, Text } from '@wordpress/ui';
@@ -140,6 +140,17 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 		},
 		[ onChangeView, sortOrder ]
 	);
+
+	// A remembered page can outlive the log that had it, and DataViews hides its
+	// footer entirely at one page — so nothing on screen would offer a way back.
+	// Read off `totalPages`, which falls back to a count derived from the rows in
+	// hand, where `totalItems` falls back to their number — zero on the out-of-range
+	// page this exists for. `>= 1` still blocks clamping to page 0 on an empty log.
+	useEffect( () => {
+		if ( ! isLoading && totalPages >= 1 && page > totalPages ) {
+			onChangeView( { ...view, page: totalPages } );
+		}
+	}, [ isLoading, totalPages, page, view, onChangeView ] );
 
 	// DataViews shows its own "No results" whenever `data` is empty, and a
 	// failed request leaves it empty — so without this a 5xx tells the

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -124,11 +124,12 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
  */
 export default function ActivityList( { selectedId, onSelect, view, onChangeView }: Props ) {
 	const { page, pageSize, sortOrder } = activityQueryArgs( view );
-	const { items, totalItems, totalPages, isLoading, isFetching, error, refetch } = useActivityLog( {
-		page,
-		pageSize,
-		sortOrder,
-	} );
+	const { items, totalItems, totalPages, isLoading, isFetching, isPaused, error, refetch } =
+		useActivityLog( {
+			page,
+			pageSize,
+			sortOrder,
+		} );
 
 	// DataViews' `SortDirectionControl` spreads `...view` and replaces only
 	// `sort`, so without this a reorder strands the reader on page 3 of an
@@ -143,14 +144,13 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 
 	// A remembered page can outlive the log that had it, and DataViews hides its
 	// footer entirely at one page — so nothing on screen would offer a way back.
-	// Read off `totalPages`, which falls back to a count derived from the rows in
-	// hand, where `totalItems` falls back to their number — zero on the out-of-range
-	// page this exists for. `>= 1` still blocks clamping to page 0 on an empty log.
+	// `totalPages` falls back to 1, so a request that is in flight, paused offline
+	// or failed reads as a one-page log; `>= 1` rejects a literal `totalPages: 0`.
 	useEffect( () => {
-		if ( ! isLoading && totalPages >= 1 && page > totalPages ) {
+		if ( ! isFetching && ! isPaused && ! error && totalPages >= 1 && page > totalPages ) {
 			onChangeView( { ...view, page: totalPages } );
 		}
-	}, [ isLoading, totalPages, page, view, onChangeView ] );
+	}, [ isFetching, isPaused, error, totalPages, page, view, onChangeView ] );
 
 	// DataViews shows its own "No results" whenever `data` is empty, and a
 	// failed request leaves it empty — so without this a 5xx tells the

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -30,6 +30,13 @@ type Result = {
 	 * whole duration of a retry.
 	 */
 	isFetching: boolean;
+	/**
+	 * True when React Query parked the request instead of sending it, which
+	 * `networkMode: 'online'` does for an offline browser. Neither fetching nor
+	 * errored, and holding no data — so callers that read an absence as an
+	 * answer need this to tell "nothing there" from "never asked".
+	 */
+	isPaused: boolean;
 	error: Error | null;
 	refetch: () => void;
 };
@@ -85,7 +92,7 @@ function useActivityPageQuery( page: number, pageSize: number, sortOrder: Activi
  * @param args.page      - 1-indexed page number.
  * @param args.pageSize  - Items per page.
  * @param args.sortOrder - Sort direction, from the list's Order control.
- * @return Items, total items, total pages, loading, error, refetch.
+ * @return Items, total items, total pages, loading, paused, error, refetch.
  */
 export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
 	const query = useActivityPageQuery( page, pageSize, sortOrder );
@@ -112,6 +119,7 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
 		totalPages: query.data?.totalPages ?? Math.max( 1, Math.ceil( items.length / pageSize ) ),
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
+		isPaused: query.isPaused,
 		error,
 		refetch: retry,
 	};

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -33,8 +33,9 @@ type Result = {
 	/**
 	 * True when React Query parked the request instead of sending it, which
 	 * `networkMode: 'online'` does for an offline browser. Neither fetching nor
-	 * errored, and holding no data — so callers that read an absence as an
-	 * answer need this to tell "nothing there" from "never asked".
+	 * errored, and any data already cached for the query is kept, not cleared —
+	 * so callers that read an absence as an answer need this to tell "nothing
+	 * there" from "never asked".
 	 */
 	isPaused: boolean;
 	error: Error | null;

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -33,9 +33,8 @@ type Result = {
 	/**
 	 * True when React Query parked the request instead of sending it, which
 	 * `networkMode: 'online'` does for an offline browser. Neither fetching nor
-	 * errored, and any data already cached for the query is kept, not cleared —
-	 * so callers that read an absence as an answer need this to tell "nothing
-	 * there" from "never asked".
+	 * errored — so callers that read an absence as an answer need this to tell
+	 * "nothing there" from "never asked".
 	 */
 	isPaused: boolean;
 	error: Error | null;

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -185,8 +185,6 @@ function OverviewBody() {
 	// `clearSelected` below always has a real change to make: without one, TanStack
 	// treats its navigate as a no-op and pushes no history entry, leaving Back with
 	// nowhere on the Overview to land. `replace`: this is not its own stop.
-	// Not only the return trip — Back onto a bare address rewrites it too, so a Back
-	// that would land on "nothing selected" lands on the remembered row instead.
 	useEffect( () => {
 		if ( urlSelectedId || ! lastSelectedId ) {
 			return;

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -173,18 +173,29 @@ function OverviewBody() {
 	// The URL still wins; the remembered row only answers for the return trip, where
 	// the reader made a choice this page load and the address no longer carries it.
 	const urlSelectedId = typeof search.selected === 'string' ? search.selected : null;
-	// State as well as module scope: clearing it has to render, and the return trip
-	// navigates to the same URL, which TanStack treats as a no-op.
-	const [ rememberedId, setRememberedId ] = useState( lastSelectedId );
-	const selectedId = urlSelectedId ?? rememberedId ?? defaultSelectedId;
+	const selectedId = urlSelectedId ?? lastSelectedId ?? defaultSelectedId;
 	// Only an explicit choice is remembered: `defaultSelectedId` moves as new backups
 	// land, and pinning the row it happened to name would outlive its own reason.
 	useEffect( () => {
 		if ( urlSelectedId ) {
 			lastSelectedId = urlSelectedId;
-			setRememberedId( urlSelectedId );
 		}
 	}, [ urlSelectedId ] );
+	// Puts the remembered row in the address whenever the address lacks one, so
+	// `clearSelected` below always has a real change to make: without one, TanStack
+	// treats its navigate as a no-op and pushes no history entry, leaving Back with
+	// nowhere on the Overview to land. `replace`: this is not its own stop.
+	// Not only the return trip — Back onto a bare address rewrites it too, so a Back
+	// that would land on "nothing selected" lands on the remembered row instead.
+	useEffect( () => {
+		if ( urlSelectedId || ! lastSelectedId ) {
+			return;
+		}
+		navigate( {
+			search: ( previous: OverviewSearch ) => ( { ...previous, selected: lastSelectedId } ),
+			replace: true,
+		} as Parameters< typeof navigate >[ 0 ] );
+	}, [ urlSelectedId, navigate ] );
 	// `/site/rewindable-activity` only lists completed restore points, so
 	// on its own it cannot tell "no backups yet" from "the first one is
 	// running" from "they're all failing". This second query answers that.
@@ -238,7 +249,6 @@ function OverviewBody() {
 		// The memory too, not just the URL: `selectedId` falls back to it, so
 		// clearing one and not the other puts the reader straight back.
 		lastSelectedId = null;
-		setRememberedId( null );
 		overviewRef.current?.focus();
 		navigate( {
 			search: ( previous: OverviewSearch ) => {

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -61,6 +61,16 @@ export const INITIAL_VIEW: View = {
 let hasRecordedPageView = false;
 
 /**
+ * Where the reader last was in the list, and which row they last chose.
+ *
+ * Module state for the same reason `hasRecordedPageView` is: a trip to Download or
+ * Restore unmounts this screen, and a gate verdict change unmounts its body — so
+ * anything held in the component is gone by the time the reader comes back.
+ */
+let lastView: View = INITIAL_VIEW;
+let lastSelectedId: string | null = null;
+
+/**
  * Reset the page-view latch. Test-only.
  *
  * The latch is module state precisely so it outlives an unmount, which
@@ -69,6 +79,17 @@ let hasRecordedPageView = false;
  */
 export function resetPageViewForTesting(): void {
 	hasRecordedPageView = false;
+}
+
+/**
+ * Forget where the reader was. Test-only.
+ *
+ * Same hazard as the latch above: this state outlives an unmount, so one test's
+ * paging would otherwise seed every later one in the same file.
+ */
+export function resetListStateForTesting(): void {
+	lastView = INITIAL_VIEW;
+	lastSelectedId = null;
 }
 
 /**
@@ -133,7 +154,13 @@ function OverviewBody() {
 	const navigate = useNavigate();
 	// View state lives here so RightPane's `useActivityById` can
 	// subscribe to the same paginated query the list reads from.
-	const [ view, setView ] = useState< View >( INITIAL_VIEW );
+	const [ view, setView ] = useState< View >( lastView );
+	// Written on the way through, because the return trip has nothing to read it from:
+	// the back links on Download and Restore carry no search.
+	const rememberView = useCallback( ( next: View ) => {
+		lastView = next;
+		setView( next );
+	}, [] );
 	// Same derivation `<ActivityList>` uses, so the right pane reads the cache
 	// entry the list filled rather than opening its own.
 	const { page, pageSize, sortOrder } = activityQueryArgs( view );
@@ -143,7 +170,21 @@ function OverviewBody() {
 	// placeholder renders. Page 1 dedupes with the list's first
 	// fetch when the list is on page 1 with the default per-page.
 	const defaultSelectedId = useDefaultBackupRewindId();
-	const selectedId = typeof search.selected === 'string' ? search.selected : defaultSelectedId;
+	// The URL still wins; the remembered row only answers for the return trip, where
+	// the reader made a choice this page load and the address no longer carries it.
+	const urlSelectedId = typeof search.selected === 'string' ? search.selected : null;
+	// State as well as module scope: clearing it has to render, and the return trip
+	// navigates to the same URL, which TanStack treats as a no-op.
+	const [ rememberedId, setRememberedId ] = useState( lastSelectedId );
+	const selectedId = urlSelectedId ?? rememberedId ?? defaultSelectedId;
+	// Only an explicit choice is remembered: `defaultSelectedId` moves as new backups
+	// land, and pinning the row it happened to name would outlive its own reason.
+	useEffect( () => {
+		if ( urlSelectedId ) {
+			lastSelectedId = urlSelectedId;
+			setRememberedId( urlSelectedId );
+		}
+	}, [ urlSelectedId ] );
 	// `/site/rewindable-activity` only lists completed restore points, so
 	// on its own it cannot tell "no backups yet" from "the first one is
 	// running" from "they're all failing". This second query answers that.
@@ -194,6 +235,10 @@ function OverviewBody() {
 	// The stale id lives in the URL, so the dead end survives a reload without this.
 	// A new history entry, not a replacement: the selection may be fine, so Back must restore it.
 	const clearSelected = useCallback( () => {
+		// The memory too, not just the URL: `selectedId` falls back to it, so
+		// clearing one and not the other puts the reader straight back.
+		lastSelectedId = null;
+		setRememberedId( null );
 		overviewRef.current?.focus();
 		navigate( {
 			search: ( previous: OverviewSearch ) => {
@@ -321,7 +366,7 @@ function OverviewBody() {
 					selectedId={ selectedId }
 					onSelect={ setSelected }
 					view={ view }
-					onChangeView={ setView }
+					onChangeView={ rememberView }
 				/>
 				<RightPane
 					selectedId={ selectedId }

--- a/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
+++ b/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
@@ -1,0 +1,249 @@
+// JETPACK-2312: a selection restored from memory carried no `?selected=`, so clearing it was a
+// no-op navigate TanStack pushed no history entry for — Back left the Overview instead of
+// undoing the clear. Driven over a real `@tanstack/react-router` memory history, not the
+// `@wordpress/route` mock the sibling suites use, since a mock has no history to miss an entry on.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import {
+	Outlet,
+	RouterProvider,
+	createMemoryHistory,
+	createRootRoute,
+	createRoute,
+	createRouter,
+} from '@tanstack/react-router';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { stage as DownloadStage } from '../routes/download/stage';
+import { queryClient } from '../src/dashboard/data/query-client';
+import { resetListStateForTesting } from '../src/dashboard/screens/overview';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SETTLE = { timeout: 10000 };
+const PER_PAGE = 10;
+const CLEAR = 'Clear selection';
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/**
+ * A rewind id, newest first.
+ *
+ * @param index - 0-based position in the log.
+ * @return The row's rewind id.
+ */
+function rewindId( index: number ): string {
+	return `${ 1786644531 - index * 100 }.100`;
+}
+
+/**
+ * The row's accessible name, which is also its heading in the detail pane.
+ *
+ * @param id - The row's rewind id.
+ * @return The row title.
+ */
+function title( id: string ): string {
+	return `Backup ${ id }`;
+}
+
+/** The log the fixture answers from, newest first. Grown mid-test to move a row to page 2. */
+let log: string[] = [];
+
+/**
+ * One page of the log, in WPCOM's rewindable-activity shape.
+ *
+ * @param page - 1-indexed page number.
+ * @return The response envelope.
+ */
+function activityPage( page: number ) {
+	const start = ( page - 1 ) * PER_PAGE;
+	return {
+		current: {
+			orderedItems: log.slice( start, start + PER_PAGE ).map( id => ( {
+				activity_id: `act-${ id }`,
+				name: 'rewind__backup_complete_full',
+				gridicon: 'cloud',
+				rewind_id: id,
+				published: '2026-08-20T10:00:00+00:00',
+				summary: title( id ),
+				actor: { type: 'Application', name: 'Jetpack' },
+				content: { text: '10 plugins, 4 themes' },
+			} ) ),
+		},
+		totalItems: log.length,
+		totalPages: Math.max( 1, Math.ceil( log.length / PER_PAGE ) ),
+	};
+}
+
+/** Point every route the two screens read at a fixed set of answers. */
+function mockEndpoints() {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan: true, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			const args = new URLSearchParams( path.split( '?' )[ 1 ] ?? '' );
+			return Promise.resolve( activityPage( Number( args.get( 'page' ) ?? 1 ) ) );
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path.includes( '/rewind/backup/ls' ) ) {
+			return Promise.resolve( { contents: {} } );
+		}
+		if ( path === '/jetpack/v4/backups' || path === '/jetpack/v4/restores' ) {
+			return Promise.resolve( [] );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * Mount the Overview and Download routes under a router with its own memory history, the
+ * same primitives `@wordpress/route` re-exports for production use.
+ *
+ * @return The router, cast down to the bits this suite reads.
+ */
+function renderApp() {
+	const rootRoute = createRootRoute( { component: Outlet } );
+	const router = createRouter( {
+		routeTree: rootRoute.addChildren( [
+			createRoute( { getParentRoute: () => rootRoute, path: '/', component: OverviewStage } ),
+			createRoute( {
+				getParentRoute: () => rootRoute,
+				path: '/download/$rewindId',
+				component: DownloadStage,
+			} ),
+		] ),
+		history: createMemoryHistory( { initialEntries: [ '/' ] } ),
+		// TanStack's options type wants a registered route tree, which nothing here declares.
+	} as never );
+	render( <RouterProvider router={ router as never } /> );
+	return router as unknown as {
+		history: { back: () => void };
+		state: { location: { search: Record< string, unknown > } };
+	};
+}
+
+/**
+ * Choose the last row on page 1, leave for Download, then follow its back link home.
+ *
+ * The back link carries no search, which is what leaves the selection with no address —
+ * see `screens/download.tsx`'s `<Link to="/">`.
+ *
+ * @param view - The app's router (a `renderApp` result), to read the address back off.
+ * @return The chosen row's rewind id.
+ */
+async function roundTripViaDownload( view: ReturnType< typeof renderApp > ): Promise< string > {
+	const chosen = rewindId( PER_PAGE - 1 );
+	await userEvent.click( await screen.findByRole( 'button', { name: title( chosen ) }, SETTLE ) );
+	await waitFor( () => expect( view.state.location.search ).toEqual( { selected: chosen } ) );
+
+	await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ }, SETTLE ) );
+	const back = await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE );
+
+	// One new row lands while they are away — a completed restore writes one, and so does a
+	// finished backup via `useRefreshActivityOnBackupComplete` — pushing their row onto page 2.
+	log.unshift( rewindId( -1 ) );
+
+	await userEvent.click( back );
+	return chosen;
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	resetListStateForTesting();
+
+	log = Array.from( { length: PER_PAGE }, ( _, index ) => rewindId( index ) );
+	mockApiFetch.mockReset();
+	mockEndpoints();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'Coming back from Download with a row chosen', () => {
+	it( 'writes the remembered row into the address without a Back step of its own', async () => {
+		const view = renderApp();
+		const chosen = await roundTripViaDownload( view );
+
+		// The write-back has to land, and land as `replace`: a `push` would cost an
+		// extra Back step landing on the bare address this fires from.
+		await waitFor( () => expect( view.state.location.search ).toEqual( { selected: chosen } ) );
+
+		await act( async () => {
+			view.history.back();
+		} );
+
+		// One Back from the restored address lands on Download — where the trip out
+		// to Download itself came from — not on an extra step this write invented.
+		await expect(
+			screen.findByRole( 'heading', { name: 'Download backup' }, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'lets Back undo clearing a selection that came from memory', async () => {
+		const view = renderApp();
+		const chosen = await roundTripViaDownload( view );
+
+		// The row is on page 2 now and the list is still on page 1, so the pane
+		// cannot resolve it and hedges instead of claiming it is gone.
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await waitFor( () =>
+			expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument()
+		);
+
+		await act( async () => {
+			view.history.back();
+		} );
+
+		// The copy admits the row may still be fine, so the discard has to be
+		// undoable — landing back on the Overview with the selection restored,
+		// not on the Download screen the return trip came from.
+		await expect(
+			screen.findByRole( 'button', { name: CLEAR }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( view.state.location.search ).toEqual( { selected: chosen } );
+	} );
+} );
+
+describe( 'A selection nobody chose', () => {
+	// The default row is the newest backup, which moves as backups land. Writing it to the
+	// address would pin the row it happened to name past its own reason for being shown.
+	it( 'never reaches the address, not even across the round trip', async () => {
+		const view = renderApp();
+
+		// The default renders, so a bare address below is not a pane that never resolved
+		// anything — it is genuinely nothing having been chosen.
+		await expect(
+			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( view.state.location.search ).toEqual( {} );
+
+		await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ }, SETTLE ) );
+		await userEvent.click(
+			await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE )
+		);
+
+		await expect(
+			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( view.state.location.search ).toEqual( {} );
+	} );
+} );

--- a/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
+++ b/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
@@ -31,13 +31,6 @@ const SETTLE = { timeout: 10000 };
 const PER_PAGE = 10;
 const CLEAR = 'Clear selection';
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * A rewind id, newest first.
  *

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -30,6 +30,7 @@ import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import ErrorBoundary from '../src/dashboard/components/error-boundary';
 import { queryClient } from '../src/dashboard/data/query-client';
+import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
@@ -117,6 +118,7 @@ function failFileTree( error: { code: string; message: string } ) {
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	resetListStateForTesting();
 
 	mockApiFetch.mockReset();
 	mockApiFetch.mockResolvedValue( CAPABILITIES );

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -565,8 +565,9 @@ describe( 'A remembered place asked for with no connection', () => {
 } );
 
 describe( 'Clearing a selection that came from memory', () => {
-	// `clearSelected` navigates to the URL it is already on, which TanStack treats
-	// as a no-op — so without state the pane never re-renders and the button is inert.
+	// The return trip now writes the remembered row into the address itself (see
+	// `cleared-selection-back-stack.test.tsx` for why), so by the time this mounts the
+	// clear this test drives is a real search change — this mock just needs telling.
 	it( 'renders the change, not just forgets it', async () => {
 		// Page 2's row, so the remembered row differs from `defaultSelectedId` — which is
 		// page 1's newest backup, and would otherwise mask the clear.
@@ -581,7 +582,7 @@ describe( 'Clearing a selection that came from memory', () => {
 		await roundTripVia( RestoreStage );
 
 		// The remembered row is gone from the log by the time they return — the case
-		// that reaches the dead end without a `?selected=` to clear.
+		// that reaches the dead end without a page to find it on.
 		mockEndpoints( {
 			activity: ( page, number ) => {
 				const fresh = activityPage( page, number );
@@ -591,18 +592,18 @@ describe( 'Clearing a selection that came from memory', () => {
 		} );
 		queryClient.clear();
 
-		render( <OverviewStage /> );
-		// The address carries nothing, so only the memory can be putting them here.
-		expect( routerSearch.selected ).toBeUndefined();
-		// The pane's own affordance stands in for its copy, which has changed once already.
+		const view = render( <OverviewStage /> );
 		await expect(
 			screen.findByRole( 'button', { name: 'Clear selection' }, SETTLE )
 		).resolves.toBeInTheDocument();
+		// The write-back effect puts the remembered row in the address once `<Gates>`
+		// admits the body — same trip the rest of this file waits out.
+		expect( routerSearch.selected ).toBe( rewindId( 2, 10 ) );
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Clear selection' } ) );
+		// As above: this stands in for the router commit `clearSelected`'s navigate makes.
+		view.rerender( <OverviewStage /> );
 
-		// Without state behind the memory the navigate is a no-op, so the pane never
-		// re-renders and the dead end stays on screen.
 		await waitFor( () =>
 			expect( screen.queryByRole( 'button', { name: 'Clear selection' } ) ).not.toBeInTheDocument()
 		);

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -1,0 +1,440 @@
+// JETPACK-2312: going into Download or Restore and coming back put the reader on page 1
+// with the newest backup selected, whatever they had been looking at. Every negative is
+// paired with the row that proves the list rendered, and the last test is the control.
+
+const mockApiFetch = jest.fn();
+const mockSearch = jest.fn< Record< string, unknown >, [] >();
+const mockNavigate = jest.fn();
+const mockParams = jest.fn< Record< string, string >, [] >();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => mockSearch(),
+	useNavigate: () => mockNavigate,
+	useParams: () => mockParams(),
+	// `search` is folded into the href rather than spread onto the node, so this
+	// suite can read back exactly what a back link would carry.
+	Link: ( {
+		children,
+		to,
+		search,
+		...rest
+	}: {
+		children: React.ReactNode;
+		to: string;
+		search?: Record< string, string >;
+	} ) => (
+		<a href={ search ? `${ to }?${ new URLSearchParams( search ).toString() }` : to } { ...rest }>
+			{ children }
+		</a>
+	),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { stage as OverviewStage } from '../routes/dashboard/stage';
+import { stage as DownloadStage } from '../routes/download/stage';
+import { stage as RestoreStage } from '../routes/restore/stage';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
+import { resetListStateForTesting } from '../src/dashboard/screens/overview';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SETTLE = { timeout: 10000 };
+const NOT_FOUND = 'That item is no longer in the activity log.';
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );
+
+/** Flipped per test, so the gate verdict can be made to change under a mounted screen. */
+let hasBackupPlan = true;
+
+/** What the address bar holds, driven by the screens themselves rather than hand-fed. */
+let routerSearch: Record< string, unknown > = {};
+
+/**
+ * The rewind id of the single backup on a given page at a given page size.
+ *
+ * @param page   - 1-indexed page number.
+ * @param number - Page size.
+ * @return The row's rewind id.
+ */
+function rewindId( page: number, number: number ): string {
+	return String( 1786600000 + page * 100 + number );
+}
+
+/**
+ * The row's accessible name, which is also its title in the detail pane.
+ *
+ * @param page   - 1-indexed page number.
+ * @param number - Page size.
+ * @return The row title.
+ */
+function rowTitle( page: number, number: number ): string {
+	return `Backup page ${ page } of ${ number }`;
+}
+
+/**
+ * One rewindable-activity page, in WPCOM's shape.
+ *
+ * One row per page, so the row's own name says which page and page size produced it.
+ *
+ * @param page   - 1-indexed page number.
+ * @param number - Page size.
+ * @return The response envelope.
+ */
+function activityPage( page: number, number: number ) {
+	return {
+		current: {
+			orderedItems: [
+				{
+					activity_id: `act-p${ page }-n${ number }`,
+					name: 'rewind__backup_complete_full',
+					gridicon: 'cloud',
+					rewind_id: rewindId( page, number ),
+					published: '2026-08-20T10:00:00+00:00',
+					summary: rowTitle( page, number ),
+					actor: { type: 'Application', name: 'Jetpack' },
+					content: { text: '10 plugins, 4 themes' },
+				},
+			],
+		},
+		totalItems: 60,
+		totalPages: Math.ceil( 60 / number ),
+	};
+}
+
+/**
+ * The list row for a page, which carries `aria-pressed` for its selected state.
+ *
+ * @param page   - 1-indexed page number.
+ * @param number - Page size.
+ * @return The row button.
+ */
+function row( page: number, number: number ): HTMLElement {
+	return screen.getByRole( 'button', { name: rowTitle( page, number ) } );
+}
+
+/**
+ * Render the Overview and wait for the list to have rows.
+ *
+ * @param page   - The page expected on screen.
+ * @param number - The page size expected on screen.
+ * @return The render result.
+ */
+async function openOverview( page: number, number: number ) {
+	const view = render( <OverviewStage /> );
+	await expect(
+		screen.findByRole( 'button', { name: rowTitle( page, number ) }, SETTLE )
+	).resolves.toBeInTheDocument();
+	return view;
+}
+
+/**
+ * A log retention pruned to one page: an out-of-range page answers empty, as
+ * WordPress.com does — otherwise the unclamped page still finds a row and the
+ * assertion is vacuous.
+ *
+ * @param options            - Fixture options.
+ * @param options.withTotals - Whether the envelope carries `totalItems` / `totalPages`.
+ * @return An activity answer for `mockEndpoints`.
+ */
+function prunedToOnePage( { withTotals }: { withTotals: boolean } ) {
+	return ( page: number, number: number ) => ( {
+		current: { orderedItems: page > 1 ? [] : activityPage( 1, number ).current.orderedItems },
+		...( withTotals ? { totalItems: 8, totalPages: 1 } : {} ),
+	} );
+}
+
+/**
+ * Point every route the Overview reads at a fixed set of answers.
+ *
+ * @param options          - Fixture options.
+ * @param options.activity - What the log answers for a page request. Defaults to a 60-row log.
+ */
+function mockEndpoints( {
+	activity = activityPage,
+}: { activity?: ( page: number, number: number ) => object } = {} ) {
+	mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+		const path = options?.path ?? '';
+		if ( path.includes( '/site/capabilities' ) ) {
+			return Promise.resolve( { hasBackupPlan, hasScan: false } );
+		}
+		if ( path.includes( '/site/rewindable-activity' ) ) {
+			const args = new URLSearchParams( path.split( '?' )[ 1 ] ?? '' );
+			return Promise.resolve(
+				activity( Number( args.get( 'page' ) ?? 1 ), Number( args.get( 'number' ) ?? 10 ) )
+			);
+		}
+		if ( path.includes( '/site/backup/size' ) ) {
+			return Promise.resolve( { ok: true, backups_stopped: false } );
+		}
+		if ( path === '/jetpack/v4/backups' || path === '/jetpack/v4/restores' ) {
+			return Promise.resolve( [] );
+		}
+		return Promise.resolve( {} );
+	} );
+}
+
+/**
+ * Leave the Overview for another route and follow that route's back link home.
+ *
+ * The unmount is the navigation, as in `tracks-events.test.tsx` — the three routes share
+ * one admin page — and the search to come back with is read off the rendered link.
+ *
+ * @param Stage - The route stage to visit.
+ */
+async function roundTripVia( Stage: () => React.JSX.Element ): Promise< void > {
+	const view = render( <Stage /> );
+	const back = await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE );
+	const [ , query = '' ] = ( back.getAttribute( 'href' ) ?? '' ).split( '?' );
+	routerSearch = Object.fromEntries( new URLSearchParams( query ) );
+	view.unmount();
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	resetListStateForTesting();
+
+	hasBackupPlan = true;
+	routerSearch = {};
+	mockSearch.mockReset();
+	mockSearch.mockImplementation( () => routerSearch );
+	mockNavigate.mockReset();
+	mockNavigate.mockImplementation(
+		( options: {
+			search?:
+				| Record< string, unknown >
+				| ( ( previous: Record< string, unknown > ) => Record< string, unknown > );
+		} ) => {
+			const next = options?.search;
+			routerSearch = typeof next === 'function' ? next( routerSearch ) : next ?? {};
+		}
+	);
+	mockParams.mockReset();
+	mockParams.mockReturnValue( { rewindId: rewindId( 2, 10 ) } );
+
+	mockApiFetch.mockReset();
+	mockEndpoints();
+
+	window.JP_CONNECTION_INITIAL_STATE = {
+		...window.JP_CONNECTION_INITIAL_STATE,
+		connectionStatus: CONNECTED,
+	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'The trip out to Download and back', () => {
+	it( 'returns the reader to the page and the row they left', async () => {
+		const overview = await openOverview( 1, 10 );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		await userEvent.click( row( 2, 10 ) );
+		// `setSelected` hands the router an updater, which the mock above applies —
+		// so the address is what there is to assert.
+		expect( routerSearch ).toEqual( { selected: rewindId( 2, 10 ) } );
+		// Stands in for the router committing what `setSelected` asked for: `useSearch`
+		// is a mock, so nothing else re-reads the address.
+		overview.rerender( <OverviewStage /> );
+		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+		// The back link carries nothing, which is why the URL cannot be what restores this.
+		expect( routerSearch ).toEqual( {} );
+
+		render( <OverviewStage /> );
+
+		// The detail pane resolves first — `useActivityById` scans every cached page —
+		// so the list's own rows are the later of the two.
+		await expect(
+			screen.findByRole( 'heading', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );
+		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'heading', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'The trip out to Restore and back', () => {
+	it( 'returns the reader to the page size they chose', async () => {
+		const overview = await openOverview( 1, 10 );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( RestoreStage );
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'A gate verdict that changes under the reader', () => {
+	// `<Gates>` mounts the Overview's body, so a verdict change unmounts it on its own —
+	// the same loss as a navigation, without one.
+	it( 'leaves the reader on their page when the plan lapses and comes back', async () => {
+		await openOverview( 1, 10 );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		hasBackupPlan = false;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+		await expect(
+			screen.findByText( "This site doesn't have an active Backup plan", {}, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		hasBackupPlan = true;
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
+		} );
+
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'A fresh page load', () => {
+	// The control for all three above: same fixtures, same round trip, only the memory
+	// reset — without it a list stuck on page 2 would pass every assertion here.
+	it( 'starts at the top of the list with the newest backup selected', async () => {
+		const overview = await openOverview( 1, 10 );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		// The reload: module state is what a new page load does not inherit.
+		resetListStateForTesting();
+		queryClient.clear();
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( row( 1, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' );
+		expect( screen.queryByRole( 'button', { name: rowTitle( 2, 10 ) } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'A remembered place that no longer exists', () => {
+	// The remembered page is not clamped by DataViews, and its footer disappears
+	// entirely at one page — so an unclamped reader has no pagination to escape with.
+	it( 'lands on the last page that exists when the log shrank while they were away', async () => {
+		const overview = await openOverview( 1, 10 );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		// Retention pruned the log to a single page while they were on Download.
+		mockEndpoints( { activity: prunedToOnePage( { withTotals: true } ) } );
+		queryClient.clear();
+
+		render( <OverviewStage /> );
+
+		// The row is the positive: without the clamp the list asks for page 2 of a
+		// one-page log and DataViews renders "No results" with no footer.
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
+	} );
+
+	// Same dead end, reached by the response shape the clamp is written for: an
+	// out-of-range page with no envelope totals. `totalItems` degrades to the rows
+	// in hand — none — so a guard reading it vetoes the escape hatch here.
+	it( 'lands there too when the log answers without the envelope totals', async () => {
+		const overview = await openOverview( 1, 10 );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		mockEndpoints( { activity: prunedToOnePage( { withTotals: false } ) } );
+		queryClient.clear();
+
+		render( <OverviewStage /> );
+
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'Clearing a selection that came from memory', () => {
+	// `clearSelected` navigates to the URL it is already on, which TanStack treats
+	// as a no-op — so without state the pane never re-renders and the button is inert.
+	it( 'renders the change, not just forgets it', async () => {
+		// Page 2's row, so the remembered row differs from `defaultSelectedId` — which is
+		// page 1's newest backup, and would otherwise mask the clear.
+		const overview = await openOverview( 1, 10 );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: rowTitle( 2, 10 ) } ) );
+		// As above: `useSearch` is a mock, so this stands in for the router commit.
+		overview.rerender( <OverviewStage /> );
+		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );
+
+		overview.unmount();
+		await roundTripVia( RestoreStage );
+
+		// The remembered row is gone from the log by the time they return — the case
+		// that reaches the dead end without a `?selected=` to clear.
+		mockEndpoints( {
+			activity: ( page, number ) => {
+				const fresh = activityPage( page, number );
+				fresh.current.orderedItems[ 0 ].rewind_id = `${ rewindId( page, number ) }5`;
+				return fresh;
+			},
+		} );
+		queryClient.clear();
+
+		render( <OverviewStage /> );
+		// The address carries nothing, so only the memory can be putting them here.
+		expect( routerSearch.selected ).toBeUndefined();
+		await expect( screen.findByText( NOT_FOUND, {}, SETTLE ) ).resolves.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Clear selection' } ) );
+
+		// Without state behind the memory the navigate is a no-op, so the pane never
+		// re-renders and the dead end stays on screen.
+		await waitFor( () => expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument() );
+	} );
+} );

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -47,13 +47,6 @@ import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const SETTLE = { timeout: 10000 };
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /** Flipped per test, so the gate verdict can be made to change under a mounted screen. */
 let hasBackupPlan = true;
 

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -35,6 +35,7 @@ jest.mock( '@wordpress/route', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
+import { onlineManager } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
@@ -45,7 +46,6 @@ import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const SETTLE = { timeout: 10000 };
-const NOT_FOUND = 'That item is no longer in the activity log.';
 
 // jsdom implements no scrolling, and DataViews' list layout calls
 // `scrollIntoView` on the selected row.
@@ -155,6 +155,25 @@ function prunedToOnePage( { withTotals }: { withTotals: boolean } ) {
 }
 
 /**
+ * The page and size of every rewindable-activity request made so far.
+ *
+ * The list's own query is the only one that moves: `useDefaultBackupRewindId` and
+ * `useHasRestorePoints` pin page 1 at the default size, so a non-default size
+ * tells the two apart.
+ *
+ * @return `page/size` strings, in call order.
+ */
+function activityRequests(): string[] {
+	return mockApiFetch.mock.calls
+		.map( ( [ options ] ) => String( ( options as { path?: string } )?.path ?? '' ) )
+		.filter( path => path.includes( '/site/rewindable-activity' ) )
+		.map( path => {
+			const args = new URLSearchParams( path.split( '?' )[ 1 ] ?? '' );
+			return `${ args.get( 'page' ) ?? '1' }/${ args.get( 'number' ) ?? '10' }`;
+		} );
+}
+
+/**
  * Point every route the Overview reads at a fixed set of answers.
  *
  * @param options          - Fixture options.
@@ -230,6 +249,10 @@ beforeEach( () => {
 		...window.JP_CONNECTION_INITIAL_STATE,
 		connectionStatus: CONNECTED,
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+afterEach( () => {
+	onlineManager.setOnline( true );
 } );
 
 describe( 'The trip out to Download and back', () => {
@@ -397,6 +420,148 @@ describe( 'A remembered place that no longer exists', () => {
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
 	} );
+
+	// `0 ?? fallback` is `0`, so a literal zero in the envelope outlives the fallback
+	// that would otherwise floor it at 1 — and page 0 is not a page anyone can ask for.
+	it( 'never asks for page 0 when the log reports no pages at all', async () => {
+		const overview = await openOverview( 1, 10 );
+		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		// Only the list's own page size answers zero. The pinned page-1 lookups keep
+		// their rows, or the first-run takeover replaces the body before the list mounts.
+		mockEndpoints( {
+			activity: ( page, number ) =>
+				number === 20
+					? { current: { orderedItems: [] }, totalItems: 0, totalPages: 0 }
+					: activityPage( page, number ),
+		} );
+		queryClient.clear();
+		mockApiFetch.mockClear();
+
+		const view = render( <OverviewStage /> );
+
+		await expect( screen.findByText( 'No results', {}, SETTLE ) ).resolves.toBeInTheDocument();
+		expect( activityRequests() ).not.toContain( '0/20' );
+
+		view.unmount();
+	} );
+} );
+
+describe( 'A remembered place the log cannot answer for', () => {
+	// The clamp reads `totalPages`, which falls back to 1 when the envelope is
+	// missing — and a failed request has no envelope either. Clamping there both
+	// moves the reader off the page they asked for and overwrites the memory of it,
+	// and the fresh page-1 query hides the list's own error report.
+	it( 'reports the failure on the page they asked for, and still remembers it', async () => {
+		const overview = await openOverview( 1, 10 );
+
+		// A non-default page size, so the list's request is distinguishable from the
+		// pinned page-1 lookups every mount makes.
+		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		// The log is unreachable by the time they come back.
+		let activityFails = true;
+		mockEndpoints( {
+			activity: ( page, number ) =>
+				activityFails
+					? Promise.reject( new Error( 'The activity log is unavailable.' ) )
+					: activityPage( page, number ),
+		} );
+		queryClient.clear();
+		mockApiFetch.mockClear();
+
+		const view = render( <OverviewStage /> );
+
+		// The reason, where DataViews would otherwise say "No results".
+		await expect(
+			screen.findByRole( 'button', { name: 'Try again' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'The activity log is unavailable.' ) ).toBeInTheDocument();
+
+		// Page 1 at this size is where a clamp would send them, and nothing asked for it.
+		await waitFor( () => expect( activityRequests() ).toContain( '2/20' ) );
+		expect( activityRequests() ).not.toContain( '1/20' );
+
+		// The retry is the only way out with the footer hidden, and it proves the
+		// memory survived: page 2 is what comes back.
+		activityFails = false;
+		await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 20 ) } ) ).not.toBeInTheDocument();
+
+		view.unmount();
+	} );
+} );
+
+describe( 'A remembered place asked for with no connection', () => {
+	// Offline, React Query parks the request rather than sending it: `fetchStatus`
+	// is `paused`, so `isFetching` is false and no error is ever reported. Nothing
+	// has answered, and `totalPages` still falls back to 1.
+	it( 'waits for the connection instead of moving the reader', async () => {
+		const overview = await openOverview( 1, 10 );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+
+		overview.unmount();
+		await roundTripVia( DownloadStage );
+
+		// Only the entry the list needs is dropped. `<Gates>` spins offline without its
+		// cached verdict, and `useHasRestorePoints` reads the pinned page-1 query — a
+		// paused one reports no rows and hands the body to the first-run takeover.
+		queryClient.removeQueries( { queryKey: keys.activityLogPage( 2, 20, 'desc' ) } );
+		mockApiFetch.mockClear();
+		onlineManager.setOnline( false );
+
+		const view = render( <OverviewStage /> );
+
+		// The premise: paused, not failing. Nothing is sent, so nothing is learned.
+		await expect(
+			screen.findByRole( 'group', { name: 'Backup activity' }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( activityRequests() ).toEqual( [] );
+
+		onlineManager.setOnline( true );
+
+		// Page 2 is what resumes, so nothing moved the reader while they were offline.
+		await expect(
+			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		).resolves.toBeInTheDocument();
+		expect( activityRequests() ).not.toContain( '1/20' );
+
+		view.unmount();
+	} );
 } );
 
 describe( 'Clearing a selection that came from memory', () => {
@@ -429,12 +594,17 @@ describe( 'Clearing a selection that came from memory', () => {
 		render( <OverviewStage /> );
 		// The address carries nothing, so only the memory can be putting them here.
 		expect( routerSearch.selected ).toBeUndefined();
-		await expect( screen.findByText( NOT_FOUND, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		// The pane's own affordance stands in for its copy, which has changed once already.
+		await expect(
+			screen.findByRole( 'button', { name: 'Clear selection' }, SETTLE )
+		).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Clear selection' } ) );
 
 		// Without state behind the memory the navigate is a no-op, so the pane never
 		// re-renders and the dead end stays on screen.
-		await waitFor( () => expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument() );
+		await waitFor( () =>
+			expect( screen.queryByRole( 'button', { name: 'Clear selection' } ) ).not.toBeInTheDocument()
+		);
 	} );
 } );

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -212,6 +212,31 @@ async function roundTripVia( Stage: () => React.JSX.Element ): Promise< void > {
 	view.unmount();
 }
 
+/**
+ * Put the list on page 2 at 20 per page, then leave the Overview and come back.
+ *
+ * The size is deliberately not the default: it is what makes the list's own request
+ * distinguishable from the pinned page-1 lookups every mount makes.
+ *
+ * @param Stage - The route stage to visit on the way out.
+ */
+async function roundTripFromPage2Of20( Stage: () => React.JSX.Element ): Promise< void > {
+	const overview = await openOverview( 1, 10 );
+
+	await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
+	await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
+	await expect(
+		screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+	).resolves.toBeInTheDocument();
+	await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+	await expect(
+		screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+	).resolves.toBeInTheDocument();
+
+	overview.unmount();
+	await roundTripVia( Stage );
+}
+
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
@@ -417,19 +442,7 @@ describe( 'A remembered place that no longer exists', () => {
 	// `0 ?? fallback` is `0`, so a literal zero in the envelope outlives the fallback
 	// that would otherwise floor it at 1 — and page 0 is not a page anyone can ask for.
 	it( 'never asks for page 0 when the log reports no pages at all', async () => {
-		const overview = await openOverview( 1, 10 );
-		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
-		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-
-		overview.unmount();
-		await roundTripVia( DownloadStage );
+		await roundTripFromPage2Of20( DownloadStage );
 
 		// Only the list's own page size answers zero. The pinned page-1 lookups keep
 		// their rows, or the first-run takeover replaces the body before the list mounts.
@@ -457,22 +470,7 @@ describe( 'A remembered place the log cannot answer for', () => {
 	// moves the reader off the page they asked for and overwrites the memory of it,
 	// and the fresh page-1 query hides the list's own error report.
 	it( 'reports the failure on the page they asked for, and still remembers it', async () => {
-		const overview = await openOverview( 1, 10 );
-
-		// A non-default page size, so the list's request is distinguishable from the
-		// pinned page-1 lookups every mount makes.
-		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
-		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-
-		overview.unmount();
-		await roundTripVia( DownloadStage );
+		await roundTripFromPage2Of20( DownloadStage );
 
 		// The log is unreachable by the time they come back.
 		let activityFails = true;
@@ -515,20 +513,7 @@ describe( 'A remembered place asked for with no connection', () => {
 	// is `paused`, so `isFetching` is false and no error is ever reported. Nothing
 	// has answered, and `totalPages` still falls back to 1.
 	it( 'waits for the connection instead of moving the reader', async () => {
-		const overview = await openOverview( 1, 10 );
-
-		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
-		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
-		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
-		).resolves.toBeInTheDocument();
-
-		overview.unmount();
-		await roundTripVia( DownloadStage );
+		await roundTripFromPage2Of20( DownloadStage );
 
 		// Only the entry the list needs is dropped. `<Gates>` spins offline without its
 		// cached verdict, and `useHasRestorePoints` reads the pinned page-1 query — a

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -43,6 +43,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { queryClient } from '../src/dashboard/data/query-client';
+import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
@@ -192,6 +193,9 @@ function mockEndpoints( {
 }
 
 beforeEach( () => {
+	// Module state, so one test's selection would otherwise seed the next.
+	resetListStateForTesting();
+
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
 

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -42,6 +42,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { queryClient } from '../src/dashboard/data/query-client';
+import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
@@ -76,6 +77,7 @@ function backupEntry( rewindId: string, title: string ) {
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	resetListStateForTesting();
 
 	mockApiFetch.mockReset();
 	mockApiFetch.mockImplementation( ( o: { path?: string; data?: { rewind_id?: string } } ) => {


### PR DESCRIPTION
Fixes JETPACK-2312

## Proposed changes

* Going into Download or Restore and coming back lost where the reader was: the page, the per-page and the chosen row. A trip to either screen unmounts the Overview, and — since #51801 — a gate verdict change unmounts its body too.
* `screens/overview.tsx` remembers the last `View` and the last *explicit* selection in module state, seeds `useState` from them, and writes on change.
* A second effect writes the remembered row back into the address with `replace: true`, so `?selected=` stays the only selection source.
* `components/activity-list/index.tsx` clamps a remembered page the log has since outgrown — but only once a query has actually answered.
* `hooks/use-activity-log.ts` exposes React Query's `isPaused`, which the clamp needs to tell "offline, never asked" from "answered".
* `@tanstack/react-router` is added as a **devDependency**. Only the new back-stack suite uses it, to drive a real memory history. Nothing ships it.

### Why the remembered row is written back into the address

A selection restored from memory carried no `?selected=`. `clearSelected` cleared the memory and navigated, but that navigate targeted the address the screen was already on. TanStack treats a same-URL navigate as a no-op: React never re-rendered, and no history entry was pushed. The button read as inert, and Back left the Overview instead of undoing the clear.

The write-back effect removes the second source rather than papering over it. When the address carries no `selected` and memory holds one, the effect navigates the remembered id into the search with `replace: true`. From then on the clear is a real search change: it renders, and it pushes an entry Back can return to. `replace` keeps the write-back itself off the history stack, so one Back from the restored Overview lands on Download — where the trip came from — not on a step this effect invented.

Only an explicit choice is written. `defaultSelectedId` moves as new backups land, so pinning the row it happened to name would outlive its own reason.

### The consequence: Back undoes a clear, Forward does not redo it

The effect fires on any bare Overview address, not only the return trip. Back onto a bare address is therefore rewritten too. So Back undoes a clear and restores the row, while Forward cannot redo the clear — the write-back puts the row straight back.

That asymmetry is deliberate. The pane's own copy admits the row may still be fine, so the discard has to be undoable; a redo of a discard is worth less than an undo of one.

### Why not thread the state through the links

`<Link to="/">` really does drop the search: `@tanstack/router-core` returns `{}` when a destination names none. And `@wordpress/boot` nests the router href inside wp-admin's `?p=`, so anything threaded through it is double-encoded. `validateSearch` is not an option either — all three route modules are `export const route = {};`, and boot wires only `path`, `beforeLoad`, `loader` and `loaderDeps`, so a `validateSearch` export is ignored. Both constraints were verified against the installed `@wordpress/boot` and `@tanstack/router-core` when the branch was written.

Threading would also need edits in four files and still could not cover `invalid-rewind-id`, which is reached *because* the URL is malformed and has nothing to thread. The decisive case is the bookmark: a back link that rebuilt `?selected=` from the path would fire on a cold load of `/download/<id>` too, sending a reader to a selection that may not be on page 1.

### Why module state, and why a reload still resets

Module scope is what this file already uses one line above, for the same unmount — `hasRecordedPageView`. It survives a back-navigation and a gate flip, and it only exists at all if the reader actually visited the Overview this page load.

`sessionStorage` was rejected for the opposite reason: it is the only option that survives a reload, and surviving a reload is wrong here. A reader who reloads is starting over, and dropping them back on page 7 with no URL to explain it is worse than starting at the top.

### The page clamp, and the three states it must not fire in

DataViews does not clamp an out-of-range page, and it hides its footer entirely at one page. An out-of-range reader therefore gets no rows and no pagination to escape with.

The guard is most of the work. `totalPages` falls back to 1 when the envelope carries no totals, and three states have no envelope:

* **In flight** (`isFetching`) — the first render of any page.
* **Paused** (`isPaused`) — `networkMode: 'online'` parks the request for an offline browser. Nothing is sent, nothing fails, and `isFetching` stays false. Without this guard an offline reader is moved to page 1 while they wait for a connection.
* **Failed** (`error`) — clamping here would move the reader off the page they asked for, overwrite the memory of it, and hide the list's own error report behind a fresh page-1 query.

`totalPages >= 1` covers a fourth case: a literal `totalPages: 0` survives the fallback's `??`, and page 0 is not a page anyone can ask for.

### Why this could not be split

Restoring only the page would put the reader back on page 3 with **page 1's newest backup** in the detail pane and no row highlighted — confirmed by running it with the selection half reverted. A half-fix would be visibly wrong.

## Related product discussion/links

* Linear: JETPACK-2312 (task F8a), under the Backup modernization project.
* Builds on #51886, which merged as `fa32a6bde13`. This PR targets `trunk`.
* The shared `QueryClient` from #51798 is why the returning render is served from cache, with no refetch and no gate spinner. It is not the mechanism, though — the cache holds data keyed by `(page, pageSize, sortOrder)` and never which page the reader was on.

## Does this pull request change what data or activity we track or use?

No. No new requests, no Tracks event. It reduces refetching only in the sense that the returning page is already in the shared cache. `@tanstack/react-router` is a devDependency and reaches no bundle.

## Testing instructions

The dashboard is behind `rsm_jetpack_ui_modernization_backup`, off by default, so this is a no-op unless the filter is on.

### Automated

From `projects/packages/backup`: `pnpm test` — **77 suites / 753 tests**, all passing on this head.

Two suites carry the new coverage:

* `tests/list-state-round-trip.test.tsx` drives the journey against the `@wordpress/route` mock: DataViews' own "Next page", the cog's per-page radio, a real row click, then unmount → render the Download/Restore stage → read the search off its back link (asserted to be `{}`) → render the Overview again. It also covers the clamp: a log pruned while the reader was away, an envelope with no totals, a literal `totalPages: 0`, a failed query and an offline one.
* `tests/cleared-selection-back-stack.test.tsx` runs the same round trip over a real `@tanstack/react-router` memory history, because a mocked router has no history stack to miss an entry on. It asserts that the write-back lands, that it costs no extra Back step, that Back undoes a clear, and that the default selection never reaches the address.

Every guard was mutation-checked on this head. Each of these kills exactly one test, except the first:

| Mutation | Tests that fail |
| --- | --- |
| Remove the write-back effect | 3, across both new suites |
| Remove `! isFetching` | `reports the failure on the page they asked for, and still remembers it` |
| Remove `! isPaused` | `waits for the connection instead of moving the reader` |
| Remove `! error` | `reports the failure on the page they asked for, and still remembers it` |
| Remove `totalPages >= 1` | `never asks for page 0 when the log reports no pages at all` |

The "fresh page load starts at the top" control survives all of them, which is what proves the fixtures do not simply always render page 2.

### By hand

On a site with the filter on, a Backup plan, and enough activity for several pages:

1. Go to **Jetpack → VaultPress Backup**. Page to 2, set per-page to 20, and click a row that is not the newest backup.
2. Click **Download** (or **Restore**) on that backup's detail card.
3. Use the screen's **back** link.
4. Expect page 2, per-page 20, and the same row still selected. Before this change you landed on page 1 with the newest backup selected.
5. Press the browser's **Back** button. Expect the Download screen, not an extra stop on the Overview.
6. Reload the page. It should now start at the top — that reset is deliberate.

Steps 1-4 and the reload in step 6 were run on a live site when the branch was written. Step 5 is covered by `cleared-selection-back-stack.test.tsx` and was not repeated by hand.

### Two behaviours that are covered by tests and are **not** reproducible by hand

Both are worth a reviewer's eyes on the code rather than the screen, because staging them needs the backup log to change underneath the reader.

**The remembered row that no longer resolves.** You cannot stage this from the address bar: reaching "Item not found." means editing the selection param, and that needs a reload, which clears the memory. It is reachable in production, though — `useActivityById` resolves the remembered row by scanning **cached** pages (30s `staleTime`, 5min `gcTime`), so a new backup arriving while the reader is on Download or Restore can shift their row onto a page nothing has cached. Covered by three tests, all of which fail when the write-back effect is removed: `writes the remembered row into the address without a Back step of its own`, `lets Back undo clearing a selection that came from memory`, and `renders the change, not just forgets it`.

**The remembered page that outlived its log.** Nothing in DataViews clamps an out-of-range page, and `hasPaginationControls` returns false at one page — so a log that shrank while the reader was away left them with no rows, no pagination and no way back. Staging it needs retention to prune the log mid-session. Covered by `lands on the last page that exists when the log shrank while they were away`, which fails when the clamp is removed.
