### PR TITLE
Fix flaky `test_export_window_closed_when_missing_stale_or_future` test

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-reprint-export-window-clock-race
+++ b/projects/plugins/jetpack/changelog/fix-reprint-export-window-clock-race
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix flaky test_export_window_closed_when_missing_stale_or_future test
+
+

--- a/projects/plugins/jetpack/src/reprint-export/class-reprint-exporter.php
+++ b/projects/plugins/jetpack/src/reprint-export/class-reprint-exporter.php
@@ -336,11 +336,13 @@ class Reprint_Exporter {
 	/**
 	 * Whether the current export window is open.
 	 *
+	 * @param int|null $now Unix time to compare against, or null for the
+	 *                      current time. Tests pass a fixed time.
 	 * @return bool
 	 */
-	public static function is_export_window_open() {
+	public static function is_export_window_open( $now = null ) {
 		$enabled_at = (int) get_option( self::ENABLED_OPTION, 0 );
-		$now        = time();
+		$now        = null === $now ? time() : (int) $now;
 		return $enabled_at > 0
 			&& $enabled_at <= $now + self::HMAC_CLOCK_SKEW
 			&& ( $now - $enabled_at ) <= HOUR_IN_SECONDS;

--- a/projects/plugins/jetpack/tests/php/src/Reprint_Exporter_Test.php
+++ b/projects/plugins/jetpack/tests/php/src/Reprint_Exporter_Test.php
@@ -806,16 +806,24 @@ class Reprint_Exporter_Test extends WP_UnitTestCase {
 	 * A missing, stale, or future enabled timestamp keeps the window closed.
 	 */
 	public function test_export_window_closed_when_missing_stale_or_future() {
-		$this->assertFalse( Reprint_Exporter::is_export_window_open() );
+		// One fixed time for both the stored value and the check, so the
+		// boundaries below are exact.
+		$now  = time();
+		$skew = Reprint_Exporter::HMAC_CLOCK_SKEW;
 
-		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, time() - ( HOUR_IN_SECONDS + 60 ) );
-		$this->assertFalse( Reprint_Exporter::is_export_window_open() );
+		$this->assertFalse( Reprint_Exporter::is_export_window_open( $now ) );
 
-		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, time() + Reprint_Exporter::HMAC_CLOCK_SKEW + 1 );
-		$this->assertFalse( Reprint_Exporter::is_export_window_open() );
+		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, $now - ( HOUR_IN_SECONDS + 1 ) );
+		$this->assertFalse( Reprint_Exporter::is_export_window_open( $now ), 'A second past the hour is stale.' );
 
-		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, time() + Reprint_Exporter::HMAC_CLOCK_SKEW - 1 );
-		$this->assertTrue( Reprint_Exporter::is_export_window_open() );
+		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, $now - HOUR_IN_SECONDS );
+		$this->assertTrue( Reprint_Exporter::is_export_window_open( $now ), 'Exactly an hour old still counts.' );
+
+		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, $now + $skew + 1 );
+		$this->assertFalse( Reprint_Exporter::is_export_window_open( $now ), 'A second past the skew tolerance is rejected.' );
+
+		$this->plant_option( Reprint_Exporter::ENABLED_OPTION, $now + $skew );
+		$this->assertTrue( Reprint_Exporter::is_export_window_open( $now ), 'Exactly the skew tolerance is allowed.' );
 
 		Reprint_Exporter::open_export_window();
 		$this->assertTrue( Reprint_Exporter::is_export_window_open() );


### PR DESCRIPTION
Fixes a flaky test from https://github.com/Automattic/jetpack/pull/51430

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Give tests the ability to inject a static time into `Reprint_Exporter::is_export_window_open` and inject a static time from the flaky test

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Unit tests should pass
