### PR TITLE
tests: Use PHPUnit `assertIsType` assertions

### DIFF
--- a/projects/packages/connection/changelog/fix-phpunit-use-assertIsFoo
+++ b/projects/packages/connection/changelog/fix-phpunit-use-assertIsFoo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use assertions like `assertIsString()` rather than `assertTrue( is_string() )`
+
+

--- a/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
+++ b/projects/packages/connection/tests/php/identity-crisis/Identity_Crisis_Test.php
@@ -1311,7 +1311,7 @@ class Identity_Crisis_Test extends BaseTestCase {
 		$expected_ip = '72.182.131.109';
 		foreach ( $result as $ip ) {
 			$this->assertEquals( $expected_ip, $ip['ip'] );
-			$this->assertTrue( is_int( $ip['expires_at'] ) );
+			$this->assertIsInt( $ip['expires_at'] );
 		}
 
 		// Test with another IP address

--- a/projects/packages/forms/changelog/fix-phpunit-use-assertIsFoo
+++ b/projects/packages/forms/changelog/fix-phpunit-use-assertIsFoo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Tests: Use assertions like `assertIsString()` rather than `assertTrue( is_string() )`
+
+

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -71,7 +71,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+		$this->assertIsString( $result, 'Form submission should be successful' );
 
 		// Check that a new feedback post was created
 		$final_posts = Posts::init()->posts;
@@ -116,7 +116,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should still be successful (email should still be sent)
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful even when not saving responses' );
+		$this->assertIsString( $result, 'Form submission should be successful even when not saving responses' );
 
 		// Check that a new feedback post was created
 		$final_posts = Posts::init()->posts;
@@ -168,7 +168,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$initial_count = count( Posts::init()->posts );
 		$result        = $form->process_submission();
 
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful for preview submissions.' );
+		$this->assertIsString( $result, 'Form submission should be successful for preview submissions.' );
 
 		$final_posts = Posts::init()->posts;
 		$this->assertCount( $initial_count + 1, $final_posts, 'A feedback post should be created for preview submissions.' );
@@ -215,7 +215,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+		$this->assertIsString( $result, 'Form submission should be successful' );
 
 		// Check that a new feedback post was created (default behavior)
 		$final_posts = Posts::init()->posts;
@@ -385,7 +385,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$submission  = get_post( $feedback_id );
@@ -444,7 +444,7 @@ class Contact_Form_Test extends BaseTestCase {
 
 		// Process the submission to create a feedback post
 		$result = $form->process_submission();
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+		$this->assertIsString( $result, 'Form submission should be successful' );
 
 		// Get the feedback ID from the most recent post
 		$feedback_id = end( Posts::init()->posts )->ID;
@@ -538,7 +538,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$submission  = get_post( $feedback_id );
@@ -558,7 +558,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result                     = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$submission  = get_post( $feedback_id );
@@ -592,7 +592,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$submission  = get_post( $feedback_id );
@@ -628,7 +628,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$response    = Feedback::get( $feedback_id );
@@ -656,7 +656,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$response    = Feedback::get( $feedback_id );
@@ -682,7 +682,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$response    = Feedback::get( $feedback_id );
@@ -708,7 +708,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$response    = Feedback::get( $feedback_id );
@@ -738,7 +738,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 
@@ -772,7 +772,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$result = $form->process_submission();
 
 		// Processing should be successful and produce the success message.
-		$this->assertTrue( is_string( $result ) );
+		$this->assertIsString( $result );
 
 		$feedback_id = end( Posts::init()->posts )->ID;
 		$submission  = get_post( $feedback_id );
@@ -2551,7 +2551,7 @@ class Contact_Form_Test extends BaseTestCase {
 		// Submit first form
 		$result1 = $form1->process_submission();
 
-		$this->assertTrue( is_string( $result1 ), 'First form submission should be successful' );
+		$this->assertIsString( $result1, 'First form submission should be successful' );
 
 		$this->add_field_values(
 			array(
@@ -2564,7 +2564,7 @@ class Contact_Form_Test extends BaseTestCase {
 		$form2   = new Contact_Form( array(), "[contact-field label='Name' type='name' required='1'/][contact-field label='Message' type='textarea' required='1'/]" );
 		$result2 = $form2->process_submission();
 
-		$this->assertTrue( is_string( $result2 ), 'First form submission should be successful' );
+		$this->assertIsString( $result2, 'First form submission should be successful' );
 
 		// Verify that the forms have different IDs
 		$this->assertNotEquals( $form1->get_attribute( 'id' ), $form2->get_attribute( 'id' ), 'Forms should have unique IDs' );

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Form_Ref_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Form_Ref_Test.php
@@ -122,7 +122,7 @@ class Feedback_Form_Ref_Test extends BaseTestCase {
 		// Submit form with form_id set
 		$result = $this->create_and_submit_form( $form_id );
 
-		$this->assertTrue( is_string( $result ), 'Form submission should be successful' );
+		$this->assertIsString( $result, 'Form submission should be successful' );
 
 		// Get final feedback count
 		$final_posts = Posts::init()->posts;

--- a/projects/plugins/jetpack/changelog/fix-phpunit-use-assertIsFoo
+++ b/projects/plugins/jetpack/changelog/fix-phpunit-use-assertIsFoo
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Tests: Use assertions like `assertIsString()` rather than `assertTrue( is_string() )`
+
+

--- a/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
+++ b/projects/plugins/jetpack/tests/php/Import_Post_Meta_Object_Injection_Test.php
@@ -88,7 +88,7 @@ class Import_Post_Meta_Object_Injection_Test extends WP_UnitTestCase {
 
 		$this->assertIsArray( $stored );
 		$this->assertSame( 'ok', $stored['safe'] );
-		$this->assertFalse( is_object( $stored['bad'] ), 'A nested object survived the import.' );
+		$this->assertIsNotObject( $stored['bad'], 'A nested object survived the import.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/OpenTable_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/OpenTable_Test.php
@@ -21,7 +21,7 @@ class OpenTable_Test extends \WP_UnitTestCase {
 		$attributes = array();
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertTrue( is_string( $content ) );
+		$this->assertIsString( $content );
 	}
 
 	/**
@@ -31,7 +31,7 @@ class OpenTable_Test extends \WP_UnitTestCase {
 		$attributes = array( 'rid' => null );
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertTrue( is_string( $content ) );
+		$this->assertIsString( $content );
 	}
 
 	/**
@@ -41,6 +41,6 @@ class OpenTable_Test extends \WP_UnitTestCase {
 		$attributes = array( 'rid' => array() );
 		$content    = OpenTable\load_assets( $attributes );
 
-		$this->assertTrue( is_string( $content ) );
+		$this->assertIsString( $content );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Constants_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Constants_Test.php
@@ -32,17 +32,17 @@ class Jetpack_Sitemap_Constants_Test extends WP_UnitTestCase {
 	#[Group( 'jetpack-sitemap' )]
 	public function test_sitemap_builder_capacity_constants() {
 		// Test range of JP_SITEMAP_MAX_BYTES.
-		$this->assertTrue( is_int( JP_SITEMAP_MAX_BYTES ) );
+		$this->assertIsInt( JP_SITEMAP_MAX_BYTES );
 		$this->assertGreaterThan( 0, JP_SITEMAP_MAX_BYTES );
 		$this->assertLessThanOrEqual( JP_SITEMAP_MAX_BYTES, 716800 );
 
 		// Test range of JP_SITEMAP_MAX_ITEMS.
-		$this->assertTrue( is_int( JP_SITEMAP_MAX_ITEMS ) );
+		$this->assertIsInt( JP_SITEMAP_MAX_ITEMS );
 		$this->assertGreaterThan( 0, JP_SITEMAP_MAX_ITEMS );
 		$this->assertLessThanOrEqual( 50000, JP_SITEMAP_MAX_ITEMS );
 
 		// Test range of JP_NEWS_SITEMAP_MAX_ITEMS.
-		$this->assertTrue( is_int( JP_NEWS_SITEMAP_MAX_ITEMS ) );
+		$this->assertIsInt( JP_NEWS_SITEMAP_MAX_ITEMS );
 		$this->assertGreaterThan( 0, JP_NEWS_SITEMAP_MAX_ITEMS );
 		$this->assertLessThanOrEqual( 1000, JP_NEWS_SITEMAP_MAX_ITEMS );
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Functions_Test.php
@@ -731,9 +731,9 @@ class Jetpack_Sync_Functions_Test extends Jetpack_Sync_TestBase {
 		$this->assertTrue( $sanitized->exclude_from_search );
 		$this->assertTrue( $sanitized->can_export );
 		$this->assertTrue( $sanitized->map_meta_cap );
-		$this->assertTrue( is_object( $sanitized->labels ) );
+		$this->assertIsObject( $sanitized->labels );
 		$this->assertIsArray( $sanitized->rewrite );
-		$this->assertTrue( is_object( $sanitized->cap ) );
+		$this->assertIsObject( $sanitized->cap );
 	}
 
 	public function test_sanitize_sync_post_type_method_all_values_set() {

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Updates_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Updates_Test.php
@@ -41,7 +41,7 @@ class Jetpack_Sync_Updates_Test extends Jetpack_Sync_TestBase {
 		$updates = $this->server_replica_storage->get_updates( 'plugins' );
 
 		$this->assertFalse( isset( $updates->no_update ) );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertIsInt( $updates->last_checked );
 
 		$this->assertArrayHasKey( 'hello', $updates->response );
 	}
@@ -105,7 +105,7 @@ class Jetpack_Sync_Updates_Test extends Jetpack_Sync_TestBase {
 		$theme   = reset( $updates->response );
 
 		$this->assertSame( 'hello', $theme['name'] );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertIsInt( $updates->last_checked );
 	}
 
 	public function test_update_themes_is_synced_once() {
@@ -169,7 +169,7 @@ class Jetpack_Sync_Updates_Test extends Jetpack_Sync_TestBase {
 
 		$this->sender->do_sync();
 		$updates = $this->server_replica_storage->get_updates( 'core' );
-		$this->assertTrue( is_int( $updates->last_checked ) );
+		$this->assertIsInt( $updates->last_checked );
 
 		// Since the transient gets updates twice and we only care about the
 		// last update we only want to see 1 sync event.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
These tend to give better output on failure versus things like `assertTrue( is_string() )`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?