### PR TITLE
Forms: let Global Styles label settings reach form labels

### DIFF
--- a/projects/packages/forms/changelog/forms-765-test-global-styles-label-with-jetpack-forms-css
+++ b/projects/packages/forms/changelog/forms-765-test-global-styles-label-with-jetpack-forms-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Apply Global Styles label settings to form labels, including the group label on multiple-choice fields. The Outlined and Animated styles keep their own label weight.

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -354,6 +354,12 @@ class Contact_Form_Plugin {
 		wp_register_style( 'grunion.css', Jetpack_Forms::plugin_url() . '../dist/contact-form/css/grunion.css', array(), \JETPACK__VERSION );
 		wp_style_add_data( 'grunion.css', 'rtl', 'replace' );
 
+		/*
+		 * Late enough that the theme and Global Styles have been resolved, early enough
+		 * that grunion.css has not been printed yet.
+		 */
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_global_styles_label_css' ), 20 );
+
 		wp_register_style(
 			'jetpack-forms-layout',
 			Jetpack_Forms::plugin_url() . '../dist/contact-form/css/jetpack-forms-layout.css',
@@ -402,6 +408,142 @@ class Contact_Form_Plugin {
 			Form_Editor::init();
 			Form_Preview::init();
 		}
+	}
+
+	/**
+	 * Return the merged Global Styles for the `label` element, or an empty array.
+	 *
+	 * `wp_get_global_styles()` is deliberately not used here for two reasons. It reads
+	 * core's resolver, which sanitizes away any element it does not know about, and core
+	 * only learns about `label` in WP 7.1 — before that the value is always empty even
+	 * though the Gutenberg plugin is emitting `label { ... }` on the page. It also returns
+	 * the *entire* styles tree when the requested path is missing, rather than nothing,
+	 * which reads as "the site set every property".
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array Style object for the label element, keyed as in theme.json.
+	 */
+	private static function get_global_styles_label_object() {
+		$resolver = class_exists( 'WP_Theme_JSON_Resolver_Gutenberg' )
+			? 'WP_Theme_JSON_Resolver_Gutenberg'
+			: 'WP_Theme_JSON_Resolver';
+
+		if ( ! class_exists( $resolver ) || ! method_exists( $resolver, 'get_merged_data' ) ) {
+			return array();
+		}
+
+		$data = $resolver::get_merged_data()->get_raw_data();
+
+		return isset( $data['styles']['elements']['label'] ) && is_array( $data['styles']['elements']['label'] )
+			? $data['styles']['elements']['label']
+			: array();
+	}
+
+	/**
+	 * Let Global Styles' `label` element reach form labels, and mirror it onto grouped fields.
+	 *
+	 * Global Styles emits `label { ... }` at specificity (0,0,1), because `label` is an
+	 * element-only selector and so is not wrapped in `:root :where()`. The form's own
+	 * defaults in grunion.css sit at (0,1,0), so `font-weight` and `margin` set in Global
+	 * Styles never reach a form label.
+	 *
+	 * Lowering those defaults instead would hand every form label to any theme that styles
+	 * `label` at all, which measurably changes existing sites, so the defaults stay put and
+	 * we only step aside when the site has actually set label styles.
+	 *
+	 * Up to two rules are emitted:
+	 *
+	 * 1. Re-assert, at our own specificity, only the properties the generic label rule in
+	 *    grunion.scss would otherwise win. Printed after grunion.css, so it takes the tie.
+	 *    Scoped to the field label so it cannot flatten the exemptions that sit at that same
+	 *    specificity -- consent text, checkbox option labels, and the inset labels used by
+	 *    the Outlined and Animated styles, which carry their own classes instead.
+	 * 2. Mirror the full style object onto `legend.grunion-field-label`. Grouped fields
+	 *    render their group label as a `<legend>`, which `label { ... }` cannot match, so
+	 *    without this a multi-choice field's label is the only unstyled label in the form.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return void
+	 */
+	public static function add_global_styles_label_css() {
+		$css = self::build_global_styles_label_css( self::get_global_styles_label_object() );
+
+		if ( '' === $css ) {
+			return;
+		}
+
+		wp_add_inline_style( 'grunion.css', $css );
+	}
+
+	/**
+	 * Build the label CSS for a Global Styles `label` style object.
+	 *
+	 * Split from the enqueue glue so the emitted CSS can be asserted directly. Core only
+	 * learns about the `label` element in WP 7.1, so on any earlier version the resolver
+	 * sanitizes it away and this is unreachable through Global Styles alone.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $label Style object for the label element, keyed as in theme.json.
+	 * @return string CSS, or an empty string when there is nothing to emit.
+	 */
+	private static function build_global_styles_label_css( $label ) {
+		if ( ! function_exists( 'wp_style_engine_get_styles' ) || empty( $label ) || ! is_array( $label ) ) {
+			return '';
+		}
+
+		/*
+		 * `declarations` is the raw property map; only the engine's `css` output is run
+		 * through wp_strip_all_tags() and safecss_filter_attr(). Theme-origin theme.json is
+		 * never passed through remove_insecure_properties(), so a value carrying `}` would
+		 * otherwise close the rule and admit arbitrary selectors. Read the map to decide
+		 * what is contested, but never emit from it unfiltered.
+		 */
+		$legend_selector = '.contact-form :where(legend.grunion-field-label)';
+		$mirror          = wp_style_engine_get_styles( $label, array( 'selector' => $legend_selector ) );
+		$declarations    = isset( $mirror['declarations'] ) ? $mirror['declarations'] : array();
+		if ( empty( $declarations ) ) {
+			return '';
+		}
+
+		$css = '';
+
+		/*
+		 * The properties grunion.scss:130-134 sets on labels and legends -- `font-weight` and
+		 * `margin-bottom` -- plus the `margin` shorthand, which theme.json emits instead of
+		 * longhands when `spacing.margin` is a string and which would otherwise leave the
+		 * label and the legend spaced differently. Any property added to that rule must be
+		 * added here too.
+		 */
+		$contested = array( 'font-weight', 'margin', 'margin-bottom' );
+		$reassert  = array();
+		foreach ( $contested as $property ) {
+			if ( isset( $declarations[ $property ] ) ) {
+				/*
+				 * safecss_filter_attr() is a property allowlist plus a character blocklist
+				 * (\ ( & = } and /*); it does not remove HTML, so a value of `600</style>`
+				 * survives it intact and would close the inline style element early. Strip
+				 * tags first, which is what the style engine does before filtering its own
+				 * `css` output.
+				 */
+				$reassert[] = $property . ':' . wp_strip_all_tags( $declarations[ $property ], true );
+			}
+		}
+
+		if ( ! empty( $reassert ) ) {
+			$filtered = safecss_filter_attr( implode( ';', $reassert ) );
+			if ( '' !== $filtered ) {
+				$css .= '.contact-form :is(:where(label.grunion-field-label:not(.consent):not(.checkbox):not(.checkbox-multiple):not(.radio)),:where(legend.grunion-field-label)){' . $filtered . '}';
+			}
+		}
+
+		if ( ! empty( $mirror['css'] ) ) {
+			$css .= $mirror['css'];
+		}
+
+		return $css;
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -1055,9 +1055,23 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 .is-style-outlined :where(.wp-block-jetpack-label),
-.contact-form :where(.is-style-outlined .grunion-field-wrap .notched-label .notched-label__label),
-.contact-form :where(.is-style-outlined .grunion-field-wrap legend.grunion-field-label) {
+.contact-form :where(.is-style-outlined .grunion-field-wrap .notched-label .notched-label__label) {
 	font-weight: 300;
+}
+
+/* A grouped field's label is a <legend>, which the Global Styles `label`
+ * element cannot reach, so Forms mirrors those styles onto it instead. Font
+ * weight is the one property this variation owns: the notch is sized to its
+ * label, and every other label in the form is 300. Kept above zero specificity
+ * so that mirror does not leave the legend the only heavy label in the form. */
+.contact-form .is-style-outlined .grunion-field-wrap legend.grunion-field-label {
+	font-weight: 300;
+}
+
+/* Animated sets no weight of its own; its labels fall through to the 700 set
+ * above. The legend needs the same guard to stay consistent with them. */
+.contact-form .is-style-animated .grunion-field-wrap legend.grunion-field-label {
+	font-weight: 700;
 }
 
 .contact-form .is-style-outlined .grunion-field-textarea-wrap .notched-label .notched-label__label {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Global_Styles_Label_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Plugin_Global_Styles_Label_Test.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Unit tests for the Global Styles `label` element CSS emitted by Contact_Form_Plugin.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+
+/**
+ * Covers Contact_Form_Plugin::build_global_styles_label_css() and its enqueue glue.
+ *
+ * Global Styles emits `label { ... }` at specificity (0,0,1). The form's own defaults in
+ * grunion.css sit at (0,1,0) and would win, so `font-weight` and `margin` are re-asserted
+ * at our specificity when -- and only when -- the site has set label styles. The full style
+ * object is also mirrored onto `legend.grunion-field-label`, which `label { ... }` can never
+ * match because a grouped field's label is a `<legend>`.
+ *
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin
+ */
+#[CoversClass( Contact_Form_Plugin::class )]
+class Contact_Form_Plugin_Global_Styles_Label_Test extends BaseTestCase {
+
+	/**
+	 * Invoke the private CSS builder.
+	 *
+	 * @param mixed $label Style object for the label element.
+	 * @return string
+	 */
+	private function build( $label ) {
+		$method = new \ReflectionMethod( Contact_Form_Plugin::class, 'build_global_styles_label_css' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		return $method->invoke( null, $label );
+	}
+
+	/**
+	 * Style objects that must produce no CSS at all.
+	 *
+	 * The empty case is the zero-regression contract: nearly every site has no label styles
+	 * set, and those sites must render byte-identically to before this feature existed.
+	 */
+	public static function emptyStyleObjects() {
+		return array(
+			'empty array'       => array( array() ),
+			'null'              => array( null ),
+			'not an array'      => array( 'nonsense' ),
+			'pseudo state only' => array( array( ':hover' => array( 'color' => array( 'text' => 'red' ) ) ) ),
+			'unknown keys only' => array( array( 'somethingElse' => array( 'nope' => '1' ) ) ),
+		);
+	}
+
+	/**
+	 * A site with no label styles must get no inline CSS whatsoever.
+	 *
+	 * @param mixed $label Style object.
+	 * @dataProvider emptyStyleObjects
+	 */
+	#[DataProvider( 'emptyStyleObjects' )]
+	public function test_emits_nothing_when_there_are_no_label_styles( $label ) {
+		$this->assertSame( '', $this->build( $label ) );
+	}
+
+	/**
+	 * The font-weight property is contested by grunion.scss, so it is re-asserted and mirrored.
+	 */
+	public function test_contested_font_weight_is_reasserted_and_mirrored() {
+		$css = $this->build( array( 'typography' => array( 'fontWeight' => '900' ) ) );
+
+		$this->assertStringContainsString( 'font-weight:900', $css, 'the re-assert rule should carry the value' );
+		$this->assertStringContainsString( 'legend.grunion-field-label', $css, 'the legend mirror should be emitted' );
+		$this->assertSame( 2, substr_count( $css, 'font-weight' ), 'font-weight belongs in both rules' );
+	}
+
+	/**
+	 * A theme.json `spacing.margin` may be a string, which the style engine emits as a
+	 * single `margin` declaration rather than longhands. If the re-assert list only looked
+	 * for longhands it would match nothing, leaving the label on grunion's margin while the
+	 * legend took the Global Styles one -- the exact label/legend split this feature exists
+	 * to remove, inverted.
+	 */
+	public function test_shorthand_margin_reaches_both_the_label_and_the_legend() {
+		$css = $this->build( array( 'spacing' => array( 'margin' => '2rem' ) ) );
+
+		$this->assertStringContainsString( 'margin:2rem', $css );
+		$this->assertSame( 2, substr_count( $css, 'margin:2rem' ), 'shorthand margin belongs in both rules' );
+	}
+
+	/**
+	 * The longhand form has to work the same way.
+	 */
+	public function test_longhand_margin_bottom_reaches_both_the_label_and_the_legend() {
+		$css = $this->build( array( 'spacing' => array( 'margin' => array( 'bottom' => '40px' ) ) ) );
+
+		$this->assertSame( 2, substr_count( $css, 'margin-bottom:40px' ), 'margin-bottom belongs in both rules' );
+	}
+
+	/**
+	 * Properties grunion.scss does not set on labels are already reachable by Global Styles
+	 * at (0,0,1), so re-asserting them would be pointless breadth. Only the legend, which
+	 * `label { ... }` cannot match, needs them.
+	 */
+	public function test_uncontested_properties_are_mirrored_but_not_reasserted() {
+		$css = $this->build( array( 'color' => array( 'text' => '#1d4ed8' ) ) );
+
+		$this->assertStringContainsString( 'legend.grunion-field-label', $css );
+		$this->assertStringNotContainsString( ':where(label.grunion-field-label', $css, 'no re-assert rule is needed' );
+		$this->assertSame( 1, substr_count( $css, '#1d4ed8' ) );
+	}
+
+	/**
+	 * The re-assert rule sits at the same specificity as several deliberate exemptions in
+	 * grunion.scss and prints after them, so it must not sweep them up. Consent text and
+	 * checkbox option labels carry their own classes; the Outlined and Animated inset labels
+	 * carry no `grunion-field-label` class at all.
+	 */
+	public function test_reassert_selector_excludes_the_deliberate_exemptions() {
+		$css = $this->build( array( 'typography' => array( 'fontWeight' => '900' ) ) );
+
+		$this->assertStringContainsString( ':where(label.grunion-field-label:not(.consent)', $css );
+		$this->assertStringContainsString( ':not(.checkbox)', $css );
+	}
+
+	/**
+	 * The safecss_filter_attr() helper is an allowlist plus a character blocklist; it does not
+	 * strip HTML. Without wp_strip_all_tags() first, `600</style>` survives intact and closes
+	 * the inline style element early.
+	 */
+	public function test_style_tag_in_a_value_cannot_escape_the_style_element() {
+		$css = $this->build( array( 'typography' => array( 'fontWeight' => '600</style><script>alert`1`</script>' ) ) );
+
+		$this->assertStringNotContainsString( '</style>', $css );
+		$this->assertStringNotContainsString( '<script', $css );
+	}
+
+	/**
+	 * A value carrying `}` would close the rule and admit arbitrary selectors after it.
+	 */
+	public function test_brace_in_a_value_cannot_break_out_of_the_rule() {
+		$css = $this->build( array( 'typography' => array( 'fontWeight' => '600; } body { display: none' ) ) );
+
+		$this->assertStringNotContainsString( 'body', $css, 'no smuggled selector should survive' );
+	}
+
+	/**
+	 * The enqueue glue must attach nothing when the resolver reports no label styles. On any
+	 * WordPress before 7.1 the `label` element is not in WP_Theme_JSON::ELEMENTS, so it is
+	 * sanitized away and this is the state every site is in today.
+	 */
+	public function test_enqueue_attaches_nothing_when_the_resolver_has_no_label_styles() {
+		wp_register_style( 'grunion.css', 'https://example.org/grunion.css', array(), '1.0' );
+
+		Contact_Form_Plugin::add_global_styles_label_css();
+
+		$this->assertEmpty( wp_styles()->get_data( 'grunion.css', 'after' ) );
+	}
+}

--- a/projects/plugins/jetpack/changelog/forms-765-test-global-styles-label-with-jetpack-forms-css
+++ b/projects/plugins/jetpack/changelog/forms-765-test-global-styles-label-with-jetpack-forms-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Apply Global Styles label settings to form labels, including the group label on multiple-choice fields. The Outlined and Animated styles keep their own label weight.


### PR DESCRIPTION
See FORMS-765

## Proposed changes

Gutenberg registers `label` as a Global Styles element ([Gutenberg PR 81160](https://github.com/WordPress/gutenberg/pull/81160), first released in **Gutenberg 23.9.0**). Because `label` is an element-only selector it is *not* wrapped in `:root :where()`, so Global Styles emits a bare rule at specificity **(0,0,1)**:

```css
label{color:#1d4ed8;font-weight:900;letter-spacing:2px;…}
```

Forms' own default sits a full level above it at **(0,1,0)**:

```css
.contact-form :is(:where(label),:where(legend.grunion-field-label)){font-weight:700;margin-bottom:.25em}
```

So `font-weight` and `margin` set in Global Styles never reached a form label. Everything else (color, font-size, letter-spacing, padding, text-transform) already worked.

* **Only step aside when the site has actually set label styles.** The merged `elements.label` object is read at `wp_enqueue_scripts`; when it is non-empty, inline CSS re-asserts the contested properties at our own specificity, printed after `grunion.css` so it takes the tie. **When nothing is set, no inline CSS is emitted at all** — the regression surface for existing sites is zero.
* **Mirror onto the grouped-field `<legend>`.** A multiple-choice field's label is a `<legend>`, which `label { … }` can never match. Without the mirror it is the only unstyled label in the form.
* **Outlined and Animated keep their own label weight.** The notch is sized to its label, so two SCSS rules hold that weight above the mirrored value and keep the legend consistent with the inset labels beside it.

The resulting rule is one sentence: **Global Styles wins everything, except `font-weight` and `margin` inside Outlined and Animated, where the variation typography is load-bearing.**

### Why not just drop to zero specificity

That was the first thing I tried. I patched the deployed `grunion.css` to `:where(.contact-form label)` and measured computed styles across 13 themes before and after — **6 of 13 changed**, labels losing their bold:

| Theme | font-weight | margin-bottom |
|---|---|---|
| Twenty Twenty-One | 700 → 500 | 4.5px → 10px |
| Twenty Fifteen | 700 → 400 | 4.75px → 0 |
| Astra | 700 → 500 | unchanged |
| Blocksy | 700 → 400 | 3.75px → 7.5px |
| OceanWP | 700 → 400 | 3.5px → 3px |
| Neve | 700 → 400 | unchanged |

Zero specificity also does nothing for the `<legend>`, which is the most visible half of the problem.

**Note for reviewers:** PR 51187 landed on this same selector a week before this branch and solved a neighbouring problem the opposite way — dropping the legend's padding to zero specificity so themes and global styles win. That is the right call for a padding reset nobody relies on; it is the wrong call here, because bare `label {}` rules are common in themes and unrelated to Global Styles. The survey above is the evidence for the split.

## Related product discussion/links

* FORMS-765
* Gutenberg PR 81160 — `label` registered as an element (released in 23.9.0)
* Gutenberg PR 81786 — Global Styles UI for Labels (**still open**)
* wordpress-develop PR 13105 — core backport (**still open**; `label` is absent from core's `WP_Theme_JSON`)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Global Styles has no UI for labels yet (81786 is open), and core does not know the element yet, so this needs the **Gutenberg plugin 23.9.0 or later** plus a `theme.json` that sets the element.

1. On a test site, install and activate **Gutenberg 23.9.0+**.
2. Create a child theme of any block theme with this `theme.json`:

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"styles": {
		"elements": {
			"label": {
				"color": { "text": "#1d4ed8" },
				"typography": { "fontWeight": "900", "textTransform": "uppercase", "letterSpacing": "2px" },
				"spacing": { "margin": { "bottom": "40px" } }
			}
		}
	}
}
```

3. Add a form with a text field, a **multiple-choice** field (give its options real labels — an option with an empty label renders nothing), and a **consent** field. Publish and view the front end.

**Before this PR:** field labels stay bold at 700 and keep a `0.25em` margin, ignoring the Global Styles values. The multiple-choice group label is plain black sentence case, sitting between blue uppercase labels above and below it.

**After:** field labels and the group label both take the weight, margin, colour, letter-spacing and uppercase. Consent text and the individual option labels keep their lighter weight, as they do today.

4. Switch the form's style to **Outlined**, then **Animated**. In each, every label — including the group label — should share one weight (300 for Outlined, 700 for Animated). Before this PR the group label was the only heavy one in an Outlined form.
5. **Regression check:** on a site with no `elements.label` in `theme.json`, view any form and confirm the page source contains no `grunion.css-inline-css` block, and that labels render exactly as before.

### Automated coverage

`Contact_Form_Plugin_Global_Styles_Label_Test` adds 13 tests over the emitted CSS: the guard path, a shorthand `spacing.margin` string, longhand margin, uncontested-only styles, the exemption-scoped selector, and hostile values (`600</style>`, `600; } body {`). I mutation-checked them — reintroducing each of the three bugs found in review fails the corresponding test.

## Status

Draft. The behaviour is verified on a live site across all three form styles, with and without Global Styles, but there is no urgency behind it: without 81786 only a theme author hand-writing `theme.json` can reach this, and without the core backport non-Gutenberg sites are unaffected entirely. Opening early for design feedback rather than a merge decision.

Two things I deliberately left open:

* The legend mirror emits the **full** style object, including `background` and `border`. A Global Styles label background will paint a filled box over the Outlined fieldset border. Narrowing the mirror to typography + margin is the candidate fix; it trades that away against the legend no longer matching labels exactly.
* Two of the four `:not()` exclusions in the re-assert selector (`.radio`, `.checkbox-multiple`) may match nothing in current markup. Harmless if dead, so I left them rather than remove them on unverified analysis.

Also unaddressed: in the editor, `.jetpack-field-label__input{padding:0}` beats the Global Styles padding while the front end applies it. This PR is front-end only.
