### PR TITLE
Backup: let the file browser tree scroll sideways when the preview card narrows it

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-file-tree-horizontal-scroll
+++ b/projects/packages/backup/changelog/fix-backup-file-tree-horizontal-scroll
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the flag: the file browser's tree now scrolls sideways when the preview card narrows it, so long names at depth stay reachable instead of being cut off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-browser/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-browser/style.scss
@@ -21,6 +21,14 @@
 		}
 	}
 
+	&__tree {
+		// `max-content` must be the track's base size, not its growth limit —
+		// a definite min like `minmax(100%, max-content)` caps at the scrollport.
+		display: grid;
+		grid-template-columns: minmax(max-content, 1fr);
+		overflow-x: auto;
+	}
+
 	&__row {
 		display: flex;
 		align-items: center;
@@ -54,6 +62,7 @@
 		font-size: inherit;
 		padding: 0;
 		color: inherit;
+		white-space: nowrap;
 	}
 
 	&__empty {


### PR DESCRIPTION
## Proposed changes

The modernized Backup dashboard's file browser cuts off long filenames, with no way to reach them.

Opening a file mounts the preview card as a second grid column, which drops the tree into a `minmax(0, 1fr)` track. At 900px that track measures 556px while the tree's own content wants 742px. Names at depth then wrap, because each row is indented `12 + depth * 16` pixels. Adding `white-space: nowrap` on its own only trades wrapping for clipping: the overflow has nowhere to go.

This makes the tree its own horizontal scroll container, with a single track whose **base size** is `max-content`:

```scss
&__tree {
	display: grid;
	grid-template-columns: minmax(max-content, 1fr);
	overflow-x: auto;
}
```

`white-space: nowrap` is also added to `&__toggle, &__file`. It is **redundant** under this rule — a `max-content` track already stops soft wrapping, confirmed with a filename containing spaces — and is kept only to state the intent. It is not what makes the fix work.

### Why the obvious variants fail

Measured in a browser against a static copy of the real DOM at 900px with the preview card open. The tree column is 556px; the tree's `max-content` is 742.45px. The "stripe" column is the alternating row tint (`.jpb-file-browser__row--alt`, `background-color: #f6f7f7`), which is how a reader sees whether a row spans the full width.

| Attempt | scrollWidth | deep stripe | shallow stripe | covers after full right-scroll |
|---|---|---|---|---|
| shipped today | 556 | 556 | 556 | n/a — wraps instead |
| `nowrap` + `overflow-x: auto` | 734 | 556 | 556 | **no** |
| `min-width: max-content` on `__tree > div` | 742 | 742.45 | **556** | deep only — ragged between roots |
| `minmax(100%, max-content)` | 734 | **556** | 556 | **no** |
| **`minmax(max-content, 1fr)`** | 742 | **742.45** | **742.45** | **yes** |

The `minmax(100%, …)` failure is the interesting one, and it is a rule rather than a quirk. Sweeping the min value shows `minmax(0px, max-content)` also caps at 556 even with 556px of free space:

> Free space is `container − Σ base sizes`, so track maximisation can never push the sum past the container. A track exceeds its container only when its **base size** is intrinsic. Any `minmax(<definite>, <intrinsic>)` is capped, whatever the min.

That is why the min has to be `max-content` and the growth limit has to be the flexible half.

### Scope

- Short trees and the card-closed state still fill the port (556/556 and 852/852) — the `1fr` growth limit keeps the track from collapsing below the container.
- The sticky preview card is unaffected, measured at three scroll positions. It is a **sibling** of `__tree`, not a descendant, so making `__tree` a scroll container never enters the card's ancestor chain. `overflow-y` computes to `auto` on the tree, but the tree's height is auto, so no vertical scrollbar appears and it steals 0px.
- `overflow-x` is an axis property, not a direction-mapped one: in horizontal writing modes it is exactly `overflow-inline`, so it is RTL-safe as written and matches the eight existing `overflow-x: auto` scroll containers in the monorepo.

A single wrapper `div` around the rows measures numerically identical. It was rejected because it needs a JSX change, and this does not.

### Note for whoever merges second

`projects/packages/backup/src/dashboard/components/file-browser/style.scss` is also edited by #51867, which makes the preview card sticky. The two rules live in different blocks — `&__layout > .jpb-file-info-card` there, `&__tree` here — and a trial merge of the two branches applies cleanly with both rules intact. Still worth a glance from whichever lands second, since the hunks are only a few lines apart.

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is CSS only. There is no JS or DOM change, so jsdom cannot cover it — jsdom does no layout, and the full package suite passes identically with and without the rule (717 tests, 73 suites, both ways). Verifying it means looking at a browser.

The file browser is part of the modernized Backup dashboard, which is behind an off-by-default filter, so enable that first.

1. Open the modernized Backup dashboard and go to a backup's detail view, where the file browser lists the backup contents.
2. Narrow the browser window to roughly 900px. A wide window hides the bug — the tree only overflows once the column is narrower than the deepest row.
3. Expand a folder two or three levels deep, so the indentation pushes a long filename toward the right edge. `wp-content/plugins/<something>/…` works well.
4. Click a file to open the preview card. The tree now shares the row with a 280px card and gets much narrower.
5. **Before this change:** long names at depth wrap onto a second line, or are cut off at the column edge with no scrollbar to reach them.
   **After:** a horizontal scrollbar appears under the tree. Scroll it fully right and every row's alternating background still spans the whole width — shallow rows as well as deep ones, with no ragged right edge between them.
6. Check the preview card stays put while you scroll the tree sideways, and that it still sticks correctly when you scroll the page down.
7. Collapse everything back to one level, or close the preview card. The tree should go back to filling the full width with no scrollbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Q64EHVbUxU5vnh17NpAb3
