### PR TITLE
Connection: ensure registration errors reach the Jetpack dashboard notice

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -25,6 +25,27 @@ class JetpackStateNotices extends Component {
 		this.setState( { showNotice: false } );
 	};
 
+	/**
+	 * Generic copy for error codes that have no message of their own.
+	 *
+	 * @param {string} key - The error code.
+	 * @return {object} Message element.
+	 */
+	getGenericErrorMessage = key =>
+		createInterpolateElement(
+			sprintf(
+				/* translators: %s: an error code and message. */
+				__(
+					'<s>Your Jetpack has a glitch.</s> We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
+					'jetpack'
+				),
+				key
+			),
+			{
+				s: <strong />,
+			}
+		);
+
 	getErrorFromKey = key => {
 		const errorDesc = this.props.jetpackStateNoticesErrorDescription || false;
 		let message;
@@ -150,23 +171,14 @@ class JetpackStateNotices extends Component {
 			case 'verify_secret_1_malformed':
 			case 'verify_secrets_missing':
 			case 'verify_secrets_mismatch':
-				message = createInterpolateElement(
-					sprintf(
-						/* translators: %s: an error code and message. */
-						__(
-							'<s>Your Jetpack has a glitch.</s> We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
-							'jetpack'
-						),
-						key
-					),
-					{
-						s: <strong />,
-					}
-				);
+				message = this.getGenericErrorMessage( key );
 				break;
 
 			default:
-				message = key;
+				// Codes with no case of their own. When a description was supplied it
+				// carries the detail, so frame the code rather than presenting it as
+				// Jetpack's own message. With no description, show the key unchanged.
+				message = errorDesc ? this.getGenericErrorMessage( key ) : key;
 		}
 
 		if ( errorDesc ) {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -36,7 +36,7 @@ class JetpackStateNotices extends Component {
 			sprintf(
 				/* translators: %s: an error code. */
 				__(
-					"<s>Your Jetpack has a glitch.</s> We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
+					'<s>Your Jetpack has a glitch.</s> We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
 					'jetpack'
 				),
 				key
@@ -177,10 +177,8 @@ class JetpackStateNotices extends Component {
 				break;
 
 			default:
-				// Codes with no case of their own. When a description was supplied it
-				// carries the detail, so frame the code rather than presenting it as
-				// Jetpack's own message. With no description, show the key unchanged.
-				message = errorDesc ? this.getGenericErrorMessage( key ) : key;
+				// Codes with no case of their own get generic glitch copy; errorDesc (if any) is appended below.
+				message = this.getGenericErrorMessage( key );
 		}
 
 		if ( errorDesc ) {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/state-notices.jsx
@@ -29,14 +29,14 @@ class JetpackStateNotices extends Component {
 	 * Generic copy for error codes that have no message of their own.
 	 *
 	 * @param {string} key - The error code.
-	 * @return {object} Message element.
+	 * @return {Element} Message element.
 	 */
 	getGenericErrorMessage = key =>
 		createInterpolateElement(
 			sprintf(
-				/* translators: %s: an error code and message. */
+				/* translators: %s: an error code. */
 				__(
-					'<s>Your Jetpack has a glitch.</s> We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s',
+					"<s>Your Jetpack has a glitch.</s> We're sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: %s",
 					'jetpack'
 				),
 				key
@@ -142,6 +142,8 @@ class JetpackStateNotices extends Component {
 				break;
 			case 'no_role':
 			case 'no_cap':
+			case 'cannot_save_secrets':
+			case 'jetpack_id':
 			case 'no_code':
 			case 'no_state':
 			case 'invalid_state':

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/state-notices.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/state-notices.test.jsx
@@ -61,11 +61,12 @@ describe( 'JetpackStateNotices', () => {
 		);
 	} );
 
-	it( 'shows an unmapped code unchanged when there is no description', () => {
+	it( 'frames an unmapped code with generic copy when there is no description', () => {
 		renderWithState( { errorCode: 'xml_rpc-32601', errorDescription: '' } );
 
-		expect( screen.getByText( 'xml_rpc-32601' ) ).toBeInTheDocument();
-		expect( screen.queryByText( /Your Jetpack has a glitch/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText( /contact support with this message: xml_rpc-32601/ )
+		).toBeInTheDocument();
 	} );
 
 	it( 'renders nothing without an error or message code', () => {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/state-notices.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/state-notices.test.jsx
@@ -1,0 +1,76 @@
+import { render, screen } from 'test/test-utils';
+import JetpackStateNotices from '../state-notices';
+
+/**
+ * Render the notice with the given Jetpack state.
+ *
+ * @param {object} jetpackStateNotices - The `jetpackStateNotices` initial state.
+ * @return {object} Render result.
+ */
+function renderWithState( jetpackStateNotices ) {
+	return render( <JetpackStateNotices />, {
+		initialState: { jetpack: { initialState: { jetpackStateNotices } } },
+	} );
+}
+
+describe( 'JetpackStateNotices', () => {
+	it( 'frames jetpack_id rather than showing the raw response body', () => {
+		renderWithState( { errorCode: 'jetpack_id', errorDescription: '' } );
+
+		expect(
+			screen.getByText( /contact support with this message: jetpack_id/ )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( /Do not publicly post this error message/ )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'frames cannot_save_secrets and keeps its message as the description', () => {
+		const { container } = renderWithState( {
+			errorCode: 'cannot_save_secrets',
+			errorDescription: 'Ask your hosting provider whether the options table is writable.',
+		} );
+
+		expect(
+			screen.getByText( /contact support with this message: cannot_save_secrets/ )
+		).toBeInTheDocument();
+		// The description is a text node beside the message, so assert on the notice's text.
+		expect( container ).toHaveTextContent(
+			'Ask your hosting provider whether the options table is writable.'
+		);
+	} );
+
+	it( 'shows the WordPress.com outage copy for wpcom_bad_response with no status number', () => {
+		renderWithState( { errorCode: 'wpcom_bad_response', errorDescription: '' } );
+
+		expect( screen.getByText( /WordPress\.com is currently having problems/ ) ).toBeInTheDocument();
+		expect( screen.queryByText( '503' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'frames an unmapped code when a description was supplied', () => {
+		const { container } = renderWithState( {
+			errorCode: 'xml_rpc-32601',
+			errorDescription: 'requested method jetpack.verifyRegistration does not exist',
+		} );
+
+		expect(
+			screen.getByText( /contact support with this message: xml_rpc-32601/ )
+		).toBeInTheDocument();
+		expect( container ).toHaveTextContent(
+			'requested method jetpack.verifyRegistration does not exist'
+		);
+	} );
+
+	it( 'shows an unmapped code unchanged when there is no description', () => {
+		renderWithState( { errorCode: 'xml_rpc-32601', errorDescription: '' } );
+
+		expect( screen.getByText( 'xml_rpc-32601' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Your Jetpack has a glitch/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing without an error or message code', () => {
+		const { container } = renderWithState( {} );
+
+		expect( container ).toHaveTextContent( '' );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/fix-registration-error-state-key
+++ b/projects/plugins/jetpack/changelog/fix-registration-error-state-key
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Connection: Show the reason a site registration failed, in cases where the notice was incomplete or did not appear at all.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4256,6 +4256,26 @@ p {
 	 */
 
 	/**
+	 * Build the user-facing description stored alongside a registration error code.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $error_code The WP_Error code.
+	 * @param string $message    The WP_Error message.
+	 * @return string The description, empty when the message is not user-facing copy.
+	 */
+	public static function get_registration_error_description( $error_code, $message ) {
+		// Manager::validate_remote_register_response() does not always put user-facing copy in the
+		// message slot: wpcom_5??, wpcom_408 and wpcom_bad_response store the HTTP status there,
+		// and jetpack_id stores the raw response body, which can also overflow the state cookie.
+		if ( 'jetpack_id' === $error_code || is_numeric( $message ) ) {
+			return '';
+		}
+
+		return mb_substr( (string) $message, 0, 500 );
+	}
+
+	/**
 	 * Handles the page load events for the Jetpack admin page
 	 */
 	public function admin_page_load() {
@@ -4293,7 +4313,8 @@ p {
 					if ( is_wp_error( $registered ) ) {
 						$error = $registered->get_error_code();
 						self::state( 'error', $error );
-						self::state( 'error_description', $registered->get_error_message() );
+
+						self::state( 'error_description', self::get_registration_error_description( $error, $registered->get_error_message() ) );
 
 						/**
 						 * Jetpack registration Error.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4293,7 +4293,7 @@ p {
 					if ( is_wp_error( $registered ) ) {
 						$error = $registered->get_error_code();
 						self::state( 'error', $error );
-						self::state( 'error', $registered->get_error_message() );
+						self::state( 'error_description', $registered->get_error_message() );
 
 						/**
 						 * Jetpack registration Error.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4272,7 +4272,7 @@ p {
 			return '';
 		}
 
-		return mb_substr( (string) $message, 0, 500 );
+		return mb_substr( (string) $message, 0, 250 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -20,6 +20,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/ai/test/tracks.js',
 		'<rootDir>/_inc/client/at-a-glance/boost/test/component.jsx',
+		'<rootDir>/_inc/client/components/jetpack-notices/test/state-notices.test.jsx',
 		'<rootDir>/_inc/client/sharing/test/component.jsx',
 		'<rootDir>/_inc/client/traffic/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
@@ -1203,4 +1203,45 @@ EXPECTED;
 			get_option( 'jetpack_active_plan' )
 		);
 	}
+
+	/**
+	 * Data provider for test_get_registration_error_description.
+	 *
+	 * @return array
+	 */
+	public static function provider_registration_error_description() {
+		$long = str_repeat( 'a', 600 );
+
+		return array(
+			'a status code is not copy'         => array( 'wpcom_5??', '503', '' ),
+			'a status code as an int'           => array( 'wpcom_408', 408, '' ),
+			'the jetpack_id response body'      => array( 'jetpack_id', 'Error Details: Jetpack ID is empty. Do not publicly post this error message! {"body":"..."}', '' ),
+			'a real message is kept'            => array( 'cannot_save_secrets', 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.', 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.' ),
+			'an empty message stays empty'      => array( 'missing_secrets', '', '' ),
+			'an over-long message is truncated' => array( 'some_code', $long, str_repeat( 'a', 500 ) ),
+		);
+	}
+
+	/**
+	 * @param string     $error_code The error code.
+	 * @param string|int $message    The error message.
+	 * @param string     $expected   The expected description.
+	 * @dataProvider provider_registration_error_description
+	 */
+	#[DataProvider( 'provider_registration_error_description' )]
+	public function test_get_registration_error_description( $error_code, $message, $expected ) {
+		$this->assertSame( $expected, Jetpack::get_registration_error_description( $error_code, $message ) );
+	}
+
+	/**
+	 * Truncation must not split a multibyte character, or the notice renders a replacement glyph.
+	 */
+	public function test_get_registration_error_description_does_not_split_multibyte_characters() {
+		$message = str_repeat( 'é', 600 );
+
+		$description = Jetpack::get_registration_error_description( 'some_code', $message );
+
+		$this->assertSame( str_repeat( 'é', 500 ), $description );
+		$this->assertSame( 500, mb_strlen( $description ) );
+	}
 } // end class

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Test.php
@@ -1210,15 +1210,16 @@ EXPECTED;
 	 * @return array
 	 */
 	public static function provider_registration_error_description() {
-		$long = str_repeat( 'a', 600 );
+		$long         = str_repeat( 'a', 400 );
+		$real_message = 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.';
 
 		return array(
 			'a status code is not copy'         => array( 'wpcom_5??', '503', '' ),
 			'a status code as an int'           => array( 'wpcom_408', 408, '' ),
 			'the jetpack_id response body'      => array( 'jetpack_id', 'Error Details: Jetpack ID is empty. Do not publicly post this error message! {"body":"..."}', '' ),
-			'a real message is kept'            => array( 'cannot_save_secrets', 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.', 'Jetpack experienced an issue trying to save options (cannot_save_secrets). We suggest that you contact your hosting provider, and ask them for help checking that the options table is writable on your site.' ),
+			'a real message is kept'            => array( 'cannot_save_secrets', $real_message, $real_message ),
 			'an empty message stays empty'      => array( 'missing_secrets', '', '' ),
-			'an over-long message is truncated' => array( 'some_code', $long, str_repeat( 'a', 500 ) ),
+			'an over-long message is truncated' => array( 'some_code', $long, str_repeat( 'a', 250 ) ),
 		);
 	}
 
@@ -1237,11 +1238,11 @@ EXPECTED;
 	 * Truncation must not split a multibyte character, or the notice renders a replacement glyph.
 	 */
 	public function test_get_registration_error_description_does_not_split_multibyte_characters() {
-		$message = str_repeat( 'é', 600 );
+		$message = str_repeat( 'é', 400 );
 
 		$description = Jetpack::get_registration_error_description( 'some_code', $message );
 
-		$this->assertSame( str_repeat( 'é', 500 ), $description );
-		$this->assertSame( 500, mb_strlen( $description ) );
+		$this->assertSame( str_repeat( 'é', 250 ), $description );
+		$this->assertSame( 250, mb_strlen( $description ) );
 	}
 } // end class


### PR DESCRIPTION
Fixes CONNECT-439

## Proposed changes

### The issue:

When site registration fails, `Jetpack::admin_page_load()` wrote the error **code** and the error **message** to the same `Jetpack::state()` key, with the second write destroying the code added just before:

```php
$error = $registered->get_error_code();
self::state( 'error', $error );
self::state( 'error', $registered->get_error_message() ); // same key
```

There were two outcomes of this, depending on what WordPress.com sent back:

* **Message present** — the message landed in the code slot and reached `state-notices.jsx` as `errorCode` (`getJetpackStateNoticesErrorCode`). No `case` matches a sentence, so it fell to `default: message = key` and was rendered as the notice headline, as though the message text were an error code. The actual code was gone.
* **Message empty** — `state( 'error', '' )` is falsy, so `renderContent()`'s `if ( ! error && ! message ) { return; }` fired and **no notice rendered at all**.

Meanwhile `error_description` — the key the notice already reads, via `Jetpack_Redux_State_Helper` → `jetpackStateNotices.errorDescription` → `getErrorFromKey()` — was never written by anything in the monorepo.  The `if ( errorDesc )` branch in `state-notices.jsx` that renders a description under the headline has been unreachable since it was added in 2016. https://github.com/Automattic/jetpack/pull/4703

### This fix in this PR:

* Writes the message to `error_description` instead of clobbering `error`, so the code survives and the description reaches the key that was always meant to carry it. We then need to filter what gets stored as the description:
  * WordPress.com sometimes sends only an HTTP status as the "message" (503, 408). Drop it, so the notice doesn't show a stray number on line two.
  * For the `jetpack_id` error, the "message" is the entire raw response body from WordPress.com, prefixed with "Do not publicly post this error message!". Drop it — it's not user copy, and it's stored in a browser cookie, where a big body could break the cookie.
  * Cap anything else at 250 characters, in case WP.com sends something unexpectedly long.
  * Those changes are extracted into a helper, so that they can also easily be tested to prevent future regressions. 
* Extracts the existing "Your Jetpack has a glitch…" copy into `getGenericErrorMessage( key )` in `state-notices.jsx`. Same string, moved verbatim — the `no_role`…`verify_secrets_mismatch` case list now calls it instead of building it inline. Needed so the `default` branch can reuse it without duplicating a translated string.
* Changes `default:` to `message = this.getGenericErrorMessage( key )`. Instead of sing the provided description (or plain key), we default to the default messaging.

So while this doesn't add much that is meaningful at the moment, it paves the way for providing more meaningful error codes in state error messages. And in the interim, with the fallback (if no error description but there is an error, and vice versa), we will report errors now in some cases where none were reported. In brief:

* Failure is registered, WPcom sends description. Before -  headline = the description text (via default:  message = key). Now,  headline = bare code`xml_rpc-32601`, description on line 2
* Register failure, no description. Before - `state( 'error', '' )` → falsy → no notice at all. Now - bare code.


### Side effect to flag


Note on `activate_new_modules()`: In `admin_page_load` this is gated on `self::state( 'error' )`, which is now always a non-empty code where an empty `WP_Error` message previously left it unset. On a fresh registration this changes nothing — `activate_new_modules()` returns immediately when there is no blog token. It is observable only when re-registration fails on a site that still holds tokens and the stored version option is behind the running plugin: previously that combination could activate new default modules and redirect to page=jetpack; now it does not, and the error notice is shown instead.


## Related product discussion/links

*  See Linear link above.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a Jetpack-connected site on the latest Jetpack trunk or bleeding edge:

* Add the following code to a mu-plugin on your site: 3c66f-pb
* Make sure you've disconnected Jetpack on the site
* Load `wp-admin/admin.php?page=jetpack`, view source, grab the `admin.php?page=jetpack&action=register&_wpnonce=…` URL (likely unicode escaped to `admin.php?page=jetpack\u0026action=register\u0026_wpnonce=...` - copy and change those back to '&')
* Visit it with `&jpsim=desc` appended
* Expect: red notice reads "requested method jetpack.verifyRegistration does not exist" — that's default: message = key rendering the message as if it were a code. `xml_rpc-32601` nowhere on screen. `errorDescription` empty, so no second line:

<img width="1161" height="81" alt="Screenshot 2026-09-02 at 16 25 20" src="https://github.com/user-attachments/assets/788fe0f1-cbcd-402f-9054-aa7f9557eb59" />

* Then visit it with `&jpsim=nodesc` appended. You should not see a notice at all.

* Then visit it with `&jpsim=wpcom5xx` appended. All you'll see is the error code eg '503'.

<img width="1145" height="59" alt="Screenshot 2026-09-03 at 15 02 37" src="https://github.com/user-attachments/assets/da23dfcd-2b6f-4b6d-9495-34b4d2eb505b" />

* Then visit it with `&jpsim=jetpack_id` appended. This should render a notice saying 'Error Details: Jetpack ID is empty. Do not publicly post this error message!' followed by the entity which continues beyond the notice border.

<img width="1139" height="79" alt="Screenshot 2026-09-03 at 15 00 53" src="https://github.com/user-attachments/assets/d361c0b9-c5b0-47a4-8b4d-6fb93a3a91ec" />

* For all cases you can also check your error log at `wp-content/debug.log` to see what survived in state as proof of the overwrite (as well as message length in bytes).

With the PR applied locally or using the Jetpack beta tester plugin:

* Run the same steps. When visiting with `with &jpsim=desc` appended to the URL, you should instead see the glitch/support copy keyed on `xml_rpc-32601`… except `xml_rpc-32601` has no case either, so it still falls to default: message = key — but now key is the code and the description renders below it:

<img width="1142" height="100" alt="Screenshot 2026-09-02 at 16 28 13" src="https://github.com/user-attachments/assets/fc4b5bd9-69f1-4d96-84d7-4ce790cdca4a" />

* When visiting with `&jpsim=nodesc` appended -- this should render a notice again with the default glitch copy, and the key:

<img width="1146" height="86" alt="Screenshot 2026-09-04 at 14 57 52" src="https://github.com/user-attachments/assets/48b691f4-470e-4d99-9459-4d31bc7f419f" />

* When visiting with `&jpsim=wpcom5xx` appended -- this should render a notice saying 'WordPress.com is currently having problems and is unable to fuel up your Jetpack. Please try again later.'

<img width="1147" height="72" alt="Screenshot 2026-09-03 at 14 47 11" src="https://github.com/user-attachments/assets/5bbe651e-ad77-4c1f-aaca-6331a43fc628" />

* When visiting with `&jpsim=jetpack_id` appended -- this should render a notice saying 'Your Jetpack has a glitch. We’re sorry for the inconvenience. Please try again later, if the issue continues please contact support with this message: jetpack_id'

<img width="1148" height="83" alt="Screenshot 2026-09-03 at 14 49 30" src="https://github.com/user-attachments/assets/2dae0790-ef2e-41e4-952e-516f06a0dd57" />


* You can again also check your error log at `wp-content/debug.log` to see what survived in state to confirm the overwrite isn't happening  (as well as message length in bytes).