### PR TITLE
Docker CLI: target the worktree's instance on every subcommand, and make `clean` ask first

### DIFF
--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -303,7 +303,7 @@ Record the PR as soon as it exists — this is the checkpoint a coordinator wait
 - `jp docker stop --name "$NAME"` — stops the containers and frees ports. DB, uploads, and `node_modules` remain on disk for review follow-ups. `$NAME` comes from `.work-on/env.json`; omitting it stops the user's primary `jetpack_dev` instead.
 
 Do NOT run automatically — wait for PR merge or explicit user request:
-- `jp docker clean --name "$NAME"` (destroys that instance's DB).
+- `jp docker clean --yes` (destroys that instance's DB). It targets the instance named in the worktree's `tools/docker/.env`, so run it from the worktree and do not pass `--name`. Without `--yes` it refuses, because an agent has no terminal to confirm at.
 - `git worktree remove <path>` (removes the worktree + scratchpad, including its `tools/docker/.env`, which releases the seeded ports and instance name for reuse).
 
 **On failure** (any phase errors out):

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -4,7 +4,7 @@ description: Optional end-to-end Jetpack workflow that drives a scoped task to a
 
 # /work-on
 
-Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. This skill exists because the default monorepo Docker setup is singleton — two `jp docker up` calls from different branches would otherwise collide — so parallel work requires the named-instance CLI flags and port isolation this skill relies on.
+Drives a task prompt all the way to a draft pull request on its own worktree and its own `jp docker` instance, without touching the primary `jetpack_dev` environment. This skill exists because the default monorepo Docker setup is singleton — two `jp docker up` calls from different branches would otherwise collide — so parallel work requires the per-instance name and port isolation this skill relies on.
 
 **This skill is an option, not a policy.** It is one way to work in this repo, offered alongside the plain in-checkout workflow and the repo-native worktree flow described below. Offer it, name what it costs, and take no for an answer — see "Relationship to the native worktree flows".
 
@@ -44,14 +44,14 @@ The skill would:
 2. **Plan** the change (inspect the block's label CSS, identify breakpoint rule), show the plan, wait for approval.
 3. **Bootstrap** via `work-on/scripts/bootstrap-worktree.sh fix-forms-label-wrap` → creates `../jetpack-fix-forms-label-wrap` on branch `change/fix-forms-label-wrap` off trunk, runs pnpm install, seeds `.work-on/`.
 4. **Isolate Docker** via `tools/docker/bin/seed-worktree-env.sh` inside the worktree → writes `COMPOSE_PROJECT_NAME=jetpack_a1b2c3` and a free `PORT_*` set into `tools/docker/.env`; record `NAME=a1b2c3` and `WP_PORT=8080`.
-5. `jp docker up -d` (no flags — `.env` supplies name and ports, and the DB auto-clones from `jetpack_dev`) → `jp docker install --name a1b2c3 --port 8080` (a no-op after a successful clone).
+5. `jp docker up -d` (no flags — `.env` supplies name and ports) → `jp docker install` to populate the empty instance.
 6. **Baseline screenshot** of the affected block at `http://localhost:8080/...` → `.work-on/screenshots/fix-forms-label-wrap-before.png`.
 7. **Implement** the CSS fix.
 8. `jp build packages/forms` → `jp test js packages/forms` → `jp phan packages/forms`.
 9. **After screenshot** → compare to Figma reference.
 10. `jp changelog add packages/forms -s patch -t fixed -e "Forms: Fix label wrap on mobile."`
 11. Commit (`Forms: Fix label wrap on mobile`), push, open **draft** PR via `jetpack-pr` skill with before/after attachments + testing steps + Figma link.
-12. `jp docker stop --name a1b2c3`. Worktree stays for review follow-ups.
+12. `jp docker stop`. Worktree stays for review follow-ups.
 
 ## When to use
 - Non-trivial features or bug fixes that land as their own PR.
@@ -170,7 +170,7 @@ tools/docker/bin/seed-worktree-env.sh
 
 That writes a unique `COMPOSE_PROJECT_NAME` plus a free `PORT_*` set into the worktree's `tools/docker/.env`. It is host-only, idempotent, and a no-op in the primary checkout. It exits non-zero with an explanatory message if the name it would use is already claimed by another worktree — read the message rather than retrying.
 
-Read the values back; every later `jp docker` subcommand needs them:
+Read the values back; `.work-on/env.json` and the screenshot URLs need them:
 
 ```bash
 # Last occurrence wins and surrounding whitespace is ignored — matches how the
@@ -181,29 +181,29 @@ read_env() {
 }
 
 INSTANCE=$(read_env COMPOSE_PROJECT_NAME)   # e.g. jetpack_a1b2c3
-NAME=${INSTANCE#jetpack_}                   # value for --name
+NAME=${INSTANCE#jetpack_}                   # short id, recorded in env.json
 WP_PORT=$(read_env PORT_WORDPRESS)
 ```
 
-> **`--name` is not the slug.** The seeder derives the instance name from git's worktree id, not from your task slug, so `NAME` is an opaque id. Record it in `.work-on/env.json` (below) — Mode 3 and every cleanup command read it from there.
+> **The instance name is not the slug.** The seeder derives it from git's worktree id, not from your task slug, so `NAME` is an opaque id. Record it in `.work-on/env.json` (below) — Mode 3 and the orphan check under "Docker instance tracking" read it from there.
 
-Bring the instance up. Pass **no `--name` or `--port*` flags**: every `dev` subcommand reads `tools/docker/.env` (`shouldReadParallelEnv` in `tools/cli/commands/docker.js`), and flags that disagree with `.env` only produce conflict warnings on `up`.
+Bring the instance up. Pass **no `--name` or `--port*` flags**: `jp docker up` reads `tools/docker/.env` on the host (`resolveDockerEnv` in `projects/js-packages/jetpack-cli/src/docker-host.js`), and `docker compose` rejects those flags outright.
 
 ```bash
 jp docker up -d
 ```
 
-Because `.env` supplies the name, the CLI treats this as a parallel instance and **auto-clones the database from `jetpack_dev`** when that instance is running — same content, users, and Jetpack connection, no separate install needed. If `jetpack_dev` isn't running the clone is skipped silently and you get the fresh-install flow, so follow up with:
+The instance comes up empty. **`jp docker up` does not clone the database** — the auto-clone lives in `tools/cli`'s `defaultDockerCmdHandler`, and `jp`'s four host subcommands bypass `tools/cli` entirely. So always follow up with:
 
 ```bash
-jp docker install --name "$NAME" --port "$WP_PORT"
+jp docker install
 ```
 
 WordPress image pulls can take several minutes on a cold cache — if `jp docker install` fails with "WordPress install is incomplete! Perhaps it is still downloading?", wait ~30s and retry once before escalating.
 
-Pass `--no-clone` to `up` to force a fresh install, or `--clone-from <name>` to seed from a specific instance instead of `jetpack_dev`. Note that `--clone-from` makes a missing source a hard error, where auto-clone degrades quietly.
+The clone flags (`--clone-from`, `--no-clone`) documented in `tools/docker/README.md` belong to `jetpack docker up`. `jp docker up` hands its arguments straight to `docker compose`, which rejects them — see the flag note below.
 
-**Every other `jp docker` subcommand needs `--name "$NAME"` explicitly** — `install`, `stop`, `clean`, and `phpunit` do not read `.env`, and without the flag they resolve to the primary `jetpack_dev` instance.
+**Run every `jp docker` subcommand from the worktree, and pass no `--name`.** They all read `tools/docker/.env`, so they already target this instance. The four that run `docker compose` on the host — `up`, `stop`, `down`, `clean` — reject `--name` outright, because compose has no such flag.
 
 Write the full session record to `$WORKTREE/.work-on/env.json` using the schema below. Mode 3 (implement-only resume) reads this file — fields are mandatory.
 
@@ -242,7 +242,7 @@ All commands are in `AGENTS.md`. Run the subset that applies:
 |---|---|
 | PHP in a project | `jp build <project>`, `jp test php <project>`, `jp phan <project>` |
 | JS/TS in a project | `jp build <project>`, `jp test js <project>` (no-op if the project doesn't define it) |
-| WP-integration plugin (jetpack / wpcomsh) | `jp docker phpunit <target> -- --name "$NAME"` — `$NAME` is the instance id from `.work-on/env.json`; without it the run hits `jetpack_dev`, not the worktree |
+| WP-integration plugin (jetpack / wpcomsh) | `jp docker phpunit <target>` — run it from the worktree, whose `tools/docker/.env` points it at this instance; from anywhere else the run hits `jetpack_dev` |
 | Root / `tools/*` change | `pnpm test` inside the affected tool package |
 | Every change | lint the touched files: `npx eslint <files>` and project-local `composer lint` / PHPCS when present |
 
@@ -300,7 +300,7 @@ Record the PR as soon as it exists — this is the checkpoint a coordinator wait
 
 **On success:**
 
-- `jp docker stop --name "$NAME"` — stops the containers and frees ports. DB, uploads, and `node_modules` remain on disk for review follow-ups. `$NAME` comes from `.work-on/env.json`; omitting it stops the user's primary `jetpack_dev` instead.
+- `jp docker stop` — stops the containers and frees ports. DB, uploads, and `node_modules` remain on disk for review follow-ups. Run it from the worktree, whose `tools/docker/.env` names the instance; from anywhere else it stops the user's primary `jetpack_dev`.
 
 Do NOT run automatically — wait for PR merge or explicit user request:
 - `jp docker clean --yes` (destroys that instance's DB). It targets the instance named in the worktree's `tools/docker/.env`, so run it from the worktree and do not pass `--name`. Without `--yes` it refuses, because an agent has no terminal to confirm at.
@@ -312,7 +312,7 @@ Do NOT run automatically — wait for PR merge or explicit user request:
   ```bash
   .agents/skills/work-on/scripts/checkpoint.sh --state failed --action "<what broke, one line>"
   ```
-- Attempt `jp docker stop --name "$NAME"` so the named instance doesn't sit orphaned holding ports.
+- Attempt `jp docker stop` from the worktree so the named instance doesn't sit orphaned holding ports.
 - Leave the worktree in place; the user may want to inspect the partial state.
 - Tell the user exactly which phase failed, what the error was, and which of the two cleanup paths to use next.
 

--- a/.agents/skills/work-on.md
+++ b/.agents/skills/work-on.md
@@ -187,7 +187,7 @@ WP_PORT=$(read_env PORT_WORDPRESS)
 
 > **`--name` is not the slug.** The seeder derives the instance name from git's worktree id, not from your task slug, so `NAME` is an opaque id. Record it in `.work-on/env.json` (below) — Mode 3 and every cleanup command read it from there.
 
-Bring the instance up. Pass **no `--name` or `--port*` flags**: `up` is the one subcommand that reads `tools/docker/.env` (`shouldManageParallelEnv` in `tools/cli/commands/docker.js`), and flags that disagree with `.env` only produce conflict warnings.
+Bring the instance up. Pass **no `--name` or `--port*` flags**: every `dev` subcommand reads `tools/docker/.env` (`shouldReadParallelEnv` in `tools/cli/commands/docker.js`), and flags that disagree with `.env` only produce conflict warnings on `up`.
 
 ```bash
 jp docker up -d

--- a/projects/js-packages/jetpack-cli/bin/docker-host.js
+++ b/projects/js-packages/jetpack-cli/bin/docker-host.js
@@ -1,0 +1,112 @@
+import fs from 'fs';
+import { resolve } from 'path';
+import process from 'process';
+
+/**
+ * Resolve the compose environment for a docker command that runs on the host.
+ *
+ * Mirrors the precedence `tools/cli/commands/docker.js` uses inside the container:
+ * process env, then tools/docker/default.env, then the worktree's tools/docker/.env,
+ * then built-in defaults for whatever is still unset.
+ *
+ * @param {string}   monorepoRoot - Path to the monorepo root.
+ * @param {Array}    args         - Raw CLI arguments.
+ * @param {Function} parseEnv     - Parser for an .env buffer; the caller owns the dependency.
+ * @return {object} Environment variables for `docker compose`.
+ */
+export const resolveDockerEnv = ( monorepoRoot, args, parseEnv ) => {
+	const isE2e = args.includes( '--type=e2e' );
+	const envVars = { ...process.env };
+
+	const defaultEnvPath = resolve( monorepoRoot, 'tools/docker/default.env' );
+	if ( fs.existsSync( defaultEnvPath ) ) {
+		Object.assign( envVars, parseEnv( fs.readFileSync( defaultEnvPath ) ) );
+	}
+
+	const envPath = resolve( monorepoRoot, 'tools/docker/.env' );
+	if ( fs.existsSync( envPath ) ) {
+		Object.assign( envVars, parseEnv( fs.readFileSync( envPath ) ) );
+	}
+
+	if ( ! envVars.COMPOSE_PROJECT_NAME ) {
+		envVars.COMPOSE_PROJECT_NAME = isE2e ? 'jetpack_e2e' : 'jetpack_dev';
+	}
+	if ( ! envVars.PORT_WORDPRESS ) {
+		envVars.PORT_WORDPRESS = isE2e ? '8889' : '80';
+	}
+
+	if (
+		! (
+			envVars.PHP_VERSION &&
+			envVars.COMPOSER_VERSION &&
+			envVars.NODE_VERSION &&
+			envVars.PNPM_VERSION
+		)
+	) {
+		const versions = fs.readFileSync( resolve( monorepoRoot, '.github/versions.sh' ), 'utf8' );
+		const versionVars = {};
+		versions.split( '\n' ).forEach( line => {
+			const match = line.match( /^([A-Z_]+)=(.+)$/ );
+			if ( match ) {
+				versionVars[ match[ 1 ] ] = match[ 2 ].replace( /['"]/g, '' );
+			}
+		} );
+
+		if ( ! envVars.PHP_VERSION ) envVars.PHP_VERSION = versionVars.PHP_VERSION;
+		if ( ! envVars.COMPOSER_VERSION ) envVars.COMPOSER_VERSION = versionVars.COMPOSER_VERSION;
+		if ( ! envVars.NODE_VERSION ) envVars.NODE_VERSION = versionVars.NODE_VERSION;
+		if ( ! envVars.PNPM_VERSION ) envVars.PNPM_VERSION = versionVars.PNPM_VERSION;
+	}
+
+	envVars.HOST_CWD = monorepoRoot;
+
+	return envVars;
+};
+
+/**
+ * Paths `docker clean` deletes for one instance. `wordpress/` and `wordpress-develop/` are
+ * shared by every instance rather than per-project, which is why the plan lists them.
+ *
+ * @param {string} monorepoRoot - Path to the monorepo root.
+ * @param {string} projectName  - Resolved compose project name (e.g. 'jetpack_dev').
+ * @return {Array<string>} Paths that will be removed.
+ */
+export const buildCleanupPaths = ( monorepoRoot, projectName ) => [
+	resolve( monorepoRoot, 'tools/docker/wordpress/' ),
+	resolve( monorepoRoot, 'tools/docker/wordpress-develop/*' ),
+	resolve( monorepoRoot, 'tools/docker/logs/', projectName ),
+	resolve( monorepoRoot, 'tools/docker/data/', `${ projectName }_mysql` ),
+];
+
+/**
+ * Decide how `clean` may proceed. A non-TTY caller is refused rather than prompted, so a
+ * script or agent that cannot read the plan has to pass --yes to destroy anything.
+ *
+ * @param {object}  opts       - Options.
+ * @param {boolean} opts.yes   - Whether --yes was passed.
+ * @param {boolean} opts.isTty - Whether stdin and stdout are both TTYs.
+ * @return {string} 'proceed', 'prompt' or 'refuse'.
+ */
+export const resolveCleanConsent = ( { yes, isTty } ) => {
+	if ( yes ) {
+		return 'proceed';
+	}
+	return isTty ? 'prompt' : 'refuse';
+};
+
+/**
+ * Remove `--yes`/`-y` from the argument list in place; `docker compose` rejects them.
+ *
+ * @param {Array} args - Raw CLI arguments, mutated in place.
+ * @return {boolean} Whether either flag was present.
+ */
+export const stripYesFlags = args => {
+	let found = false;
+	for ( let i = args.length - 1; i >= 0; i-- ) {
+		if ( args[ i ] === '--yes' || args[ i ] === '-y' ) {
+			args.splice( i, 1 );
+			found = true;
+		}
+	}
+	return found;
+};

--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -10,6 +10,12 @@ import chalk from 'chalk';
 import * as dotenv from 'dotenv';
 import prompts from 'prompts';
 import updateNotifier from 'update-notifier';
+import {
+	buildCleanupPaths,
+	resolveCleanConsent,
+	resolveDockerEnv,
+	stripYesFlags,
+} from './docker-host.js';
 
 // Get package.json path relative to this file
 const packageJson = JSON.parse(
@@ -524,6 +530,51 @@ const runRsyncWithProxy = async ( monorepoRoot, args ) => {
 	}
 };
 
+/**
+ * Announce what `docker clean` will destroy and get the user's consent.
+ *
+ * @param {string}  projectName  - Resolved compose project name.
+ * @param {Array}   cleanupPaths - Paths that will be removed.
+ * @param {boolean} yes          - Whether --yes was passed.
+ * @throws {Error} When there is no terminal to confirm at and --yes was not passed.
+ * @return {Promise<boolean>} True when the caller may proceed.
+ */
+const confirmClean = async ( projectName, cleanupPaths, yes ) => {
+	console.log(
+		chalk.yellow( `\n'clean' will permanently destroy the '${ projectName }' instance:` )
+	);
+	console.log( chalk.yellow( '  - its containers and Docker volumes (`compose down -v`)' ) );
+	for ( const path of cleanupPaths ) {
+		console.log( chalk.yellow( `  - ${ path }` ) );
+	}
+	console.log();
+
+	const consent = resolveCleanConsent( {
+		yes,
+		isTty: Boolean( process.stdin.isTTY && process.stdout.isTTY ),
+	} );
+
+	if ( consent === 'proceed' ) {
+		return true;
+	}
+	if ( consent === 'refuse' ) {
+		throw new Error(
+			`No terminal to confirm at, so '${ projectName }' was left alone. Pass --yes if you really mean to destroy it.`
+		);
+	}
+
+	const { confirmed } = await prompts( {
+		type: 'confirm',
+		name: 'confirmed',
+		message: `Destroy '${ projectName }'?`,
+		initial: false,
+	} );
+	if ( ! confirmed ) {
+		console.log( chalk.green( 'Nothing was removed.' ) );
+	}
+	return Boolean( confirmed );
+};
+
 // Main execution
 const main = async () => {
 	try {
@@ -594,6 +645,8 @@ const main = async () => {
 		if ( args[ 0 ] === 'docker' ) {
 			const hostCommands = [ 'up', 'down', 'stop', 'clean' ];
 			if ( hostCommands.includes( args[ 1 ] ) ) {
+				let afterCompose = null;
+
 				// Handle command-specific setup/cleanup
 				if ( args[ 1 ] === 'up' ) {
 					// Create required directories
@@ -621,17 +674,22 @@ const main = async () => {
 						throw new Error( 'Failed to generate Docker config' );
 					}
 				} else if ( args[ 1 ] === 'clean' ) {
-					// After docker-compose down -v, also remove local files
-					const projectName = args.includes( '--type=e2e' ) ? 'jetpack_e2e' : 'jetpack_dev';
-					const cleanupPaths = [
-						resolve( monorepoRoot, 'tools/docker/wordpress/' ),
-						resolve( monorepoRoot, 'tools/docker/wordpress-develop/*' ),
-						resolve( monorepoRoot, 'tools/docker/logs/', projectName ),
-						resolve( monorepoRoot, 'tools/docker/data/', `${ projectName }_mysql` ),
-					];
+					// Same resolution the compose call below uses, so the containers we stop and the
+					// data we delete can never belong to different instances.
+					const { COMPOSE_PROJECT_NAME: projectName } = resolveDockerEnv(
+						monorepoRoot,
+						args,
+						dotenv.parse
+					);
+					const cleanupPaths = buildCleanupPaths( monorepoRoot, projectName );
 
-					// Function to clean up after docker-compose down
-					const cleanupFiles = () => {
+					const yes = stripYesFlags( args );
+					if ( ! ( await confirmClean( projectName, cleanupPaths, yes ) ) ) {
+						return;
+					}
+
+					// Only after `down -v` succeeds: a failed teardown must not leave the data deleted.
+					afterCompose = () => {
 						for ( const path of cleanupPaths ) {
 							try {
 								fs.rmSync( path, { recursive: true, force: true } );
@@ -643,73 +701,11 @@ const main = async () => {
 						}
 					};
 
-					// Add cleanup to process events to ensure it runs after docker-compose
-					process.once( 'beforeExit', cleanupFiles );
-
 					// Replace 'clean' with 'down -v' in the arguments
 					args.splice( 1, 1, 'down', '-v' );
 				}
 
-				// Get project name (from docker.js)
-				const projectName = args.includes( '--type=e2e' ) ? 'jetpack_e2e' : 'jetpack_dev';
-
-				// Build environment variables (from docker.js)
-				const envVars = {
-					...process.env, // Start with process.env
-				};
-
-				// Add default env vars if they exist
-				if ( fs.existsSync( resolve( monorepoRoot, 'tools/docker/default.env' ) ) ) {
-					Object.assign(
-						envVars,
-						dotenv.parse( fs.readFileSync( resolve( monorepoRoot, 'tools/docker/default.env' ) ) )
-					);
-				}
-
-				// Add user overrides from .env if they exist
-				if ( fs.existsSync( resolve( monorepoRoot, 'tools/docker/.env' ) ) ) {
-					Object.assign(
-						envVars,
-						dotenv.parse( fs.readFileSync( resolve( monorepoRoot, 'tools/docker/.env' ) ) )
-					);
-				}
-
-				// Only set these specific vars if they're not already set in .env
-				if ( ! envVars.COMPOSE_PROJECT_NAME ) {
-					envVars.COMPOSE_PROJECT_NAME = projectName;
-				}
-				if ( ! envVars.PORT_WORDPRESS ) {
-					envVars.PORT_WORDPRESS = args.includes( '--type=e2e' ) ? '8889' : '80';
-				}
-
-				// Load versions from .github/versions.sh if not already set
-				if (
-					! (
-						envVars.PHP_VERSION &&
-						envVars.COMPOSER_VERSION &&
-						envVars.NODE_VERSION &&
-						envVars.PNPM_VERSION
-					)
-				) {
-					const versionsPath = resolve( monorepoRoot, '.github/versions.sh' );
-					const versions = fs.readFileSync( versionsPath, 'utf8' );
-					const versionVars = {};
-					versions.split( '\n' ).forEach( line => {
-						const match = line.match( /^([A-Z_]+)=(.+)$/ );
-						if ( match ) {
-							versionVars[ match[ 1 ] ] = match[ 2 ].replace( /['"]/g, '' );
-						}
-					} );
-
-					// Only set version vars if they're not already set
-					if ( ! envVars.PHP_VERSION ) envVars.PHP_VERSION = versionVars.PHP_VERSION;
-					if ( ! envVars.COMPOSER_VERSION ) envVars.COMPOSER_VERSION = versionVars.COMPOSER_VERSION;
-					if ( ! envVars.NODE_VERSION ) envVars.NODE_VERSION = versionVars.NODE_VERSION;
-					if ( ! envVars.PNPM_VERSION ) envVars.PNPM_VERSION = versionVars.PNPM_VERSION;
-				}
-
-				// Always set HOST_CWD as it's required for Docker context
-				envVars.HOST_CWD = monorepoRoot;
+				const envVars = resolveDockerEnv( monorepoRoot, args, dotenv.parse );
 
 				// Build the list of compose files to use
 				const composeFiles =
@@ -735,6 +731,9 @@ const main = async () => {
 
 				if ( result.status !== 0 ) {
 					throw new Error( `Docker command failed with status ${ result.status }` );
+				}
+				if ( afterCompose ) {
+					afterCompose();
 				}
 				return;
 			}

--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -647,11 +647,11 @@ const main = async () => {
 			const hostCommands = [ 'up', 'down', 'stop', 'clean' ];
 			if ( hostCommands.includes( args[ 1 ] ) ) {
 				// Before anything announces or destroys an instance: these subcommands forward their
-				// arguments straight to `docker compose`, which has no --name.
+				// arguments straight to `docker compose`, which has neither flag.
 				const unsupportedFlag = findUnsupportedHostFlag( args );
 				if ( unsupportedFlag ) {
 					throw new Error(
-						`\`jp docker ${ args[ 1 ] }\` runs \`docker compose\` directly, which has no ${ unsupportedFlag }. Set COMPOSE_PROJECT_NAME in this checkout's tools/docker/.env instead — \`tools/docker/bin/seed-worktree-env.sh\` writes it for you.`
+						`\`jp docker ${ args[ 1 ] }\` runs \`docker compose\` directly, which has no ${ unsupportedFlag }. These subcommands take their instance from tools/docker/.env, which \`tools/docker/bin/seed-worktree-env.sh\` writes for you. Use \`jetpack docker\` if you need ${ unsupportedFlag }.`
 					);
 				}
 

--- a/projects/js-packages/jetpack-cli/bin/jp.js
+++ b/projects/js-packages/jetpack-cli/bin/jp.js
@@ -12,10 +12,11 @@ import prompts from 'prompts';
 import updateNotifier from 'update-notifier';
 import {
 	buildCleanupPaths,
+	findUnsupportedHostFlag,
 	resolveCleanConsent,
 	resolveDockerEnv,
 	stripYesFlags,
-} from './docker-host.js';
+} from '../src/docker-host.js';
 
 // Get package.json path relative to this file
 const packageJson = JSON.parse(
@@ -645,12 +646,25 @@ const main = async () => {
 		if ( args[ 0 ] === 'docker' ) {
 			const hostCommands = [ 'up', 'down', 'stop', 'clean' ];
 			if ( hostCommands.includes( args[ 1 ] ) ) {
+				// Before anything announces or destroys an instance: these subcommands forward their
+				// arguments straight to `docker compose`, which has no --name.
+				const unsupportedFlag = findUnsupportedHostFlag( args );
+				if ( unsupportedFlag ) {
+					throw new Error(
+						`\`jp docker ${ args[ 1 ] }\` runs \`docker compose\` directly, which has no ${ unsupportedFlag }. Set COMPOSE_PROJECT_NAME in this checkout's tools/docker/.env instead — \`tools/docker/bin/seed-worktree-env.sh\` writes it for you.`
+					);
+				}
+
+				// One resolution for the whole block, so the instance we announce, create data
+				// directories for, and hand to compose can never come out different.
+				const envVars = resolveDockerEnv( monorepoRoot, args, dotenv.parse );
+				const projectName = envVars.COMPOSE_PROJECT_NAME;
 				let afterCompose = null;
 
 				// Handle command-specific setup/cleanup
 				if ( args[ 1 ] === 'up' ) {
 					// Create required directories
-					fs.mkdirSync( resolve( monorepoRoot, 'tools/docker/data/jetpack_dev_mysql' ), {
+					fs.mkdirSync( resolve( monorepoRoot, 'tools/docker/data/', `${ projectName }_mysql` ), {
 						recursive: true,
 					} );
 					fs.mkdirSync( resolve( monorepoRoot, 'tools/docker/data/ssh.keys' ), {
@@ -674,13 +688,6 @@ const main = async () => {
 						throw new Error( 'Failed to generate Docker config' );
 					}
 				} else if ( args[ 1 ] === 'clean' ) {
-					// Same resolution the compose call below uses, so the containers we stop and the
-					// data we delete can never belong to different instances.
-					const { COMPOSE_PROJECT_NAME: projectName } = resolveDockerEnv(
-						monorepoRoot,
-						args,
-						dotenv.parse
-					);
 					const cleanupPaths = buildCleanupPaths( monorepoRoot, projectName );
 
 					const yes = stripYesFlags( args );
@@ -704,8 +711,6 @@ const main = async () => {
 					// Replace 'clean' with 'down -v' in the arguments
 					args.splice( 1, 1, 'down', '-v' );
 				}
-
-				const envVars = resolveDockerEnv( monorepoRoot, args, dotenv.parse );
 
 				// Build the list of compose files to use
 				const composeFiles =

--- a/projects/js-packages/jetpack-cli/changelog/docker-clean-confirm
+++ b/projects/js-packages/jetpack-cli/changelog/docker-clean-confirm
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Docker: `clean` now lists the instance and the paths it will destroy and asks for confirmation. Pass `--yes` to skip the prompt; without a terminal to confirm at, it refuses instead of prompting.

--- a/projects/js-packages/jetpack-cli/changelog/docker-clean-guard
+++ b/projects/js-packages/jetpack-cli/changelog/docker-clean-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Docker: derive the paths `clean` deletes from the same compose project name it stops containers for, so cleaning a parallel instance no longer removes the primary instance's database and logs.

--- a/projects/js-packages/jetpack-cli/changelog/docker-clean-wordpress-develop
+++ b/projects/js-packages/jetpack-cli/changelog/docker-clean-wordpress-develop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Docker: `clean` now removes the contents of `tools/docker/wordpress-develop`, which it listed in its plan but left on disk.

--- a/projects/js-packages/jetpack-cli/changelog/docker-host-name-flag
+++ b/projects/js-packages/jetpack-cli/changelog/docker-host-name-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Docker: `up`, `stop`, `down` and `clean` now explain that they take no `--name` instead of failing inside `docker compose`. These run on the host and read the instance name from `tools/docker/.env`.

--- a/projects/js-packages/jetpack-cli/changelog/docker-host-name-flag
+++ b/projects/js-packages/jetpack-cli/changelog/docker-host-name-flag
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Docker: `up`, `stop`, `down` and `clean` now explain that they take no `--name` instead of failing inside `docker compose`. These run on the host and read the instance name from `tools/docker/.env`.
+Docker: `up`, `stop`, `down` and `clean` now explain that they take no `--name` or `--type`, instead of naming one instance and then failing inside `docker compose`. These run on the host and read the instance from `tools/docker/.env`.

--- a/projects/js-packages/jetpack-cli/changelog/docker-up-instance-data-dir
+++ b/projects/js-packages/jetpack-cli/changelog/docker-up-instance-data-dir
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Docker: `up` now creates the MySQL data directory for the instance named in `tools/docker/.env`, instead of always creating the primary `jetpack_dev` one.

--- a/projects/js-packages/jetpack-cli/package.json
+++ b/projects/js-packages/jetpack-cli/package.json
@@ -20,7 +20,8 @@
 		"./package.json": "./package.json"
 	},
 	"files": [
-		"bin"
+		"bin",
+		"src"
 	],
 	"dependencies": {
 		"chalk": "^5.4.1",

--- a/projects/js-packages/jetpack-cli/src/docker-host.js
+++ b/projects/js-packages/jetpack-cli/src/docker-host.js
@@ -5,9 +5,10 @@ import process from 'process';
 /**
  * Resolve the compose environment for a docker command that runs on the host.
  *
- * Mirrors the precedence `tools/cli/commands/docker.js` uses inside the container:
- * process env, then tools/docker/default.env, then the worktree's tools/docker/.env,
- * then built-in defaults for whatever is still unset.
+ * Precedence, last wins: process env, tools/docker/default.env, the worktree's
+ * tools/docker/.env, then built-in defaults for whatever is still unset. Note the file beats
+ * an exported variable here, the reverse of `tools/cli/commands/docker.js`, whose
+ * `shellExecutor` layers `process.env` last.
  *
  * @param {string}   monorepoRoot - Path to the monorepo root.
  * @param {Array}    args         - Raw CLI arguments.
@@ -67,16 +68,44 @@ export const resolveDockerEnv = ( monorepoRoot, args, parseEnv ) => {
  * Paths `docker clean` deletes for one instance. `wordpress/` and `wordpress-develop/` are
  * shared by every instance rather than per-project, which is why the plan lists them.
  *
+ * `wordpress-develop` is expanded to its entries because `fs.rmSync` does no globbing, and
+ * dotfiles are skipped so `.gitkeep` survives, as it does under `rm -rf .../*`.
+ *
  * @param {string} monorepoRoot - Path to the monorepo root.
  * @param {string} projectName  - Resolved compose project name (e.g. 'jetpack_dev').
  * @return {Array<string>} Paths that will be removed.
  */
-export const buildCleanupPaths = ( monorepoRoot, projectName ) => [
-	resolve( monorepoRoot, 'tools/docker/wordpress/' ),
-	resolve( monorepoRoot, 'tools/docker/wordpress-develop/*' ),
-	resolve( monorepoRoot, 'tools/docker/logs/', projectName ),
-	resolve( monorepoRoot, 'tools/docker/data/', `${ projectName }_mysql` ),
-];
+export const buildCleanupPaths = ( monorepoRoot, projectName ) => {
+	const wpDevelop = resolve( monorepoRoot, 'tools/docker/wordpress-develop' );
+	const wpDevelopEntries = fs.existsSync( wpDevelop )
+		? fs
+				.readdirSync( wpDevelop )
+				.filter( entry => ! entry.startsWith( '.' ) )
+				.map( entry => resolve( wpDevelop, entry ) )
+		: [];
+
+	return [
+		resolve( monorepoRoot, 'tools/docker/wordpress/' ),
+		...wpDevelopEntries,
+		resolve( monorepoRoot, 'tools/docker/logs/', projectName ),
+		resolve( monorepoRoot, 'tools/docker/data/', `${ projectName }_mysql` ),
+	];
+};
+
+/**
+ * Find the first `jetpack docker` flag in `args` that `docker compose` does not accept.
+ *
+ * `up`, `down`, `stop` and `clean` run compose directly on the host, so their arguments are
+ * forwarded verbatim. `--name` belongs to the container-side CLI; compose rejects it with
+ * `unknown flag`, after the host path has already announced the wrong instance.
+ *
+ * @param {Array} args - Raw CLI arguments.
+ * @return {string|null} The offending flag, or null when there is none.
+ */
+export const findUnsupportedHostFlag = args => {
+	const match = args.find( arg => arg === '--name' || arg === '-n' || arg.startsWith( '--name=' ) );
+	return match ? match.split( '=' )[ 0 ] : null;
+};
 
 /**
  * Decide how `clean` may proceed. A non-TTY caller is refused rather than prompted, so a

--- a/projects/js-packages/jetpack-cli/src/docker-host.js
+++ b/projects/js-packages/jetpack-cli/src/docker-host.js
@@ -93,17 +93,21 @@ export const buildCleanupPaths = ( monorepoRoot, projectName ) => {
 };
 
 /**
- * Find the first `jetpack docker` flag in `args` that `docker compose` does not accept.
+ * Find the first instance-selecting `jetpack docker` flag in `args`.
  *
- * `up`, `down`, `stop` and `clean` run compose directly on the host, so their arguments are
- * forwarded verbatim. `--name` belongs to the container-side CLI; compose rejects it with
- * `unknown flag`, after the host path has already announced the wrong instance.
+ * `up`, `down`, `stop` and `clean` run compose directly on the host and forward their arguments
+ * verbatim, so every `jetpack docker` flag fails there. These two are refused rather than
+ * forwarded because they choose which instance the command acts on: a seeded `.env` wins over
+ * both, so `clean` would name one instance in its confirmation prompt and the user another.
+ *
+ * `-t` is deliberately absent — `jetpack docker` reads it as `--type`, but `docker compose`
+ * defines it as `--timeout`, so refusing it would break `jp docker down -t 30`.
  *
  * @param {Array} args - Raw CLI arguments.
  * @return {string|null} The offending flag, or null when there is none.
  */
 export const findUnsupportedHostFlag = args => {
-	const match = args.find( arg => arg === '--name' || arg === '-n' || arg.startsWith( '--name=' ) );
+	const match = args.find( arg => [ '--name', '-n', '--type' ].includes( arg.split( '=' )[ 0 ] ) );
 	return match ? match.split( '=' )[ 0 ] : null;
 };
 

--- a/projects/js-packages/jetpack-cli/src/index.jsx
+++ b/projects/js-packages/jetpack-cli/src/index.jsx
@@ -1,2 +1,0 @@
-// Put your code in this `src/` folder!
-// Feel free to delete or rename this file.

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -344,19 +344,43 @@ export const applyUpdateEnv = ( filePath, conflicts ) => {
 };
 
 /**
- * Whether the hybrid tools/docker/.env parallel-instance machinery (reading keys as a base
- * layer, conflict warnings, append-on-`up --name` persistence) applies to this invocation.
+ * Whether this invocation resolves its target instance from tools/docker/.env.
  *
- * Scoped to `up` on `type === 'dev'`. The e2e flow runs `docker --type e2e --name t1 up`,
- * which sets argv.name but manages its own fixed ports and project name — it must neither
- * read parallel keys from nor write them to the shared .env. Keeping the gate here (rather
- * than only inline at the call sites) mirrors resolveDevCloneSource being "correct on its
- * own terms" and makes the e2e exclusion unit-testable.
+ * Every dev subcommand does, so `stop`/`down`/`clean`/`wp` from a seeded worktree hit that
+ * worktree's containers rather than the shared jetpack_dev. The e2e flow is excluded: it runs
+ * `docker --type e2e --name t1 …` with its own fixed name and ports.
  *
  * @param {object} argv - Yargs argv.
- * @return {boolean} true when parallel-env reads/writes should run.
+ * @return {boolean} true when .env should be read as a base layer for argv.
  */
-export const shouldManageParallelEnv = argv => argv.type === 'dev' && argv._[ 1 ] === 'up';
+export const shouldReadParallelEnv = argv => argv.type === 'dev';
+
+/**
+ * Whether this invocation may write tools/docker/.env — conflict warnings, --update-env
+ * rewrites, and append-on-`up --name` persistence.
+ *
+ * Scoped to `up`, the only subcommand that takes the flags .env can disagree with.
+ *
+ * @param {object} argv - Yargs argv.
+ * @return {boolean} true when parallel-env writes should run.
+ */
+export const shouldWriteParallelEnv = argv => shouldReadParallelEnv( argv ) && argv._[ 1 ] === 'up';
+
+/**
+ * Fill argv's parallel-instance fields from tools/docker/.env so the command targets this
+ * worktree's instance. Flags already set win; safe to call more than once per invocation.
+ *
+ * @param {object} argv - Yargs argv (mutated in place).
+ * @return {object} Parsed .env, or {} when the read does not apply.
+ */
+export const applyParallelEnv = argv => {
+	if ( ! shouldReadParallelEnv( argv ) ) {
+		return {};
+	}
+	const fileEnv = readEnvFile();
+	augmentArgvFromEnvFile( argv, fileEnv );
+	return fileEnv;
+};
 
 /**
  * Decides which source instance to clone the DB from when bringing up a dev container, if any.
@@ -818,20 +842,16 @@ async function retry( action, { times, delay = 5000 } ) {
  *
  * @param {object} argv - Arguments passed.
  */
-const defaultDockerCmdHandler = async argv => {
+export const defaultDockerCmdHandler = async argv => {
 	printPreCmdMsg( argv );
 
-	// Hybrid .env handling for `up`: read .env as a base layer (flags still win),
-	// surface conflicts as warnings (or rewrite when --update-env is set), and persist
-	// parallel-instance keys after a successful `up --name`. See tools/docker/README.md
-	// § "Parallel development environments" for the full precedence + semantics.
-	// Scoped via shouldManageParallelEnv (`up` + `type === 'dev'`): the e2e flow runs with a
-	// fixed `--name t1` and manages its own ports, so it must neither read parallel keys from
-	// nor write them to the shared tools/docker/.env.
-	if ( shouldManageParallelEnv( argv ) ) {
-		const flagSnapshot = snapshotFlagArgv( argv );
-		const fileEnv = readEnvFile();
-		augmentArgvFromEnvFile( argv, fileEnv );
+	// Read .env as a base layer so every dev subcommand targets this worktree's instance, not
+	// the shared jetpack_dev; flags still win. Writing back (conflict warnings, --update-env)
+	// stays on `up`, the only subcommand taking flags .env can disagree with. See
+	// tools/docker/README.md § "Parallel development environments" for the full semantics.
+	const flagSnapshot = snapshotFlagArgv( argv );
+	const fileEnv = applyParallelEnv( argv );
+	if ( shouldWriteParallelEnv( argv ) ) {
 		const conflicts = detectEnvConflicts( flagSnapshot, fileEnv );
 		if ( conflicts.length ) {
 			if ( argv.updateEnv ) {
@@ -916,12 +936,11 @@ const defaultDockerCmdHandler = async argv => {
 		}
 	}
 
-	// Persist parallel-instance config to .env on `up --name`. Idempotent: only appends
-	// keys that aren't already in the file (Strategy B). Skipped for the primary
-	// `jetpack_dev` flow (no --name) so the main checkout's .env is never written to.
-	// Also skipped for non-dev types: the e2e flow always passes `--name t1`, but it
-	// must not write COMPOSE_PROJECT_NAME/PORT_* into the shared tools/docker/.env.
-	if ( shouldManageParallelEnv( argv ) && argv.name ) {
+	// Persist parallel-instance config to .env on `up --name`. Idempotent: only appends keys
+	// that aren't already in the file (Strategy B). Skipped without --name so the primary
+	// `jetpack_dev` flow never writes to the main checkout's .env, and skipped for e2e, which
+	// always passes `--name t1` but must not claim the shared file.
+	if ( shouldWriteParallelEnv( argv ) && argv.name ) {
 		const written = persistParallelEnv( envOpts );
 		if ( written.length ) {
 			console.log(
@@ -1061,9 +1080,10 @@ export const buildExecCmd = argv => {
  *
  * @param {object} argv - Yargs object
  */
-const execDockerCmdHandler = argv => {
+export const execDockerCmdHandler = argv => {
 	printPreCmdMsg( argv );
 
+	applyParallelEnv( argv );
 	const envOpts = buildEnv( argv );
 	const opts = buildExecCmd( argv );
 
@@ -1414,6 +1434,7 @@ export function dockerDefine( yargs ) {
 							array: true,
 						} ),
 					handler: argv => {
+						applyParallelEnv( argv );
 						// Get all the commands to run
 						const allCmds = buildExecCmd( argv );
 						let hasFailure = false;

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import chalk from 'chalk';
+import enquirer from 'enquirer';
 import * as envfile from 'envfile';
 import { dockerFolder, setConfig } from '../helpers/docker-config.js';
 
@@ -1178,6 +1179,95 @@ async function generateConfig( argv ) {
 }
 
 /**
+ * Paths `docker clean` deletes for one instance. `wordpress/` and `wordpress-develop/` are
+ * shared by every instance rather than per-project, which is why the plan lists them.
+ *
+ * @param {string} project - Compose project name (e.g. 'jetpack_dev').
+ * @return {Array<string>} Paths, exactly as handed to `rm -rf`.
+ */
+export const buildCleanPaths = project => [
+	`${ dockerFolder }/wordpress/`,
+	`${ dockerFolder }/wordpress-develop/*`,
+	`${ dockerFolder }/logs/${ project }/`,
+	`${ dockerFolder }/data/${ project }_mysql/`,
+];
+
+/**
+ * Decide how `clean` may proceed. A non-TTY caller is refused rather than prompted, so a
+ * script or agent that cannot read the plan has to pass --yes to destroy anything.
+ *
+ * @param {object}  opts       - Options.
+ * @param {boolean} opts.yes   - Whether --yes was passed.
+ * @param {boolean} opts.isTty - Whether stdin and stdout are both TTYs.
+ * @return {string} 'proceed', 'prompt' or 'refuse'.
+ */
+export const resolveCleanConsent = ( { yes, isTty } ) => {
+	if ( yes ) {
+		return 'proceed';
+	}
+	return isTty ? 'prompt' : 'refuse';
+};
+
+/**
+ * Print what `clean` is about to destroy, before anything is destroyed.
+ *
+ * @param {string}        project - Compose project name.
+ * @param {Array<string>} paths   - Paths that will be removed.
+ */
+const printCleanPlan = ( project, paths ) => {
+	console.log( chalk.yellow( `\n'clean' will permanently destroy the '${ project }' instance:` ) );
+	console.log( chalk.yellow( '  - its containers and Docker volumes (`compose down -v`)' ) );
+	for ( const path of paths ) {
+		console.log( chalk.yellow( `  - ${ path }` ) );
+	}
+	console.log();
+};
+
+/**
+ * Handler for `docker clean`: announce the target, get consent, then tear it down.
+ *
+ * @param {object} argv - Yargs
+ */
+export const cleanCmdHandler = async argv => {
+	const project = getProjectName( argv );
+	const paths = buildCleanPaths( project );
+	printCleanPlan( project, paths );
+
+	const consent = resolveCleanConsent( {
+		yes: Boolean( argv.yes ),
+		isTty: Boolean( process.stdin.isTTY && process.stdout.isTTY ),
+	} );
+
+	if ( consent === 'refuse' ) {
+		console.error(
+			chalk.red(
+				`No terminal to confirm at, so '${ project }' was left alone. Pass --yes if you really mean to destroy it.`
+			)
+		);
+		process.exit( 1 );
+	}
+
+	if ( consent === 'prompt' ) {
+		const { confirmed } = await enquirer.prompt( {
+			type: 'confirm',
+			name: 'confirmed',
+			initial: false,
+			message: `Destroy '${ project }'?`,
+		} );
+		if ( ! confirmed ) {
+			console.log( chalk.green( 'Nothing was removed.' ) );
+			return;
+		}
+	}
+
+	await defaultDockerCmdHandler( argv );
+	const res = executor( argv, () =>
+		shellExecutor( argv, 'rm', [ '-rf', ...paths ], { shell: true } )
+	);
+	checkProcessResult( res );
+};
+
+/**
  * Definition for the Docker commands.
  *
  * @param {object} yargs - The Yargs dependency.
@@ -1217,26 +1307,14 @@ export function dockerDefine( yargs ) {
 				.command( {
 					command: 'clean',
 					description: 'Remove docker volumes, MySql and WordPress data and logs.',
-					builder: yargCmd => defaultOpts( yargCmd ),
-					handler: async argv => {
-						await defaultDockerCmdHandler( argv );
-						const project = getProjectName( argv );
-						const res = executor( argv, () =>
-							shellExecutor(
-								argv,
-								'rm',
-								[
-									'-rf',
-									`${ dockerFolder }/wordpress/`,
-									`${ dockerFolder }/wordpress-develop/*`,
-									`${ dockerFolder }/logs/${ project }/`,
-									`${ dockerFolder }/data/${ project }_mysql/`,
-								],
-								{ shell: true }
-							)
-						);
-						checkProcessResult( res );
-					},
+					builder: yargCmd =>
+						defaultOpts( yargCmd ).option( 'yes', {
+							alias: 'y',
+							type: 'boolean',
+							default: false,
+							describe: 'Skip the confirmation prompt. Required when there is no terminal.',
+						} ),
+					handler: async argv => await cleanCmdHandler( argv ),
 				} )
 				.command( {
 					command: 'build-image',

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -1179,51 +1179,6 @@ async function generateConfig( argv ) {
 }
 
 /**
- * Paths `docker clean` deletes for one instance. `wordpress/` and `wordpress-develop/` are
- * shared by every instance rather than per-project, which is why the plan lists them.
- *
- * @param {string} project - Compose project name (e.g. 'jetpack_dev').
- * @return {Array<string>} Paths, exactly as handed to `rm -rf`.
- */
-export const buildCleanPaths = project => [
-	`${ dockerFolder }/wordpress/`,
-	`${ dockerFolder }/wordpress-develop/*`,
-	`${ dockerFolder }/logs/${ project }/`,
-	`${ dockerFolder }/data/${ project }_mysql/`,
-];
-
-/**
- * Decide how `clean` may proceed. A non-TTY caller is refused rather than prompted, so a
- * script or agent that cannot read the plan has to pass --yes to destroy anything.
- *
- * @param {object}  opts       - Options.
- * @param {boolean} opts.yes   - Whether --yes was passed.
- * @param {boolean} opts.isTty - Whether stdin and stdout are both TTYs.
- * @return {string} 'proceed', 'prompt' or 'refuse'.
- */
-export const resolveCleanConsent = ( { yes, isTty } ) => {
-	if ( yes ) {
-		return 'proceed';
-	}
-	return isTty ? 'prompt' : 'refuse';
-};
-
-/**
- * Print what `clean` is about to destroy, before anything is destroyed.
- *
- * @param {string}        project - Compose project name.
- * @param {Array<string>} paths   - Paths that will be removed.
- */
-const printCleanPlan = ( project, paths ) => {
-	console.log( chalk.yellow( `\n'clean' will permanently destroy the '${ project }' instance:` ) );
-	console.log( chalk.yellow( '  - its containers and Docker volumes (`compose down -v`)' ) );
-	for ( const path of paths ) {
-		console.log( chalk.yellow( `  - ${ path }` ) );
-	}
-	console.log();
-};
-
-/**
  * Handler for `docker clean`: announce the target, get consent, then tear it down.
  *
  * @param {object} argv - Yargs
@@ -1235,15 +1190,26 @@ export const cleanCmdHandler = async argv => {
 	applyParallelEnv( argv );
 
 	const project = getProjectName( argv );
-	const paths = buildCleanPaths( project );
-	printCleanPlan( project, paths );
+	// `wordpress/` and `wordpress-develop/` are shared by every instance rather than
+	// per-project, which is why the plan lists them. The glob is expanded by `shell: true`.
+	const paths = [
+		`${ dockerFolder }/wordpress/`,
+		`${ dockerFolder }/wordpress-develop/*`,
+		`${ dockerFolder }/logs/${ project }/`,
+		`${ dockerFolder }/data/${ project }_mysql/`,
+	];
 
-	const consent = resolveCleanConsent( {
-		yes: Boolean( argv.yes ),
-		isTty: Boolean( process.stdin.isTTY && process.stdout.isTTY ),
-	} );
+	console.log( chalk.yellow( `\n'clean' will permanently destroy the '${ project }' instance:` ) );
+	console.log( chalk.yellow( '  - its containers and Docker volumes (`compose down -v`)' ) );
+	for ( const path of paths ) {
+		console.log( chalk.yellow( `  - ${ path }` ) );
+	}
+	console.log();
 
-	if ( consent === 'refuse' ) {
+	// Refuse a non-TTY caller rather than prompting, so a script or agent that cannot read the
+	// plan has to pass --yes to destroy anything.
+	const isTty = Boolean( process.stdin.isTTY && process.stdout.isTTY );
+	if ( ! argv.yes && ! isTty ) {
 		console.error(
 			chalk.red(
 				`No terminal to confirm at, so '${ project }' was left alone. Pass --yes if you really mean to destroy it.`
@@ -1252,7 +1218,7 @@ export const cleanCmdHandler = async argv => {
 		process.exit( 1 );
 	}
 
-	if ( consent === 'prompt' ) {
+	if ( ! argv.yes ) {
 		const { confirmed } = await enquirer.prompt( {
 			type: 'confirm',
 			name: 'confirmed',

--- a/tools/cli/commands/docker.js
+++ b/tools/cli/commands/docker.js
@@ -1229,6 +1229,11 @@ const printCleanPlan = ( project, paths ) => {
  * @param {object} argv - Yargs
  */
 export const cleanCmdHandler = async argv => {
+	// Resolve the target before announcing it. defaultDockerCmdHandler does this too, but only
+	// once the plan is already printed, which would have `clean` name one instance and delete
+	// another's paths. Idempotent, so the second call is a no-op.
+	applyParallelEnv( argv );
+
 	const project = getProjectName( argv );
 	const paths = buildCleanPaths( project );
 	printCleanPlan( project, paths );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -25,10 +25,18 @@ jest.unstable_mockModule( 'child_process', () => ( {
 	...cpStub,
 } ) );
 
+// setConfig parses the real docker config yaml, which the fs stub cannot serve.
+jest.unstable_mockModule( '../../../helpers/docker-config.js', () => ( {
+	dockerFolder: 'tools/docker',
+	setConfig: jest.fn(),
+} ) );
+
 const {
 	getProjectName,
 	buildEnv,
 	buildExecCmd,
+	execDockerCmdHandler,
+	defaultDockerCmdHandler,
 	resolveDevCloneSource,
 	normalizeProjectShortName,
 	pipeDbDump,
@@ -38,7 +46,9 @@ const {
 	detectEnvConflicts,
 	persistParallelEnv,
 	applyUpdateEnv,
-	shouldManageParallelEnv,
+	shouldReadParallelEnv,
+	shouldWriteParallelEnv,
+	applyParallelEnv,
 	PARALLEL_ENV_KEYS,
 } = await import( '../../../commands/docker.js' );
 
@@ -227,14 +237,14 @@ describe( 'resolveDevCloneSource', () => {
 	} );
 } );
 
-describe( 'shouldManageParallelEnv', () => {
+describe( 'shouldWriteParallelEnv', () => {
 	test( 'true for `up` on the default dev type', () => {
-		expect( shouldManageParallelEnv( { type: 'dev', _: [ 'docker', 'up' ] } ) ).toBe( true );
+		expect( shouldWriteParallelEnv( { type: 'dev', _: [ 'docker', 'up' ] } ) ).toBe( true );
 	} );
 
 	test( 'true for `up --name` on dev', () => {
 		expect(
-			shouldManageParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'up' ] } )
+			shouldWriteParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'up' ] } )
 		).toBe( true );
 	} );
 
@@ -242,16 +252,163 @@ describe( 'shouldManageParallelEnv', () => {
 	// type gate, that --name leaked COMPOSE_PROJECT_NAME/PORT_* into the shared
 	// tools/docker/.env of a plain checkout. See PR #48643 review follow-up.
 	test( 'false for the e2e flow (--type e2e --name t1 up)', () => {
-		expect( shouldManageParallelEnv( { type: 'e2e', name: 't1', _: [ 'docker', 'up' ] } ) ).toBe(
+		expect( shouldWriteParallelEnv( { type: 'e2e', name: 't1', _: [ 'docker', 'up' ] } ) ).toBe(
 			false
 		);
 	} );
 
 	test( 'false for non-up commands on dev', () => {
-		expect( shouldManageParallelEnv( { type: 'dev', _: [ 'docker', 'down' ] } ) ).toBe( false );
+		expect( shouldWriteParallelEnv( { type: 'dev', _: [ 'docker', 'down' ] } ) ).toBe( false );
 		expect(
-			shouldManageParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'clean' ] } )
+			shouldWriteParallelEnv( { type: 'dev', name: 'feature', _: [ 'docker', 'clean' ] } )
 		).toBe( false );
+	} );
+} );
+
+describe( 'shouldReadParallelEnv', () => {
+	test.each( [ [ 'up' ], [ 'stop' ], [ 'down' ], [ 'clean' ], [ 'wp' ], [ 'phpunit' ] ] )(
+		'true for `%s` on dev, so it targets this worktree',
+		cmd => {
+			expect( shouldReadParallelEnv( { type: 'dev', _: [ 'docker', cmd ] } ) ).toBe( true );
+		}
+	);
+
+	test( 'false for the e2e flow, which brings its own name and ports', () => {
+		expect( shouldReadParallelEnv( { type: 'e2e', name: 't1', _: [ 'docker', 'down' ] } ) ).toBe(
+			false
+		);
+	} );
+
+	// Commands registered without defaultOpts leave argv.type undefined.
+	test( 'false when no container type was parsed', () => {
+		expect( shouldReadParallelEnv( { _: [ 'docker', 'link-plugin' ] } ) ).toBe( false );
+	} );
+} );
+
+describe( 'applyParallelEnv', () => {
+	// A worktree seeded by tools/docker/bin/seed-worktree-env.sh.
+	const seededEnv = [
+		'COMPOSE_PROJECT_NAME=jetpack_wtfix',
+		'PORT_WORDPRESS=8080',
+		'PORT_PHPMY=8282',
+	].join( '\n' );
+
+	// buildEnv reads .github/versions.sh through the same stub, so match on path or its
+	// contents get parsed as the .env and clobber the assertion.
+	const isEnvPath = p => String( p ).endsWith( '/.env' );
+
+	const seedEnvFile = contents => {
+		fsStub.existsSync.mockImplementation( isEnvPath );
+		fsStub.readFileSync.mockImplementation( p => ( isEnvPath( p ) ? contents : '' ) );
+	};
+
+	// The bug this guards: `down`/`clean` used to skip the .env read, so getProjectName fell
+	// back to jetpack_dev and tore down the shared instance from a seeded worktree.
+	test.each( [ [ 'stop' ], [ 'down' ], [ 'clean' ], [ 'wp' ], [ 'exec' ], [ 'phpunit' ] ] )(
+		'`%s` targets the worktree instance from .env',
+		cmd => {
+			seedEnvFile( seededEnv );
+			const argv = { type: 'dev', _: [ 'docker', cmd ] };
+			applyParallelEnv( argv );
+			expect( argv.name ).toBe( 'wtfix' );
+			expect( buildEnv( argv ).COMPOSE_PROJECT_NAME ).toBe( 'jetpack_wtfix' );
+		}
+	);
+
+	test( 'fills the ports a compose invocation needs', () => {
+		seedEnvFile( seededEnv );
+		const argv = { type: 'dev', _: [ 'docker', 'down' ] };
+		applyParallelEnv( argv );
+		expect( argv.port ).toBe( 8080 );
+		expect( argv.portPhpmy ).toBe( 8282 );
+	} );
+
+	test( 'leaves e2e alone, so it keeps its own name and 8889 default', () => {
+		seedEnvFile( seededEnv );
+		const argv = { type: 'e2e', name: 't1', _: [ 'docker', 'down' ] };
+		expect( applyParallelEnv( argv ) ).toEqual( {} );
+		expect( argv.name ).toBe( 't1' );
+		expect( argv.port ).toBeUndefined();
+		expect( buildEnv( argv ).PORT_WORDPRESS ).toBe( 8889 );
+	} );
+
+	test( 'flags win over .env', () => {
+		seedEnvFile( seededEnv );
+		const argv = { type: 'dev', name: 'other', port: 9000, _: [ 'docker', 'down' ] };
+		applyParallelEnv( argv );
+		expect( buildEnv( argv ).COMPOSE_PROJECT_NAME ).toBe( 'jetpack_other' );
+		expect( argv.port ).toBe( 9000 );
+	} );
+
+	// The main checkout: no COMPOSE_PROJECT_NAME, so the shared instance is still the target.
+	test( 'stays on jetpack_dev when .env is absent', () => {
+		const argv = { type: 'dev', _: [ 'docker', 'down' ] };
+		expect( applyParallelEnv( argv ) ).toEqual( {} );
+		expect( argv.name ).toBeUndefined();
+		expect( buildEnv( argv ).COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+	} );
+
+	// augmentArgvFromEnvFile's guard: a hand-set jetpack_dev must not become `--name dev`.
+	test( 'does not infer a name from a jetpack_dev .env', () => {
+		seedEnvFile( 'COMPOSE_PROJECT_NAME=jetpack_dev\nPORT_WORDPRESS=80' );
+		const argv = { type: 'dev', _: [ 'docker', 'down' ] };
+		applyParallelEnv( argv );
+		expect( argv.name ).toBeUndefined();
+		expect( buildEnv( argv ).COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+	} );
+
+	test( 'is idempotent, so the clean handler can re-read after the compose step', () => {
+		seedEnvFile( seededEnv );
+		const argv = { type: 'dev', _: [ 'docker', 'clean' ] };
+		applyParallelEnv( argv );
+		applyParallelEnv( argv );
+		expect( argv.name ).toBe( 'wtfix' );
+		expect( argv.port ).toBe( 8080 );
+	} );
+
+	// The env of the last spawnSync is what compose actually runs against.
+	const composeEnv = () => cpStub.spawnSync.mock.calls.at( -1 )[ 2 ].env;
+
+	describe( 'wired into execDockerCmdHandler', () => {
+		test.each( [ [ 'wp' ], [ 'exec' ], [ 'phpunit' ] ] )(
+			'`%s` runs compose against the worktree instance',
+			cmd => {
+				seedEnvFile( seededEnv );
+				execDockerCmdHandler( { type: 'dev', _: [ 'docker', cmd ] } );
+				expect( composeEnv().COMPOSE_PROJECT_NAME ).toBe( 'jetpack_wtfix' );
+			}
+		);
+
+		test( 'stays on jetpack_dev when .env is absent', () => {
+			execDockerCmdHandler( { type: 'dev', _: [ 'docker', 'wp' ] } );
+			expect( composeEnv().COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+		} );
+	} );
+
+	describe( 'wired into defaultDockerCmdHandler', () => {
+		// `down` and `clean` used to tear down the shared jetpack_dev from a seeded worktree.
+		test.each( [ [ 'stop' ], [ 'down' ], [ 'clean' ] ] )(
+			'`%s` runs compose against the worktree instance',
+			async cmd => {
+				seedEnvFile( seededEnv );
+				await defaultDockerCmdHandler( { type: 'dev', _: [ 'docker', cmd ] } );
+				expect( composeEnv().COMPOSE_PROJECT_NAME ).toBe( 'jetpack_wtfix' );
+			}
+		);
+
+		test( 'stays on jetpack_dev when .env is absent', async () => {
+			await defaultDockerCmdHandler( { type: 'dev', _: [ 'docker', 'down' ] } );
+			expect( composeEnv().COMPOSE_PROJECT_NAME ).toBe( 'jetpack_dev' );
+		} );
+
+		// `clean` derives its rm -rf paths from getProjectName after the compose step, so an
+		// unaugmented argv would delete the primary instance's mysql data and logs.
+		test( '`clean` names the worktree instance in the paths it removes', async () => {
+			seedEnvFile( seededEnv );
+			const argv = { type: 'dev', _: [ 'docker', 'clean' ] };
+			await defaultDockerCmdHandler( argv );
+			expect( getProjectName( argv ) ).toBe( 'jetpack_wtfix' );
+		} );
 	} );
 } );
 

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -56,8 +56,6 @@ const {
 	shouldWriteParallelEnv,
 	applyParallelEnv,
 	PARALLEL_ENV_KEYS,
-	buildCleanPaths,
-	resolveCleanConsent,
 	cleanCmdHandler,
 } = await import( '../../../commands/docker.js' );
 
@@ -820,36 +818,6 @@ describe( 'pipeDbDump', () => {
 	} );
 } );
 
-describe( 'buildCleanPaths', () => {
-	test( 'scopes the logs and mysql paths to the given project', () => {
-		expect( buildCleanPaths( 'jetpack_feature' ) ).toEqual( [
-			'tools/docker/wordpress/',
-			'tools/docker/wordpress-develop/*',
-			'tools/docker/logs/jetpack_feature/',
-			'tools/docker/data/jetpack_feature_mysql/',
-		] );
-	} );
-
-	test( 'never names another instance', () => {
-		expect( buildCleanPaths( 'jetpack_feature' ).join( '\n' ) ).not.toContain( 'jetpack_dev' );
-	} );
-} );
-
-describe( 'resolveCleanConsent', () => {
-	test( '--yes proceeds with or without a TTY', () => {
-		expect( resolveCleanConsent( { yes: true, isTty: true } ) ).toBe( 'proceed' );
-		expect( resolveCleanConsent( { yes: true, isTty: false } ) ).toBe( 'proceed' );
-	} );
-
-	test( 'prompts when a TTY is available', () => {
-		expect( resolveCleanConsent( { yes: false, isTty: true } ) ).toBe( 'prompt' );
-	} );
-
-	test( 'refuses without a TTY and without --yes', () => {
-		expect( resolveCleanConsent( { yes: false, isTty: false } ) ).toBe( 'refuse' );
-	} );
-} );
-
 describe( 'cleanCmdHandler', () => {
 	const rmCalls = () => cpStub.spawnSync.mock.calls.filter( call => call[ 0 ] === 'rm' );
 	const composeCalls = () =>
@@ -882,8 +850,12 @@ describe( 'cleanCmdHandler', () => {
 	} );
 
 	test( 'removes the paths of the instance it just took down', async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+
 		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', name: 'feature', yes: true } );
 
+		expect( enquirerStub.prompt ).not.toHaveBeenCalled();
 		expect( rmCalls() ).toHaveLength( 1 );
 		expect( rmCalls()[ 0 ][ 1 ] ).toEqual( [
 			'-rf',

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -25,6 +25,12 @@ jest.unstable_mockModule( 'child_process', () => ( {
 	...cpStub,
 } ) );
 
+const enquirerStub = { prompt: jest.fn() };
+jest.unstable_mockModule( 'enquirer', () => ( {
+	default: enquirerStub,
+	...enquirerStub,
+} ) );
+
 // setConfig parses the real docker config yaml, which the fs stub cannot serve.
 jest.unstable_mockModule( '../../../helpers/docker-config.js', () => ( {
 	dockerFolder: 'tools/docker',
@@ -50,6 +56,9 @@ const {
 	shouldWriteParallelEnv,
 	applyParallelEnv,
 	PARALLEL_ENV_KEYS,
+	buildCleanPaths,
+	resolveCleanConsent,
+	cleanCmdHandler,
 } = await import( '../../../commands/docker.js' );
 
 /**
@@ -808,5 +817,139 @@ describe( 'pipeDbDump', () => {
 		await expect( pipeDbDump( 'src-wp-1', 'tgt-wp-1', '/var/www/html' ) ).rejects.toThrow(
 			/source.*exit 1.*target.*exit 3/is
 		);
+	} );
+} );
+
+describe( 'buildCleanPaths', () => {
+	test( 'scopes the logs and mysql paths to the given project', () => {
+		expect( buildCleanPaths( 'jetpack_feature' ) ).toEqual( [
+			'tools/docker/wordpress/',
+			'tools/docker/wordpress-develop/*',
+			'tools/docker/logs/jetpack_feature/',
+			'tools/docker/data/jetpack_feature_mysql/',
+		] );
+	} );
+
+	test( 'never names another instance', () => {
+		expect( buildCleanPaths( 'jetpack_feature' ).join( '\n' ) ).not.toContain( 'jetpack_dev' );
+	} );
+} );
+
+describe( 'resolveCleanConsent', () => {
+	test( '--yes proceeds with or without a TTY', () => {
+		expect( resolveCleanConsent( { yes: true, isTty: true } ) ).toBe( 'proceed' );
+		expect( resolveCleanConsent( { yes: true, isTty: false } ) ).toBe( 'proceed' );
+	} );
+
+	test( 'prompts when a TTY is available', () => {
+		expect( resolveCleanConsent( { yes: false, isTty: true } ) ).toBe( 'prompt' );
+	} );
+
+	test( 'refuses without a TTY and without --yes', () => {
+		expect( resolveCleanConsent( { yes: false, isTty: false } ) ).toBe( 'refuse' );
+	} );
+} );
+
+describe( 'cleanCmdHandler', () => {
+	const rmCalls = () => cpStub.spawnSync.mock.calls.filter( call => call[ 0 ] === 'rm' );
+	const composeCalls = () =>
+		cpStub.spawnSync.mock.calls.filter(
+			call => call[ 0 ] === 'docker' && call[ 1 ]?.includes( 'down' )
+		);
+
+	let ttyBackup;
+	let exitSpy;
+	const silenced = [];
+
+	beforeEach( () => {
+		ttyBackup = { stdin: process.stdin.isTTY, stdout: process.stdout.isTTY };
+		enquirerStub.prompt.mockReset();
+		// process.exit() never returns in production, so the stub must not either.
+		exitSpy = jest.spyOn( process, 'exit' ).mockImplementation( code => {
+			throw new Error( `EXIT:${ code }` );
+		} );
+		silenced.push(
+			jest.spyOn( console, 'log' ).mockImplementation( () => {} ),
+			jest.spyOn( console, 'error' ).mockImplementation( () => {} )
+		);
+	} );
+
+	afterEach( () => {
+		process.stdin.isTTY = ttyBackup.stdin;
+		process.stdout.isTTY = ttyBackup.stdout;
+		exitSpy.mockRestore();
+		silenced.splice( 0 ).forEach( spy => spy.mockRestore() );
+	} );
+
+	test( 'removes the paths of the instance it just took down', async () => {
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', name: 'feature', yes: true } );
+
+		expect( rmCalls() ).toHaveLength( 1 );
+		expect( rmCalls()[ 0 ][ 1 ] ).toEqual( [
+			'-rf',
+			'tools/docker/wordpress/',
+			'tools/docker/wordpress-develop/*',
+			'tools/docker/logs/jetpack_feature/',
+			'tools/docker/data/jetpack_feature_mysql/',
+		] );
+	} );
+
+	test( 'refuses and exits non-zero without a TTY and without --yes', async () => {
+		process.stdin.isTTY = false;
+		process.stdout.isTTY = false;
+
+		await expect(
+			cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', yes: false } )
+		).rejects.toThrow( 'EXIT:1' );
+
+		expect( enquirerStub.prompt ).not.toHaveBeenCalled();
+		expect( composeCalls() ).toHaveLength( 0 );
+		expect( rmCalls() ).toHaveLength( 0 );
+	} );
+
+	test( 'destroys nothing when the prompt is declined', async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		enquirerStub.prompt.mockResolvedValue( { confirmed: false } );
+
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', yes: false } );
+
+		expect( enquirerStub.prompt ).toHaveBeenCalled();
+		expect( composeCalls() ).toHaveLength( 0 );
+		expect( rmCalls() ).toHaveLength( 0 );
+	} );
+
+	test( 'defaults the prompt to no', async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		enquirerStub.prompt.mockResolvedValue( { confirmed: false } );
+
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', yes: false } );
+
+		expect( enquirerStub.prompt ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'confirm', initial: false } )
+		);
+	} );
+
+	test( 'proceeds when the prompt is accepted', async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		enquirerStub.prompt.mockResolvedValue( { confirmed: true } );
+
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', yes: false } );
+
+		expect( rmCalls() ).toHaveLength( 1 );
+	} );
+
+	test( 'names the instance and its paths before asking', async () => {
+		process.stdin.isTTY = true;
+		process.stdout.isTTY = true;
+		enquirerStub.prompt.mockResolvedValue( { confirmed: false } );
+
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', name: 'feature', yes: false } );
+
+		const printed = console.log.mock.calls.flat().join( '\n' );
+		expect( printed ).toContain( 'jetpack_feature' );
+		expect( printed ).toContain( 'tools/docker/data/jetpack_feature_mysql/' );
 	} );
 } );

--- a/tools/cli/tests/unit/commands/docker.test.js
+++ b/tools/cli/tests/unit/commands/docker.test.js
@@ -894,6 +894,35 @@ describe( 'cleanCmdHandler', () => {
 		] );
 	} );
 
+	// The two halves of this PR meet here: targeting resolves .env inside
+	// defaultDockerCmdHandler, which runs after the plan is printed. Resolve it first, or
+	// `clean` in a seeded worktree announces jetpack_dev, stops the worktree and deletes the
+	// primary's data.
+	test( 'announces, takes down and removes one and the same instance', async () => {
+		const isEnvPath = path => String( path ).endsWith( '/.env' );
+		fsStub.existsSync.mockImplementation( isEnvPath );
+		fsStub.readFileSync.mockImplementation( path =>
+			isEnvPath( path ) ? 'COMPOSE_PROJECT_NAME=jetpack_wtfix\nPORT_WORDPRESS=8080' : ''
+		);
+
+		await cleanCmdHandler( { _: [ 'docker', 'clean' ], type: 'dev', yes: true } );
+
+		const announced = console.log.mock.calls.flat().join( '\n' );
+		expect( announced ).toContain( 'jetpack_wtfix' );
+		expect( announced ).not.toContain( 'jetpack_dev' );
+
+		expect( composeCalls() ).toHaveLength( 1 );
+		expect( composeCalls()[ 0 ][ 2 ].env.COMPOSE_PROJECT_NAME ).toBe( 'jetpack_wtfix' );
+
+		expect( rmCalls()[ 0 ][ 1 ] ).toEqual( [
+			'-rf',
+			'tools/docker/wordpress/',
+			'tools/docker/wordpress-develop/*',
+			'tools/docker/logs/jetpack_wtfix/',
+			'tools/docker/data/jetpack_wtfix_mysql/',
+		] );
+	} );
+
 	test( 'refuses and exits non-zero without a TTY and without --yes', async () => {
 		process.stdin.isTTY = false;
 		process.stdout.isTTY = false;

--- a/tools/cli/tests/unit/commands/jp-docker-clean.test.js
+++ b/tools/cli/tests/unit/commands/jp-docker-clean.test.js
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 const fsStub = {
 	readFileSync: jest.fn( () => '' ),
 	existsSync: jest.fn( () => false ),
+	readdirSync: jest.fn( () => [] ),
 };
 jest.unstable_mockModule( 'fs', () => ( {
 	default: fsStub,
@@ -10,20 +11,27 @@ jest.unstable_mockModule( 'fs', () => ( {
 } ) );
 
 // The `jp` host CLI is excluded from the pnpm workspace, so it has no jest of its own.
-const { resolveDockerEnv, buildCleanupPaths, resolveCleanConsent, stripYesFlags } = await import(
-	'../../../../../projects/js-packages/jetpack-cli/bin/docker-host.js'
-);
+const {
+	resolveDockerEnv,
+	buildCleanupPaths,
+	findUnsupportedHostFlag,
+	resolveCleanConsent,
+	stripYesFlags,
+} = await import( '../../../../../projects/js-packages/jetpack-cli/src/docker-host.js' );
 
 const ROOT = '/repo';
 const ENV_FILE = '/repo/tools/docker/.env';
+const WP_DEVELOP = '/repo/tools/docker/wordpress-develop';
 
 const parseEnv = buffer => Object.fromEntries( new URLSearchParams( String( buffer ) ) );
 
 beforeEach( () => {
 	fsStub.readFileSync.mockReset();
 	fsStub.existsSync.mockReset();
+	fsStub.readdirSync.mockReset();
 	fsStub.readFileSync.mockReturnValue( '' );
 	fsStub.existsSync.mockReturnValue( false );
+	fsStub.readdirSync.mockReturnValue( [] );
 	delete process.env.COMPOSE_PROJECT_NAME;
 } );
 
@@ -56,7 +64,21 @@ describe( 'buildCleanupPaths', () => {
 	test( 'scopes the logs and mysql paths to the given project', () => {
 		expect( buildCleanupPaths( ROOT, 'jetpack_cleanguard' ) ).toEqual( [
 			'/repo/tools/docker/wordpress',
-			'/repo/tools/docker/wordpress-develop/*',
+			'/repo/tools/docker/logs/jetpack_cleanguard',
+			'/repo/tools/docker/data/jetpack_cleanguard_mysql',
+		] );
+	} );
+
+	// fs.rmSync does no glob expansion and force:true swallows the ENOENT, so a literal
+	// 'wordpress-develop/*' entry deleted nothing while the plan promised it would.
+	test( 'expands wordpress-develop to its entries, skipping dotfiles like rm -rf does', () => {
+		fsStub.existsSync.mockImplementation( path => path === WP_DEVELOP );
+		fsStub.readdirSync.mockReturnValue( [ '.gitkeep', 'tests', 'wp-tests-config.php' ] );
+
+		expect( buildCleanupPaths( ROOT, 'jetpack_cleanguard' ) ).toEqual( [
+			'/repo/tools/docker/wordpress',
+			'/repo/tools/docker/wordpress-develop/tests',
+			'/repo/tools/docker/wordpress-develop/wp-tests-config.php',
 			'/repo/tools/docker/logs/jetpack_cleanguard',
 			'/repo/tools/docker/data/jetpack_cleanguard_mysql',
 		] );
@@ -93,6 +115,20 @@ describe( 'resolveCleanConsent', () => {
 
 	test( 'refuses without a TTY and without --yes', () => {
 		expect( resolveCleanConsent( { yes: false, isTty: false } ) ).toBe( 'refuse' );
+	} );
+} );
+
+describe( 'findUnsupportedHostFlag', () => {
+	test.each( [ '--name', '-n' ] )( 'catches %s, which docker compose rejects', flag => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'clean', flag, 'foo' ] ) ).toBe( flag );
+	} );
+
+	test( 'reports the flag, not the value, for the --name=value form', () => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'up', '--name=foo' ] ) ).toBe( '--name' );
+	} );
+
+	test( 'passes flags compose does accept', () => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'up', '-d', '--type=e2e' ] ) ).toBeNull();
 	} );
 } );
 

--- a/tools/cli/tests/unit/commands/jp-docker-clean.test.js
+++ b/tools/cli/tests/unit/commands/jp-docker-clean.test.js
@@ -1,0 +1,117 @@
+import { jest } from '@jest/globals';
+
+const fsStub = {
+	readFileSync: jest.fn( () => '' ),
+	existsSync: jest.fn( () => false ),
+};
+jest.unstable_mockModule( 'fs', () => ( {
+	default: fsStub,
+	...fsStub,
+} ) );
+
+// The `jp` host CLI is excluded from the pnpm workspace, so it has no jest of its own.
+const { resolveDockerEnv, buildCleanupPaths, resolveCleanConsent, stripYesFlags } = await import(
+	'../../../../../projects/js-packages/jetpack-cli/bin/docker-host.js'
+);
+
+const ROOT = '/repo';
+const ENV_FILE = '/repo/tools/docker/.env';
+
+const parseEnv = buffer => Object.fromEntries( new URLSearchParams( String( buffer ) ) );
+
+beforeEach( () => {
+	fsStub.readFileSync.mockReset();
+	fsStub.existsSync.mockReset();
+	fsStub.readFileSync.mockReturnValue( '' );
+	fsStub.existsSync.mockReturnValue( false );
+	delete process.env.COMPOSE_PROJECT_NAME;
+} );
+
+describe( 'resolveDockerEnv', () => {
+	test( 'defaults to jetpack_dev when no .env sets a project name', () => {
+		expect( resolveDockerEnv( ROOT, [ 'docker', 'clean' ], parseEnv ).COMPOSE_PROJECT_NAME ).toBe(
+			'jetpack_dev'
+		);
+	} );
+
+	test( 'defaults to jetpack_e2e for --type=e2e', () => {
+		expect(
+			resolveDockerEnv( ROOT, [ 'docker', 'clean', '--type=e2e' ], parseEnv ).COMPOSE_PROJECT_NAME
+		).toBe( 'jetpack_e2e' );
+	} );
+
+	test( "takes the worktree .env's project name over the default", () => {
+		fsStub.existsSync.mockImplementation( path => path === ENV_FILE );
+		fsStub.readFileSync.mockImplementation( path =>
+			path === ENV_FILE ? 'COMPOSE_PROJECT_NAME=jetpack_cleanguard' : ''
+		);
+
+		expect( resolveDockerEnv( ROOT, [ 'docker', 'clean' ], parseEnv ).COMPOSE_PROJECT_NAME ).toBe(
+			'jetpack_cleanguard'
+		);
+	} );
+} );
+
+describe( 'buildCleanupPaths', () => {
+	test( 'scopes the logs and mysql paths to the given project', () => {
+		expect( buildCleanupPaths( ROOT, 'jetpack_cleanguard' ) ).toEqual( [
+			'/repo/tools/docker/wordpress',
+			'/repo/tools/docker/wordpress-develop/*',
+			'/repo/tools/docker/logs/jetpack_cleanguard',
+			'/repo/tools/docker/data/jetpack_cleanguard_mysql',
+		] );
+	} );
+
+	test( 'never names another instance', () => {
+		expect( buildCleanupPaths( ROOT, 'jetpack_cleanguard' ).join( '\n' ) ).not.toContain(
+			'jetpack_dev'
+		);
+	} );
+
+	test( 'follows the .env project name the compose call resolves', () => {
+		fsStub.existsSync.mockImplementation( path => path === ENV_FILE );
+		fsStub.readFileSync.mockImplementation( path =>
+			path === ENV_FILE ? 'COMPOSE_PROJECT_NAME=jetpack_cleanguard' : ''
+		);
+		const { COMPOSE_PROJECT_NAME } = resolveDockerEnv( ROOT, [ 'docker', 'clean' ], parseEnv );
+
+		expect( buildCleanupPaths( ROOT, COMPOSE_PROJECT_NAME ) ).toContain(
+			'/repo/tools/docker/data/jetpack_cleanguard_mysql'
+		);
+	} );
+} );
+
+describe( 'resolveCleanConsent', () => {
+	test( '--yes proceeds with or without a TTY', () => {
+		expect( resolveCleanConsent( { yes: true, isTty: true } ) ).toBe( 'proceed' );
+		expect( resolveCleanConsent( { yes: true, isTty: false } ) ).toBe( 'proceed' );
+	} );
+
+	test( 'prompts when a TTY is available', () => {
+		expect( resolveCleanConsent( { yes: false, isTty: true } ) ).toBe( 'prompt' );
+	} );
+
+	test( 'refuses without a TTY and without --yes', () => {
+		expect( resolveCleanConsent( { yes: false, isTty: false } ) ).toBe( 'refuse' );
+	} );
+} );
+
+describe( 'stripYesFlags', () => {
+	test( 'removes --yes so it never reaches docker compose', () => {
+		const args = [ 'docker', 'clean', '--yes' ];
+		expect( stripYesFlags( args ) ).toBe( true );
+		expect( args ).toEqual( [ 'docker', 'clean' ] );
+	} );
+
+	test( 'removes -y as well', () => {
+		const args = [ 'docker', 'clean', '-y' ];
+		expect( stripYesFlags( args ) ).toBe( true );
+		expect( args ).toEqual( [ 'docker', 'clean' ] );
+	} );
+
+	test( 'reports false and changes nothing when neither flag is present', () => {
+		const args = [ 'docker', 'clean' ];
+		expect( stripYesFlags( args ) ).toBe( false );
+		expect( args ).toEqual( [ 'docker', 'clean' ] );
+	} );
+} );

--- a/tools/cli/tests/unit/commands/jp-docker-clean.test.js
+++ b/tools/cli/tests/unit/commands/jp-docker-clean.test.js
@@ -119,16 +119,24 @@ describe( 'resolveCleanConsent', () => {
 } );
 
 describe( 'findUnsupportedHostFlag', () => {
-	test.each( [ '--name', '-n' ] )( 'catches %s, which docker compose rejects', flag => {
+	test.each( [ '--name', '-n', '--type' ] )( 'catches %s, which docker compose rejects', flag => {
 		expect( findUnsupportedHostFlag( [ 'docker', 'clean', flag, 'foo' ] ) ).toBe( flag );
 	} );
 
-	test( 'reports the flag, not the value, for the --name=value form', () => {
-		expect( findUnsupportedHostFlag( [ 'docker', 'up', '--name=foo' ] ) ).toBe( '--name' );
+	test.each( [ '--name=foo', '--type=e2e' ] )( 'reports %s as the flag, not the value', arg => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'up', arg ] ) ).toBe( arg.split( '=' )[ 0 ] );
 	} );
 
-	test( 'passes flags compose does accept', () => {
-		expect( findUnsupportedHostFlag( [ 'docker', 'up', '-d', '--type=e2e' ] ) ).toBeNull();
+	// A seeded .env outranks both flags in resolveDockerEnv, so `clean --type=e2e` from a
+	// worktree would prompt to destroy the dev instance the user did not name.
+	test( 'catches --type, which selects an instance just as --name does', () => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'clean', '--type=e2e' ] ) ).toBe( '--type' );
+	} );
+
+	// `docker compose down -t 30` is a timeout, not `jetpack docker`'s --type.
+	test( 'passes flags compose does accept, including -t', () => {
+		expect( findUnsupportedHostFlag( [ 'docker', 'down', '-v', '-t', '30' ] ) ).toBeNull();
+		expect( findUnsupportedHostFlag( [ 'docker', 'up', '-d' ] ) ).toBeNull();
 	} );
 } );
 

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -337,6 +337,8 @@ To remove all docker images, all MySQL data, and all docker-related files from y
 jetpack docker clean
 ```
 
+`clean` first prints the compose project it resolved and every path it will delete, then asks you to confirm; the default answer is no. Add `--yes` to skip the prompt in a script. Without a terminal to confirm at, `clean` refuses unless `--yes` is passed, so it can never destroy an instance from a pipe or a CI job by default.
+
 **Note:** this command does not work in Windows.
 
 ### Using WP CLI

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -294,6 +294,8 @@ git worktree remove ../jetpack-feature
 
 Each of the above needs the same `--name` you used when bringing the instance up. The primary `jetpack_dev` instance is untouched.
 
+**`jp` is not `jetpack` here.** `jp docker up|stop|down|clean` run `docker compose` on the host rather than forwarding to this CLI, so they have no `--name` and refuse it. They read `COMPOSE_PROJECT_NAME` from `tools/docker/.env` instead — use the seeded-worktree flow above, or run these four as `jetpack docker`.
+
 #### Notes & gotchas
 
 * The `mailpit` container is no longer globally named — each instance gets its own `jetpack_<name>-mailpit-1`. Internal SMTP routing still uses the compose service name `mailpit`, so PHP mail from within any container routes to that instance's MailPit.

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -155,7 +155,9 @@ You can run a second (or third, …) Jetpack Docker instance alongside your main
 
 #### Quick isolation in a worktree (recommended)
 
-`jetpack docker up` reads `COMPOSE_PROJECT_NAME` and `PORT_*` from this directory's `tools/docker/.env` and, when they're absent, falls back to the shared `jetpack_dev` instance on the default ports. So if you run a bare `up` from several worktrees, they collide — sharing one set of containers, with the bind-mounts re-pointed at whichever worktree ran `up` last.
+`jetpack docker` reads `COMPOSE_PROJECT_NAME` and `PORT_*` from this directory's `tools/docker/.env` and, when they're absent, falls back to the shared `jetpack_dev` instance on the default ports. So if you run a bare `up` from several worktrees, they collide — sharing one set of containers, with the bind-mounts re-pointed at whichever worktree ran `up` last.
+
+Every `dev` subcommand reads the file, so once a worktree is seeded, `stop`, `down`, `clean`, `wp`, `exec` and `phpunit` all target that worktree's instance without `--name`. Only `up` writes back to it.
 
 To avoid that, seed the worktree's `.env` once:
 
@@ -232,13 +234,16 @@ jetpack docker install --name clean --port 8090
 
 The CLI treats the worktree's `tools/docker/.env` as a per-instance config file, in addition to (not instead of) the CLI flags. This means a worktree configured once can be brought back up with bare `jetpack docker up` afterwards — the flag set above is only needed on the first invocation.
 
-**Read precedence on `up`** (last wins):
+**Read precedence** (last wins), on every `dev` subcommand:
 
 `tools/docker/default.env` → worktree's `tools/docker/.env` → CLI flags → `process.env`
+
+Reading applies to `up`, `stop`, `down`, `clean`, `wp`, `exec`, `phpunit` and the rest, so a seeded worktree tears down and shells into its own instance rather than the shared `jetpack_dev`. The `--type e2e` flow is excluded: it passes its own `--name t1` and ports.
 
 **What the CLI writes:**
 
 * On `up --name <slug>`, after the instance is up, the CLI **appends** any of the following keys to `tools/docker/.env` that aren't already present: `COMPOSE_PROJECT_NAME`, `PORT_WORDPRESS`, `PORT_PHPMY`, `PORT_INBOX`, `PORT_SMTP`, `PORT_SFTP`. Existing lines are never modified or reordered.
+* Only `up` writes. Every other subcommand reads `.env` and leaves it alone.
 * The primary `jetpack_dev` flow (no `--name`) **never** writes to `.env`. Your main checkout's `.env` stays as you've set it.
 
 **Conflicts between flags and `.env`:**

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -56,7 +56,6 @@ reset_env() {
 
 clean_env() {
 	$BASE_CMD uninstall || true
-	# --yes: this env is disposable and the script is often run without a terminal to confirm at.
 	$BASE_CMD clean --yes
 }
 

--- a/tools/e2e-commons/bin/e2e-env.sh
+++ b/tools/e2e-commons/bin/e2e-env.sh
@@ -56,7 +56,8 @@ reset_env() {
 
 clean_env() {
 	$BASE_CMD uninstall || true
-	$BASE_CMD clean
+	# --yes: this env is disposable and the script is often run without a terminal to confirm at.
+	$BASE_CMD clean --yes
 }
 
 new_env() {


### PR DESCRIPTION
## Proposed changes

`jetpack docker` and `jp docker` can destroy the wrong instance when you run them from a git worktree. This PR fixes the targeting and makes `clean` say what it is about to destroy. The two halves are one PR because fixing either alone leaves the other broken, as explained below.

### What breaks today

**1. Only `up` read `tools/docker/.env`.** `augmentArgvFromEnvFile()` is the only thing that turns `.env`'s `COMPOSE_PROJECT_NAME` into `argv.name`, and its gate was `type === 'dev' && argv._[1] === 'up'`. So `stop`, `down`, `clean`, `wp`, `exec` and `phpunit` run from a seeded worktree all fell back to `jetpack_dev` and hit the shared instance. Seeding a worktree bought you an isolated `up` and nothing else.

**2. `jp docker clean` stopped one instance and deleted another's data.** On trunk, `jp.js` computes its `rm -rf` paths from a hardcoded project name:

```js
const projectName = args.includes( '--type=e2e' ) ? 'jetpack_e2e' : 'jetpack_dev';
```

while the `docker compose` call a few lines down uses `envVars`, which *does* read `.env`. With a seeded `.env`, `compose down -v` took down the worktree's containers and the file deletion removed `tools/docker/data/jetpack_dev_mysql` and `tools/docker/logs/jetpack_dev` — the primary instance's database and logs.

This was reproduced in an isolated fixture, not inferred: with `.env` naming a different instance, trunk's `jp.js` deleted `data/jetpack_dev_mysql` and `logs/jetpack_dev` and printed **nothing at all**. The deletion is silent by construction — `fs.rmSync( path, { recursive: true, force: true } )` suppresses ENOENT, and a successful removal prints nothing either.

**3. The deletion ran from a `beforeExit` hook.** `process.once( 'beforeExit', cleanupFiles )` fired even when `compose down -v` failed, because the error path sets `process.exitCode = 1` rather than calling `process.exit()`, so the process still reaches `beforeExit`. A teardown that errored out still deleted the data.

### The two halves, and why they are one PR

**Targeting.** The predicate splits into `shouldReadParallelEnv` (every `type === 'dev'` subcommand) and `shouldWriteParallelEnv` (`up` only, the one subcommand that takes flags `.env` can disagree with). A new `applyParallelEnv()` applies the read, called from the default, exec and phpunit-integration handlers. The `--type e2e` flow stays excluded: it brings its own `--name t1` and fixed ports.

**Consent.** `resolveDockerEnv()` moves into a new `projects/js-packages/jetpack-cli/src/docker-host.js`, so `jp docker clean`'s deleted paths and its compose call come from one resolution. Both `clean` entry points now print the resolved project and every path they will remove, then ask. The file deletion moves off `beforeExit` to run only after `down -v` succeeds.

They are one PR because **combining them naively reintroduces the same class of bug.** Targeting resolves `.env` inside `defaultDockerCmdHandler`, which the clean handler calls *after* it has printed its plan. So `clean` in a seeded worktree would announce `jetpack_dev`, tear down the worktree's instance, and delete `jetpack_dev`'s paths — announcing one thing and destroying another. The fix is ordering, not a second guard: `cleanCmdHandler` resolves the target first, so the announced name, the containers taken down and the deleted paths all come from a single resolution. A test pins this (`announces, takes down and removes one and the same instance`); it fails on the naive combination.

### The non-TTY decision

`clean` without `--yes` and without a TTY **refuses and exits non-zero** rather than prompting or proceeding. A caller that cannot read the plan should not be able to destroy an instance by accident.

Every `clean` caller in the repo was checked:

* `tools/e2e-commons/bin/e2e-env.sh` is the **only** one. It is reached by every plugin's `env:clean` and `env:new` script, and it now passes `--yes`; that environment is disposable.
* The GitHub e2e workflow never invokes `clean`. `.github/workflows/e2e-tests.yml` runs `pnpm run env:up` and nothing else.

So no automated caller is affected.

### Changelog

Five entries under `projects/js-packages/jetpack-cli/`. No plugin entries are owed: `@automattic/jetpack-cli` is excluded from the pnpm workspace (`pnpm-workspace.yaml` line 3) and `jetpack dependencies list js-packages/jetpack-cli --add-dependents` returns only itself. The `tools/` changes need no entry, being outside `/projects`.

### Caveats, kept in the open

* **`clean` also deletes `tools/docker/wordpress/`, which every instance shares.** An e2e `clean` therefore wipes the WordPress directory the primary instance uses. Not fixed here — the change would be larger than this PR. The confirmation now lists those paths, so it is at least visible before you agree. Worth its own issue.
* **`tools/cli/tests/unit/commands/jp-docker-clean.test.js` tests a file in `projects/` from `tools/cli/`.** `jetpack-cli` is excluded from the pnpm workspace, and although it carries a `tests/jest.config.cjs`, that is `jetpack generate` scaffolding — its `composer.json` declares no `test-js`, so nothing runs it. This remains the only place the extracted helpers can be covered. (Thanks @dhasilva for the correction.)
* **The wiring inside `jp.js` is not unit-tested.** `jp.js` calls `main()` at module scope, so it has no seam. Only the extracted helpers (`resolveDockerEnv`, `buildCleanupPaths`, `findUnsupportedHostFlag`, `resolveCleanConsent`, `stripYesFlags`) have tests. The call sites were verified by running the CLI against a fixture monorepo root — see Testing instructions step 7 — not by a test.
* **A worktree-refusal guard was considered and deliberately left out.** Once targeting is fixed, it would only fire for worktrees that never seeded a `.env` — which is exactly the case where `jetpack_dev` genuinely is their instance.

### Added after review

Two more instances of the same defect, found while checking how far the two implementations of these four subcommands have drifted. `jp` cannot forward `up`/`down`/`stop`/`clean` into the monorepo container, because compose does not run in there — so it reimplements them against the host daemon, and the two copies are kept in step by hand.

* **`jp docker up` created `data/jetpack_dev_mysql` regardless of the resolved project name**, so a seeded worktree got the primary instance's directory and never its own. `docker-compose.yml` mounts `./data/${COMPOSE_PROJECT_NAME}_mysql`, so compose then created the right one itself, as root. The resolution is now hoisted once for the whole block and feeds the announce, the directory creation, and the compose call alike.
* **`.agents/skills/work-on.md` promised a database clone that `jp docker up` never performs.** The auto-clone lives in `tools/cli`'s `defaultDockerCmdHandler`; the four host subcommands bypass `tools/cli` entirely. The skill now says the instance comes up empty and `jp docker install` is always required. Six stale `--name` instructions went with it, including one asserting the opposite of this PR — that `install`, `stop`, `clean` and `phpunit` "do not read `.env`".

**`--name` and `--type` are now refused on the four host subcommands**, rather than naming one instance and then being rejected by compose. Those two select which instance the command acts on, and a seeded `.env` outranks both — so `jp docker clean --type=e2e` from a worktree announced the *dev* instance and prompted to destroy it. `-t` is deliberately still allowed: `jetpack docker` reads it as `--type`, but compose defines it as `--timeout`, and `jp docker down -t 30` works today.

`--port*`, `--clone-from`, `--clone` and `--update-env` are rejected by compose the same way but cannot misname anything, so they are left for a follow-up. Note they are not quite side-effect-free: on `up` the directory creation and the `docker config` regeneration both run before compose sees the flag. Two more follow-ups: making `--type=e2e` work on this path — the `isE2e` branch in `resolveDockerEnv` is now unreachable from `jp`, and is kept for that rather than deleted — and `compose-*.built.yml` being regenerated only on `up`.

**On `files`.** `docker-host.js` moved from `bin/` to `src/` at review request, so `package.json`'s `files` now lists `src` as well as `bin`. Measured against the real publish path — `jetpack build --for-mirrors` then `npm pack` — the tarball gains exactly `src/docker-host.js` and nothing else; the unused `src/index.jsx` scaffolding placeholder was removed so that stays true today. What the change widens going forward is "any file committed under `src/`", which is what `src/` is for. Untracked files still cannot reach the tarball: the mirror build lists files with `git ls-files`, and `.gitattributes` `production-exclude` strips `tests/**`, `changelog/`, `eslint.config.mjs` and the rest before `files` is consulted.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

None of this needs a live Docker. **Please do not run `docker clean` against a real instance to test it** — the unit tests cover the destructive paths precisely because trying it by hand is how data gets lost.

**1. The suite.**

```bash
cd tools/cli && pnpm test
```

225 passed, 3 skipped, 228 total. Each branch alone was lower: 204 for the targeting half, 199 for the consent half.

**2. Prove the ordering fix is load-bearing.** In `tools/cli/commands/docker.js`, move the `applyParallelEnv( argv );` call at the top of `cleanCmdHandler` down to just above `await defaultDockerCmdHandler( argv );` — that is, resolve *after* the plan is printed, which is what a naive combine gives you. Re-run the suite:

```
● cleanCmdHandler › announces, takes down and removes one and the same instance
  Expected substring: "jetpack_wtfix"
```

Deleting the call entirely fails the same test. Restore it.

**3. Prove the guards are load-bearing.** Each edit below should fail exactly the listed tests and nothing else. Every row was re-run after the review changes; these are the counts I got.

| Edit | Expected failures |
|---|---|
| `docker-host.js` `resolveCleanConsent`: `return isTty ? 'prompt' : 'refuse'` → `return 'proceed'` | 2 — `refuses without a TTY…`, `prompts when a TTY is available` |
| `docker.js` `cleanCmdHandler`: drop the `! argv.yes && ! isTty` refusal | 1 — `cleanCmdHandler › refuses and exits non-zero…` |
| `docker.js` `cleanCmdHandler` prompt: `initial: false` → `initial: true` | 1 — `cleanCmdHandler › defaults the prompt to no` |
| `docker.js` `shouldReadParallelEnv`: re-add `&& argv._[ 1 ] === 'up'` | 21 |
| `docker-host.js` `buildCleanupPaths`: hardcode `'jetpack_dev'` | 3 — all of `buildCleanupPaths` |
| `docker-host.js` `buildCleanupPaths`: drop the `startsWith( '.' )` filter | 1 — `expands wordpress-develop…skipping dotfiles` |
| `docker-host.js` `findUnsupportedHostFlag`: `return null` | 6 — all of `findUnsupportedHostFlag` bar `passes flags compose does accept` |

**4. Read the call sites that have no test.** In `projects/js-packages/jetpack-cli/bin/jp.js`, the host-command block: confirm `resolveDockerEnv()` is called once and its `COMPOSE_PROJECT_NAME` feeds the `up` branch's `mkdir`, the `clean` branch's `buildCleanupPaths()`, and the compose call alike; and that `afterCompose()` runs only after the exit-status check rather than from `beforeExit`.

**5. If you do want a live check**, do it on a throwaway instance and stop at the prompt:

```bash
# from a seeded worktree, with a terminal
jetpack docker clean          # read the plan, answer no. Nothing is removed.
```

Confirm the project name it prints is the worktree's, not `jetpack_dev`. Answering no is enough to verify the fix — the announced name is the thing that was wrong.

**6. Lint and changelogger.**

```bash
pnpm run lint-changed                          # clean
php tools/check-changelogger-use.php trunk HEAD # exit 0
```

**7. The `jp.js` paths that unit tests cannot reach.** `jp.js` runs `main()` at module scope, so these were checked by running the CLI. Build a fixture root — the CLI only needs `tools/docker/bin/monorepo` to exist to recognise one — and point its `.env` at a non-default instance:

```bash
mkdir -p /tmp/fake/tools/docker/bin /tmp/fake/.github
printf '#!/bin/sh\nexit 1\n' > /tmp/fake/tools/docker/bin/monorepo   # makes `docker config` fail,
chmod +x /tmp/fake/tools/docker/bin/monorepo                          # so compose is never reached
cp .github/versions.sh /tmp/fake/.github/
printf 'COMPOSE_PROJECT_NAME=jetpack_wtfake\n' > /tmp/fake/tools/docker/.env
cd /tmp/fake && node <monorepo>/projects/js-packages/jetpack-cli/bin/jp.js docker up -d
ls tools/docker/data     # jetpack_wtfake_mysql — on trunk this is jetpack_dev_mysql
```

Delete `.env` and repeat: the primary checkout still gets `jetpack_dev_mysql`. Then, from any monorepo checkout:

```bash
jp docker clean --name foo   # refused, exit 1, nothing announced or removed
jp docker clean --type=e2e   # refused too: .env outranks the e2e default, so this
                             # used to announce the worktree's dev instance
jp docker down -t 30         # still forwarded — that is compose's --timeout
jp docker clean | cat        # plan, then refuses — stdout behind a pipe is not a TTY
jp docker clean              # in a real terminal: plan, then prompts. Answer no.
```

**8. The published package.** The tarball is a mirror build, not `npm pack` of the source directory, so check it that way. Run it **on the host** — through `jp` it would write the mirror inside the container — and in a throwaway worktree, because `--for-mirrors` leaves changes in the working tree and prompts you to confirm that:

```bash
git worktree add -f --detach /tmp/mirrorsrc HEAD
cd /tmp/mirrorsrc
pnpm jetpack build js-packages/jetpack-cli --production --for-mirrors /tmp/mirror
cd /tmp/mirror/Automattic/jetpack-cli && npm pack --dry-run
```

Expect trunk's four files (`LICENSE.txt`, `README.md`, `bin/jp.js`, `package.json`) plus `src/docker-host.js`, and nothing else. Repeat on `origin/trunk` for the baseline.


