### PR TITLE
AI Assistant: keep the "Improve with AI" panel when the Writing Assistant is off

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-writing-assistant-panel-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-writing-assistant-panel-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: keep the "Improve with AI" editor panel when the Writing Assistant is turned off. The switch now hides only the title and feedback sections, so the image generator, usage meter and upgrade prompt stay.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-ai-writing-assistant-panel-gate
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-ai-writing-assistant-panel-gate
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: other
+Comment: AI Hub: the Writing Assistant switch hides only its own sections of the "Improve with AI" panel. The switch is not released yet.
 
-AI Assistant: keep the "Improve with AI" editor panel when the Writing Assistant is turned off. The switch now hides only the title and feedback sections, so the image generator, usage meter and upgrade prompt stay.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/ai-assistant.php
@@ -74,12 +74,15 @@ add_action(
 	'jetpack_register_gutenberg_extensions',
 	function () {
 		if ( \Jetpack_AI_Settings::is_ai_enabled() ) {
+			// The usage meter reports on every AI feature, so it follows the
+			// master switch alone.
+			Jetpack_Gutenberg::set_extension_available( 'ai-assistant-usage-panel' );
+
 			if ( \Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' ) ) {
 				Jetpack_Gutenberg::set_extension_available( 'ai-content-lens' );
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-support' );
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-form-support' );
 				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-backend-prompts' );
-				Jetpack_Gutenberg::set_extension_available( 'ai-assistant-usage-panel' );
 				Jetpack_Gutenberg::set_extension_available( 'ai-title-optimization' );
 				Jetpack_Gutenberg::set_extension_available( 'ai-title-optimization-keywords-support' );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-assistant-plugin.php
@@ -27,9 +27,11 @@ require_once __DIR__ . '/../../../_inc/lib/class-jetpack-ai-settings.php';
  * @return void
  */
 function register_plugin() {
-	// Connection check, the AI master switch, and the writing toggle that owns
-	// the legacy "Improve with AI" panel on the AI settings page. Grouping the
-	// connection term explicitly also makes the master gate (host + master via
+	// Connection check and the AI master switch. The per-feature switches on
+	// the AI settings page hide sections inside the "Improve with AI" panel
+	// (see extensions/blocks/ai-assistant/ai-assistant.php), not the panel:
+	// it also carries the usage meter and the upgrade prompt. Grouping the
+	// connection term explicitly makes the master gate (host + master via
 	// is_ai_enabled()) effective on WordPress.com Simple — the previous
 	// precedence short-circuited it there.
 	if (
@@ -38,7 +40,6 @@ function register_plugin() {
 			|| ( ( new Connection_Manager( 'jetpack' ) )->has_connected_owner() && ! ( new Status() )->is_offline_mode() )
 		)
 		&& \Jetpack_AI_Settings::is_ai_enabled()
-		&& \Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' )
 	) {
 		// Register AI assistant plugin.
 		\Jetpack_Gutenberg::set_extension_available( FEATURE_NAME );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -84,6 +84,7 @@ const JetpackAndSettingsContent = ( {
 	const { checkoutUrl } = useAICheckout();
 	const { productPageUrl } = useAiProductPage();
 	const isBreveAvailable = getBreveAvailability();
+	const showWriteBrief = canWriteBriefBeEnabled() && isBreveAvailable;
 	const {
 		usagePanel: isUsagePanelAvailable,
 		featuredImage: isAIFeaturedImageAvailable,
@@ -149,14 +150,15 @@ const JetpackAndSettingsContent = ( {
 					</BaseControl>
 				</PanelRow>
 			) }
-			{ isPostEmpty && (
-				<PanelRow className="jetpack-ai-sidebar__warning-content">
-					<Notice isDismissible={ false } status="warning">
-						{ __( 'The following features require content to work.', 'jetpack' ) }
-					</Notice>
-				</PanelRow>
-			) }
-			{ canWriteBriefBeEnabled() && isBreveAvailable && (
+			{ isPostEmpty &&
+				( showWriteBrief || isAITitleOptimizationAvailable || isAIFeedbackAvailable ) && (
+					<PanelRow className="jetpack-ai-sidebar__warning-content">
+						<Notice isDismissible={ false } status="warning">
+							{ __( 'The following features require content to work.', 'jetpack' ) }
+						</Notice>
+					</PanelRow>
+				) }
+			{ showWriteBrief && (
 				<PanelRow>
 					<BaseControl __nextHasNoMarginBottom={ true }>
 						<BaseControl.VisualLabel>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -57,24 +57,22 @@ const DocumentPanel = PluginDocumentSettingPanel as ComponentType< PanelProps >;
 
 const debug = debugFactory( 'jetpack-ai-assistant-plugin:sidebar' );
 /**
- * TODO: use getFeatureAvailability for all the checks below.
+ * Which sections the panel shows. The title and feedback sections follow the
+ * Writing Assistant switch on the AI settings page, the image section follows
+ * the Image Editor switch, and the usage meter follows the AI master switch
+ * alone. The panel itself stays while AI is on for the site.
+ *
+ * @return {object} Availability of each section.
  */
-// Determine if the usage panel is enabled or not
-const isUsagePanelAvailable =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-assistant-usage-panel' ]
-		?.available || false;
-// Determine if the AI Featured Image feature is available
-const isAIFeaturedImageAvailable =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-featured-image-generator' ]
-		?.available || false;
-// Determine if the AI Title Optimization feature is available
-const isAITitleOptimizationAvailable =
-	window?.Jetpack_Editor_Initial_State?.available_blocks?.[ 'ai-title-optimization' ]?.available ||
-	false;
-// Determine if the AI Title Optimization Keywords feature is available
-const isAITitleOptimizationKeywordsFeatureAvailable = getFeatureAvailability(
-	'ai-title-optimization-keywords-support'
-);
+const getSectionAvailability = () => ( {
+	usagePanel: getFeatureAvailability( 'ai-assistant-usage-panel' ),
+	featuredImage: getFeatureAvailability( 'ai-featured-image-generator' ),
+	titleOptimization: getFeatureAvailability( 'ai-title-optimization' ),
+	titleOptimizationKeywords: getFeatureAvailability( 'ai-title-optimization-keywords-support' ),
+	// The feedback section has no flag of its own; ai-assistant-support is set
+	// exactly when the Writing Assistant is on.
+	feedback: getFeatureAvailability( 'ai-assistant-support' ),
+} );
 
 const JetpackAndSettingsContent = ( {
 	placement,
@@ -86,6 +84,13 @@ const JetpackAndSettingsContent = ( {
 	const { checkoutUrl } = useAICheckout();
 	const { productPageUrl } = useAiProductPage();
 	const isBreveAvailable = getBreveAvailability();
+	const {
+		usagePanel: isUsagePanelAvailable,
+		featuredImage: isAIFeaturedImageAvailable,
+		titleOptimization: isAITitleOptimizationAvailable,
+		titleOptimizationKeywords: isAITitleOptimizationKeywordsFeatureAvailable,
+		feedback: isAIFeedbackAvailable,
+	} = getSectionAvailability();
 	const isPostEmpty = useSelect( select => select( editorStore ).isEditedPostEmpty(), [] );
 	const { editPost } = useDispatch( editorStore );
 
@@ -189,12 +194,14 @@ const JetpackAndSettingsContent = ( {
 					</BaseControl>
 				</PanelRow>
 			) }
-			<PanelRow className="jetpack-ai-sidebar__feature-section">
-				<BaseControl __nextHasNoMarginBottom={ true }>
-					<BaseControl.VisualLabel>{ __( 'Get Feedback', 'jetpack' ) }</BaseControl.VisualLabel>
-					<Feedback placement={ placement } busy={ false } disabled={ requireUpgrade } />
-				</BaseControl>
-			</PanelRow>
+			{ isAIFeedbackAvailable && (
+				<PanelRow className="jetpack-ai-sidebar__feature-section">
+					<BaseControl __nextHasNoMarginBottom={ true }>
+						<BaseControl.VisualLabel>{ __( 'Get Feedback', 'jetpack' ) }</BaseControl.VisualLabel>
+						<Feedback placement={ placement } busy={ false } disabled={ requireUpgrade } />
+					</BaseControl>
+				</PanelRow>
+			) }
 			{ requireUpgrade && ! isUsagePanelAvailable && (
 				<PanelRow>
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
@@ -263,6 +270,11 @@ export default function AiAssistantPluginSidebar() {
 	}
 
 	const isBreveAvailable = getBreveAvailability();
+	const { titleOptimization: isAITitleOptimizationAvailable, feedback: isAIFeedbackAvailable } =
+		getSectionAvailability();
+	// The pre-publish panel only holds writing sections, so it goes with them.
+	const showPrePublishPanel =
+		showAgentNotice || isAITitleOptimizationAvailable || isAIFeedbackAvailable;
 
 	// The panels close up rather than sit empty. Write Brief's highlights stay on,
 	// but its on/off control lived in the panel above and now has no home.
@@ -324,30 +336,34 @@ export default function AiAssistantPluginSidebar() {
 				) }
 			</DocumentPanel>
 
-			<PrePublishPanel
-				title={ title }
-				icon={ <JetpackEditorPanelLogo /> }
-				initialOpen={ showAgentNotice }
-			>
-				{ showAgentNotice ? (
-					<WordPressAgentNotice placement={ PLACEMENT_PRE_PUBLISH } />
-				) : (
-					<>
-						{ isAITitleOptimizationAvailable && (
-							<TitleOptimization
-								placement={ PLACEMENT_PRE_PUBLISH }
-								busy={ false }
-								disabled={ requireUpgrade }
-							/>
-						) }
-						<Feedback
-							placement={ PLACEMENT_PRE_PUBLISH }
-							busy={ false }
-							disabled={ requireUpgrade }
-						/>
-					</>
-				) }
-			</PrePublishPanel>
+			{ showPrePublishPanel && (
+				<PrePublishPanel
+					title={ title }
+					icon={ <JetpackEditorPanelLogo /> }
+					initialOpen={ showAgentNotice }
+				>
+					{ showAgentNotice ? (
+						<WordPressAgentNotice placement={ PLACEMENT_PRE_PUBLISH } />
+					) : (
+						<>
+							{ isAITitleOptimizationAvailable && (
+								<TitleOptimization
+									placement={ PLACEMENT_PRE_PUBLISH }
+									busy={ false }
+									disabled={ requireUpgrade }
+								/>
+							) }
+							{ isAIFeedbackAvailable && (
+								<Feedback
+									placement={ PLACEMENT_PRE_PUBLISH }
+									busy={ false }
+									disabled={ requireUpgrade }
+								/>
+							) }
+						</>
+					) }
+				</PrePublishPanel>
+			) }
 		</>
 	);
 }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -204,7 +204,7 @@ const JetpackAndSettingsContent = ( {
 					</BaseControl>
 				</PanelRow>
 			) }
-			{ requireUpgrade && ! isUsagePanelAvailable && (
+			{ requireUpgrade && ! showUsagePanel && (
 				<PanelRow>
 					<Upgrade placement={ placement } type={ upgradeType } upgradeUrl={ checkoutUrl } />
 				</PanelRow>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -8,6 +8,7 @@ import { useSidebarOpenFromUrl } from '../open-sidebar-from-url';
 const mockEditPost = jest.fn();
 const mockRecordEvent = jest.fn();
 let mockIsAgentNoticeDismissed = false;
+let mockIsPostEmpty = false;
 
 jest.mock( '@wordpress/hooks', () => ( {
 	applyFilters: jest.fn(),
@@ -26,7 +27,7 @@ jest.mock( '@wordpress/data', () => ( {
 		const stores: Record< string, unknown > = {
 			'core/editor': {
 				getCurrentPostType: () => 'post',
-				isEditedPostEmpty: () => false,
+				isEditedPostEmpty: () => mockIsPostEmpty,
 			},
 			core: {
 				getPostType: () => ( { viewable: true } ),
@@ -258,6 +259,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 		jest.mocked( applyFilters ).mockReturnValue( null );
 		withFeatures( DEFAULT_FEATURES );
 		mockIsAgentNoticeDismissed = false;
+		mockIsPostEmpty = false;
 		// The notice reads this to decide whether to offer its action, so stand in
 		// for a loaded Agents Manager the way production has one.
 		( window as unknown as { __agentsManagerActions?: unknown } ).__agentsManagerActions = {
@@ -413,6 +415,19 @@ describe( 'AiAssistantPluginSidebar', () => {
 				within( documentPanel ).getByText( 'Learn more about Jetpack AI' )
 			).toBeInTheDocument();
 			expect( screen.queryByTestId( 'pre-publish-panel' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'warns about an empty post only when a section that needs content is shown', () => {
+			mockIsPostEmpty = true;
+			const warning = 'The following features require content to work.';
+
+			const { unmount } = render( <AiAssistantPluginSidebar /> );
+			expect( screen.getAllByText( warning ).length ).toBeGreaterThan( 0 );
+			unmount();
+
+			withFeatures( [ 'ai-featured-image-generator' ] );
+			render( <AiAssistantPluginSidebar /> );
+			expect( screen.queryByText( warning ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'keeps the panel when every feature is off, so the upgrade and usage rows still have a home', () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -205,14 +205,7 @@ jest.mock( '@wordpress/ui', () => ( {
 jest.mock( '@wordpress/core-data', () => {
 	// Runs before imports due to jest.mock hoisting; the component reads this at module scope
 	Object.defineProperty( globalThis, 'Jetpack_Editor_Initial_State', {
-		value: {
-			available_blocks: {
-				'ai-assistant-usage-panel': { available: false },
-				'ai-featured-image-generator': { available: true },
-				'ai-title-optimization': { available: false },
-				'ai-title-optimization-keywords-support': { available: false },
-			},
-		},
+		value: { available_blocks: {} },
 		writable: true,
 		configurable: true,
 	} );
@@ -252,6 +245,10 @@ jest.mock( '../upgrade', () => ( { __esModule: true, default: () => null } ) );
 jest.mock( '../style.scss', () => ( {} ) );
 
 const AGENT_NOTICE_FEATURE = 'ai-sidebar-agent-notice';
+// What a site with the writing assistant and the image editor both on exposes.
+const DEFAULT_FEATURES = [ 'ai-featured-image-generator', 'ai-assistant-support' ];
+const withFeatures = ( features: string[] ) =>
+	jest.mocked( getFeatureAvailability ).mockImplementation( f => features.includes( f ) );
 const AGENT_NOTICE_TEXT =
 	'AI tools have moved to the WordPress Agent. Look for the "Ask AI" button at the top of the screen.';
 
@@ -259,7 +256,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		jest.mocked( applyFilters ).mockReturnValue( null );
-		jest.mocked( getFeatureAvailability ).mockReturnValue( false );
+		withFeatures( DEFAULT_FEATURES );
 		mockIsAgentNoticeDismissed = false;
 		// The notice reads this to decide whether to offer its action, so stand in
 		// for a loaded Agents Manager the way production has one.
@@ -335,7 +332,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 		} );
 
 		it( 'leaves the collapsed panels alone when there is no notice to show', () => {
-			jest.mocked( getFeatureAvailability ).mockReturnValue( false );
+			withFeatures( DEFAULT_FEATURES );
 
 			render( <AiAssistantPluginSidebar /> );
 
@@ -381,7 +378,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 		} );
 
 		it( 'keeps the AI tools when the notice is not available for the site', () => {
-			jest.mocked( getFeatureAvailability ).mockReturnValue( false );
+			withFeatures( DEFAULT_FEATURES );
 
 			render( <AiAssistantPluginSidebar /> );
 
@@ -389,6 +386,46 @@ describe( 'AiAssistantPluginSidebar', () => {
 			expect(
 				within( screen.getByTestId( 'document-panel' ) ).getByText( 'Get Feedback' )
 			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'writing assistant switch', () => {
+		it( 'shows the feedback section and the pre-publish panel when the writing assistant is on', () => {
+			render( <AiAssistantPluginSidebar /> );
+
+			expect(
+				within( screen.getByTestId( 'document-panel' ) ).getByText( 'Get Feedback' )
+			).toBeInTheDocument();
+			expect( screen.getByTestId( 'pre-publish-panel' ) ).toBeInTheDocument();
+		} );
+
+		it( 'hides only the writing sections when the writing assistant is off', () => {
+			withFeatures( [ 'ai-featured-image-generator' ] );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			expect( within( documentPanel ).queryByText( 'Get Feedback' ) ).not.toBeInTheDocument();
+			expect(
+				within( documentPanel ).getByRole( 'button', { name: 'Generate using AI' } )
+			).toBeInTheDocument();
+			expect(
+				within( documentPanel ).getByText( 'Learn more about Jetpack AI' )
+			).toBeInTheDocument();
+			expect( screen.queryByTestId( 'pre-publish-panel' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps the panel when every feature is off, so the upgrade and usage rows still have a home', () => {
+			withFeatures( [] );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			expect( screen.getByTestId( 'jetpack-sidebar' ) ).toBeInTheDocument();
+			expect( screen.getByTestId( 'document-panel' ) ).toBeInTheDocument();
+			expect( screen.queryByText( 'Get Feedback' ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'button', { name: 'Generate using AI' } )
+			).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -9,6 +9,8 @@ const mockEditPost = jest.fn();
 const mockRecordEvent = jest.fn();
 let mockIsAgentNoticeDismissed = false;
 let mockIsPostEmpty = false;
+let mockRequireUpgrade = false;
+let mockPlanType = 'free';
 
 jest.mock( '@wordpress/hooks', () => ( {
 	applyFilters: jest.fn(),
@@ -55,7 +57,7 @@ jest.mock( '@automattic/jetpack-components', () => ( {
 jest.mock( '@automattic/jetpack-ai-client', () => ( {
 	useAICheckout: () => ( { checkoutUrl: 'https://checkout.example.com' } ),
 	useAiFeature: () => ( {
-		requireUpgrade: false,
+		requireUpgrade: mockRequireUpgrade,
 		upgradeType: 'default',
 		currentTier: { value: 1 },
 		isOverLimit: false,
@@ -68,7 +70,7 @@ jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
 	useAnalytics: () => ( { tracks: { recordEvent: mockRecordEvent } } ),
 	PLAN_TYPE_FREE: 'free',
 	PLAN_TYPE_UNLIMITED: 'unlimited',
-	usePlanType: () => 'free',
+	usePlanType: () => mockPlanType,
 } ) );
 
 jest.mock( '@automattic/jetpack-shared-extension-utils/components', () => ( {
@@ -203,15 +205,7 @@ jest.mock( '@wordpress/ui', () => ( {
 	},
 } ) );
 
-jest.mock( '@wordpress/core-data', () => {
-	// Runs before imports due to jest.mock hoisting; the component reads this at module scope
-	Object.defineProperty( globalThis, 'Jetpack_Editor_Initial_State', {
-		value: { available_blocks: {} },
-		writable: true,
-		configurable: true,
-	} );
-	return { store: 'core' };
-} );
+jest.mock( '@wordpress/core-data', () => ( { store: 'core' } ) );
 
 jest.mock( '../../../../../blocks/ai-assistant/hooks/use-ai-product-page', () => () => ( {
 	productPageUrl: 'https://product.example.com',
@@ -241,13 +235,23 @@ jest.mock( '../../breve/utils/get-availability', () => ( {
 
 jest.mock( '../../feedback', () => ( { __esModule: true, default: () => null } ) );
 jest.mock( '../../title-optimization', () => ( { __esModule: true, default: () => null } ) );
-jest.mock( '../../usage-panel', () => ( { __esModule: true, default: () => null } ) );
-jest.mock( '../upgrade', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '../../usage-panel', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="usage-panel" />,
+} ) );
+jest.mock( '../upgrade', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="upgrade-row" />,
+} ) );
 jest.mock( '../style.scss', () => ( {} ) );
 
 const AGENT_NOTICE_FEATURE = 'ai-sidebar-agent-notice';
-// What a site with the writing assistant and the image editor both on exposes.
-const DEFAULT_FEATURES = [ 'ai-featured-image-generator', 'ai-assistant-support' ];
+// What a site with AI on, the writing assistant and the image editor exposes.
+const DEFAULT_FEATURES = [
+	'ai-assistant-usage-panel',
+	'ai-featured-image-generator',
+	'ai-assistant-support',
+];
 const withFeatures = ( features: string[] ) =>
 	jest.mocked( getFeatureAvailability ).mockImplementation( f => features.includes( f ) );
 const AGENT_NOTICE_TEXT =
@@ -260,6 +264,8 @@ describe( 'AiAssistantPluginSidebar', () => {
 		withFeatures( DEFAULT_FEATURES );
 		mockIsAgentNoticeDismissed = false;
 		mockIsPostEmpty = false;
+		mockRequireUpgrade = false;
+		mockPlanType = 'free';
 		// The notice reads this to decide whether to offer its action, so stand in
 		// for a loaded Agents Manager the way production has one.
 		( window as unknown as { __agentsManagerActions?: unknown } ).__agentsManagerActions = {
@@ -441,6 +447,30 @@ describe( 'AiAssistantPluginSidebar', () => {
 			expect(
 				screen.queryByRole( 'button', { name: 'Generate using AI' } )
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'upgrade prompt', () => {
+		it( 'shows the usage meter, not the upgrade row, on the free plan', () => {
+			mockRequireUpgrade = true;
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			expect( within( documentPanel ).getByTestId( 'usage-panel' ) ).toBeInTheDocument();
+			expect( within( documentPanel ).queryByTestId( 'upgrade-row' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows the upgrade row on a paid plan that is over its limit, even with every feature off', () => {
+			mockRequireUpgrade = true;
+			mockPlanType = 'tiered';
+			withFeatures( [] );
+
+			render( <AiAssistantPluginSidebar /> );
+
+			const documentPanel = screen.getByTestId( 'document-panel' );
+			expect( within( documentPanel ).getByTestId( 'upgrade-row' ) ).toBeInTheDocument();
+			expect( within( documentPanel ).queryByTestId( 'usage-panel' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
@@ -116,6 +116,7 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 		$this->assertFalse( Blocks::is_registered( self::BLOCK_NAME ) );
 		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-content-lens' ) );
+		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-assistant-usage-panel' ) );
 	}
 
 	/**
@@ -127,10 +128,12 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertTrue( Jetpack_Gutenberg::is_available( 'ai-content-lens' ) );
+		$this->assertTrue( Jetpack_Gutenberg::is_available( 'ai-assistant-usage-panel' ) );
 	}
 
 	/**
-	 * Disabling writing disables the writing and excerpt extensions.
+	 * Disabling writing disables the writing and excerpt extensions. The usage
+	 * meter is not a writing feature, so it stays.
 	 */
 	public function test_writing_toggle_disables_writing_and_excerpt_extensions() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
@@ -139,7 +142,9 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-assistant-support' ) );
 		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-content-lens' ) );
+		$this->assertFalse( Jetpack_Gutenberg::is_available( 'ai-title-optimization' ) );
 		$this->assertTrue( Jetpack_Gutenberg::is_available( 'ai-featured-image-generator' ) );
+		$this->assertTrue( Jetpack_Gutenberg::is_available( 'ai-assistant-usage-panel' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
@@ -177,15 +177,17 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The writing toggle from the AI settings page turns the legacy panel off.
+	 * The writing toggle hides the writing sections inside the panel, not the
+	 * panel itself: it still carries the image generator, the usage meter and
+	 * the upgrade prompt.
 	 */
-	public function test_not_registered_when_writing_toggle_off() {
+	public function test_registered_when_writing_toggle_off() {
 		$this->reset_availability();
 		$this->simulate_connected_owner();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 
 		AiAssistantPlugin\register_plugin();
 
-		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\FEATURE_NAME ) );
+		$this->assertTrue( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\FEATURE_NAME ) );
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
* Keep the "Improve with AI" editor panel when the Writing Assistant is off. The switch now hides only the title and feedback sections.
* Move the usage meter to the AI master switch, so it stays with the Upgrade button.

| Both off | Writing assistant off | Image generation off | Both on |
| :--- | :--- | :--- | :--- |
| <img width="283" height="663" alt="Screenshot 2026-09-03 at 15 44 47" src="https://github.com/user-attachments/assets/8ea16efd-c26c-4bae-ae5b-de61933aefed" /> | <img width="279" height="671" alt="Screenshot 2026-09-03 at 15 45 07" src="https://github.com/user-attachments/assets/a5e22ad0-1b92-443f-88a7-a3eb53f1bd78" /> | <img width="278" height="676" alt="Screenshot 2026-09-03 at 15 48 07" src="https://github.com/user-attachments/assets/cf64f8e7-b371-48c0-91b2-0dc8d3b89405" /> | <img width="281" height="679" alt="Screenshot 2026-09-03 at 15 45 25" src="https://github.com/user-attachments/assets/6933259c-8458-43fc-8ea0-44b61e6418b2" /> |


## Related product discussion/links
* pdtkmj-4Vi-p2#comment-9568

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Jetpack → Jetpack AI → AI Features. Turn Writing Assistant off.
* Open a post. "Improve with AI" is still there with Get Featured Image, the usage meter and the links. No Optimize Title or Get Feedback. No panel in the pre-publish sidebar.
* Turn Writing Assistant on. Reload. The 2 sections and the pre-publish panel are back.
* Turn Jetpack AI off in My Jetpack. Reload. The panel is gone.
* On sites where WordPress Agent enabled, the panel is replaced by a notice in all cases
