### PR TITLE
Sync tests: stop the dedicated-lock expiry assertions flaking

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-flaky-dedicated-sync-lock-expiry-assertions
+++ b/projects/plugins/jetpack/changelog/fix-flaky-dedicated-sync-lock-expiry-assertions
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Fix a flaky timing assertion in the dedicated sync lock tests.
+
+

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Sender_Test.php
@@ -741,7 +741,9 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		self::factory()->post->create();
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$before_sync = microtime( true );
 		$this->sender->do_sync();
+		$after_sync = microtime( true );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
 
 		$this->assertTrue( $this->dedicated_sync_request_spawned );
@@ -749,9 +751,7 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
 		$this->assertNotFalse( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
-		$lock_expires_name  = $lock_option_name . '_expires';
-		$lock_expires_value = \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
+		$this->assert_lock_expiry_was_set_between( $before_sync, $after_sync );
 	}
 
 	/**
@@ -790,15 +790,16 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		self::factory()->post->create();
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$before_sync = microtime( true );
 		$this->sender->do_sync();
+		$after_sync = microtime( true );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
 
 		$this->assertTrue( $this->dedicated_sync_request_spawned );
 		$this->assertNotSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
 		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
-		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
+		$this->assert_lock_expiry_was_set_between( $before_sync, $after_sync );
 	}
 
 	/**
@@ -809,19 +810,19 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 		Settings::update_settings( array( 'dedicated_sync_enabled' => 1 ) );
 		$lock_option_name = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME;
 		\Jetpack_Options::update_raw_option( $lock_option_name, 'dummy' );
-		$lock_expires_name = $lock_option_name . '_expires';
 		self::factory()->post->create();
 
 		add_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ), 10, 3 );
+		$before_sync = microtime( true );
 		$this->sender->do_sync();
+		$after_sync = microtime( true );
 		remove_filter( 'pre_http_request', array( $this, 'pre_http_sync_request_spawned' ) );
 
 		$this->assertTrue( $this->dedicated_sync_request_spawned );
 		$this->assertNotSame( 'dummy', \Jetpack_Options::get_raw_option( $lock_option_name ) );
 		$this->assertNotEmpty( \Jetpack_Options::get_raw_option( $lock_option_name ) );
 
-		$lock_expires_value = (float) \Jetpack_Options::get_raw_option( $lock_expires_name );
-		$this->assertEqualsWithDelta( microtime( true ) + Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT, $lock_expires_value, 0.02 );
+		$this->assert_lock_expiry_was_set_between( $before_sync, $after_sync );
 	}
 
 	/**
@@ -979,5 +980,25 @@ class Jetpack_Sync_Sender_Test extends Jetpack_Sync_TestBase {
 			'status_code' => 200,
 			'body'        => Dedicated_Sender::DEDICATED_SYNC_VALIDATION_STRING,
 		);
+	}
+
+	/**
+	 * Assert the spawn lock's expiry was written from a clock read during the given window.
+	 *
+	 * The lock stores `microtime( true ) + TTL` when it is acquired, so bracketing the call pins the
+	 * value however slow the run is - an absolute delta has to out-guess the call's own duration,
+	 * which is what made this flaky. The padding covers the options table holding the float as a
+	 * string formatted at PHP's `precision` ini, which drops a ~1e-5 tail off a timestamp.
+	 *
+	 * @param float $before Clock reading taken immediately before the lock is acquired.
+	 * @param float $after  Clock reading taken immediately after.
+	 */
+	private function assert_lock_expiry_was_set_between( float $before, float $after ) {
+		$stored_float_tolerance = 0.001;
+		$ttl                    = Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_TIMEOUT;
+		$expires                = (float) \Jetpack_Options::get_raw_option( Dedicated_Sender::DEDICATED_SYNC_REQUEST_LOCK_OPTION_NAME . '_expires' );
+
+		$this->assertGreaterThanOrEqual( $before + $ttl - $stored_float_tolerance, $expires );
+		$this->assertLessThanOrEqual( $after + $ttl + $stored_float_tolerance, $expires );
 	}
 }


### PR DESCRIPTION
## Proposed changes
* Fixes three flaky assertions in `Jetpack_Sync_Sender_Test` that compare the dedicated-sync spawn lock's stored expiry against the clock.

The tests read `microtime( true )` *after* `do_sync()` returns, add the 60s TTL, and assert the stored expiry matches within 0.02s. That tolerance has to be wider than `do_sync()` itself takes to run, so it's really a bet on how fast the machine is - and CI keeps losing it. Both PHP jobs on #51864 failed here, on a different one of the three tests each time, about 0.1s out:

```
1) Jetpack_Sync_Sender_Test::test_do_sync_will_spawn_with_dedicated_sync_lock_set_without_expiry
Failed asserting that 1788333686.3747 matches expected 1788333686.477102.
```

`Dedicated_Sender::try_lock_spawn_request()` stores `microtime( true ) + TTL` at the moment it takes the lock, so reading the clock either side of `do_sync()` brackets that value exactly - `$before + TTL <= $expires <= $after + TTL` holds no matter how slow the run is. That replaces the guessed tolerance with an actual bound, in a shared `assert_lock_expiry_was_set_between()` helper.

The window does still need a small pad, for a different and importantly *bounded* reason: the value round-trips through the options table as a string, and `$wpdb` formats floats at PHP's `precision` ini (14 by default), which drops a ~1e-5 tail off a second-scale timestamp:

```
float:  1788333746.47710227966308594
string: 1788333746.4771
back:   1788333746.47709989547729492
```

That's a rounding artifact of storage, not of timing, so 0.001 covers it with a lot of room and - unlike the old 0.02 - never needs to grow with machine load.

Noticed while working on #51864; unrelated to that change, so it's here on its own.

## Related product discussion/links
* n/a - test-only fix, no product change.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `jp docker phpunit jetpack -- --filter Jetpack_Sync_Sender_Test` and ensure it passes.
  * Note: this currently can't run locally on the published `automattic/jetpack-wordpress-dev` image - it ships PHP 8.2 while the vendored PHPUnit requires >= 8.3. CI runs it fine, and that mismatch is not caused by this PR.
* To confirm the assertion is load-proof rather than merely looser, put a `usleep( 500000 );` inside the `pre_http_request` filter (`pre_http_sync_request_spawned()`) so `do_sync()` takes half a second, and ensure the three tests still pass here. The same change on trunk should fail them, since the old 0.02s tolerance can't absorb the extra half second - I reasoned that out from the code rather than running it, for the PHP-version reason above, so treat it as the thing to check rather than a result.
