### PR TITLE
AI Hub: Remove the "Setting up agentic workflows" link from the Overview tab

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -66,7 +66,7 @@ const WALKTHROUGH_VIDEOS = [
 	},
 ];
 
-// Redirect-service sources for the documentation links. All five are
+// Redirect-service sources for the documentation links. All four are
 // registered and resolving (as are the four video sources above).
 const DOC_LINKS = [
 	{
@@ -76,10 +76,6 @@ const DOC_LINKS = [
 	{
 		slug: 'jetpack-ai-hub-overview-docs-features',
 		title: __( 'AI features overview', 'jetpack' ),
-	},
-	{
-		slug: 'jetpack-ai-hub-overview-docs-agent-setup',
-		title: __( 'Setting up agentic workflows', 'jetpack' ),
 	},
 	{ slug: 'jetpack-ai-hub-overview-docs-billing', title: __( 'Billing & plans', 'jetpack' ) },
 	{

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -391,7 +391,7 @@ describe( 'AiOverview', () => {
 		}
 	} );
 
-	test( 'documentation: renders all five links through the redirect service', async () => {
+	test( 'documentation: renders all four links through the redirect service', async () => {
 		apiFetch.mockResolvedValueOnce( freePayload() );
 
 		render( <AiOverview { ...PROPS } /> );
@@ -403,7 +403,6 @@ describe( 'AiOverview', () => {
 		const slugByName = {
 			'MCP integration guide': 'jetpack-ai-hub-overview-docs-mcp-guide',
 			'AI features overview': 'jetpack-ai-hub-overview-docs-features',
-			'Setting up agentic workflows': 'jetpack-ai-hub-overview-docs-agent-setup',
 			'Billing & plans': 'jetpack-ai-hub-overview-docs-billing',
 			'Available capabilities': 'jetpack-ai-hub-overview-docs-mcp-tools',
 		};

--- a/projects/plugins/jetpack/changelog/change-remove-ai-hub-agent-setup-link
+++ b/projects/plugins/jetpack/changelog/change-remove-ai-hub-agent-setup-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Hub: Remove the "Setting up agentic workflows" link from the Overview tab.

--- a/projects/plugins/jetpack/changelog/change-remove-ai-hub-agent-setup-link
+++ b/projects/plugins/jetpack/changelog/change-remove-ai-hub-agent-setup-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
+Comment: AI Hub: remove the "Setting up agentic workflows" link from the Overview tab. The tab has not shipped in a stable release, so there is nothing for users to be told about.
 
-AI Hub: Remove the "Setting up agentic workflows" link from the Overview tab.


### PR DESCRIPTION
## Proposed changes
* Remove the "Setting up agentic workflows" link from the Jetpack AI Hub Overview tab.
* The link redirects to the WordPress.com WordPress Agent support page, which does not apply to self-hosted sites. Since the 16.2 release targets self-hosted sites, the link is removed for now. It can return once a Jetpack-specific Agent guide exists.

## Related product discussion/links
* Jetpack AI Hub Call for Testing, thread on the "Setting up agentic workflows" link: pdtkmj-4vI-p2#comment-9570
* Original destination decision: "One hub for Jetpack AI i4" on the Jetpack P2, comment 78413

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a Jetpack-connected site (Jurassic Ninja or local), make sure you are proxied or otherwise see the new tabs.
* Go to Jetpack → Jetpack AI → Overview.
* Check the documentation list shows 4 links: MCP integration guide, AI features overview, Billing & plans, Available capabilities.
* Confirm "Setting up agentic workflows" is no longer listed.
* Run the tests: `cd projects/plugins/jetpack && NODE_PATH=tests:_inc/client pnpm exec jest --config=tests/jest.config.gui.js _inc/client/ai/overview`
