### PR TITLE
Backup: report a failed plan check as an error, and let the UI handle it

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2309b-plan-check-errors
+++ b/projects/packages/backup/changelog/jetpack-2309b-plan-check-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report a WordPress.com failure on the Backup plan check as an error instead of as a missing plan.

--- a/projects/packages/backup/src/class-jetpack-backup.php
+++ b/projects/packages/backup/src/class-jetpack-backup.php
@@ -361,7 +361,7 @@ class Jetpack_Backup {
 			'/has-backup-plan',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::has_backup_plan',
+				'callback'            => __CLASS__ . '::get_backup_plan_state',
 				'permission_callback' => __CLASS__ . '::backups_permissions_callback',
 			)
 		);
@@ -582,13 +582,12 @@ class Jetpack_Backup {
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/rewind', $site_id ) . '?force=wpcom', '2', array( 'timeout' => 5 ), null, 'wpcom' );
 
 		// Cast: `wp_remote_retrieve_response_code()` hands back whatever the
-		// transport put there, and a numeric-string `'200'` fails this
-		// strict comparison. `has_backup_plan()` answers false for a
-		// `WP_Error`, so a site that does have Backup would be told it does
-		// not — and that answer is acted on: it backs the `/has-backup-plan`
-		// route and the standalone-license upsell.
-		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'rewind_state_fetch_failed' );
+		// transport put there, and a numeric-string `'200'` fails this strict
+		// comparison.
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 200 !== $response_code ) {
+			return self::get_failed_fetch_error( $response_code );
 		}
 
 		$state = json_decode( wp_remote_retrieve_body( $response ) );
@@ -597,7 +596,11 @@ class Jetpack_Backup {
 		// plan. Caching it would hold that answer for the rest of the request;
 		// refusing lets a later caller ask again and get a real one.
 		if ( ! is_object( $state ) || ! isset( $state->state ) ) {
-			return new WP_Error( 'rewind_state_unreadable' );
+			return new WP_Error(
+				'rewind_state_unreadable',
+				esc_html__( 'Unable to read the backup plan details for this site.', 'jetpack-backup-pkg' ),
+				array( 'status' => 500 )
+			);
 		}
 
 		self::$rewind_state = $state;
@@ -605,18 +608,34 @@ class Jetpack_Backup {
 	}
 
 	/**
-	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 * Checks whether the site supports the product, reporting an unreadable answer as an error.
 	 *
-	 * @return boolean
+	 * @since $$next-version$$
+	 *
+	 * @return bool|WP_Error True when the site has Backup, or a WP_Error if WordPress.com could not be read.
 	 */
-	public static function has_backup_plan() {
+	public static function get_backup_plan_state() {
 		$rewind_data = static::get_rewind_state_from_wpcom();
 
 		if ( is_wp_error( $rewind_data ) ) {
-			return false;
+			return $rewind_data;
 		}
 
 		return 'unavailable' !== $rewind_data->state;
+	}
+
+	/**
+	 * Checks whether the current plan (or purchases) of the site already supports the product
+	 *
+	 * Answers a plan it could not read as absent, which is the one place that
+	 * decision is made for every `bool` caller.
+	 *
+	 * @return bool
+	 */
+	public static function has_backup_plan() {
+		$state = static::get_backup_plan_state();
+
+		return ! is_wp_error( $state ) && $state;
 	}
 
 	/**

--- a/projects/packages/backup/src/js/components/Admin/hooks.js
+++ b/projects/packages/backup/src/js/components/Admin/hooks.js
@@ -31,10 +31,16 @@ export const useSiteHasBackupProduct = () => {
 			return;
 		}
 
-		apiFetch( { path: '/jetpack/v4/has-backup-plan' } ).then( res => {
-			setSiteHasBackupProduct( res );
-			setIsLoading( false );
-		} );
+		// The route reports a WordPress.com failure as an error. Without this
+		// branch the rejection leaves `isLoading` true and the secondary admin
+		// sits on a placeholder forever.
+		apiFetch( { path: '/jetpack/v4/has-backup-plan' } ).then(
+			res => {
+				setSiteHasBackupProduct( res );
+				setIsLoading( false );
+			},
+			() => setIsLoading( false )
+		);
 	}, [ isFullyConnected ] );
 
 	return { siteHasBackupProduct, isLoadingBackupProduct: isLoading };

--- a/projects/packages/backup/src/js/components/backup-connection-screen/index.jsx
+++ b/projects/packages/backup/src/js/components/backup-connection-screen/index.jsx
@@ -40,8 +40,11 @@ export const BackupConnectionScreen = () => {
 	const registrationNonce = useSelect( select => select( STORE_ID ).getRegistrationNonce(), [] );
 	const { price, priceAfter } = useBackupProductInfo();
 
+	// Two jobs: an unknown plan answers as no plan, and this also guards
+	// `useProductCheckoutWorkflow`, whose `handleAfterRegistration()` has no
+	// rejection path — a rejection there stalls the purchase button forever.
 	const checkSiteHasBackupProduct = useCallback(
-		() => apiFetch( { path: '/jetpack/v4/has-backup-plan' } ),
+		() => apiFetch( { path: '/jetpack/v4/has-backup-plan' } ).catch( () => false ),
 		[]
 	);
 

--- a/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
+++ b/projects/packages/backup/tests/php/Jetpack_Backup_Test.php
@@ -341,17 +341,18 @@ class Jetpack_Backup_Test extends TestCase {
 	 * @dataProvider provide_cacheable_unreadable_states
 	 */
 	#[DataProvider( 'provide_cacheable_unreadable_states' )]
-	public function test_has_backup_plan_does_not_cache_an_unreadable_200( $label, $body ) {
+	public function test_backup_plan_state_does_not_cache_an_unreadable_200( $label, $body ) {
 		$this->sign_in_as_connected_admin();
 		$this->wpcom_body = $body;
 		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
 
-		$unreadable = Jetpack_Backup::has_backup_plan();
+		$unreadable = Jetpack_Backup::get_backup_plan_state();
 
 		$this->wpcom_body = '{"state":"active"}';
-		$recovered        = Jetpack_Backup::has_backup_plan();
+		$recovered        = Jetpack_Backup::get_backup_plan_state();
 
-		$this->assertFalse( $unreadable, $label );
+		$this->assertInstanceOf( WP_Error::class, $unreadable, $label );
+		$this->assertSame( 'rewind_state_unreadable', $unreadable->get_error_code(), $label );
 		$this->assertSame( 2, $this->http_requests, $label );
 		$this->assertTrue( $recovered, $label );
 	}
@@ -384,6 +385,107 @@ class Jetpack_Backup_Test extends TestCase {
 		Jetpack_Backup::has_backup_plan();
 
 		$this->assertSame( 5, $this->captured_timeout );
+	}
+
+	/**
+	 * A WordPress.com failure is reported as one, not as "no plan".
+	 *
+	 * That answer is acted on: `GET /jetpack/v4/has-backup-plan` backs the
+	 * connect screen's own-it-already check, so a blip sent a paying site's
+	 * owner to checkout to buy Backup again.
+	 */
+	public function test_backup_plan_state_forwards_a_non_200() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = 503;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = Jetpack_Backup::get_backup_plan_state();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'failed_to_fetch_data', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A request that never reaches WordPress.com has no status to forward, and
+	 * the 0 that casting produces is not one the REST layer can serve.
+	 *
+	 * This is the shape a timeout arrives in, which is the case the two plan
+	 * checks used to disagree about.
+	 */
+	public function test_backup_plan_state_reports_a_transport_failure_as_500() {
+		$this->sign_in_as_connected_admin();
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
+
+		$result = Jetpack_Backup::get_backup_plan_state();
+
+		$this->assertSame( 1, $this->http_requests );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * The route serves the failure. It used to serve `false` as an HTTP 200,
+	 * which no caller can tell from "this site has no Backup plan".
+	 */
+	public function test_has_backup_plan_route_serves_a_failure_as_an_error() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_status = 503;
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		rest_get_server();
+		Jetpack_Backup::register_rest_routes();
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/jetpack/v4/has-backup-plan' ) );
+
+		$this->assertTrue( $response->is_error() );
+		$this->assertSame( 503, $response->get_status() );
+	}
+
+	/**
+	 * A site that genuinely has no plan still answers a plain `false`. The
+	 * wrapper must not turn the legitimate negative into a positive.
+	 */
+	public function test_has_backup_plan_answers_false_for_an_unavailable_state() {
+		$this->sign_in_as_connected_admin();
+		$this->wpcom_body = '{"state":"unavailable"}';
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_response' ) );
+
+		$result = Jetpack_Backup::has_backup_plan();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * `has_backup_plan()` stays a `bool`. It is public in a versioned namespace,
+	 * and `WP_Error` is truthy — so a consumer written against `bool` would not
+	 * error on a widened return, it would answer the opposite question.
+	 */
+	public function test_has_backup_plan_stays_a_boolean_when_the_read_fails() {
+		$this->sign_in_as_connected_admin();
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
+
+		$result = Jetpack_Backup::has_backup_plan();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * `jetpack_connection_user_has_license` is a boolean filter, so the error
+	 * must not reach it. An unknown plan is answered as absent on purpose: that
+	 * routes the reader to the licence they already own rather than to checkout.
+	 */
+	public function test_user_license_check_answers_a_boolean_when_the_plan_is_unknown() {
+		$this->sign_in_as_connected_admin();
+		add_filter( 'pre_http_request', array( $this, 'mock_wpcom_unreachable' ) );
+
+		$result = Jetpack_Backup::jetpack_check_user_licenses(
+			false,
+			array( (object) array( 'product_id' => 2112 ) ),
+			'jetpack-backup'
+		);
+
+		$this->assertTrue( $result );
 	}
 
 	public function test_list_backup_events_returns_response_and_pins_backup_actions_on_success() {

--- a/projects/plugins/backup/changelog/jetpack-2309b-plan-check-errors
+++ b/projects/plugins/backup/changelog/jetpack-2309b-plan-check-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report a WordPress.com failure on the Backup plan check as an error instead of as a missing plan.


### PR DESCRIPTION
Fixes JETPACK-2309

> **Stacked on #51869 — review that first.** This PR targets `jetpack-2309-plan-checks`, so the diff is only this change. GitHub re-targets it to `trunk` when that one merges.

## ⚠️ One open question for the reviewer

**When the plan is unknown, should the connect screen answer "no plan" or "has plan"?** This PR ships **no plan**. It terminates either way, so this is a product call rather than a correctness one.

| | answers `false` (this PR) | answers `true` |
| -- | -- | -- |
| what happens | the reader is sent to checkout | the account is linked, no charge |
| the risk | a site that owns Backup is asked to buy it again | a site with no plan links and sees the upsell on the dashboard instead |
| precedent | what the screen did before the route reported failures at all | — |

**Two screens make this call, not one.** `backup-connection-screen/index.jsx` answers it with `.catch( () => false )`; `Admin/hooks.js` answers it by leaving `siteHasBackupProduct` at its initial `false`, so during an outage a secondary admin falls past `BackupSecondaryAdminConnectionScreen` into the full `AdminPage` rather than the "log in to Jetpack" screen. That is much better than the permanent placeholder it replaces, and it is the same `false` — but it is a second instance of the decision, so it belongs in the table above rather than being resolved silently.

On the PHP side the decision is now made once, in `has_backup_plan()`, for every `bool` caller.

The argument for `false` got much stronger with #51869. Before it, `has_backup_plan()` was bounded at 2 seconds against a measured 780–1174ms round trip, so roughly **one call in six** answered "unknown" on a perfectly healthy site. With the bound at 5s, "unknown" now means only:

* a non-200 from WordPress.com,
* a transport failure,
* a 200 whose body carries no `state`, or
* a read that genuinely exceeds 5 seconds.

So the money-losing case now needs a real outage rather than ordinary latency. If you would rather not send anyone to checkout on an outage at all, the change is one character in `backup-connection-screen/index.jsx`.

## Proposed changes

* **New `get_backup_plan_state()`** returns `bool|WP_Error` instead of collapsing every failure to `false`. `get_rewind_state_from_wpcom()` forwards WordPress.com's own status through `get_failed_fetch_error()` — the same helper and the same shape as the seven routes JETPACK-2325 fixed in #51625. `GET /jetpack/v4/has-backup-plan` now serves this.
* **`has_backup_plan()` keeps its `bool` contract** and wraps it (`! is_wp_error( $state ) && $state`). It is `public static` in the versioned namespace `Automattic\Jetpack\Backup\V0005`, `WP_Error` is truthy, and both `plugins/backup` and `plugins/jetpack` bundle the package — so widening it would not *error* a consumer written against `bool`, it would quietly answer the opposite question. Keeping it also puts "a plan we could not read is absent" in one place instead of two: `jetpack_check_user_licenses()` needs no `is_wp_error` branch of its own.
* `src/js/components/Admin/hooks.js` gains a rejection path. It was a bare `.then()`, so a rejection left `isLoading` true and a secondary admin sat on a placeholder forever.
* `src/js/components/backup-connection-screen/index.jsx` gains one too. It passed the raw promise to `ConnectScreenRequiredPlan`, where an unrejected promise stalls the purchase button, because `hasCheckoutStarted` only clears by navigating away.
* The new `rewind_state_unreadable` message uses `esc_html__()` and is worded without an apostrophe, matching `get_failed_fetch_error()` and the other three strings in the file rather than disagreeing with them.

### Why this is a second PR rather than part of #51869

The error contract and the two rejection paths have to land together. Shipping the contract alone trades a wrong answer for a permanent spinner, which is worse. Splitting the other way — rejection paths first — would be dead code. `/has-backup-plan` was deliberately excluded from JETPACK-2325's seven routes for exactly this reason.

## Related product discussion/links

* Linear: JETPACK-2309 (task I3), under the Backup modernization project.
* Depends on #51869. Its I4 half shipped as JETPACK-2325 / #51625.

## Does this pull request change what data or activity we track or use?

No. Same endpoint, same token, same callers. Only the shape of a failed answer changes.

## Testing instructions

This is reachable with the modernization filter **off** — it backs the legacy dashboard and the licence-activation filter — so it is not a no-op.

Automated, from `projects/packages/backup`: `composer phpunit` — 407 tests / 1062 assertions. `composer phpcs:changed` clean, `jetpack phan packages/backup` 0 issues.

The PHP tests are mutation-checked:

* Widening `has_backup_plan()` back to `bool|WP_Error` (`return $state;`) fails `test_has_backup_plan_stays_a_boolean_when_the_read_fails` and `test_user_license_check_answers_a_boolean_when_the_plan_is_unknown`.
* Pointing the route back at `::has_backup_plan` fails `test_has_backup_plan_route_serves_a_failure_as_an_error`.
* Inverting `'unavailable' !==` fails `test_has_backup_plan_answers_false_for_an_unavailable_state` (`true is false`), with `test_has_backup_plan_reads_a_string_status_200` failing the other way as the positive control.

**Honest gap: neither JS rejection path has test coverage.** The legacy `src/js/` tree has no harness for these hooks — only `src/js/actions/test/` — and standing one up is a bigger piece of work than the fix. The PHP side is mutation-checked; the JS side is verified by reading only.

By hand, on a connected site:

1. With a Backup plan, confirm nothing changed: `/wp-json/jetpack/v4/has-backup-plan` returns `true`, and the dashboard behaves as before.
2. Simulate an outage with a mu-plugin returning a 503 from `pre_http_request` for the `/rewind` call. The route should now answer **503**, not a 200 carrying `false`.
3. As a secondary admin (no WordPress.com connection of your own) under that same simulated outage, open the Backup page. Expect the screen to settle rather than spin — before this change it stayed on the loading placeholder forever.
4. Under the same outage, click **Get VaultPress Backup** on the connect screen. Expect it to complete rather than hang. Whether it should route to checkout or link the account is the open question above.
5. With a plan of `{"state":"unavailable"}`, confirm the legitimate negative survives: the route answers `false` at HTTP 200, not an error.

## Notes

The wpcom side has been checked: outside the vendored copies of this package itself, nothing in that repo references `has-backup-plan` or `has_backup_plan`. Verified with a positive control — the same grep finds the four vendored files — so the route has no consumer beyond the two in this repo, both handled here.

The shared-hook gap this exposed is tracked separately as JETPACK-2479. `useProductCheckoutWorkflow`'s `handleAfterRegistration()` has no rejection path, which is why the `catch` here sits at the call site rather than in the hook.
