### PR TITLE
Podcast: bump Mission Control stats on every host

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-bump-stats
+++ b/projects/packages/podcast/changelog/add-podcast-bump-stats
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Tracks: Bump Mission Control stats for episode publishes, show launches, directory URL additions, and podcasting status changes on every host.
+Podcast: Bump Mission Control stats for episode publishes, show launches, directory URL additions, and podcasting status changes on every host.

--- a/projects/packages/podcast/changelog/add-podcast-bump-stats
+++ b/projects/packages/podcast/changelog/add-podcast-bump-stats
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Tracks: Bump Mission Control stats for episode publishes, show launches, directory URL additions, and podcasting status changes on every host.

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -5,6 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.4",
+		"automattic/jetpack-a8c-mc-stats": "@dev",
 		"automattic/jetpack-admin-ui": "@dev",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-blocks": "@dev",

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace Automattic\Jetpack\Podcast;
 
+use Automattic\Jetpack\A8c_Mc_Stats;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
 use Automattic\Jetpack\Podcast\Feed\Episode_Block_Tags;
@@ -147,6 +148,7 @@ class Tracks {
 				),
 				self::identity_for_post( $post )
 			);
+			self::bump_stat( 'wpcom-podcast-episodes', 'published' );
 
 			// Atomic INSERT — only one concurrent caller per site wins, so
 			// `show_launched` fires exactly once per site.
@@ -156,6 +158,7 @@ class Tracks {
 					array( 'post_id' => (int) $post->ID ),
 					self::identity_for_post( $post )
 				);
+				self::bump_stat( 'wpcom-podcast-episodes', 'show-launched' );
 			}
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Tracks is best-effort — never break a publish.
@@ -295,6 +298,7 @@ class Tracks {
 						'surface' => self::$surface,
 					)
 				);
+				self::bump_stat( 'wpcom-podcast-distribution', (string) $app );
 				return;
 			}
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
@@ -492,8 +496,29 @@ class Tracks {
 			)
 		);
 
-		/** This action is documented in projects/packages/forms/src/contact-form/class-util.php */
-		do_action( 'jetpack_bump_stats_extras', 'wpcom-podcasting-status', $status );
+		self::bump_stat( 'wpcom-podcasting-status', $status );
+	}
+
+	/**
+	 * Bump a Mission Control stat. Calls `bump_stats_extras` directly on
+	 * Simple; elsewhere pings the pixel so Atomic and self-hosted count too.
+	 * The URL is built with the bare group rather than `A8c_Mc_Stats::add()`,
+	 * whose `x_jetpack-` prefix would file the pixel bumps under a second name.
+	 *
+	 * @param string $group Stat group.
+	 * @param string $bin   Stat name within the group.
+	 */
+	private static function bump_stat( string $group, string $bin ): void {
+		try {
+			if ( function_exists( 'bump_stats_extras' ) ) {
+				bump_stats_extras( $group, $bin );
+				return;
+			}
+
+			$stats = new A8c_Mc_Stats();
+			$stats->do_server_side_stat( $stats->build_stats_url( array( "x_{$group}" => $bin ) ) );
+		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		}
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -517,7 +517,8 @@ class Tracks {
 
 			$stats = new A8c_Mc_Stats();
 			$stats->do_server_side_stat( $stats->build_stats_url( array( "x_{$group}" => $bin ) ) );
-		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		} catch ( Throwable $e ) {
+			unset( $e );
 		}
 	}
 

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -31,6 +31,7 @@ class Tracks_Test extends BaseTestCase {
 		}
 
 		$GLOBALS['jetpack_podcast_test_captured_events'] = array();
+		$GLOBALS['jetpack_podcast_test_captured_stats']  = array();
 	}
 
 	protected function tearDown(): void {
@@ -42,7 +43,7 @@ class Tracks_Test extends BaseTestCase {
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
 		WorDBless_Users::init()->clear_all_users();
-		unset( $GLOBALS['jetpack_podcast_test_captured_events'] );
+		unset( $GLOBALS['jetpack_podcast_test_captured_events'], $GLOBALS['jetpack_podcast_test_captured_stats'] );
 		parent::tearDown();
 	}
 
@@ -53,6 +54,22 @@ class Tracks_Test extends BaseTestCase {
 				static function ( array $event ) use ( $event_name ) {
 					return $event['event_name'] === $event_name;
 				}
+			)
+		);
+	}
+
+	private function stats_in_group( string $group ): array {
+		return array_values(
+			array_map(
+				static function ( array $stat ) {
+					return $stat['bin'];
+				},
+				array_filter(
+					$GLOBALS['jetpack_podcast_test_captured_stats'],
+					static function ( array $stat ) use ( $group ) {
+						return $stat['group'] === $group;
+					}
+				)
 			)
 		);
 	}
@@ -109,6 +126,7 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $events );
 		$this->assertSame( $post->ID, $events[0]['properties']['post_id'] );
 		$this->assertTrue( $events[0]['properties']['is_first_episode_for_site'] );
+		$this->assertSame( array( 'published', 'show-launched' ), $this->stats_in_group( 'wpcom-podcast-episodes' ) );
 	}
 
 	public function test_episode_published_fires_show_launched_only_once_per_site() {
@@ -122,6 +140,7 @@ class Tracks_Test extends BaseTestCase {
 
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_show_launched' ) );
 		$this->assertCount( 2, $this->events_named( 'wpcom_podcast_episode_published' ) );
+		$this->assertSame( array( 'published', 'show-launched', 'published' ), $this->stats_in_group( 'wpcom-podcast-episodes' ) );
 	}
 
 	public function test_episode_published_skips_when_post_was_already_published() {
@@ -133,6 +152,7 @@ class Tracks_Test extends BaseTestCase {
 		Tracks::record_episode_published( $post->ID, $post, true, $before );
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+		$this->assertEmpty( $this->stats_in_group( 'wpcom-podcast-episodes' ) );
 	}
 
 	public function test_episode_published_skips_when_post_not_in_podcast_category() {
@@ -260,6 +280,7 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertSame( 'enabled', $events[0]['properties']['status'] );
 		$this->assertSame( 0, $events[0]['properties']['previous_category_id'] );
 		$this->assertSame( 42, $events[0]['properties']['new_category_id'] );
+		$this->assertSame( array( 'enabled' ), $this->stats_in_group( 'wpcom-podcasting-status' ) );
 	}
 
 	public function test_status_changed_emits_disabled_when_category_cleared() {
@@ -268,6 +289,7 @@ class Tracks_Test extends BaseTestCase {
 		$events = $this->events_named( 'wpcom_podcasting_status_changed' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'disabled', $events[0]['properties']['status'] );
+		$this->assertSame( array( 'disabled' ), $this->stats_in_group( 'wpcom-podcasting-status' ) );
 	}
 
 	public function test_status_changed_emits_changed_when_category_swapped() {
@@ -276,6 +298,7 @@ class Tracks_Test extends BaseTestCase {
 		$events = $this->events_named( 'wpcom_podcasting_status_changed' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'changed', $events[0]['properties']['status'] );
+		$this->assertSame( array( 'changed' ), $this->stats_in_group( 'wpcom-podcasting-status' ) );
 	}
 
 	public function test_show_url_added_emits_on_first_entry_per_directory() {
@@ -287,6 +310,7 @@ class Tracks_Test extends BaseTestCase {
 		$events = $this->events_named( 'wpcom_podcasting_show_url_saved' );
 		$this->assertCount( 1, $events );
 		$this->assertSame( 'apple', $events[0]['properties']['app'] );
+		$this->assertSame( array( 'apple' ), $this->stats_in_group( 'wpcom-podcast-distribution' ) );
 	}
 
 	public function test_show_url_updated_skips_when_directory_already_had_url() {
@@ -297,6 +321,7 @@ class Tracks_Test extends BaseTestCase {
 		);
 
 		$this->assertEmpty( $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
+		$this->assertEmpty( $this->stats_in_group( 'wpcom-podcast-distribution' ) );
 	}
 
 	public function test_show_url_added_emits_only_once_for_first_new_directory() {
@@ -309,5 +334,6 @@ class Tracks_Test extends BaseTestCase {
 		);
 
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
+		$this->assertSame( array( 'apple' ), $this->stats_in_group( 'wpcom-podcast-distribution' ) );
 	}
 }

--- a/projects/packages/podcast/tests/php/bootstrap.php
+++ b/projects/packages/podcast/tests/php/bootstrap.php
@@ -2,8 +2,8 @@
 /**
  * Bootstrap.
  *
- * Shadows the wpcom Simple `tracks_record_event` from wpcom-stubs at test
- * runtime so dispatched events land in a per-test buffer.
+ * Shadows the wpcom Simple `tracks_record_event` and `bump_stats_extras`
+ * from wpcom-stubs at test runtime so dispatches land in per-test buffers.
  *
  * @phan-file-suppress PhanRedefineFunction
  *
@@ -22,6 +22,16 @@ if ( ! function_exists( 'tracks_record_event' ) ) {
 			'user'       => $user,
 			'event_name' => $event_name,
 			'properties' => $properties,
+		);
+		return true;
+	}
+}
+
+if ( ! function_exists( 'bump_stats_extras' ) ) {
+	function bump_stats_extras( $name, $value ) {
+		$GLOBALS['jetpack_podcast_test_captured_stats'][] = array(
+			'group' => $name,
+			'bin'   => $value,
 		);
 		return true;
 	}

--- a/projects/plugins/jetpack/changelog/add-podcast-bump-stats
+++ b/projects/plugins/jetpack/changelog/add-podcast-bump-stats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/changelog/add-podcast-bump-stats
+++ b/projects/plugins/jetpack/changelog/add-podcast-bump-stats
@@ -1,3 +1,4 @@
 Significance: patch
 Type: other
-Comment: Podcast: update composer.lock.
+
+Podcast: update composer.lock.

--- a/projects/plugins/jetpack/changelog/add-podcast-bump-stats
+++ b/projects/plugins/jetpack/changelog/add-podcast-bump-stats
@@ -1,5 +1,3 @@
 Significance: patch
 Type: other
-Comment: Update composer.lock.
-
-
+Comment: Podcast: update composer.lock.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2859,9 +2859,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "a5cce0f43ce63560233013fbf62df82345e3e283"
+                "reference": "ca6eac6cf97203a28c539fd915b3f6728e9cecbb"
             },
             "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
                 "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
@@ -1,5 +1,3 @@
 Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-
+Type: other
+Comment: Podcast: update composer.lock.

--- a/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
+++ b/projects/plugins/mu-wpcom-plugin/changelog/add-podcast-bump-stats
@@ -1,3 +1,4 @@
 Significance: patch
-Type: other
-Comment: Podcast: update composer.lock.
+Type: changed
+
+Podcast: update composer.lock.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1773,9 +1773,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "a5cce0f43ce63560233013fbf62df82345e3e283"
+                "reference": "ca6eac6cf97203a28c539fd915b3f6728e9cecbb"
             },
             "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
                 "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",

--- a/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
+++ b/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
+++ b/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
@@ -1,5 +1,3 @@
 Significance: patch
-Type: changed
-Comment: Update composer.lock.
-
-
+Type: other
+Comment: Podcast: update composer.lock.

--- a/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
+++ b/projects/plugins/wpcomsh/changelog/add-podcast-bump-stats
@@ -1,3 +1,4 @@
 Significance: patch
-Type: other
-Comment: Podcast: update composer.lock.
+Type: changed
+
+Podcast: update composer.lock.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1889,9 +1889,10 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "3c836a10d5e0c2acd955fa065fd64e0a4431a295"
+                "reference": "f2995197d7d9a90af87f9cce125ddf0c99f63a7e"
             },
             "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
                 "automattic/jetpack-admin-ui": "@dev",
                 "automattic/jetpack-assets": "@dev",
                 "automattic/jetpack-blocks": "@dev",


### PR DESCRIPTION
Fixes PODS-215

## Proposed changes
* Add a `bump_stat()` helper to the podcast package's `Tracks` class. On Simple it calls `bump_stats_extras` directly. Everywhere else it pings the stats pixel through `A8c_Mc_Stats`, so Atomic and self-hosted sites count too.
* Bump `wpcom-podcast-episodes` (`published`, `show-launched`), `wpcom-podcast-distribution` (the directory key), and `wpcom-podcasting-status` (`enabled`, `disabled`, `changed`) alongside the existing Tracks events.
* Replace the `jetpack_bump_stats_extras` action in the status recorder. Nothing in Jetpack listens for it, so that bump only ever fired on Simple.
* The pixel URL uses the bare group name instead of `A8c_Mc_Stats::add()`. That method prefixes keys with `x_jetpack-`, which would have filed pixel bumps under `jetpack-wpcom-podcast-*` while Simple files them under `wpcom-podcast-*`.
* Add `automattic/jetpack-a8c-mc-stats` as a package dependency. Plugin lock files updated to match.

## Does this pull request change what data or activity we track or use?
Yes. Adds aggregate Mission Control counters for episode publishes, first-episode show launches, directory URL additions, and podcasting enable/disable. No per-user or per-site data, only counts.

## Testing instructions
* Run `jp test php packages/podcast`. `Tracks_Test` asserts each bump through a `bump_stats_extras` stub in the test bootstrap.
* On a Jurassic Ninja site with the podcast module active, hook `pre_http_request` or watch the network log, then publish a post in the podcast category with audio. Expect a request to `https://pixel.wp.com/b.gif?v=wpcom2&...&x_wpcom-podcast-episodes=published`, plus one with `show-launched` on the first episode.
* Set or clear the podcast category in settings. Expect `x_wpcom-podcasting-status=enabled` or `disabled`.
* Add an Apple Podcasts URL in the distribution dashboard. Expect `x_wpcom-podcast-distribution=apple`.
* On a Simple sandbox, check that `wpcom-podcasting-status` still increments in Mission Control and that the two new groups appear.
