### PR TITLE
Jetpack AI: launch feature controls on self-hosted sites

### DIFF
--- a/projects/packages/my-jetpack/changelog/atomic-ai-self-hosted-rollout
+++ b/projects/packages/my-jetpack/changelog/atomic-ai-self-hosted-rollout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Jetpack AI: Show the AI card's on/off control, real module state, and AI page destination on self-hosted sites.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -531,11 +531,7 @@ class Initializer {
 			// Only says which destination `manage_url` is: the legacy Stats page
 			// caches its report and wants a `force_refresh` hint the dashboard does not.
 			'premiumAnalyticsEnabled'  => Products\Stats::is_premium_analytics_enabled(),
-			// Pre-release gate: only internal testing environments get the AI
-			// card's module toggle. The helper lives in the Jetpack plugin, so
-			// standalone installs resolve to false. Remove when the AI settings
-			// page goes public.
-			'showAiModuleToggle'       => function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment(),
+			'showAiModuleToggle'       => Products\Jetpack_Ai::is_feature_ui_enabled(),
 		);
 
 		return $flags;

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -11,6 +11,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\My_Jetpack\Initializer;
 use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
+use Automattic\Jetpack\Status\Host;
 use WP_Post;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -517,19 +518,43 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
-	 * Get the URL where the user manages the product
+	 * Whether My Jetpack should surface the AI feature controls.
 	 *
-	 * Pre-release gate: the Jetpack AI Hub's gated views are limited to
-	 * internal testing environments, so only they land there — everyone else
-	 * keeps the My Jetpack product page. Drop the gate when the views go public.
+	 * @return bool
+	 */
+	public static function is_feature_ui_enabled() {
+		if (
+			! self::is_plugin_active()
+			|| ! method_exists( '\\Jetpack', 'is_module' )
+			|| ! \Jetpack::is_module( 'ai' )
+			// @phan-suppress-next-line PhanUndeclaredClassReference -- Supplied by the optional Jetpack plugin.
+			|| ! method_exists( '\\Jetpack_AI_Settings', 'is_feature_enabled' )
+		) {
+			return false;
+		}
+
+		$connection = new Connection_Manager();
+		if ( ! $connection->is_connected() || ! $connection->has_connected_owner() ) {
+			return false;
+		}
+
+		$host = new Host();
+		if ( ! $host->is_wpcom_platform() ) {
+			return true;
+		}
+
+		return $host->is_woa_site()
+			&& function_exists( 'jetpack_is_internal_testing_environment' )
+			&& jetpack_is_internal_testing_environment();
+	}
+
+	/**
+	 * Get the URL where the user manages the product.
 	 *
 	 * @return ?string
 	 */
 	public static function get_manage_url() {
-		if (
-			function_exists( 'jetpack_is_internal_testing_environment' ) &&
-			jetpack_is_internal_testing_environment()
-		) {
+		if ( self::is_feature_ui_enabled() ) {
 			return admin_url( 'admin.php?page=jetpack-ai' );
 		}
 
@@ -578,22 +603,12 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
-	 * Whether the 'ai' module backs this product.
-	 *
-	 * Pre-release gate: the module-backed card is limited to internal testing
-	 * environments. Everywhere else this reports the module as active so the
-	 * product's status and every card built from it match the pre-module
-	 * behavior — the module state never surfaces in My Jetpack.
-	 *
-	 * Remove this override when the AI settings page goes public.
+	 * Whether the 'ai' module backs this product's UI state.
 	 *
 	 * @return bool
 	 */
 	public static function is_module_active() {
-		if (
-			! function_exists( 'jetpack_is_internal_testing_environment' ) ||
-			! jetpack_is_internal_testing_environment()
-		) {
+		if ( ! self::is_feature_ui_enabled() ) {
 			return true;
 		}
 

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -239,16 +239,9 @@ class Initializer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The AI card's pre-release toggle flag follows the Jetpack plugin's
-	 * internal-testing helper.
+	 * The AI card keeps its legacy action without a compatible Jetpack plugin.
 	 */
-	public function test_my_jetpack_flags_gate_the_ai_module_toggle() {
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
-		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
-
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+	public function test_my_jetpack_flags_hide_the_ai_module_toggle_without_compatible_jetpack() {
 		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
-
-		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -2,8 +2,11 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
+use Automattic\Jetpack\Status\Cache as StatusCache;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -30,6 +33,9 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		Constants::clear_constants();
+		StatusCache::clear();
+		( new Connection_Manager() )->reset_connection_status();
 		$this->install_mock_plugins();
 		wp_cache_delete( 'plugins', 'plugins' );
 
@@ -62,15 +68,20 @@ class Jetpack_Ai_Product_Test extends TestCase {
 		parent::tearDown();
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
+		( new Connection_Manager() )->reset_connection_status();
 		// Remove all filters to avoid interference between tests.
 		remove_all_filters( 'jetpack_ai_enabled' );
 		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
+		Constants::clear_constants();
+		StatusCache::clear();
 		// Reset the mock Jetpack module state so it doesn't leak between tests.
 		if ( class_exists( 'Jetpack' ) && property_exists( 'Jetpack', 'active_modules' ) ) {
 			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
 			\Jetpack::$active_modules = array();
 			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
 			\Jetpack::$return_false = false;
+			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
+			\Jetpack::$available_modules = array( 'ai' );
 		}
 	}
 
@@ -157,13 +168,10 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * Pre-release gate: outside internal testing environments the product is not
-	 * module-backed at all, so an inactive module never surfaces — the status is
-	 * what it was before the module existed.
+	 * Atomic keeps the pre-launch card state, so an inactive module stays masked.
 	 */
-	public function test_jetpack_ai_ignores_the_module_outside_internal_testing() {
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
-
+	public function test_jetpack_ai_ignores_the_module_on_atomic() {
+		$this->set_atomic_site();
 		Jetpack_Options::update_option( 'id', 123 );
 		activate_plugins( 'jetpack/jetpack.php' );
 		\Jetpack::deactivate_module( 'ai' );
@@ -173,74 +181,138 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	}
 
 	/**
-	 * In internal testing environments the manage URL points at the Jetpack AI
-	 * Hub, whose Overview tab is visible behind the same gate.
+	 * Self-hosted sites manage AI on the Jetpack AI page.
 	 */
-	public function test_manage_url_points_at_the_jetpack_ai_hub_in_internal_testing() {
+	public function test_manage_url_points_at_the_jetpack_ai_page_on_self_hosted() {
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$this->connect_site_and_owner();
 
 		$manage_url = Jetpack_Ai::get_manage_url();
 
+		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), $manage_url );
 		$this->assertStringNotContainsString( 'page=my-jetpack', (string) $manage_url );
 	}
 
 	/**
-	 * Outside internal testing the Jetpack AI Hub shows only MCP Settings, so
-	 * the manage URL must keep landing on the My Jetpack product page.
+	 * A disconnected site keeps the existing connection action.
 	 */
-	public function test_manage_url_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+	public function test_feature_ui_stays_hidden_without_a_connection() {
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 
+		$this->assertFalse( Jetpack_Ai::is_feature_ui_enabled() );
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
 	}
 
 	/**
-	 * Post-checkout landing in internal testing environments is the Jetpack AI Hub.
+	 * A site connection without an owner keeps the account connection action.
 	 */
-	public function test_post_checkout_lands_on_the_jetpack_ai_hub_in_internal_testing() {
+	public function test_feature_ui_stays_hidden_without_a_connected_owner() {
 		activate_plugins( 'jetpack/jetpack.php' );
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		$this->assertFalse( Jetpack_Ai::is_feature_ui_enabled() );
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * An older Jetpack cannot expose controls supplied by a newer shared package.
+	 */
+	public function test_feature_ui_stays_hidden_when_active_jetpack_lacks_the_ai_module() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
+		\Jetpack::$available_modules = array();
+
+		$this->assertFalse( Jetpack_Ai::is_feature_ui_enabled() );
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * Atomic sites keep managing AI on the My Jetpack product page.
+	 */
+	public function test_manage_url_stays_on_the_my_jetpack_product_page_on_atomic() {
+		$this->set_atomic_site();
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * WordPress.com Simple keeps the existing My Jetpack card action even for
+	 * internal requests.
+	 */
+	public function test_manage_url_stays_on_the_my_jetpack_product_page_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
 		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		$this->assertFalse( Jetpack_Ai::is_feature_ui_enabled() );
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * Internal Atomic requests retain the pre-release feature UI.
+	 */
+	public function test_internal_atomic_request_gets_the_feature_ui() {
+		$this->set_atomic_site();
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		activate_plugins( 'jetpack/jetpack.php' );
+		$this->connect_site_and_owner();
+
+		$this->assertTrue( Jetpack_Ai::is_feature_ui_enabled() );
+		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * Post-checkout landing on self-hosted sites is the Jetpack AI page.
+	 */
+	public function test_post_checkout_lands_on_the_jetpack_ai_page_on_self_hosted() {
+		activate_plugins( 'jetpack/jetpack.php' );
+		$this->connect_site_and_owner();
 
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
 	}
 
 	/**
-	 * Post-checkout landing outside internal testing stays on the My Jetpack product page.
+	 * Post-checkout landing on Atomic stays on the My Jetpack product page.
 	 */
-	public function test_post_checkout_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+	public function test_post_checkout_stays_on_the_my_jetpack_product_page_on_atomic() {
+		$this->set_atomic_site();
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 
 		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_checkout_url() );
 	}
 
 	/**
-	 * Post-activation landing in internal testing environments is the Jetpack AI Hub.
+	 * Post-activation landing on self-hosted sites is the Jetpack AI page.
 	 */
-	public function test_post_activation_lands_on_the_jetpack_ai_hub_in_internal_testing() {
+	public function test_post_activation_lands_on_the_jetpack_ai_page_on_self_hosted() {
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$this->connect_site_and_owner();
 
 		$this->assertSame( admin_url( 'admin.php?page=jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
 	}
 
 	/**
-	 * Post-activation landing outside internal testing stays on the My Jetpack product page.
+	 * Post-activation landing on Atomic stays on the My Jetpack product page.
 	 */
-	public function test_post_activation_stays_on_the_my_jetpack_product_page_outside_internal_testing() {
+	public function test_post_activation_stays_on_the_my_jetpack_product_page_on_atomic() {
+		$this->set_atomic_site();
 		activate_plugins( 'jetpack/jetpack.php' );
-		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 
 		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_post_activation_url() );
 	}
 
 	/**
-	 * Standalone plugins ship My Jetpack without the Jetpack plugin, so the gate
-	 * helper never exists and the manage URL must fall back to My Jetpack. Separate
-	 * process so no earlier activate_plugins() call has defined the helper.
+	 * Standalone plugins ship My Jetpack without the Jetpack AI page, so its
+	 * manage URL must fall back to My Jetpack.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -248,7 +320,27 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_manage_url_stays_on_the_my_jetpack_product_page_without_the_jetpack_plugin() {
-		$this->assertFalse( function_exists( 'jetpack_is_internal_testing_environment' ) );
+		$this->assertFalse( Jetpack_Ai::is_plugin_active(), 'Precondition: the Jetpack plugin is not active.' );
 		$this->assertSame( admin_url( 'admin.php?page=my-jetpack#/jetpack-ai' ), Jetpack_Ai::get_manage_url() );
+	}
+
+	/**
+	 * Connect the test site and its owner to WordPress.com.
+	 */
+	private function connect_site_and_owner() {
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+	}
+
+	/**
+	 * Mark the current test site as WordPress.com Atomic.
+	 */
+	private function set_atomic_site() {
+		Constants::set_constant( 'ATOMIC_SITE_ID', 123 );
+		Constants::set_constant( 'ATOMIC_CLIENT_ID', 123 );
+		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', '/tmp/wpcomsh/wpcomsh.php' );
+		StatusCache::clear();
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
@@ -27,6 +27,7 @@ function jetpack_is_internal_testing_environment() {
 class Jetpack {
 
 	static $active_modules = array();
+	static $available_modules = array( 'ai' );
 
 	static $return_false = false; // Force return false in action methods.
 
@@ -41,6 +42,10 @@ class Jetpack {
 
 	public static function is_module_active( $module_name ) {
 		return in_array( $module_name, self::$active_modules );
+	}
+
+	public static function is_module( $module_name ) {
+		return in_array( $module_name, self::$available_modules, true );
 	}
 
 	public static function activate_module( $module_name, $exit = true, $redirect = true ) {
@@ -67,6 +72,12 @@ class Jetpack {
 	}
 
 	public static function is_connection_ready() {
+		return true;
+	}
+}
+
+class Jetpack_AI_Settings {
+	public static function is_feature_enabled( $feature ) {
 		return true;
 	}
 }

--- a/projects/packages/search/changelog/atomic-ai-self-hosted-rollout
+++ b/projects/packages/search/changelog/atomic-ai-self-hosted-rollout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Answers: Apply the site-wide Jetpack AI switch on self-hosted sites.

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -118,18 +118,21 @@ class AI_Answers {
 	}
 
 	/**
-	 * Whether master enforcement has rolled out here — mirrors the Jetpack
-	 * plugin's rollout scoping: Simple keeps its option contract; elsewhere
-	 * the rollout is internal-only for now.
+	 * Whether master enforcement has rolled out here.
+	 *
+	 * Simple keeps its existing option contract, self-hosted sites use the
+	 * Jetpack module, and Atomic remains limited to internal testing.
 	 *
 	 * @return bool
 	 */
 	private static function is_master_rollout_active() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
+		$host = new Host();
+		if ( $host->is_wpcom_simple() ) {
 			return true;
 		}
 
-		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
+		return ! $host->is_woa_site()
+			|| ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() );
 	}
 
 	/**

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
 
 /**
  * Unit tests for the AI_Answers class.
@@ -30,6 +31,7 @@ class AI_Answers_Test extends Search_TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		Status_Cache::set( 'is_woa_site', false );
 		// Default to a paid plan; tests exercising the gate override this.
 		Search_Blocks::set_supports_paid_search_for_testing( true );
 	}
@@ -48,6 +50,7 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->remove_ai_master_filters();
 		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 		Constants::clear_single_constant( 'IS_WPCOM' );
+		Status_Cache::clear();
 
 		if ( $this->posts_query_filter !== null ) {
 			remove_filter( 'posts_pre_query', $this->posts_query_filter, 10 );
@@ -57,6 +60,13 @@ class AI_Answers_Test extends Search_TestCase {
 			unregister_post_type( 'wp_guideline' );
 		}
 		Search_Blocks::reset_supports_paid_search_cache();
+	}
+
+	/**
+	 * Make the current request look like WordPress.com Atomic.
+	 */
+	private function force_atomic_site() {
+		Status_Cache::set( 'is_woa_site', true );
 	}
 
 	public function test_is_enabled_defaults_to_false() {
@@ -163,23 +173,36 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertFalse( AI_Answers::should_enforce_master() );
 	}
 
-	public function test_should_enforce_master_is_true_outside_internal_testing_environments() {
-		// The master switch UI ships internal-only for now, so a public site must not be
-		// gated on a switch its owner cannot see. Module present but inactive, yet ungated.
+	public function test_should_enforce_master_follows_the_module_on_self_hosted() {
 		$this->turn_ai_module_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::should_enforce_master() );
+		$this->assertFalse( AI_Answers::should_enforce_master() );
 	}
 
-	public function test_is_enabled_ignores_the_module_outside_internal_testing_environments() {
-		// Module-only setup: pins that the package's own enforcement is env-scoped.
-		// (With the Jetpack plugin loaded, its filter gate still applies publicly.)
+	public function test_is_enabled_follows_the_module_on_self_hosted() {
 		update_option( 'jetpack_search_ai_answers_enabled', true );
 		$this->turn_ai_module_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::is_enabled() );
+		$this->assertFalse( AI_Answers::is_enabled() );
+	}
+
+	public function test_should_enforce_master_waives_the_module_on_ordinary_atomic() {
+		$this->force_atomic_site();
+		$this->turn_ai_module_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertTrue( AI_Answers::should_enforce_master() );
+		$this->assertTrue( AI_Answers::is_master_enabled() );
+	}
+
+	public function test_should_enforce_master_follows_the_module_on_internal_atomic() {
+		$this->force_atomic_site();
+		$this->turn_ai_module_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = true;
+
+		$this->assertFalse( AI_Answers::should_enforce_master() );
 	}
 
 	public function test_is_enabled_is_false_when_the_master_is_off() {
@@ -235,13 +258,11 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertTrue( AI_Answers::is_master_enabled() );
 	}
 
-	public function test_is_master_enabled_reports_on_outside_internal_testing_environments() {
-		// The master rollout is a12s-scoped: public sites report ungated even
-		// when the gate is registered, so no master-off UI leaks before the sweep.
+	public function test_is_master_enabled_reports_the_gate_on_self_hosted() {
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
-		$this->assertTrue( AI_Answers::is_master_enabled() );
+		$this->assertFalse( AI_Answers::is_master_enabled() );
 	}
 
 	public function test_is_master_enabled_reports_the_gate_on_wpcom_simple_regardless_of_environment() {
@@ -265,9 +286,8 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertFalse( AI_Answers::is_master_enabled() );
 	}
 
-	public function test_is_enabled_still_gated_outside_internal_testing_environments() {
-		// Enforcement is the plugin's public filter — only the *reporting* is
-		// scoped. A public master-off site still reports the feature off.
+	public function test_is_enabled_stays_gated_on_self_hosted() {
+		// A master-off site reports the feature off.
 		update_option( 'jetpack_search_ai_answers_enabled', true );
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -283,18 +283,14 @@ class Ai_Answer_Render_Test extends TestCase {
 		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
 	}
 
-	public function test_renders_when_master_is_off_outside_internal_testing_environments() {
-		// The master switch UI ships internal-only for now, so on a public site
-		// the front-end gate must stay inert: even with the master off, the
-		// block keeps rendering. If the rollout scoping ever moves out of
-		// `should_enforce_master()`, this pin has to change deliberately with it.
+	public function test_renders_nothing_when_master_is_off_on_self_hosted() {
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$markup = $this->render();
 
-		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
-		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
 	}
 
 	public function test_renders_when_ai_module_is_not_registered() {

--- a/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
+++ b/projects/packages/search/tests/php/Initial_Javascript_State_Test.php
@@ -21,13 +21,13 @@ class Initial_Javascript_State_Test extends Search_TestCase {
 		parent::tearDown();
 	}
 
-	public function test_it_reports_the_master_as_on_outside_internal_testing_environments() {
+	public function test_it_reports_the_master_as_off_on_self_hosted() {
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$state = Helper::generate_initial_javascript_state();
 
-		$this->assertTrue( $state['aiMasterEnabled'] );
+		$this->assertFalse( $state['aiMasterEnabled'] );
 	}
 
 	public function test_it_reports_the_ai_master_switch_as_off() {

--- a/projects/packages/search/tests/php/REST_Controller_Test.php
+++ b/projects/packages/search/tests/php/REST_Controller_Test.php
@@ -877,25 +877,25 @@ class REST_Controller_Test extends Search_TestCase {
 	}
 
 	/**
-	 * Outside internal testing environments the payload reports the master as
-	 * on and enabling stays allowed — the rollout must not leak publicly.
+	 * Self-hosted settings report the real master state and reject enabling AI
+	 * Answers while that master is off.
 	 */
-	public function test_master_reporting_is_scoped_to_internal_testing_environments() {
+	public function test_master_reporting_follows_the_master_on_self_hosted() {
 		wp_set_current_user( $this->admin_id );
 		$this->enable_instant_search();
 		$this->turn_ai_master_off();
 		$GLOBALS['jetpack_search_test_internal_env'] = false;
 
 		$get = new WP_REST_Request( 'GET', '/jetpack/v4/search/settings' );
-		$this->assertTrue( $this->server->dispatch( $get )->get_data()['ai_master_enabled'] );
+		$this->assertFalse( $this->server->dispatch( $get )->get_data()['ai_master_enabled'] );
 
 		$post = new WP_REST_Request( 'POST', '/jetpack/v4/search/settings' );
 		$post->set_header( 'content-type', 'application/json' );
 		$post->set_body( wp_json_encode( array( 'ai_answers_enabled' => true ), JSON_UNESCAPED_SLASHES ) );
 		$response = $this->server->dispatch( $post );
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertFalse( (bool) get_option( 'jetpack_search_ai_answers_enabled', false ) );
 
 		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 	}

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -5,7 +5,7 @@
  * with hash-based routing. The MCP tab owns the read | write | setup sub-views,
  * which render with breadcrumbs in place of the tab bar.
  *
- * Overview and AI Features share an internal-testing gate. Scheduled tasks
+ * Overview and AI Features share a host-controlled gate. Scheduled tasks
  * is controlled independently by the ai-hub-scheduled-tasks server-side feature
  * flag. Without either flag the page keeps its original MCP-only shape, with the
  * MCP hub as the landing view and no tab bar.
@@ -35,8 +35,8 @@ const SETTINGS_REF = 'jetpack-ai-mcp-settings';
 
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 
-// Views that only exist in internal testing environments. MCP and Connectors ships
-// publicly, so it is not in here.
+// Views that retain an internal-testing badge when a host enables them for a
+// test request. MCP and Connectors ships publicly, so it is not in here.
 const GATED_VIEWS = [ 'overview', 'features' ];
 
 // Read at call time, not module scope, so the flag reflects the injected page data.
@@ -142,6 +142,7 @@ export default function App() {
 		planAutoRenew,
 		isUserConnected,
 		showFeaturesView = false,
+		showA12sBadge = false,
 	} = window?.jetpackAiSettings ?? {};
 	const [ view, setView ] = useState( getViewFromHash );
 	// Save feedback goes through the shared GlobalNotices snackbars (the
@@ -267,10 +268,8 @@ export default function App() {
 							{ tabViews.map( tab => (
 								<Tabs.Tab key={ tab } value={ tab }>
 									{ VIEW_TITLES[ tab ] }
-									{ /* Overview and Features ship behind the internal-testing gate;
-									     label them so Automatticians don't mistake them for public UI.
-									     Remove with the gate. */ }
-									{ GATED_VIEWS.includes( tab ) && (
+									{ /* Keep the badge when a host exposes these views to internal testers. */ }
+									{ showA12sBadge && GATED_VIEWS.includes( tab ) && (
 										<Badge intent="medium" className="jetpack-ai-admin__tab-badge">
 											{ __( 'A12s only', 'jetpack' ) }
 										</Badge>

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -93,14 +93,12 @@ beforeEach( () => {
 	jest.spyOn( window, 'scrollTo' ).mockImplementation();
 	apiFetch.mockReset();
 	analytics.tracks.recordEvent.mockClear();
-	// The suite renders as an internal tester by default so the Features view
-	// is reachable; the a11n-gate tests below override this per test.
+	// The suite renders with the host-gated Features view available by default.
 	window.jetpackAiSettings = { showFeaturesView: true };
 	window.location.hash = '#/features';
 } );
 
 afterEach( () => {
-	// Tests that exercise the internal-testing flag set this global.
 	delete window.jetpackAiSettings;
 	delete window.__agentsManagerActions;
 	// The @wordpress/notices store is module-global: drain it so a snackbar
@@ -206,11 +204,7 @@ describe( 'AI admin page (main.jsx)', () => {
 	} );
 
 	test( 'internal-testing flag: every gated tab carries an A12s only badge', async () => {
-		// Overview and Features are both gated to internal testing environments;
-		// when the injected flag says we are in one, each tab must say so —
-		// Automatticians should not mistake either view for public UI. MCP
-		// Settings ships publicly, so it must not be labelled.
-		window.jetpackAiSettings = { showFeaturesView: true };
+		window.jetpackAiSettings = { showFeaturesView: true, showA12sBadge: true };
 		mockApiFetch();
 
 		render( <App /> );
@@ -247,20 +241,13 @@ describe( 'AI admin page (main.jsx)', () => {
 		delete window.__agentsManagerActions;
 	} );
 
-	test( 'no internal-testing flag: no A12s only badge renders', async () => {
-		// Without the flag the gate hides the Features view entirely (MCP-only
-		// shape), so the internal-testing label must not appear anywhere.
-		window.jetpackAiSettings = {};
+	test( 'public self-hosted views have no A12s only badge', async () => {
+		window.jetpackAiSettings = { showFeaturesView: true, showA12sBadge: false };
 		mockApiFetch();
 
 		render( <App /> );
 
-		await expect(
-			screen.findByText(
-				'This site is not connected to WordPress.com. Please connect Jetpack to manage MCP settings.',
-				IGNORE_A11Y
-			)
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Writing Assistant' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'A12s only' ) ).not.toBeInTheDocument();
 	} );
 
@@ -442,7 +429,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		expect( screen.queryByRole( 'button', { name: 'AI' } ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: without showFeaturesView the page is MCP-only with no tab bar', async () => {
+	test( 'host gate: without showFeaturesView the page is MCP-only with no tab bar', async () => {
 		window.jetpackAiSettings = {};
 		window.location.hash = '';
 		mockApiFetch();
@@ -466,7 +453,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: a #/features deep link falls back to the MCP view when gated', async () => {
+	test( 'host gate: a #/features deep link falls back to the MCP view when gated', async () => {
 		window.jetpackAiSettings = {};
 		window.location.hash = '#/features';
 		mockApiFetch();
@@ -484,7 +471,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'a11n gate: with showFeaturesView the tab bar shows and Overview is the default view', async () => {
+	test( 'host gate: with showFeaturesView the tab bar shows and Overview is the default view', async () => {
 		// Connected, so the Overview usage card renders rather than the
 		// not-connected notice.
 		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -263,6 +263,8 @@ class Jetpack_AI_Page {
 			Connection_Initial_State::render_script( 'jetpack-ai-admin' );
 		}
 
+		$host = new Host();
+
 		/**
 		 * Filters the host-specific AI Hub configuration.
 		 *
@@ -273,10 +275,10 @@ class Jetpack_AI_Page {
 		$config = apply_filters(
 			'jetpack_ai_admin_config',
 			array(
-				// Pre-release gate for the Overview and Features views. When opening
-				// them to everyone, also drop the matching gate in My Jetpack's
-				// Jetpack_Ai::get_manage_url() so its links land here too.
-				'showGatedViews'  => $is_internal_test,
+				// The Overview and Features views launch on self-hosted sites first.
+				// Keep this filterable so hosts can close them independently.
+				'showGatedViews'  => ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ),
+				'showA12sBadge'   => $host->is_woa_site() && $is_internal_test,
 				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
 				'mcpSettingsApi'  => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
@@ -316,6 +318,7 @@ class Jetpack_AI_Page {
 			// auto-renew, matching My Jetpack and the wpcom subscriptions page.
 			'planAutoRenew'    => $plan_info['auto_renew'],
 			'showFeaturesView' => $show_gated_views,
+			'showA12sBadge'    => ! empty( $config['showA12sBadge'] ),
 			// The tab and its Agents Manager sidebar ship disabled by default.
 			'featureFlags'     => array(
 				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -209,17 +209,19 @@ class Jetpack_AI_Settings {
 
 	/**
 	 * Whether the AI controls — the master switch and the toggles this class owns
-	 * — take effect here. They are not publicly launched, so off Simple they apply
-	 * on internal testing environments only. Remove at public launch.
+	 * — take effect here. Simple keeps its existing option contract, self-hosted
+	 * sites use the Jetpack controls, and Atomic remains limited to internal testing.
 	 *
 	 * @return bool
 	 */
 	private static function should_enforce_ai_controls() {
-		if ( ( new Host() )->is_wpcom_simple() ) {
+		$host = new Host();
+		if ( $host->is_wpcom_simple() ) {
 			return true;
 		}
 
-		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
+		return ! $host->is_woa_site()
+			|| ( function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment() );
 	}
 
 	/**
@@ -332,9 +334,9 @@ class Jetpack_AI_Settings {
 		}
 
 		// The toggles this class owns stay on wherever they do not apply: Simple keeps
-		// the existing wp.com settings contract, and elsewhere they are not publicly
-		// launched. The reused Search option ships today with its own settings
-		// surface, so it always honors its stored value.
+		// the existing wp.com settings contract, while Atomic keeps them hidden.
+		// The reused Search option has its own settings surface, so it always honors
+		// its stored value.
 		if ( in_array( $feature, self::OWNED_FEATURES, true )
 			&& ( ( new Host() )->is_wpcom_simple() || ! self::should_enforce_ai_controls() ) ) {
 			return true;

--- a/projects/plugins/jetpack/changelog/atomic-ai-self-hosted-rollout
+++ b/projects/plugins/jetpack/changelog/atomic-ai-self-hosted-rollout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: Make the Overview and AI Features tabs available on self-hosted sites and apply their controls.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Redux_State_Helper_Test.php
@@ -68,16 +68,11 @@ class Jetpack_Redux_State_Helper_Test extends WP_UnitTestCase {
 
 	/**
 	 * The initial state reports the effective AI state through the same gate
-	 * chain the editor enforces: waived master outside internal testing
-	 * environments, enforced master (the inactive `ai` module) inside them.
+	 * chain the editor enforces on self-hosted sites.
 	 */
 	public function test_ai_effectively_enabled_reflects_the_ai_gates() {
 		$redux_state = Jetpack_Redux_State_Helper::get_initial_state();
-		$this->assertTrue( $redux_state['isAiEnabled'], 'Outside internal testing envs the master is waived, so AI reads on.' );
 
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		$redux_state                    = Jetpack_Redux_State_Helper::get_initial_state();
-
-		$this->assertFalse( $redux_state['isAiEnabled'], 'On internal testing envs the inactive ai module reads as master off.' );
+		$this->assertFalse( $redux_state['isAiEnabled'], 'The inactive ai module reads as master off.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -2,10 +2,8 @@
 /**
  * Tests for the Jetpack AI admin page script data.
  *
- * The contract worth locking down: the pre-release a11n gate flag rides the
- * jetpackAiSettings inline script and follows
- * jetpack_is_internal_testing_environment(), so the Features view stays hidden
- * outside internal testing environments while the MCP-only page keeps working.
+ * The Overview and AI Features views are public on self-hosted sites, gated on
+ * Atomic, and remain filterable by the host.
  *
  * @package automattic/jetpack
  */
@@ -266,35 +264,83 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Outside internal testing environments the Features view flag is off.
+	 * The Overview and AI Features views render publicly on self-hosted sites.
 	 */
-	public function test_features_view_flag_is_off_by_default() {
+	public function test_features_view_flag_is_on_for_self_hosted_site() {
+		$this->given_woa( false );
+
 		$settings = $this->get_injected_settings();
 
 		$this->assertArrayHasKey( 'showFeaturesView', $settings );
-		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertTrue( $settings['showFeaturesView'] );
+		$this->assertFalse( $settings['showA12sBadge'] );
+		$this->assertFalse( $settings['isTest'] );
 		$this->assertArrayHasKey( 'featureFlags', $settings );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
 	}
 
 	/**
-	 * A proxied a8c request marks an internal testing environment and turns
-	 * the Features view flag on.
+	 * Internal self-hosted requests still present the views as public UI.
 	 */
-	public function test_features_view_flag_follows_internal_testing_environment() {
+	public function test_self_hosted_internal_request_has_no_a12s_badge() {
+		$this->given_woa( false );
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$settings = $this->get_injected_settings();
 
 		$this->assertTrue( $settings['showFeaturesView'] );
+		$this->assertFalse( $settings['showA12sBadge'] );
+		$this->assertTrue( $settings['isTest'] );
+	}
+
+	/**
+	 * The views remain hidden from an ordinary Atomic request.
+	 */
+	public function test_features_view_flag_is_off_for_ordinary_woa_site() {
+		$this->given_woa( true );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertFalse( $settings['showA12sBadge'] );
+		$this->assertFalse( $settings['isTest'] );
+	}
+
+	/**
+	 * The views remain hidden from Simple sites, including internal requests.
+	 */
+	public function test_features_view_flag_is_off_for_simple_site() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->given_woa( false );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertFalse( $settings['showA12sBadge'] );
+		$this->assertTrue( $settings['isTest'] );
+	}
+
+	/**
+	 * A proxied Atomic request retains access for internal testing.
+	 */
+	public function test_features_view_flag_is_on_for_proxied_woa_site() {
+		$this->given_woa( true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertTrue( $settings['showFeaturesView'] );
+		$this->assertTrue( $settings['showA12sBadge'] );
+		$this->assertTrue( $settings['isTest'] );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
 	}
 
 	/**
-	 * Hosts can hide pre-release views even in an internal testing environment.
+	 * Hosts retain final control over the views.
 	 */
 	public function test_features_view_flag_can_be_filtered_by_the_host() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->given_woa( false );
 		add_filter(
 			'jetpack_ai_admin_config',
 			function ( $config ) {
@@ -700,7 +746,6 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	 * Self-hosted sites keep the Jetpack purchase name, brand prefix trimmed.
 	 */
 	public function test_self_hosted_site_shows_the_jetpack_plan() {
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->given_woa( false );
 		$this->given_site( array( $this->jetpack_ai_purchase() ) );
 
@@ -761,11 +806,10 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The name is only looked up for the gated views, so an ungated page ships
-	 * an empty value rather than paying for the purchase lookup.
+	 * Atomic skips the plan lookup while the views remain gated.
 	 */
-	public function test_plan_name_is_absent_without_the_gate() {
-		$this->given_woa( false );
+	public function test_plan_name_is_absent_on_ordinary_woa_site() {
+		$this->given_woa( true );
 		$this->given_site( array( $this->jetpack_ai_purchase() ) );
 
 		$settings = $this->get_injected_settings();

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -13,6 +13,7 @@
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -25,6 +26,14 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 #[CoversClass( Jetpack_AI_Settings::class )]
 class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Default each test to a self-hosted site.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Status_Cache::set( 'is_woa_site', false );
+	}
 
 	/**
 	 * Filter callback used to simulate the `ai` module being active without the
@@ -49,11 +58,17 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Master enforcement only runs on internal testing environments while the
-	 * AI controls are not publicly launched. The predicate treats a proxied
-	 * A8C request as internal, so that is the lever the enforcement tests pull.
+	 * Make the current request look like WordPress.com Atomic.
+	 */
+	private function force_atomic_site() {
+		Status_Cache::set( 'is_woa_site', true );
+	}
+
+	/**
+	 * Make the current Atomic request internal and proxied.
 	 */
 	private function force_internal_testing_env() {
+		$this->force_atomic_site();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 	}
 
@@ -79,6 +94,7 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 
 		// Reset the platform: every test in this class defaults to off-Simple.
 		Constants::clear_single_constant( 'IS_WPCOM' );
+		Status_Cache::clear();
 		\Jetpack_Options::update_option( 'active_modules', array() );
 
 		parent::tear_down();
@@ -126,12 +142,12 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Until the AI controls ship publicly, the master gate is waived outside
-	 * internal testing environments: an inactive `ai` module must not turn AI
-	 * off for the public.
+	 * Ordinary Atomic requests keep the master gate waived while the controls
+	 * remain hidden there.
 	 */
-	public function test_master_not_enforced_outside_internal_testing_env() {
-		// Plain test env: not internal, module inactive.
+	public function test_master_not_enforced_for_ordinary_atomic_request() {
+		$this->force_atomic_site();
+
 		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'Precondition: the stored master state reads off.' );
 
 		$this->assertTrue( apply_filters( 'jetpack_ai_enabled', true ) );
@@ -143,14 +159,14 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The waiver covers only the master gate: the host gate (a server-owner
-	 * decision) keeps enforcing everywhere.
+	 * The Atomic waiver covers only the master gate; the host gate still applies.
 	 */
-	public function test_host_gate_enforced_outside_internal_testing_env() {
+	public function test_host_gate_enforced_for_ordinary_atomic_request() {
 		if ( ! function_exists( 'wp_supports_ai' ) ) {
 			$this->markTestSkipped( 'wp_supports_ai() is not available in this WordPress version.' );
 		}
 
+		$this->force_atomic_site();
 		add_filter( 'wp_supports_ai', '__return_false' );
 
 		$this->assertFalse( Jetpack_AI_Settings::is_ai_enabled() );
@@ -402,11 +418,11 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The controls this class owns are not publicly launched, so a stored-off
-	 * toggle is inert outside internal testing environments: the feature keeps
-	 * the behavior the released version has.
+	 * The hidden Atomic controls remain inert on ordinary requests.
 	 */
-	public function test_owned_toggles_are_inert_outside_internal_testing() {
+	public function test_owned_toggles_are_inert_for_ordinary_atomic_request() {
+		$this->force_atomic_site();
+
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'jetpack_ai_image_editor_enabled', 0 );
 		update_option( 'jetpack_ai_feature_clip_enabled', 0 );
@@ -571,15 +587,14 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Off Simple the same option still switches the feature off, where the
-	 * owned toggles apply.
+	 * Self-hosted sites honor a saved off value for the owned feature controls.
 	 */
-	public function test_owned_features_honor_their_option_off_wpcom_simple() {
-		Constants::set_constant( 'IS_WPCOM', false );
-		$this->force_internal_testing_env();
-
+	public function test_owned_features_honor_their_option_on_self_hosted() {
+		// Seed on first so WordPress persists the later false value instead of treating it as an absent default.
+		update_option( 'jetpack_ai_image_editor_enabled', 1 );
 		update_option( 'jetpack_ai_image_editor_enabled', 0 );
 
+		$this->assertFalse( get_option( 'jetpack_ai_image_editor_enabled', 'missing' ) );
 		$this->assertFalse( Jetpack_AI_Settings::is_feature_enabled( 'image_editor' ) );
 	}
 


### PR DESCRIPTION
## Proposed changes

* Launch the Jetpack AI Overview and feature controls on connected self-hosted sites.
* Keep the launch UI hidden on WordPress.com Simple and ordinary Atomic requests. Preserve the existing internal Atomic test gate.
* Keep the new Jetpack-owned feature settings effectively on where their controls remain hidden.
* Keep enforcement and visibility in separate commits so the UI can be closed without reverting saved-state enforcement.

## Related product discussion/links

* #51879
* #51880

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Self-hosted

1. Use a self-hosted site with Jetpack connected at both the site and user level.
2. Install and activate the Jetpack build from this PR.
3. Go to **Jetpack → Jetpack AI**.
4. Confirm the page shows **Overview**, **WordPress Agent**, and **MCP Settings**. Confirm there is no **A12s only** badge.
5. Go to **Jetpack → My Jetpack** and confirm the AI card shows its on/off switch.
6. Select **Manage** and confirm the Jetpack AI page opens.
7. Open **WordPress Agent**, turn off **Writing Assistant**, and reload the post editor.
8. Confirm the AI Assistant block and writing tools are unavailable.
9. Turn **Writing Assistant** on again and confirm the tools return after reloading the editor.
10. Turn off the AI card's master switch and confirm the editor AI tools and Search AI Answers are unavailable.
11. Turn the master switch on again.

### Self-hosted connection states

1. Disconnect the current WordPress.com user while keeping the site connection.
2. Open **My Jetpack** and confirm the AI card shows **Needs user account** instead of the module switch.
3. Disconnect the site completely.
4. Open **My Jetpack** and confirm the AI card shows its connection action instead of the module switch.

### WordPress.com Atomic

1. Deploy the Jetpack build from this PR to a connected Atomic test site.
2. Open wp-admin through an ordinary, non-proxied request and visit the Jetpack AI page.
3. Confirm **Overview** and **WordPress Agent** are absent while the existing MCP experience remains available.
4. Open **My Jetpack** and confirm the AI card does not show the new module switch.
5. Open the same site through an internal or proxied request.
6. Confirm **Overview**, **WordPress Agent**, and the My Jetpack AI switch are available and carry the **A12s only** marker where applicable.
7. Turn off **Writing Assistant**, return to the ordinary request, and reload the post editor.
8. Confirm the ordinary Atomic request still uses the current effective-on behavior.
9. Return to the internal view and turn **Writing Assistant** on again.

### WordPress.com Simple

1. Deploy the build from this PR to a WordPress.com Simple test site.
2. Ensure that there is no Jetpack AI settings page 
