### PR TITLE
Podcast: list only posts with an enclosure as episodes

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-episode-tagging
+++ b/projects/packages/podcast/changelog/add-podcast-episode-tagging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: List only posts that have an audio enclosure as episodes.

--- a/projects/packages/podcast/src/class-episode-query.php
+++ b/projects/packages/podcast/src/class-episode-query.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Narrows post queries to real podcast episodes.
+ *
+ * @package automattic/jetpack-podcast
+ */
+
+declare( strict_types = 1 );
+
+namespace Automattic\Jetpack\Podcast;
+
+use WP_Query;
+use WP_REST_Request;
+
+/**
+ * Exposes a `podcast_episodes` param on the posts REST collection that keeps
+ * only posts carrying an `enclosure` meta row, the same rule the feed uses.
+ */
+class Episode_Query {
+
+	const QUERY_VAR = 'podcast_episodes';
+
+	/**
+	 * Whether `init()` has wired its hooks.
+	 *
+	 * @var bool
+	 */
+	private static $registered = false;
+
+	/**
+	 * Wire the REST param and the SQL constraint.
+	 */
+	public static function init() {
+		if ( self::$registered ) {
+			return;
+		}
+		self::$registered = true;
+
+		add_filter( 'rest_post_collection_params', array( __CLASS__, 'register_collection_param' ) );
+		add_filter( 'rest_post_query', array( __CLASS__, 'apply_rest_param' ), 10, 2 );
+		add_filter( 'posts_where', array( __CLASS__, 'constrain_query' ), 10, 2 );
+	}
+
+	/**
+	 * Add `podcast_episodes` to the posts collection schema.
+	 *
+	 * @param array $params Collection params.
+	 * @return array
+	 */
+	public static function register_collection_param( $params ) {
+		$params[ self::QUERY_VAR ] = array(
+			'description' => __( 'Limit results to posts with an audio enclosure.', 'jetpack-podcast' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		);
+		return $params;
+	}
+
+	/**
+	 * Carry the REST param into the `WP_Query` args.
+	 *
+	 * @param array           $args    Query args.
+	 * @param WP_REST_Request $request REST request.
+	 * @return array
+	 */
+	public static function apply_rest_param( $args, $request ) {
+		if ( $request->get_param( self::QUERY_VAR ) ) {
+			$args[ self::QUERY_VAR ] = true;
+		}
+		return $args;
+	}
+
+	/**
+	 * Append the enclosure constraint when the query asked for episodes.
+	 *
+	 * A correlated `EXISTS` rather than a `meta_query` join: episodes carry
+	 * several `enclosure` rows, and a join would duplicate posts and break `LIMIT`.
+	 *
+	 * @param string   $where The `WHERE` clause of the query.
+	 * @param WP_Query $query Query about to run.
+	 * @return string
+	 */
+	public static function constrain_query( $where, $query ) {
+		if ( ! $query->get( self::QUERY_VAR ) ) {
+			return $where;
+		}
+
+		global $wpdb;
+
+		return $where . $wpdb->prepare(
+			" AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID AND {$wpdb->postmeta}.meta_key = %s )",
+			'enclosure'
+		);
+	}
+}

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -45,6 +45,7 @@ class Podcast {
 		// Wire the RSS feed customizations (`<itunes:*>` + `<podcast:*>` tags,
 		// stats-tracked enclosure URLs) for the configured podcast category.
 		Customize_Feed::init();
+		Episode_Query::init();
 
 		Tracks::init();
 

--- a/projects/packages/podcast/src/dashboard/episodes/use-episodes-query.ts
+++ b/projects/packages/podcast/src/dashboard/episodes/use-episodes-query.ts
@@ -34,6 +34,7 @@ export function useEpisodesQuery( args: EpisodesQueryArgs ): {
 	const query = useMemo(
 		() => ( {
 			categories: args.categoryId,
+			podcast_episodes: 1,
 			page: args.page ?? 1,
 			per_page: args.perPage ?? 20,
 			orderby: args.orderBy ?? 'date',

--- a/projects/packages/podcast/src/feed/class-customize-feed.php
+++ b/projects/packages/podcast/src/feed/class-customize-feed.php
@@ -11,6 +11,7 @@ declare( strict_types = 1 );
 namespace Automattic\Jetpack\Podcast\Feed;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Podcast\Episode_Query;
 use Automattic\Jetpack\Podcast\Settings;
 use WP_Post;
 
@@ -64,15 +65,10 @@ class Customize_Feed {
 		// they're registered up-front and self-gated to the podcast feed query,
 		// rather than wired conditionally in `maybe_register_feed_hooks`.
 		//
-		// `posts_where` constrains the SQL itself so LIMIT/OFFSET paginate over
-		// episodes that actually have an enclosure; `the_posts` is a cheap final
-		// guard for the rare row the SQL constraint can't reach.
-		//
 		// `pre_get_posts` runs last so the gate reads the category every other
 		// callback has finished rewriting — and so `get_queried_object()` doesn't
-		// memoize a term ahead of them, which `posts_where` would then inherit.
-		add_action( 'pre_get_posts', array( __CLASS__, 'apply_feed_limit' ), PHP_INT_MAX );
-		add_filter( 'posts_where', array( __CLASS__, 'constrain_feed_query' ), 10, 2 );
+		// memoize a term ahead of them.
+		add_action( 'pre_get_posts', array( __CLASS__, 'configure_feed_query' ), PHP_INT_MAX );
 		add_filter( 'the_posts', array( __CLASS__, 'filter_posts_with_enclosure' ), 10, 2 );
 	}
 
@@ -398,51 +394,20 @@ class Customize_Feed {
 	}
 
 	/**
-	 * Cap the podcast feed at the configured number of episodes. Core reads the
-	 * `posts_per_rss` *query var* before the site option of the same name, so the
-	 * podcast feed gets its own length and every other feed keeps the site's.
+	 * Cap the podcast feed at the configured number of episodes and keep it to
+	 * posts with an enclosure, so `LIMIT`/`OFFSET` paginate over real episodes.
+	 * Core reads the `posts_per_rss` query var before the site option of the
+	 * same name, so every other feed keeps the site's length.
 	 *
 	 * @param \WP_Query $query Query about to run.
 	 */
-	public static function apply_feed_limit( $query ) {
+	public static function configure_feed_query( $query ) {
 		if ( ! self::is_podcast_feed_query( $query ) ) {
 			return;
 		}
 
 		$query->set( 'posts_per_rss', Settings::feed_limit() );
-	}
-
-	/**
-	 * Constrain the podcast feed's main query to episodes that carry an
-	 * `enclosure` meta row, so the SQL `LIMIT`/`OFFSET` paginate over valid
-	 * episodes only. Without this the enclosure filter runs on `the_posts` —
-	 * after pagination — so a nominal ten-item page could come back short or
-	 * empty while older valid episodes sit stranded on later pages.
-	 *
-	 * A correlated `EXISTS` subquery (semi-join) is used rather than a
-	 * `meta_query` clause on purpose: episodes routinely accumulate several
-	 * `enclosure` meta rows (see {@see self::rewrite_enclosure()}), and a
-	 * single-clause `meta_query` INNER JOIN would multiply those into duplicate
-	 * posts, breaking the `LIMIT` count all over again.
-	 *
-	 * @param string    $where The `WHERE` clause of the query.
-	 * @param \WP_Query $query Query about to run.
-	 * @return string
-	 */
-	public static function constrain_feed_query( $where, $query ) {
-		if ( ! self::is_podcast_feed_query( $query ) ) {
-			return $where;
-		}
-
-		global $wpdb;
-
-		// Table names come from `$wpdb`; `meta_key` runs through `prepare()`.
-		$where .= $wpdb->prepare(
-			" AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID AND {$wpdb->postmeta}.meta_key = %s )",
-			'enclosure'
-		);
-
-		return $where;
+		$query->set( Episode_Query::QUERY_VAR, true );
 	}
 
 	/**
@@ -450,8 +415,8 @@ class Customize_Feed {
 	 * take down the whole submission. The `enclosure` post meta is what
 	 * `rss_enclosure()` reads, so it's the authoritative signal here too.
 	 *
-	 * The SQL constraint in {@see self::constrain_feed_query()} already excludes
-	 * these at query time; this stays as a cheap final guard.
+	 * {@see Episode_Query} already excludes these at query time; this stays as
+	 * a cheap final guard.
 	 *
 	 * Doubles as the warm-up point for the render: this is the first hook that
 	 * sees the whole page of episodes, so {@see Episode_Media_Cache::prime()}
@@ -481,7 +446,7 @@ class Customize_Feed {
 
 	/**
 	 * Whether `$query` is the main podcast category feed query — the shared gate
-	 * for the two query-time hooks ({@see self::constrain_feed_query()} and
+	 * for the query-time hooks ({@see self::configure_feed_query()} and
 	 * {@see self::filter_posts_with_enclosure()}), which fire before the `wp`
 	 * action and so can't lean on `maybe_register_feed_hooks()`.
 	 *

--- a/projects/packages/podcast/tests/php/Episode_Query_Test.php
+++ b/projects/packages/podcast/tests/php/Episode_Query_Test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @package automattic/jetpack-podcast
+ */
+
+namespace Automattic\Jetpack\Podcast\Tests;
+
+use Automattic\Jetpack\Podcast\Episode_Query;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+use WP_Query;
+use WP_REST_Request;
+
+/**
+ * @covers \Automattic\Jetpack\Podcast\Episode_Query
+ */
+#[CoversClass( Episode_Query::class )]
+class Episode_Query_Test extends BaseTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Episode_Query::init();
+	}
+
+	public function test_register_collection_param_adds_boolean_param() {
+		$params = Episode_Query::register_collection_param( array() );
+
+		$this->assertSame( 'boolean', $params['podcast_episodes']['type'] );
+		$this->assertFalse( $params['podcast_episodes']['default'] );
+	}
+
+	public function test_apply_rest_param_forwards_truthy_param_only() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$this->assertArrayNotHasKey( 'podcast_episodes', Episode_Query::apply_rest_param( array(), $request ) );
+
+		$request->set_param( 'podcast_episodes', true );
+		$this->assertTrue( Episode_Query::apply_rest_param( array(), $request )['podcast_episodes'] );
+	}
+
+	public function test_constrain_query_leaves_where_untouched_without_query_var() {
+		$where = ' AND 1=1';
+		$this->assertSame( $where, Episode_Query::constrain_query( $where, new WP_Query() ) );
+	}
+
+	public function test_constrain_query_appends_enclosure_exists_subquery() {
+		global $wpdb;
+		$query = new WP_Query();
+		$query->set( 'podcast_episodes', true );
+
+		$result = Episode_Query::constrain_query( ' AND 1=1', $query );
+
+		$this->assertStringStartsWith( ' AND 1=1', $result );
+		$this->assertStringContainsString(
+			"EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID AND {$wpdb->postmeta}.meta_key = 'enclosure' )",
+			$result
+		);
+	}
+}

--- a/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Customize_Feed_Test.php
@@ -516,57 +516,26 @@ class Customize_Feed_Test extends BaseTestCase {
 		delete_post_meta( 100, 'enclosure' );
 	}
 
-	public function test_constrain_feed_query_leaves_where_untouched_for_non_podcast_query() {
-		$where = ' AND 1=1';
-		$query = $this->build_podcast_feed_query_mock( 17, array( 'is_feed' => false ) );
-
-		$this->assertSame( $where, Customize_Feed::constrain_feed_query( $where, $query ) );
-	}
-
-	public function test_constrain_feed_query_leaves_where_untouched_when_queried_term_does_not_match() {
-		$this->seed_category_term( 17 );
-		update_option( 'podcasting_category_id', 17 );
-
-		$where = ' AND 1=1';
-		$query = $this->build_podcast_feed_query_mock( 999 );
-
-		$this->assertSame( $where, Customize_Feed::constrain_feed_query( $where, $query ) );
-	}
-
-	public function test_constrain_feed_query_appends_enclosure_exists_subquery_for_podcast_feed() {
-		global $wpdb;
-		$this->seed_category_term( 17 );
-		update_option( 'podcasting_category_id', 17 );
-
-		$query  = $this->build_podcast_feed_query_mock( 17 );
-		$result = Customize_Feed::constrain_feed_query( ' AND 1=1', $query );
-
-		// Constraint is a correlated EXISTS semi-join, so an episode with
-		// several `enclosure` rows still yields exactly one post row — no
-		// LIMIT-breaking duplicates.
-		$this->assertStringContainsString(
-			"EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE {$wpdb->postmeta}.post_id = {$wpdb->posts}.ID AND {$wpdb->postmeta}.meta_key = 'enclosure' )",
-			$result
-		);
-		$this->assertStringStartsWith( ' AND 1=1', $result );
-	}
-
-	public function test_apply_feed_limit_sets_posts_per_rss_for_podcast_feed() {
+	public function test_configure_feed_query_sets_limit_and_episode_var_for_podcast_feed() {
 		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );
 		update_option( 'podcasting_feed_limit', 25 );
 
 		$query = $this->build_podcast_feed_query_mock( 17, array(), true );
-		$query->expects( $this->once() )->method( 'set' )->with( 'posts_per_rss', 25 );
+		$query->expects( $this->exactly( 2 ) )->method( 'set' )->willReturnCallback(
+			function ( $key, $value ) {
+				$this->assertContains( array( $key, $value ), array( array( 'posts_per_rss', 25 ), array( 'podcast_episodes', true ) ) );
+			}
+		);
 
-		Customize_Feed::apply_feed_limit( $query );
+		Customize_Feed::configure_feed_query( $query );
 	}
 
 	/**
 	 * `pre_get_posts` runs for every query on the site, so the gate is what keeps
 	 * the podcast limit off everyone else's feeds.
 	 */
-	public function test_apply_feed_limit_ignores_queries_that_are_not_the_podcast_feed() {
+	public function test_configure_feed_query_ignores_queries_that_are_not_the_podcast_feed() {
 		$this->seed_category_term( 17 );
 		update_option( 'podcasting_category_id', 17 );
 		update_option( 'podcasting_feed_limit', 25 );
@@ -574,14 +543,14 @@ class Customize_Feed_Test extends BaseTestCase {
 		$query = $this->build_podcast_feed_query_mock( 999, array(), true );
 		$query->expects( $this->never() )->method( 'set' );
 
-		Customize_Feed::apply_feed_limit( $query );
+		Customize_Feed::configure_feed_query( $query );
 	}
 
 	/**
 	 * Build a `WP_Query` double pre-stubbed for the podcast-feed happy path,
 	 * with optional per-method overrides.
 	 *
-	 * A stub unless `$expects_calls` — only the `apply_feed_limit` tests assert on
+	 * A stub unless `$expects_calls` — only the `configure_feed_query` tests assert on
 	 * a call, and handing every caller a mock makes PHPUnit flag the ones that
 	 * configure no expectations.
 	 *

--- a/projects/plugins/jetpack/changelog/add-podcast-episode-tagging
+++ b/projects/plugins/jetpack/changelog/add-podcast-episode-tagging
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Podcast: List only posts that have an audio enclosure as episodes in the dashboard.


### PR DESCRIPTION
## Proposed changes
* Add a `podcast_episodes` param to the `wp/v2/posts` collection. When set, a `posts_where` filter keeps only posts that have an `enclosure` meta row, the same rule the podcast feed already uses.
* The podcast dashboard passes that param, so the episodes list matches what the feed serves instead of showing every post in the category.
* The feed now sets the same query var instead of carrying its own copy of the enclosure clause.

Core only writes `enclosure` meta on publish, so drafts no longer appear in the episodes list. That is intentional for now.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Set up a podcast category with a couple of published posts that contain audio (Podcast Episode block or Audio block) and one published post with no audio.
* Open Jetpack → Podcast. Only the posts with audio should be listed.
* Request `/wp-json/wp/v2/posts?categories=<id>&podcast_episodes=1` and confirm the audio-less post is absent. Drop the param and it comes back.
* Load the category feed and confirm it still lists the same episodes as before.
