### PR TITLE
AI Hub: rename the WordPress Agent tab to AI Features

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -1,7 +1,7 @@
 /**
  * AI Features view — per-feature toggles for Jetpack AI, grouped by area
  * (Content, Media, SEO, Search) inside a single card per the AI-Settings
- * design.
+ * design. The card carries no heading of its own: the tab names it.
  *
  * Each feature has its own on/off switch, backed by the feature-settings
  * endpoint. A disabled feature must genuinely stop loading (its assets are
@@ -315,18 +315,16 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 			) }
 			{ sections.length > 0 && (
 				<Card.Root className="jetpack-ai-features__card">
-					{ /* Single Card.Content, no Card.Header: the FullBleed dividers —
-					     including the one under the header — must stay direct children
-					     of Card.Content per the component's contract. */ }
+					{ /* Single Card.Content, no Card.Header: the FullBleed dividers must
+					     stay direct children of Card.Content per the component's contract. */ }
 					<Card.Content className="jetpack-ai-features__card-content">
-						<Text variant="body-sm" className="jetpack-ai-features__card-subtitle">
-							{ __( 'Choose what AI can help with across your site.', 'jetpack' ) }
-						</Text>
-						{ sections.map( section => {
+						{ sections.map( ( section, index ) => {
 							const titleId = `jetpack-ai-features-${ section.key }-title`;
 							return (
 								<Fragment key={ section.key }>
-									<Card.FullBleed render={ <hr /> } className="jetpack-ai-features__divider" />
+									{ index > 0 && (
+										<Card.FullBleed render={ <hr /> } className="jetpack-ai-features__divider" />
+									) }
 									{ /* Labelled by its heading so each group is a named region —
 									     screen readers can jump between them inside the merged card. */ }
 									<Stack

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -1,7 +1,7 @@
 /**
  * AI Features view — per-feature toggles for Jetpack AI, grouped by area
- * (Content, Media, SEO, Search) inside a single "Agent capabilities" card
- * per the AI-Settings design.
+ * (Content, Media, SEO, Search) inside a single card per the AI-Settings
+ * design.
  *
  * Each feature has its own on/off switch, backed by the feature-settings
  * endpoint. A disabled feature must genuinely stop loading (its assets are
@@ -319,15 +319,9 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 					     including the one under the header — must stay direct children
 					     of Card.Content per the component's contract. */ }
 					<Card.Content className="jetpack-ai-features__card-content">
-						<Stack direction="column" gap="sm">
-							<Card.Title render={ <h2 /> }>{ __( 'Agent capabilities', 'jetpack' ) }</Card.Title>
-							<Text variant="body-sm" className="jetpack-ai-features__card-subtitle">
-								{ __(
-									'Choose what your WordPress Agent can help with across your site.',
-									'jetpack'
-								) }
-							</Text>
-						</Stack>
+						<Text variant="body-sm" className="jetpack-ai-features__card-subtitle">
+							{ __( 'Choose what AI can help with across your site.', 'jetpack' ) }
+						</Text>
 						{ sections.map( section => {
 							const titleId = `jetpack-ai-features-${ section.key }-title`;
 							return (
@@ -341,7 +335,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 										render={ <section aria-labelledby={ titleId } /> }
 									>
 										<div className="jetpack-ai-features__section-header">
-											<Text variant="heading-lg" render={ <h3 id={ titleId } /> }>
+											<Text variant="heading-lg" render={ <h2 id={ titleId } /> }>
 												{ section.title }
 											</Text>
 											{ isConnected &&

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -39,17 +39,9 @@ describe( 'AiFeatures rendering', () => {
 		);
 	} );
 
-	test( 'renders one card, described by its lead line and no heading of its own', () => {
-		renderFeatures();
-
-		expect(
-			screen.getByText( 'Choose what AI can help with across your site.' )
-		).toBeInTheDocument();
-	} );
-
-	// One divider per visible section — the first doubles as the header rule
-	// per the Figma — and the group headers are real h2s, one level below the
-	// page title "AI"; the card itself carries no heading.
+	// Dividers separate the groups and never lead the card — the group headers
+	// are real h2s, one level below the page title "AI", and the card itself
+	// carries no heading or lead line.
 	test.each( [
 		[ 'one section', { writing_assistant: { enabled: true } }, [ 'Content' ] ],
 		[ 'two sections', null, [ 'Content', 'Search' ] ],
@@ -62,21 +54,22 @@ describe( 'AiFeatures rendering', () => {
 			},
 			[ 'Content', 'Media', 'Search' ],
 		],
-	] )( '%s: one divider per section, h2 group headers in order', ( _label, features, titles ) => {
-		renderFeatures( features ? { features } : {} );
+	] )(
+		'%s: dividers between groups only, h2 group headers in order',
+		( _label, features, titles ) => {
+			renderFeatures( features ? { features } : {} );
 
-		expect( screen.getAllByRole( 'separator' ) ).toHaveLength( titles.length );
-		const headings = screen.getAllByRole( 'heading', { level: 2 } );
-		expect( headings.map( heading => heading.textContent ) ).toEqual( titles );
-	} );
+			expect( screen.queryAllByRole( 'separator' ) ).toHaveLength( titles.length - 1 );
+			const headings = screen.getAllByRole( 'heading', { level: 2 } );
+			expect( headings.map( heading => heading.textContent ) ).toEqual( titles );
+		}
+	);
 
 	test( 'no reported features: no empty card shell', () => {
 		// Everything else healthy — the empty payload alone must suppress the card.
 		renderFeatures( { features: {} } );
 
-		expect(
-			screen.queryByText( 'Choose what AI can help with across your site.' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'region' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'separator' ) ).not.toBeInTheDocument();
 	} );
 
@@ -85,9 +78,7 @@ describe( 'AiFeatures rendering', () => {
 
 		// The notices live outside the card and must not go down with it.
 		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Choose what AI can help with across your site.' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'region' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'the AI SEO row renders from the ai_seo feature key inside the SEO group', () => {

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -39,20 +39,17 @@ describe( 'AiFeatures rendering', () => {
 		);
 	} );
 
-	test( 'renders one Agent capabilities card with title and subtitle', () => {
+	test( 'renders one card, described by its lead line and no heading of its own', () => {
 		renderFeatures();
 
 		expect(
-			screen.getByRole( 'heading', { level: 2, name: 'Agent capabilities' } )
-		).toBeInTheDocument();
-		expect(
-			screen.getByText( 'Choose what your WordPress Agent can help with across your site.' )
+			screen.getByText( 'Choose what AI can help with across your site.' )
 		).toBeInTheDocument();
 	} );
 
 	// One divider per visible section — the first doubles as the header rule
-	// per the Figma — and the group headers are real h3s, one level below the
-	// card's h2 (the page title "AI" is the h1 above both).
+	// per the Figma — and the group headers are real h2s, one level below the
+	// page title "AI"; the card itself carries no heading.
 	test.each( [
 		[ 'one section', { writing_assistant: { enabled: true } }, [ 'Content' ] ],
 		[ 'two sections', null, [ 'Content', 'Search' ] ],
@@ -65,11 +62,11 @@ describe( 'AiFeatures rendering', () => {
 			},
 			[ 'Content', 'Media', 'Search' ],
 		],
-	] )( '%s: one divider per section, h3 group headers in order', ( _label, features, titles ) => {
+	] )( '%s: one divider per section, h2 group headers in order', ( _label, features, titles ) => {
 		renderFeatures( features ? { features } : {} );
 
 		expect( screen.getAllByRole( 'separator' ) ).toHaveLength( titles.length );
-		const headings = screen.getAllByRole( 'heading', { level: 3 } );
+		const headings = screen.getAllByRole( 'heading', { level: 2 } );
 		expect( headings.map( heading => heading.textContent ) ).toEqual( titles );
 	} );
 
@@ -78,11 +75,9 @@ describe( 'AiFeatures rendering', () => {
 		renderFeatures( { features: {} } );
 
 		expect(
-			screen.queryByRole( 'heading', { name: 'Agent capabilities' } )
+			screen.queryByText( 'Choose what AI can help with across your site.' )
 		).not.toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Choose what your WordPress Agent can help with across your site.' )
-		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'separator' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'the page notices survive the card disappearing', () => {
@@ -91,7 +86,7 @@ describe( 'AiFeatures rendering', () => {
 		// The notices live outside the card and must not go down with it.
 		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'heading', { name: 'Agent capabilities' } )
+			screen.queryByText( 'Choose what AI can help with across your site.' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -112,7 +107,7 @@ describe( 'AiFeatures rendering', () => {
 	test( 'the upgrade badge sits inside the Search group', () => {
 		renderFeatures();
 
-		// Each group is a region named by its h3, so the badge's placement is
+		// Each group is a region named by its heading, so the badge's placement is
 		// part of the accessibility tree, not just visual layout.
 		const searchGroup = screen.getByRole( 'region', { name: 'Search' } );
 		expect(

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -1,11 +1,11 @@
 /**
  * Root component for the Jetpack AI admin page.
  *
- * Four top-level tabs (Overview | WordPress Agent | Scheduled tasks | MCP Settings) with hash-based
+ * Four top-level tabs (Overview | AI Features | Scheduled tasks | MCP Settings) with hash-based
  * routing. The MCP tab owns the read | write | setup sub-views, which render
  * with breadcrumbs in place of the tab bar.
  *
- * Overview and WordPress Agent share an internal-testing gate. Scheduled tasks
+ * Overview and AI Features share an internal-testing gate. Scheduled tasks
  * is controlled independently by the ai-hub-scheduled-tasks server-side feature
  * flag. Without either flag the page keeps its original MCP-only shape, with the
  * MCP hub as the landing view and no tab bar.
@@ -62,8 +62,7 @@ const getViewFromHash = () => {
 
 const VIEW_TITLES = {
 	overview: __( 'Overview', 'jetpack' ),
-	// "WordPress Agent" is a product name and should not be translated.
-	features: 'WordPress Agent',
+	features: __( 'AI Features', 'jetpack' ),
 	'scheduled-tasks': __( 'Scheduled tasks', 'jetpack' ),
 	mcp: __( 'MCP Settings', 'jetpack' ),
 	read: __( 'Read', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -173,8 +173,8 @@ body.jetpack_page_jetpack-ai {
 	margin-inline-start: 40px;
 }
 
-// The Agent capabilities card, values read off the Figma (AI-Settings
-// node 6021-4152): 20px card padding with 24px above the title. The
+// The feature card, values read off the Figma (AI-Settings
+// node 6021-4152): 20px card padding with 24px above the description. The
 // Card.FullBleed dividers inherit the same padding var for their
 // edge-to-edge negative margins, so they stay in sync.
 .jetpack-ai-features__card {
@@ -190,7 +190,7 @@ body.jetpack_page_jetpack-ai {
 	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 }
 
-// Section divider inside the Agent capabilities card. Card.FullBleed already
+// Section divider inside the feature card. Card.FullBleed already
 // pulls the hr edge-to-edge past the card padding (margin-inline); this only
 // draws the rule and sets the vertical rhythm.
 .jetpack-ai-features__divider {

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -174,7 +174,7 @@ body.jetpack_page_jetpack-ai {
 }
 
 // The feature card, values read off the Figma (AI-Settings
-// node 6021-4152): 20px card padding with 24px above the description. The
+// node 6021-4152): 20px card padding with 24px above the first group. The
 // Card.FullBleed dividers inherit the same padding var for their
 // edge-to-edge negative margins, so they stay in sync.
 .jetpack-ai-features__card {
@@ -183,11 +183,6 @@ body.jetpack_page_jetpack-ai {
 
 .jetpack-ai-features__card-content {
 	padding-block-start: var(--wpds-dimension-padding-2xl, 24px);
-}
-
-// Figma: Body SM in foreground/content/neutral-weak.
-.jetpack-ai-features__card-subtitle {
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 }
 
 // Section divider inside the feature card. Card.FullBleed already

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -459,7 +459,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).resolves.toBeInTheDocument();
 
 		// No Features UI and no tab bar (a single tab renders no tabs at all).
-		expect( screen.queryByText( 'WordPress Agent' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'AI Features' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'MCP Settings' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Writing Assistant/ } )
@@ -499,7 +499,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			screen.findByText( 'Available requests', IGNORE_A11Y )
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Overview' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'WordPress Agent' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'AI Features' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'MCP Settings' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Writing Assistant/ } )

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-features-tab-name
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-features-tab-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: AI Hub: rename the "WordPress Agent" tab to "AI Features" and drop the repeated heading inside it. The tab has not shipped in a stable release, so there is nothing for users to be told about.
+


### PR DESCRIPTION
## Proposed changes

* Renames the Jetpack AI Hub's **WordPress Agent** tab to **AI Features**. The old name collided with the separate WordPress Agent setting on WordPress.com, which this tab does not control.
* Drops the card heading inside the tab (`Agent capabilities`), now that the tab itself names the section. The group headings move from `h3` to `h2` so the heading order stays `h1 → h2`.
* Updates the description under it to "Choose what AI can help with across your site."

The tab has not shipped in a stable release, so the changelog entry is an empty one with a comment.

## Related product discussion/links

* pdtkmj-4Vi-p2 (comment 9550 onward)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Jetpack → Jetpack AI** on an Atomic or self-hosted site, proxied (the tab is a12s-only on trunk).
* The second tab reads **AI Features**, not WordPress Agent.
* Open it: the card starts with "Choose what AI can help with across your site." — no heading above it, and no mention of WordPress Agent.
* Content / Media / SEO / Search still head their groups, and each group is still announced as a named region by a screen reader.
