### PR TITLE
Search: drop the Preview label from AI Answers

### DIFF
--- a/projects/packages/search/changelog/update-search-drop-ai-answers-preview
+++ b/projects/packages/search/changelog/update-search-drop-ai-answers-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Drop the Preview label from AI Answers.

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -327,12 +327,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						<Tabs.List variant="minimal">
 							<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-search-pkg' ) }</Tabs.Tab>
 							<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-search-pkg' ) }</Tabs.Tab>
-							<Tabs.Tab value="ai-answers">
-								{ __( 'AI Answers', 'jetpack-search-pkg' ) }
-								<span className="jp-search-dashboard-tabs__tab-preview-label">
-									&nbsp;{ __( '(Preview)', 'jetpack-search-pkg' ) }
-								</span>
-							</Tabs.Tab>
+							<Tabs.Tab value="ai-answers">{ __( 'AI Answers', 'jetpack-search-pkg' ) }</Tabs.Tab>
 						</Tabs.List>
 					</div>
 					<Tabs.Panel value="overview">

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -564,7 +564,7 @@ const searchBlocksPricingItems = [
 const aiAnswersPricingItems = [
 	{
 		id: 'ai-answers',
-		name: __( 'AI Answers (Preview)', 'jetpack-search-pkg' ),
+		name: __( 'AI Answers', 'jetpack-search-pkg' ),
 		tooltipInfo: __(
 			'Let visitors ask a question and get an instant, AI-generated answer drawn from your own content — right at the top of the search results.',
 			'jetpack-search-pkg'

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/test/index.test.jsx
@@ -139,12 +139,12 @@ describe( 'UpsellPage pricing grid — AI Answers (paid-only)', () => {
 	test( 'always shows the AI Answers row regardless of the Search blocks gate', () => {
 		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: false } );
 		const { unmount } = render( <UpsellPage /> );
-		expect( screen.getByText( 'AI Answers (Preview)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'AI Answers' ) ).toBeInTheDocument();
 		unmount();
 
 		mockSelectMethods = createSelectMethods( { isSearchBlocksEnabled: true } );
 		render( <UpsellPage /> );
-		expect( screen.getByText( 'AI Answers (Preview)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'AI Answers' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Jetpack Search blocks' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -101,7 +101,7 @@ const SECTIONS = [
 		features: [
 			{
 				key: 'ai_search',
-				label: __( 'AI Search', 'jetpack' ),
+				label: __( 'AI Answers', 'jetpack' ),
 				description: __(
 					'Help visitors and AI agents find answers in your content, via Jetpack Search.',
 					'jetpack'
@@ -228,7 +228,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 	// The badge tooltip names the remedy for the gated Search section. A site
 	// with a paid Search plan is pointed at Search setup; one with no Search
 	// entitlement — or only the free tier, which reports supports_search but
-	// cannot run AI Search — is asked to upgrade instead. Unlike the gates
+	// cannot run AI Answers — is asked to upgrade instead. Unlike the gates
 	// above this defaults to the upgrade copy: pointing an unentitled site at
 	// setup would send it down the wrong path, and the badge cannot render
 	// before the payload (which carries `plan`) has arrived anyway.

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -129,7 +129,7 @@ describe( 'AiFeatures rendering', () => {
 		renderFeatures();
 
 		expect( screen.getByText( 'Requires upgrade' ) ).toBeInTheDocument();
-		const toggle = screen.getByRole( 'checkbox', { name: /AI Search/ } );
+		const toggle = screen.getByRole( 'checkbox', { name: /AI Answers/ } );
 		expect( toggle ).toBeDisabled();
 		expect( toggle ).not.toBeChecked();
 		const searchGroup = screen.getByRole( 'region', { name: 'Search' } );
@@ -156,7 +156,7 @@ describe( 'AiFeatures rendering', () => {
 	} );
 
 	test( 'free Search plan: the remedy is an upgrade, not setup', async () => {
-		// The free tier reports supports_search, but AI Search needs the paid
+		// The free tier reports supports_search, but AI Answers needs the paid
 		// product — the setup copy would send the user down the wrong path.
 		renderFeatures( {
 			plan: { supports_ai: true, supports_search: true, is_free_search_plan: true },
@@ -282,9 +282,9 @@ describe( 'AiFeatures rendering', () => {
 		renderFeatures( { is_connected: true, plan: { supports_ai: false } } );
 
 		// The per-feature requires_upgrade path is the only upgrade surface —
-		// AI Search stays gated while the free-tier rows work.
+		// AI Answers stays gated while the free-tier rows work.
 		expect( screen.getByText( 'Requires upgrade' ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'checkbox', { name: /AI Search/ } ) ).toBeDisabled();
+		expect( screen.getByRole( 'checkbox', { name: /AI Answers/ } ) ).toBeDisabled();
 	} );
 
 	test( 'free plan AND master off: the master-off notice shows', () => {
@@ -453,7 +453,7 @@ describe( 'AiFeatures rendering', () => {
 			'upload.php?ai-assistant'
 		);
 
-		// AI Search opens the Search dashboard on its AI tab, not Overview.
+		// AI Answers opens the Search dashboard on its AI tab, not Overview.
 		expect( screen.getByRole( 'link', { name: 'Open Search Settings' } ) ).toHaveAttribute(
 			'href',
 			'admin.php?page=jetpack-search#/ai-answers'

--- a/projects/plugins/jetpack/changelog/update-search-drop-ai-answers-preview
+++ b/projects/plugins/jetpack/changelog/update-search-drop-ai-answers-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Rename the AI Search row to AI Answers, and drop the Preview label from the Search dashboard.

--- a/projects/plugins/search/changelog/update-search-drop-ai-answers-preview
+++ b/projects/plugins/search/changelog/update-search-drop-ai-answers-preview
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Drop the Preview label from AI Answers.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Drops the "(Preview)" label from AI Answers in two places: the Search dashboard tab, and the AI Answers row of the upsell pricing grid.
* Renames the "AI Search" row on Jetpack AI → WordPress Agent to "AI Answers", so both surfaces call the feature the same thing.

Labels only — the tab, its panel, the "Enable AI Answers" toggle, the `ai_search` settings key and the `#/ai-answers` link are all unchanged.

Follows the discussion on #51690, which proposed the opposite rename (AI Answers → AI Search) and was closed: Jetpack Search is still keyword-based, so "AI Search" over-promises, and the "Preview" label has outlived the early-launch decision behind it.

## Related product discussion/links

* JETPACK-2384

## Does this pull request change what data or activity we track or use?

No.

## Before / after

Captured on an Atomic site with a paid Search plan, trunk vs. this branch.

**Search dashboard tab** — `admin.php?page=jetpack-search`

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/before-search-tab.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/after-search-tab.png) |

**Jetpack AI → WordPress Agent** — `admin.php?page=jetpack-ai#/features`

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/before-ai-hub.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/after-ai-hub.png) |

<details><summary>Full-page versions</summary>

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/before-search-full.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/after-search-full.png) |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/before-ai-hub-full.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/search-drop-ai-answers-preview/after-ai-hub-full.png) |

</details>

## Testing instructions

1. On a site with a paid Jetpack Search plan, go to `https://<your-site>/wp-admin/admin.php?page=jetpack-search`.
2. The third tab reads "AI Answers". Before this change it read "AI Answers (Preview)".
3. Click it — the AI Answers panel and its "Enable AI Answers" toggle work as before.
4. On a site with no paid Search plan, go to the same page to get the upgrade screen. In the pricing comparison grid, the row reads "AI Answers". Before this change it read "AI Answers (Preview)".
5. Go to `https://<your-site>/wp-admin/admin.php?page=jetpack#/ai/features`. In the Search section, the row reads "AI Answers". Before this change it read "AI Search".
6. Click "Open Search Settings" on that row — it still opens the Search dashboard on its AI Answers tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Y4JbiPDYw3srmyBc7ttiC
