### PR TITLE
Jetpack AI: offer the AI SEO control only where a surface can run

### DIFF
--- a/projects/packages/seo/changelog/update-jetpack-ai-seo-row-reachable-surface
+++ b/projects/packages/seo/changelog/update-jetpack-ai-seo-row-reachable-surface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI SEO: only offer the AI SEO control where a surface it governs can actually run.

--- a/projects/packages/seo/src/class-ai-seo.php
+++ b/projects/packages/seo/src/class-ai-seo.php
@@ -36,4 +36,32 @@ class Ai_Seo {
 			&& ( new Modules() )->is_active( 'seo-tools' )
 			&& Current_Plan::supports( 'advanced-seo' );
 	}
+
+	/**
+	 * Whether an AI SEO surface can actually run here, so a control that governs
+	 * nothing is never offered. The sidebar's suggestions need a host that loads
+	 * the sidebar; the editor's generation needs `ai-seo-enhancer`.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function has_reachable_surface() {
+		return self::is_available()
+			&& ( self::is_sidebar_reachable() || Current_Plan::supports( 'ai-seo-enhancer' ) );
+	}
+
+	/**
+	 * Whether this host loads the AI sidebar. Called as a string callable: the
+	 * class lives in plugins/jetpack, which bundles this package, and asking it
+	 * anything wider would route back through {@see self::is_available()}.
+	 *
+	 * @return bool
+	 */
+	private static function is_sidebar_reachable() {
+		$callback = array( 'Automattic\\Jetpack\\Extensions\\AiAssistantPlugin\\Jetpack_AI_Sidebar', 'is_host_enabled' );
+
+		// @phan-suppress-next-line PhanUndeclaredClassInCallable -- Jetpack_AI_Sidebar lives in plugins/jetpack and is guarded by is_callable.
+		return is_callable( $callback ) && (bool) call_user_func( $callback );
+	}
 }

--- a/projects/packages/seo/tests/php/AiSeoTest.php
+++ b/projects/packages/seo/tests/php/AiSeoTest.php
@@ -25,6 +25,8 @@ class AiSeoTest extends SeoTestCase {
 		remove_all_filters( 'jetpack_active_modules' );
 		remove_all_filters( 'jetpack_disable_seo_tools' );
 
+		\Automattic\Jetpack\Extensions\AiAssistantPlugin\Jetpack_AI_Sidebar::$is_host_enabled = false;
+
 		self::reset_plan();
 
 		parent::tearDown();
@@ -87,5 +89,50 @@ class AiSeoTest extends SeoTestCase {
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
 		$this->assertFalse( Ai_Seo::is_available() );
+	}
+
+	/**
+	 * The editor's generation is reachable on a plan holding `ai-seo-enhancer`.
+	 */
+	public function test_has_reachable_surface_when_the_plan_supports_the_enhancer() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( true );
+
+		$this->assertTrue( Ai_Seo::has_reachable_surface() );
+	}
+
+	/**
+	 * A free plan off WordPress.com is entitled to AI SEO but reaches neither
+	 * surface: no sidebar on this host, no `ai-seo-enhancer` for the editor.
+	 */
+	public function test_has_no_reachable_surface_on_a_free_plan_without_the_sidebar() {
+		self::set_plan( 'jetpack_free' );
+		self::set_seo_tools_active( true );
+
+		$this->assertTrue( Ai_Seo::is_available() );
+		$this->assertFalse( Ai_Seo::has_reachable_surface() );
+	}
+
+	/**
+	 * A host that loads the sidebar reaches its SEO suggestions without the
+	 * enhancer entitlement.
+	 */
+	public function test_has_reachable_surface_when_the_host_loads_the_sidebar() {
+		self::set_plan( 'jetpack_free' );
+		self::set_seo_tools_active( true );
+		\Automattic\Jetpack\Extensions\AiAssistantPlugin\Jetpack_AI_Sidebar::$is_host_enabled = true;
+
+		$this->assertTrue( Ai_Seo::has_reachable_surface() );
+	}
+
+	/**
+	 * A falsified availability term vetoes a reachable surface too.
+	 */
+	public function test_has_no_reachable_surface_when_seo_tools_module_inactive() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( false );
+		\Automattic\Jetpack\Extensions\AiAssistantPlugin\Jetpack_AI_Sidebar::$is_host_enabled = true;
+
+		$this->assertFalse( Ai_Seo::has_reachable_surface() );
 	}
 }

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -33,6 +33,7 @@ require_once __DIR__ . '/SeoTestCase.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-utils.php';
 require_once __DIR__ . '/stubs/class-jetpack-redux-state-helper.php';
 require_once __DIR__ . '/stubs/class-jetpack-ai-settings.php';
+require_once __DIR__ . '/stubs/class-jetpack-ai-sidebar.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-posts.php';
 require_once __DIR__ . '/stubs/class-jetpack-options.php';
 require_once __DIR__ . '/stubs/class-wc-structured-data.php';

--- a/projects/packages/seo/tests/php/stubs/class-jetpack-ai-sidebar.php
+++ b/projects/packages/seo/tests/php/stubs/class-jetpack-ai-sidebar.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Test stub for the host plugin's Jetpack_AI_Sidebar class.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\Extensions\AiAssistantPlugin;
+
+if ( ! class_exists( __NAMESPACE__ . '\\Jetpack_AI_Sidebar' ) ) {
+
+	/**
+	 * Stub of the host plugin's AI sidebar loader.
+	 */
+	class Jetpack_AI_Sidebar {
+
+		/**
+		 * Whether the stub reports a host that loads the sidebar.
+		 *
+		 * @var bool
+		 */
+		public static $is_host_enabled = false;
+
+		/**
+		 * Return the configured host state.
+		 *
+		 * @return bool
+		 */
+		public static function is_host_enabled(): bool {
+			return self::$is_host_enabled;
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -281,22 +281,22 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	}
 
 	/**
-	 * Whether the AI SEO row is available, so the settings page can hide it.
-	 * The row governs user-initiated suggestions as well as automatic
-	 * generation, so it follows the package's shared AI SEO gate.
+	 * Whether the AI SEO row is available, so the settings page can hide it. The
+	 * row is offered only where a surface it governs can run: the sidebar's
+	 * suggestions or the editor's generation.
 	 *
-	 * Guarded with class_exists: the autoloader can pick an older jetpack-seo
-	 * copy from another plugin, predating this class. Without the gate's verdict
-	 * the row is hidden rather than offered.
+	 * Guarded with is_callable: the autoloader can pick an older jetpack-seo copy
+	 * from another plugin, predating this gate. Without its verdict the row is
+	 * hidden rather than offered.
 	 *
 	 * @return bool
 	 */
 	private function is_ai_seo_available() {
-		if ( ! class_exists( Ai_Seo::class ) ) {
+		if ( ! is_callable( array( Ai_Seo::class, 'has_reachable_surface' ) ) ) {
 			return false;
 		}
 
-		return Ai_Seo::is_available();
+		return Ai_Seo::has_reachable_surface();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-row-reachable-surface
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-seo-row-reachable-surface
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: only show the AI SEO control on sites where the feature it turns on can run.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -318,19 +318,25 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * UI feature flag for the public Jetpack AI Sidebar Preview surface.
-	 *
-	 * Defaults to enabled only on WordPress.com platform sites (Simple or WoA)
-	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
-	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
-	 * is a host-level override of that default, respected by init() and every
-	 * sidebar surface that gates on this method. Independently of the filter,
-	 * the sidebar requires at least one of its features (writing assistant or
-	 * SEO enhancer) to be enabled.
+	 * UI feature flag for the public Jetpack AI Sidebar Preview surface: this
+	 * host loads the sidebar, and at least one feature it surfaces is on.
 	 *
 	 * @return bool
 	 */
 	private static function is_jetpack_ai_sidebar_preview_enabled(): bool {
+		return self::is_host_enabled() && self::has_enabled_sidebar_features();
+	}
+
+	/**
+	 * Whether this host loads the sidebar at all: a WordPress.com platform site
+	 * with Big Sky enabled, past the filter and the master switch. Public and
+	 * feature-free so the AI SEO gate can ask without asking back through it.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_host_enabled(): bool {
 		$host = new Host();
 
 		$enabled = false;
@@ -353,12 +359,10 @@ class Jetpack_AI_Sidebar {
 		 */
 		$enabled = (bool) apply_filters( 'jetpack_ai_sidebar_enabled', $enabled );
 
-		// Re-asserted after the filter so a later filter cannot surface a
-		// sidebar whose features are all off, or one blocked by the host or
-		// master gates — the gates are final, as with is_ai_enabled().
-		return $enabled
-			&& \Jetpack_AI_Settings::apply_master_gates( true )
-			&& self::has_enabled_sidebar_features();
+		// Re-asserted after the filter so a later filter cannot surface a sidebar
+		// blocked by the host or master gates — the gates are final, as with
+		// is_ai_enabled().
+		return $enabled && \Jetpack_AI_Settings::apply_master_gates( true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -262,18 +262,17 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	}
 
 	/**
-	 * Input 3 on a free plan: the row follows `advanced-seo`, which sits in the
-	 * free plan's supports list, so it is offered wherever SEO tools run. The
-	 * row governs user-initiated suggestions as well as automatic generation,
-	 * and only the automatic half needs the higher `ai-seo-enhancer` tier.
+	 * Input 3 on a free plan: entitled to AI SEO, but neither surface it governs
+	 * can run here — no sidebar off WordPress.com, and the editor's generation
+	 * needs `ai-seo-enhancer`. A control over nothing is not offered.
 	 */
-	public function test_seo_row_available_on_a_free_plan() {
+	public function test_seo_row_unavailable_on_a_free_plan_without_a_surface() {
 		wp_set_current_user( self::$admin_id );
 
 		self::set_seo_tools_active( true );
 		self::set_plan( 'jetpack_free' );
 
-		$this->assertTrue( $this->get_seo_available() );
+		$this->assertFalse( $this->get_seo_available() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

* Adds `Ai_Seo::has_reachable_surface()` — the shared gate, plus at least one live surface: the AI sidebar's SEO suggestions, or the editor's generation (`ai-seo-enhancer`).
* Points the hub's AI SEO row at it, instead of `Ai_Seo::is_available()`.
* Splits the sidebar's host check into a public `Jetpack_AI_Sidebar::is_host_enabled()`, feature-free so the AI SEO gate can call it without a cycle.
* Leaves `Ai_Seo::is_available()` untouched, so the sidebar keeps following `advanced-seo`.
* Repins the endpoint's free-plan test, adds 4 package tests and a sidebar stub.

Why: the row followed `advanced-seo`, which is free on every self-hosted plan, while everything it turns on follows `ai-seo-enhancer`, which needs Jetpack Business. Off WordPress.com a Jetpack AI site got a row that saved its state and did nothing, with no upgrade notice — that only renders on WordPress.com. No entitlements change; this only decides who is shown a control.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs an Automattic-proxied site off WordPress.com Simple — the AI feature controls are gated to those. Activate SEO Tools (Jetpack → Settings → Traffic) everywhere below.

**Self-hosted, Jetpack AI, no Business — the fix**

* Jetpack → Jetpack AI: no AI SEO row.
* On trunk: the row shows, switches on, and the Optimize SEO panel has no generate buttons and no explanation.

**Self-hosted, Jetpack Business or Complete — no regression**

* Jetpack → Jetpack AI: AI SEO row shows.
* On: the SEO title and description generate buttons work in Optimize SEO. Off, reload: buttons gone.

**Atomic, Business or higher — no regression**

* Jetpack → Jetpack AI: AI SEO row shows and toggles as on trunk.
* The row still governs the generate buttons in Optimize SEO.

**Simple, Business or higher — no regression**

* Jetpack → Jetpack AI: AI SEO row shows and toggles as on trunk.
* Off: the AI sidebar's SEO suggestions are gone. On: they return.

**Sidebar — the check changed shape**

* Writing assistant on, AI SEO off: sidebar still loads.
* Both off: sidebar does not load.
* Master AI switch off: sidebar does not load.

**SEO Tools off**

* No AI SEO row on any of the above.
