### PR TITLE
tests: Use PHPUnit `assertMatchesRegularExpression` when applicable

### DIFF
--- a/projects/packages/connection/changelog/fix-phpunit-assertsame-preg_match
+++ b/projects/packages/connection/changelog/fix-phpunit-assertsame-preg_match
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` where applicable, versus things like `assertSame( 1, preg_match( ... ) )`.
+
+

--- a/projects/packages/connection/tests/php/identity-crisis/URL_Secret_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/URL_Secret_Test.php
@@ -42,8 +42,8 @@ class URL_Secret_Test extends TestCase {
 
 		static::assertTrue( $is_created );
 		static::assertTrue( $does_exist );
-		static::assertSame( 1, preg_match( '/^[a-z0-9]{12}$/i', $secret ) );
-		static::assertTrue( (bool) preg_match( '/^\d+$/', $expires_at ) );
+		static::assertMatchesRegularExpression( '/^[a-z0-9]{12}$/i', $secret );
+		static::assertMatchesRegularExpression( '/^\d+$/', $expires_at );
 		static::assertEquals( strlen( (string) time() ), strlen( $expires_at ) );
 	}
 

--- a/projects/packages/cookie-consent/changelog/fix-phpunit-assertsame-preg_match
+++ b/projects/packages/cookie-consent/changelog/fix-phpunit-assertsame-preg_match
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` where applicable, versus things like `assertSame( 1, preg_match( ... ) )`.
+
+

--- a/projects/packages/cookie-consent/tests/php/Consent_Log_Controller_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Consent_Log_Controller_Test.php
@@ -630,7 +630,7 @@ class Consent_Log_Controller_Test extends TestCase {
 
 		// Retry-After is the seconds left in the current window (1..window); Reset mirrors it.
 		$retry_after = $headers['Retry-After'];
-		$this->assertSame( 1, preg_match( '/^[0-9]+$/', (string) $retry_after ) );
+		$this->assertMatchesRegularExpression( '/^[0-9]+$/', (string) $retry_after );
 		$this->assertGreaterThanOrEqual( 1, (int) $retry_after );
 		$this->assertLessThanOrEqual( 60, (int) $retry_after );
 		$this->assertSame( $retry_after, $headers['RateLimit-Reset'] );

--- a/projects/packages/cookie-consent/tests/php/Cookie_Banner_Content_Test.php
+++ b/projects/packages/cookie-consent/tests/php/Cookie_Banner_Content_Test.php
@@ -44,16 +44,6 @@ class Cookie_Banner_Content_Test extends TestCase {
 	}
 
 	/**
-	 * Assert that a string matches a regex pattern.
-	 *
-	 * @param string $pattern Regex pattern.
-	 * @param string $string  String to check.
-	 */
-	private function assert_string_matches_pattern( $pattern, $string ) {
-		$this->assertSame( 1, preg_match( $pattern, $string ) );
-	}
-
-	/**
 	 * Empty cookie policy URLs hide the Cookie Policy link.
 	 */
 	public function test_empty_cookie_policy_url_hides_cookie_policy_link() {
@@ -71,7 +61,7 @@ class Cookie_Banner_Content_Test extends TestCase {
 		$this->assertStringNotContainsString( 'Cookie Policy', $html );
 		$this->assertStringNotContainsString( 'automattic.com/cookies', $html );
 		// The lead-in introduces the single Privacy Policy link.
-		$this->assert_string_matches_pattern( '/Learn more in our\\s*<a [^>]*>\\s*Privacy Policy\\s*<\\/a>\\./', $html );
+		$this->assertMatchesRegularExpression( '/Learn more in our\\s*<a [^>]*>\\s*Privacy Policy\\s*<\\/a>\\./', $html );
 	}
 
 	/**
@@ -94,7 +84,7 @@ class Cookie_Banner_Content_Test extends TestCase {
 		$links_pattern = '/Privacy Policy\\s*<\\/a>\\s+and\\s+'
 			. '<a href="https:\\/\\/example\\.com\\/cookies\\/"[^>]*>\\s*'
 			. 'Cookie Policy\\s*<\\/a>\\./';
-		$this->assert_string_matches_pattern(
+		$this->assertMatchesRegularExpression(
 			$links_pattern,
 			$html
 		);
@@ -114,7 +104,7 @@ class Cookie_Banner_Content_Test extends TestCase {
 
 		$this->assertStringNotContainsString( 'Cookie Policy', $html );
 		$this->assertStringNotContainsString( 'href="https://example.com/top-level-cookies/"', $html );
-		$this->assert_string_matches_pattern( '/Privacy Policy\\s*<\\/a>\\s*\\./', $html );
+		$this->assertMatchesRegularExpression( '/Privacy Policy\\s*<\\/a>\\s*\\./', $html );
 	}
 
 	/**
@@ -133,7 +123,7 @@ class Cookie_Banner_Content_Test extends TestCase {
 
 		$this->assertStringContainsString( 'Privacy Policy', $html );
 		$this->assertStringNotContainsString( 'Cookie Policy', $html );
-		$this->assert_string_matches_pattern( '/Privacy Policy\\s*<\\/a>\\./', $html );
+		$this->assertMatchesRegularExpression( '/Privacy Policy\\s*<\\/a>\\./', $html );
 	}
 
 	/**
@@ -153,7 +143,7 @@ class Cookie_Banner_Content_Test extends TestCase {
 		$this->assertStringNotContainsString( 'jetpack-cookie-consent__link', $html );
 		// With no links to introduce, the "Learn more in our" lead-in must not render either.
 		$this->assertStringNotContainsString( 'Learn more in our', $html );
-		$this->assert_string_matches_pattern( '/settings below\\.\\s*<\\/p>/', $html );
+		$this->assertMatchesRegularExpression( '/settings below\\.\\s*<\\/p>/', $html );
 	}
 
 	/**

--- a/projects/packages/search/changelog/fix-phpunit-assertsame-preg_match
+++ b/projects/packages/search/changelog/fix-phpunit-assertsame-preg_match
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` where applicable, versus things like `assertSame( 1, preg_match( ... ) )`.
+
+

--- a/projects/packages/search/tests/php/Filter_Wc_Attribute_Render_Test.php
+++ b/projects/packages/search/tests/php/Filter_Wc_Attribute_Render_Test.php
@@ -146,9 +146,9 @@ class Filter_Wc_Attribute_Render_Test extends TestCase {
 		// paint. Match `hidden` only as a standalone attribute (preceded by
 		// whitespace, followed by whitespace / `>` / `=`) so the assertion can't
 		// be satisfied by `data-wp-bind--hidden` or `aria-hidden`.
-		$this->assertSame( 1, preg_match( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		$this->assertMatchesRegularExpression( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup );
 		// The wrapper is hidden too — no buckets and no initial load.
-		$this->assertSame( 1, preg_match( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		$this->assertMatchesRegularExpression( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup );
 	}
 
 	/**
@@ -168,8 +168,8 @@ class Filter_Wc_Attribute_Render_Test extends TestCase {
 		// `hidden` only as a standalone attribute so the indirect bindings
 		// (`data-wp-bind--hidden`, `aria-hidden`, `wrapperHidden`) don't
 		// false-positive.
-		$this->assertSame( 0, preg_match( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
-		$this->assertSame( 0, preg_match( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup ) );
+		$this->assertDoesNotMatchRegularExpression( '/<div[^>]*\s+hidden(?=\s|\/|>|=)/', $markup );
+		$this->assertDoesNotMatchRegularExpression( '/<ul[^>]*\s+hidden(?=\s|\/|>|=)/', $markup );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Render_Test.php
@@ -94,14 +94,14 @@ class Filters_Popover_Render_Test extends TestCase {
 	 */
 	public function test_panel_has_no_hidden_attribute_or_dialog_role() {
 		$markup = $this->render();
-		$this->assertSame(
-			0,
-			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*\bhidden\b[^>]*>/', $markup ),
+		$this->assertDoesNotMatchRegularExpression(
+			'/<div[^>]*jetpack-search-filters-popover__panel[^>]*\bhidden\b[^>]*>/',
+			$markup,
 			'panel must not carry the hidden attribute'
 		);
-		$this->assertSame(
-			0,
-			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="dialog"[^>]*>/', $markup ),
+		$this->assertDoesNotMatchRegularExpression(
+			'/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="dialog"[^>]*>/',
+			$markup,
 			'panel must not carry role="dialog"'
 		);
 		$this->assertStringNotContainsString( 'data-wp-bind--hidden="!state.isFilterPopoverOpen"', $markup );
@@ -114,14 +114,14 @@ class Filters_Popover_Render_Test extends TestCase {
 	 */
 	public function test_panel_exposes_search_filters_landmark() {
 		$markup = $this->render();
-		$this->assertSame(
-			1,
-			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="region"[^>]*>/', $markup ),
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*jetpack-search-filters-popover__panel[^>]*role="region"[^>]*>/',
+			$markup,
 			'panel must carry role="region"'
 		);
-		$this->assertSame(
-			1,
-			preg_match( '/<div[^>]*jetpack-search-filters-popover__panel[^>]*aria-label="Search filters"[^>]*>/', $markup ),
+		$this->assertMatchesRegularExpression(
+			'/<div[^>]*jetpack-search-filters-popover__panel[^>]*aria-label="Search filters"[^>]*>/',
+			$markup,
 			'panel must carry aria-label="Search filters"'
 		);
 	}

--- a/projects/packages/search/tests/php/No_Results_Render_Test.php
+++ b/projects/packages/search/tests/php/No_Results_Render_Test.php
@@ -262,12 +262,9 @@ class No_Results_Render_Test extends TestCase {
 		// condition, not loose in the container. Only the nesting is asserted:
 		// the paragraph's attributes come from core, and WP 7.0 adds a
 		// `wp-block-paragraph` class to them.
-		$this->assertSame(
-			1,
-			preg_match(
-				'/<div class="jetpack-search-no-results__variant"[^>]*>\s*<p[^>]*>STRAY COPY<\/p>\s*<\/div>/',
-				$markup
-			),
+		$this->assertMatchesRegularExpression(
+			'/<div class="jetpack-search-no-results__variant"[^>]*>\s*<p[^>]*>STRAY COPY<\/p>\s*<\/div>/',
+			$markup,
 			'the stray block must be wrapped in an unscoped variant'
 		);
 		$this->assertStringContainsString( 'data-wp-bind--hidden="!state.showNoResultsFiltered"', $markup );

--- a/projects/plugins/boost/changelog/fix-phpunit-assertsame-preg_match
+++ b/projects/plugins/boost/changelog/fix-phpunit-assertsame-preg_match
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` where applicable, versus things like `assertSame( 1, preg_match( ... ) )`.
+
+

--- a/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
+++ b/projects/plugins/boost/tests/php/lib/critical-css/Critical_CSS_Storage_Test.php
@@ -413,9 +413,9 @@ class Critical_CSS_Storage_Test extends BaseTestCase {
 		// Assert the pattern directly as well. Naming an absent class makes unserialize()
 		// fail on its own, so the outcome below is the same with E: dropped from the
 		// pattern, and narrowing it to [OC] would otherwise pass the whole suite.
-		$this->assertSame(
-			1,
-			preg_match( Storage_Post_Type::OBJECT_TOKEN_PATTERN, $payload ),
+		$this->assertMatchesRegularExpression(
+			Storage_Post_Type::OBJECT_TOKEN_PATTERN,
+			$payload,
 			'The wire-format check must still recognise an E: enum token.'
 		);
 

--- a/projects/plugins/jetpack/changelog/fix-phpunit-assertsame-preg_match
+++ b/projects/plugins/jetpack/changelog/fix-phpunit-assertsame-preg_match
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Tests: Use `assertMatchesRegularExpression` and `assertDoesNotMatchRegularExpression` where applicable, versus things like `assertSame( 1, preg_match( ... ) )`.
+
+

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -821,9 +821,9 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			preg_match_all( '/add_action\s*\(\s*[\'"]init[\'"]/', $source ),
 			"Lazy block {$feature} must add exactly one init registration callback."
 		);
-		$this->assertSame(
-			0,
-			preg_match( '/jetpack_register_block\s*\(\s*[\'"](?!jetpack\/' . preg_quote( $feature, '/' ) . '[\'"])/', $source ),
+		$this->assertDoesNotMatchRegularExpression(
+			'/jetpack_register_block\s*\(\s*[\'"](?!jetpack\/' . preg_quote( $feature, '/' ) . '[\'"])/',
+			$source,
 			"Lazy block {$feature} must not explicitly register a differently named block."
 		);
 		$this->assertStringNotContainsString( 'render_email_callback', $source, "Lazy block {$feature} must not register an e-mail renderer." );

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Endpoint_Rest_Route_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Endpoint_Rest_Route_Test.php
@@ -136,7 +136,7 @@ class WPCOM_JSON_API_Endpoint_Rest_Route_Test extends WP_UnitTestCase {
 		$pattern  = $endpoint->build_rest_route_regex();
 		$concrete = $endpoint->build_concrete_rest_route( $url );
 
-		$this->assertSame( 1, preg_match( '#^' . $pattern . '$#', $concrete ), "Concrete route '$concrete' should match registered pattern '$pattern'." );
+		$this->assertMatchesRegularExpression( '#^' . $pattern . '$#', $concrete, "Concrete route '$concrete' should match registered pattern '$pattern'." );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
These could have been being used all along with `Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames`, but it seems devs weren't aware of that and did like `assertSame( 1, preg_match( ... ) )` in various places.

Now that we've dropped support for PHP <7.4 and therefore PHPUnit <9.6, we don't even need the polyfill anymore.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
Kind of a followup to #51515, I guess

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?