### PR TITLE
Search: upgrade react-redux to 9.3.0 and redux to 5.0.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4736,11 +4736,11 @@ importers:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
       react-redux:
-        specifier: 7.2.8
-        version: 7.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 9.3.0
+        version: 9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1)
       redux:
-        specifier: 4.2.1
-        version: 4.2.1
+        specifier: 5.0.1
+        version: 5.0.1
       refx:
         specifier: 3.1.1
         version: 3.1.1
@@ -10416,11 +10416,6 @@ packages:
   '@types/highlight-words-core@1.2.3':
     resolution: {integrity: sha512-PWNU/NR0CaYEsK38mcCTyDzeS2TlEGK9kRhRMz1i86jVAe836ZlA3gl6QYpu+CG6IpfNKTgWpEnJuRededvC0g==}
 
-  '@types/hoist-non-react-statics@3.3.7':
-    resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
@@ -10494,9 +10489,6 @@ packages:
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-redux@7.1.34':
-    resolution: {integrity: sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==}
 
   '@types/react@18.3.31':
     resolution: {integrity: sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==}
@@ -16624,18 +16616,6 @@ packages:
 
   react-property@2.0.2:
     resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
-
-  react-redux@7.2.8:
-    resolution: {integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==}
-    peerDependencies:
-      react: ^16.8.3 || ^17 || ^18
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
 
   react-redux@9.3.0:
     resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
@@ -22825,11 +22805,6 @@ snapshots:
 
   '@types/highlight-words-core@1.2.3': {}
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31)':
-    dependencies:
-      '@types/react': 18.3.31
-      hoist-non-react-statics: 3.3.2
-
   '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -22901,13 +22876,6 @@ snapshots:
   '@types/react-dom@18.3.7(@types/react@18.3.31)':
     dependencies:
       '@types/react': 18.3.31
-
-  '@types/react-redux@7.1.34':
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@18.3.31)
-      '@types/react': 18.3.31
-      hoist-non-react-statics: 3.3.2
-      redux: 4.2.1
 
   '@types/react@18.3.31':
     dependencies:
@@ -36782,18 +36750,6 @@ snapshots:
       warning: 4.0.3
 
   react-property@2.0.2: {}
-
-  react-redux@7.2.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@types/react-redux': 7.1.34
-      hoist-non-react-statics: 3.3.2
-      loose-envify: 1.4.0
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-is: 17.0.2
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
 
   react-redux@9.3.0(@types/react@18.3.31)(react@18.3.1)(redux@5.0.1):
     dependencies:

--- a/projects/packages/search/changelog/update-react-redux
+++ b/projects/packages/search/changelog/update-react-redux
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update react-redux to 9.3.0 and redux to 5.0.1.

--- a/projects/packages/search/package.json
+++ b/projects/packages/search/package.json
@@ -77,8 +77,8 @@
 		"qss": "3.0.0",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"react-redux": "7.2.8",
-		"redux": "4.2.1",
+		"react-redux": "9.3.0",
+		"redux": "5.0.1",
 		"refx": "3.1.1",
 		"strip": "3.0.0",
 		"tiny-lru": "7.0.6"


### PR DESCRIPTION
Fixes #

## Proposed changes
* The PR bumps `react-redux` 7.2.8 → 9.3.0 and `redux` 4.2.1 → 5.0.1 in `packages/search`. This was the last project still on react-redux 7 - the Jetpack plugin moved to 9.3.0 in #50246, so we've been shipping two majors, and the Jetpack plugin actually ships both because it vendors Search's built bundles.
* No source changes needed. Search only uses `connect()` (4 call sites) and `Provider` (2 mounts), no react-redux hooks at all - the `useSelector`/`useDispatch` in Search are all `@wordpress/data`. Nothing here touches an API that v8/v9 dropped, and there's no redux-thunk either, Search uses `refx`.
* `redux` has to move with it. react-redux 9 lists `redux: ^5.0.0` as an *optional* peer, but optional only means it doesn't have to be installed at all - when it is installed the range still applies, and we have `strictPeerDependencies: true`, so leaving 4.2.1 in place fails the install.
* Worth calling out that this also fixes sth latent - the Customberg bundle externalises React to `wp.element`, so react-redux 7 has been running against a real React 18 concurrent root while still using its own manual subscription instead of `useSyncExternalStore`.

## Related product discussion/links
* SEARCH-343

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

No user-visible change, so there's no before/after to look at. The risky bit is that instant-search aliases `react` to `preact/compat`, and react-redux 9 dropped the shim and wants React 18's `useSyncExternalStore`. Preact 10.28.2 does have it, but nothing covers that path in CI because all three react-redux tests mock `connect` out - so this needs a real spin in a browser.

* Build Search and open the overlay on a site with Instant Search enabled.
* Search for sth. Ensure results come back and the highlighting works.
* Ensure sort (Relevance / Newest / Oldest) updates both the results and the URL.
* Put a search filter widget in the Instant Search sidebar. Ensure the checkboxes filter, the counts recalculate, and `Clear filters` resets them.
* Ensure `Load more` appends the next page, and that scrolling to the bottom auto-loads it too.
* Ensure browser back/forward restores the query, sort and filters.
* Ensure the AI answer panel streams, and `Show more` streams the extended answer.
* Open the Search customiser (Options tab). Ensure the preview renders, and flips live when you switch Light/Dark.
* Keep the console open the whole way through. Ensure there's no `Cannot update a component while rendering` warning - #50246 hit an infinite render loop on this same bump, because v9 re-renders synchronously through `useSyncExternalStore`.

I ran all of the above on a local docker env. Console stayed clean, and the overlay sat completely idle (zero DOM mutations over 3s) after every state change, so no render loop. `SearchApp` dispatches from its constructor which I thought would be the risky one, but it's fine.

Known gap: `TabbedSearchFilters` needs static filters and I couldn't configure those on a single site, so that one component is untested.

### Safe today, not structurally safe

Worth writing down properly, because the reasoning isn't obvious and it decays quietly.

`SearchApp` dispatches from its constructor (`search-app.jsx:90-95`) - `initializeQueryValues()` or `disableQueryStringIntegration()`, depending on `shouldIntegrateWithDom`. A constructor runs in the render phase, so that's a store write during render, which is the exact shape that caused the infinite loop in #50246.

Under react-redux 7 that was harmless by construction: v7 subscribed in a layout effect and ran its own `checkForUpdates()` inline, so a render-phase store write just got picked up after commit. v9 reads the store through `useSyncExternalStore` instead, which is the mechanism #50246 tripped over. So the question is live again, and the answer is different per bundle.

**Instant Search (preact/compat).** `preact/compat`'s `useSyncExternalStore` re-checks the snapshot in a `useLayoutEffect` and subscribes in a `useEffect`. That layout re-check is pre-paint, i.e. the same timing v7 had, and preact has no pre-commit consistency check and so no throw-away-the-tree-and-re-render path at all. This path doesn't really change.

**Customberg (real React 18).** `react` is externalised to `wp.element` here, so this is genuine React 18, and `mountSyncExternalStore` registers both the subscribe and the snapshot re-check as *passive* effects - so the catch-up moved from pre-paint to post-paint. It doesn't bite only because `app-wrapper/index.jsx` passes `shouldIntegrateWithDom={ false }`, so the constructor dispatches `disableQueryStringIntegration()`, and no reducer handles that action (it's effects-only, `effects.js:196`). `combineReducers` hands back the identical root object, the snapshot never changes, and there's nothing to catch up on.

So both are fine, but neither is fine *by design*. Any one of these breaks it:

- A reducer starts handling `DISABLE_QUERY_STRING_INTEGRATION`.
- Customberg starts passing `shouldIntegrateWithDom` - the constructor would then run `initializeQueryValues()`, which does change state on every call, since `reducer/query-string.js` returns a fresh `{}` for `CLEAR_FILTERS` unconditionally.
- Instant Search stops aliasing to preact and runs on real React.

If you're about to do any of those, move the constructor dispatch into `componentDidMount()` first. That's what #50246 landed on, and it makes the question go away instead of leaving it resting on coincidences.

`pnpm test-size` passes and the instant-search payload is basically flat - 22.46 → 22.48 kB brotlied, against a 51.2 kB limit.

![instant search running on react-redux 9](https://github.com/user-attachments/assets/81445989-9aaf-4cf0-bd47-e442cd26db76)


