### PR TITLE
tests: Drop unneeded PHPUnit polyfill

### DIFF
--- a/projects/packages/changelogger/changelog/remove-unneeded-yoast-polyfill
+++ b/projects/packages/changelogger/changelog/remove-unneeded-yoast-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove no-longer-needed use of `Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames`, now that we've dropped PHP <7.4 and PHPUnit <9.6.
+
+

--- a/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
@@ -22,7 +22,6 @@ use Wikimedia\TestingAccessWrapper;
  */
 #[CoversClass( \Automattic\Jetpack\Changelogger\AddCommand::class )]
 class AddCommandTest extends CommandTestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ApplicationTest.php
@@ -23,7 +23,6 @@ use Wikimedia\TestingAccessWrapper;
  */
 #[CoversClass( Application::class )]
 class ApplicationTest extends TestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/changelogger/tests/php/tests/src/SquashCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/SquashCommandTest.php
@@ -26,7 +26,6 @@ use Wikimedia\TestingAccessWrapper;
  */
 #[CoversClass( SquashCommand::class )]
 class SquashCommandTest extends CommandTestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
@@ -29,7 +29,6 @@ use Symfony\Component\Process\Process;
 #[CoversClass( Utils::class )]
 class UtilsTest extends TestCase {
 	use \Yoast\PHPUnitPolyfills\Polyfills\AssertObjectProperty;
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Test runCommand.

--- a/projects/packages/changelogger/tests/php/tests/src/ValidateCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/ValidateCommandTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[CoversClass( \Automattic\Jetpack\Changelogger\ValidateCommand::class )]
 class ValidateCommandTest extends CommandTestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/changelogger/tests/php/tests/src/VersionCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/VersionCommandTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 #[CoversClass( \Automattic\Jetpack\Changelogger\VersionCommand::class )]
 class VersionCommandTest extends CommandTestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/WriteCommandTest.php
@@ -26,7 +26,6 @@ use Wikimedia\TestingAccessWrapper;
  */
 #[CoversClass( WriteCommand::class )]
 class WriteCommandTest extends CommandTestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Set up.

--- a/projects/packages/connection/changelog/remove-unneeded-yoast-polyfill
+++ b/projects/packages/connection/changelog/remove-unneeded-yoast-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove no-longer-needed use of `Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames`, now that we've dropped PHP <7.4 and PHPUnit <9.6.
+
+

--- a/projects/packages/connection/tests/php/Connection_Notice_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Notice_Test.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
  * The nonce handler tests.
  */
 class Connection_Notice_Test extends TestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Handle of the script that drives the "choose new owner" form.

--- a/projects/packages/masterbar/changelog/remove-unneeded-yoast-polyfill
+++ b/projects/packages/masterbar/changelog/remove-unneeded-yoast-polyfill
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove no-longer-needed use of `Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames`, now that we've dropped PHP <7.4 and PHPUnit <9.6.
+
+

--- a/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/masterbar/tests/php/Admin_Menu_Test.php
@@ -23,7 +23,6 @@ require_once __DIR__ . '/data/admin-menu.php';
  */
 #[CoversClass( Admin_Menu::class )]
 class Admin_Menu_Test extends TestCase {
-	use \Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
 
 	/**
 	 * Menu data fixture.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Since we've dropped support for PHP <7.4, and therefore PHPUnit <9.6, we no longer need to use `Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Kind of a followup to #51515, I guess.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?