### PR TITLE
Jetpack: Load module state before shared store

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/packages/forms/changelog/fix-contact-form-modules-store-initialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Load active module state before the editor module store.

--- a/projects/packages/forms/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/packages/forms/changelog/fix-contact-form-modules-store-initialization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Load active module state before the editor module store.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Extensions\Contact_Form;
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Assets\Shared_Stores_Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Forms\ContactForm\Contact_Form;
@@ -1273,7 +1274,7 @@ class Contact_Form_Block {
 		// - feature_flags: hasFeatureFlag() reads this for central-form-management,
 		// form-webhooks, and multistep-form.
 		wp_localize_script(
-			'jetpack-blocks-editor',
+			Shared_Stores_Assets::SCRIPT_HANDLE,
 			'Jetpack_Editor_Initial_State',
 			array(
 				'available_blocks' => array(

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Assets\Shared_Stores_Assets;
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -790,15 +791,16 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		// The fallback style should also be registered.
 		$this->assertTrue( wp_style_is( 'jetpack-blocks-editor', 'registered' ), 'jetpack-blocks-editor style should be registered as a fallback.' );
 
-		// Verify the localized Jetpack_Editor_Initial_State data contains expected keys.
+		// The shared store must receive state before it executes as a Forms dependency.
 		$scripts = wp_scripts();
-		$data    = $scripts->get_data( 'jetpack-blocks-editor', 'data' );
+		$data    = $scripts->get_data( Shared_Stores_Assets::SCRIPT_HANDLE, 'data' );
 
-		$this->assertNotEmpty( $data, 'jetpack-blocks-editor should have localized data.' );
+		$this->assertNotEmpty( $data, 'jetpack-shared-stores should have localized data.' );
 		$this->assertStringContainsString( 'available_blocks', $data );
 		$this->assertStringContainsString( 'contact-form', $data );
 		$this->assertStringContainsString( 'modules', $data );
 		$this->assertStringContainsString( 'feature_flags', $data );
+		$this->assertEmpty( $scripts->get_data( 'jetpack-blocks-editor', 'data' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Contact Form Block: load active module state before the editor module store.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: bugfix
 
 Contact Form Block: load active module state before the editor module store.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Contact Form Block: load active module state before the editor module store.
+Editor: restore active module state for module-dependent features.

--- a/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
+++ b/projects/plugins/jetpack/changelog/fix-contact-form-modules-store-initialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Contact Form Block: load active module state before the editor module store.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -7,6 +7,7 @@
  */
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Assets\Shared_Stores_Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
@@ -976,7 +977,7 @@ class Jetpack_Gutenberg {
 		);
 
 		wp_localize_script(
-			'jetpack-blocks-editor',
+			Shared_Stores_Assets::SCRIPT_HANDLE,
 			'Jetpack_Editor_Initial_State',
 			$initial_state
 		);

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -107,19 +107,24 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_editor_initial_state_is_localized_on_shared_modules_store() {
 		global $current_screen;
 
+		$previous_screen = $current_screen;
 		$current_screen = convert_to_screen( 'post' );
 		$current_screen->is_block_editor( true );
 		Shared_Stores_Assets::register_assets();
 		wp_register_style( 'jetpack-blocks-editor', false, array(), JETPACK__VERSION );
 
-		Jetpack_Gutenberg::enqueue_block_editor_assets();
+		try {
+			Jetpack_Gutenberg::enqueue_block_editor_assets();
 
-		$scripts = wp_scripts();
-		$this->assertStringContainsString(
-			'Jetpack_Editor_Initial_State',
-			(string) $scripts->get_data( Shared_Stores_Assets::SCRIPT_HANDLE, 'data' )
-		);
-		$this->assertEmpty( $scripts->get_data( 'jetpack-blocks-editor', 'data' ) );
+			$scripts = wp_scripts();
+			$this->assertStringContainsString(
+				'Jetpack_Editor_Initial_State',
+				(string) $scripts->get_data( Shared_Stores_Assets::SCRIPT_HANDLE, 'data' )
+			);
+			$this->assertEmpty( $scripts->get_data( 'jetpack-blocks-editor', 'data' ) );
+		} finally {
+			$current_screen = $previous_screen;
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -5,6 +5,8 @@ use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @covers \Jetpack_Gutenberg
@@ -103,12 +105,17 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * The modules store initializes immediately, so its state must be localized on
 	 * the shared-store handle rather than on a later editor script.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_editor_initial_state_is_localized_on_shared_modules_store() {
 		global $current_screen;
 
 		$previous_screen = $current_screen;
-		$current_screen = convert_to_screen( 'post' );
+		$current_screen  = convert_to_screen( 'post' );
 		$current_screen->is_block_editor( true );
 		Shared_Stores_Assets::register_assets();
 		wp_register_style( 'jetpack-blocks-editor', false, array(), JETPACK__VERSION );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -109,6 +109,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 
 		$current_screen = convert_to_screen( 'post' );
 		$current_screen->is_block_editor( true );
+		Shared_Stores_Assets::register_assets();
 		wp_register_style( 'jetpack-blocks-editor', false, array(), JETPACK__VERSION );
 
 		Jetpack_Gutenberg::enqueue_block_editor_assets();

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack\Assets\Shared_Stores_Assets;
 use Automattic\Jetpack\Blocks;
 use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -97,6 +98,26 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			'potato',
 			'tomato',
 		);
+	}
+
+	/**
+	 * The modules store initializes immediately, so its state must be localized on
+	 * the shared-store handle rather than on a later editor script.
+	 */
+	public function test_editor_initial_state_is_localized_on_shared_modules_store() {
+		global $current_screen;
+
+		$current_screen = convert_to_screen( 'post' );
+		$current_screen->is_block_editor( true );
+
+		Jetpack_Gutenberg::enqueue_block_editor_assets();
+
+		$scripts = wp_scripts();
+		$this->assertStringContainsString(
+			'Jetpack_Editor_Initial_State',
+			(string) $scripts->get_data( Shared_Stores_Assets::SCRIPT_HANDLE, 'data' )
+		);
+		$this->assertEmpty( $scripts->get_data( 'jetpack-blocks-editor', 'data' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -109,6 +109,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 
 		$current_screen = convert_to_screen( 'post' );
 		$current_screen->is_block_editor( true );
+		wp_register_style( 'jetpack-blocks-editor', false, array(), JETPACK__VERSION );
 
 		Jetpack_Gutenberg::enqueue_block_editor_assets();
 


### PR DESCRIPTION
## Proposed changes

- Localize `Jetpack_Editor_Initial_State` on `jetpack-shared-stores`, before every module-dependent editor feature reads it.
- Apply the same ordering to the normal Jetpack editor path and the Forms fallback path.
- Add focused regression coverage and patch changelog entries for Jetpack and Forms.

The shared-store externalization made `jetpack-shared-stores` a dependency of `jetpack-blocks-editor`, but the initial state remained attached to the parent handle. WordPress therefore executed the store before printing its state. The store permanently initialized with an empty modules object and incorrectly reported active modules as inactive. This broke Forms and other module-dependent editor features, including SEO Enhancer's Auto-generate metadata setting.

Fixes #51861.

## Related product discussion/links

- [JETPACK-2467](https://linear.app/a8c/issue/JETPACK-2467/forms-active-contact-form-module-is-reported-inactive-after-shared)

## Testing instructions:

- Built the Jetpack plugin with `corepack pnpm@11.14.0 exec jetpack build plugins/jetpack --no-pnpm-install --concurrency 1`.
- Ran the focused Forms PHPUnit suite: 61 tests, 130 assertions, passing.
- Ran PHP syntax checks on all four modified PHP files.
- Ran `git diff --check`.
- Reproduced and verified the user-facing behavior in isolated WP Codebox fixtures using WordPress 7.1 and PHP 8.3. The fixtures activated Jetpack, set `jetpack_active_modules` to `contact-form`, seeded a `jetpack/contact-form` block, and opened it in Gutenberg. The repaired fixture also used Jetpack's canonical Contact Form pattern with Name, Email, Message, and submit controls.

### Before

The server initial state marks `contact-form` active, but the shared store is empty and the editor replaces the form with the activation placeholder.

![Contact Form incorrectly shown as inactive](https://github.com/user-attachments/assets/7a3d76f6-015e-4dd9-a0e0-87c43a4bed8c)

### After

The shared store contains `contact-form`, `isModuleActive( 'contact-form' )` returns true, and the editable form controls render without the activation placeholder.

![Contact Form editor showing Name, Email, Message, and Contact us controls after the fix](https://github.com/user-attachments/assets/d027d2ac-8b1d-425e-8104-76cb3fc9f78d)

## Does this pull request change what data or activity we track or use?

No.

## AI assistance disclosure

OpenAI GPT-5.6-Sol was used through OpenCode to inspect the Jetpack and WordPress runtime, isolate the script-ordering failure, implement the fix and regression tests, and orchestrate verification. Conclusions were verified through repository tests, build and syntax checks, and matched before/after WordPress browser fixtures.
