### PR TITLE
Jetpack AI: fix plan card for expired plan

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -140,6 +140,7 @@ export default function App() {
 		planName,
 		planRenewsOn,
 		planAutoRenew,
+		planExpired,
 		isUserConnected,
 		showFeaturesView = false,
 	} = window?.jetpackAiSettings ?? {};
@@ -367,6 +368,7 @@ export default function App() {
 						planName={ planName }
 						planRenewsOn={ planRenewsOn }
 						planAutoRenew={ planAutoRenew }
+						planExpired={ planExpired }
 						isUserConnected={ isUserConnected }
 						hostAllowsAi={ aiSettings?.host_allows_ai }
 						// Same preconditions the MCP hub applies to its copy of the

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -248,7 +248,13 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew, planExp
 									<Text
 										render={ <p /> }
 										variant="body-sm"
-										className="jetpack-ai-overview__muted jetpack-ai-overview__renewal"
+										// Exclusive, not additive: both classes set a color, and
+										// equal specificity would leave source order to decide.
+										className={ `jetpack-ai-overview__renewal ${
+											planExpired
+												? 'jetpack-ai-overview__renewal--expired'
+												: 'jetpack-ai-overview__muted'
+										}` }
 									>
 										{ createInterpolateElement( renewalLine, {
 											date: <span className="jetpack-ai-overview__renewal-date" />,

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -102,15 +102,32 @@ const DOC_LINKS = [
  *                                        the usage-period rollover, which is monthly.
  * @param {boolean} [props.planAutoRenew] - Whether the purchase auto-renews; decides
  *                                        whether the date reads Renews on or Expires on.
+ * @param {boolean} [props.planExpired]   - Whether the purchase has already lapsed; puts
+ *                                        the date in the past tense, over auto-renew.
  * @return {object} Component markup.
  */
-function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
+function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew, planExpired } ) {
 	const { isLoading, data, error } = useAiUsage();
 	const usage = normalizeUsage( data );
 	// Only the purchase's own renewal belongs under "Renews on"; the usage
 	// period's rollover is a different date. Rendered in the site's timezone to
 	// match My Jetpack and the other purchase surfaces (review call).
 	const renewsOnDisplay = planRenewsOn && dateI18n( getDateSettings().formats.date, planRenewsOn );
+	// A lapsed plan reads in the past tense whatever its auto-renew flag says:
+	// it keeps granting AI through the grace period, which is when this shows.
+	let renewalTemplate =
+		/* translators: %s: localized date the plan renews on. */
+		__( 'Renews on: <date>%s</date>', 'jetpack' );
+	if ( planExpired ) {
+		renewalTemplate =
+			/* translators: %s: localized date the plan expired on. */
+			__( 'Expired on: <date>%s</date>', 'jetpack' );
+	} else if ( planAutoRenew === false ) {
+		renewalTemplate =
+			/* translators: %s: localized date the plan expires on. */
+			__( 'Expires on: <date>%s</date>', 'jetpack' );
+	}
+	const renewalLine = sprintf( renewalTemplate, renewsOnDisplay );
 	// The purchase name only labels a paid state — the usage endpoint is
 	// authoritative for the tier, so an expired purchase cannot relabel Free.
 	const planLabel = ( ! usage.isFree && planName ) || usage.planLabel;
@@ -233,20 +250,9 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
 										variant="body-sm"
 										className="jetpack-ai-overview__muted jetpack-ai-overview__renewal"
 									>
-										{ createInterpolateElement(
-											planAutoRenew !== false
-												? sprintf(
-														/* translators: %s: localized date the plan renews on. */
-														__( 'Renews on: <date>%s</date>', 'jetpack' ),
-														renewsOnDisplay
-												  )
-												: sprintf(
-														/* translators: %s: localized date the plan expires on. */
-														__( 'Expires on: <date>%s</date>', 'jetpack' ),
-														renewsOnDisplay
-												  ),
-											{ date: <span className="jetpack-ai-overview__renewal-date" /> }
-										) }
+										{ createInterpolateElement( renewalLine, {
+											date: <span className="jetpack-ai-overview__renewal-date" />,
+										} ) }
 									</Text>
 								) }
 							</Stack>
@@ -268,6 +274,7 @@ function UsageCard( { upgradeUrl, planName, planRenewsOn, planAutoRenew } ) {
  * @param {string}  [props.planName]        - Purchase name granting AI, from the page data.
  * @param {string}  [props.planRenewsOn]    - The purchase's renewal date, from the page data.
  * @param {boolean} [props.planAutoRenew]   - Whether that purchase auto-renews, from the page data.
+ * @param {boolean} [props.planExpired]     - Whether that purchase has lapsed, from the page data.
  * @param {boolean} [props.showActivityLog] - Whether the activity-log row applies: the row's
  *                                          copy promises AI-agent actions, which need MCP.
  * @param {boolean} [props.hostAllowsAi]    - The host's AI switch; when explicitly false, no
@@ -283,6 +290,7 @@ export default function AiOverview( {
 	planName,
 	planRenewsOn,
 	planAutoRenew,
+	planExpired,
 	showActivityLog,
 	hostAllowsAi,
 	isUserConnected,
@@ -321,6 +329,7 @@ export default function AiOverview( {
 					planName={ planName }
 					planRenewsOn={ planRenewsOn }
 					planAutoRenew={ planAutoRenew }
+					planExpired={ planExpired }
 				/>
 			) }
 			{ ! blogId && (

--- a/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/style.scss
@@ -74,6 +74,11 @@
 		white-space: nowrap;
 	}
 
+	// Matches how My Jetpack colours a lapsed purchase in its Plans section.
+	&__renewal--expired {
+		color: var(--wpds-color-foreground-content-error-weak, #cc1818);
+	}
+
 	// The frame gives the requests number a taller line box than the plan name,
 	// which one shared heading-xl variant cannot express. Two classes, because the
 	// variant's runtime-injected line-height rule outranks a lone class in order.

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -150,6 +150,44 @@ describe( 'AiOverview', () => {
 		expect( screen.queryByText( /Renews on/ ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'renewal date: reads as already expired while the plan is in its grace period', async () => {
+		// The tier still reports paid after a plan lapses, so the cell has to
+		// name the plan and say it expired rather than render empty.
+		apiFetch.mockResolvedValueOnce( unlimitedPayload() );
+
+		render(
+			<AiOverview
+				{ ...PROPS }
+				planName="Business"
+				planRenewsOn="2026-08-27T00:00:00+00:00"
+				planExpired
+			/>
+		);
+
+		await expect( screen.findByText( 'Business' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( renewalLine( 'Expired on: August 27, 2026' ) ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Renews on/ ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renewal date: an expired plan on a free tier reads Free, not the lapsed name', async () => {
+		// Once the grace period ends the tier drops to free, and the usage
+		// endpoint — not the purchase — owns what the cell says.
+		apiFetch.mockResolvedValueOnce( freePayload() );
+
+		render(
+			<AiOverview
+				{ ...PROPS }
+				planName="Business"
+				planRenewsOn="2026-08-27T00:00:00+00:00"
+				planExpired
+			/>
+		);
+
+		await expect( screen.findByText( 'Free' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Business' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Expired on/ ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renewal date: an unknown auto-renew state keeps the renewal wording', async () => {
 		// The flag is absent on payloads that predate it; unknown must not be
 		// read as "off", which would mislabel every auto-renewing plan.

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -165,8 +165,13 @@ describe( 'AiOverview', () => {
 		);
 
 		await expect( screen.findByText( 'Business' ) ).resolves.toBeInTheDocument();
-		expect( screen.getByText( renewalLine( 'Expired on: August 27, 2026' ) ) ).toBeInTheDocument();
+		const line = screen.getByText( renewalLine( 'Expired on: August 27, 2026' ) );
+		expect( line ).toBeInTheDocument();
 		expect( screen.queryByText( /Renews on/ ) ).not.toBeInTheDocument();
+		// Both classes set a color, so the muted one has to be gone rather
+		// than merely outranked.
+		expect( line ).toHaveClass( 'jetpack-ai-overview__renewal--expired' );
+		expect( line ).not.toHaveClass( 'jetpack-ai-overview__muted' );
 	} );
 
 	test( 'renewal date: an expired plan on a free tier reads Free, not the lapsed name', async () => {

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -291,6 +291,7 @@ class Jetpack_AI_Page {
 			'name'       => '',
 			'renews_on'  => '',
 			'auto_renew' => true,
+			'expired'    => false,
 		);
 
 		$settings = array(
@@ -313,8 +314,10 @@ class Jetpack_AI_Page {
 			// usage-period rollover is a different, monthly date.
 			'planRenewsOn'     => $plan_info['renews_on'],
 			// The same date reads "Renews on" or "Expires on" depending on
-			// auto-renew, matching My Jetpack and the wpcom subscriptions page.
+			// auto-renew, matching the wpcom subscriptions page.
 			'planAutoRenew'    => $plan_info['auto_renew'],
+			// Past tense wins over the auto-renew wording above.
+			'planExpired'      => $plan_info['expired'],
 			'showFeaturesView' => $show_gated_views,
 			// The tab and its Agents Manager sidebar ship disabled by default.
 			'featureFlags'     => array(
@@ -419,15 +422,16 @@ class Jetpack_AI_Page {
 	 * The renewal is the purchase's expiry date, matching what My Jetpack
 	 * shows — not the AI usage-period rollover, which is a different date.
 	 *
-	 * @return array{name: string, renews_on: string} Empty strings when nothing
-	 *                                                paid grants AI or the data
-	 *                                                is unavailable.
+	 * @return array{name: string, renews_on: string, auto_renew: bool, expired: bool}
+	 *         Empty strings when nothing paid grants AI or the data is
+	 *         unavailable.
 	 */
 	private static function get_ai_plan_info() {
 		$empty = array(
 			'name'       => '',
 			'renews_on'  => '',
 			'auto_renew' => true,
+			'expired'    => false,
 		);
 
 		if ( ! class_exists( '\Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai' ) ) {
@@ -455,7 +459,7 @@ class Jetpack_AI_Page {
 		}
 
 		$info = $empty;
-		if ( $purchase && ! empty( $purchase->product_name ) && 'expired' !== ( $purchase->expiry_status ?? '' ) ) {
+		if ( $purchase && ! empty( $purchase->product_name ) ) {
 			// The design shows the bare plan name ("Complete", "Business"), so
 			// trim the store names' brand prefixes; they are untranslated.
 			$info['name']      = (string) preg_replace( '/^(Jetpack|WordPress\.com) /', '', (string) $purchase->product_name );
@@ -464,6 +468,9 @@ class Jetpack_AI_Page {
 			// reports auto-renew off should relabel the date as an expiry.
 			$info['auto_renew'] = ! isset( $purchase->is_auto_renew_enabled )
 				|| (bool) $purchase->is_auto_renew_enabled;
+			// A lapsed plan keeps working through its grace period, so the card
+			// names it and says it expired instead of leaving the cell empty.
+			$info['expired'] = 'expired' === ( $purchase->expiry_status ?? '' );
 		}
 
 		set_transient( 'jetpack_ai_overview_plan_info', $info, HOUR_IN_SECONDS );

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-expired-plan
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-overview-expired-plan
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: name the plan and say when it expired on the Overview, instead of leaving the plan empty.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -724,9 +724,11 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * An expired purchase names nothing, so a lapsed site cannot read as paid.
+	 * An expired purchase is still named and dated, flagged so the card can
+	 * say the plan expired rather than leaving the cell empty during the
+	 * grace period, when AI still works.
 	 */
-	public function test_expired_purchase_is_not_named() {
+	public function test_expired_purchase_is_named_and_flagged() {
 		$expired                = $this->jetpack_ai_purchase();
 		$expired->expiry_status = 'expired';
 
@@ -736,7 +738,67 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 		$settings = $this->get_injected_settings();
 
-		$this->assertSame( '', $settings['planName'] );
+		$this->assertSame( 'AI Assistant', $settings['planName'] );
+		$this->assertSame( '2027-03-15T00:00:00+00:00', $settings['planRenewsOn'] );
+		$this->assertTrue( $settings['planExpired'] );
+	}
+
+	/**
+	 * A live purchase must not be flagged, or every plan would read as expired.
+	 */
+	public function test_a_live_purchase_is_not_flagged_as_expired() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->given_woa( false );
+		$this->given_site( array( $this->jetpack_ai_purchase() ) );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['planExpired'] );
+	}
+
+	/**
+	 * The Dotcom branch carries the flag too — the reported case was an
+	 * expired WordPress.com plan on an Atomic site.
+	 */
+	public function test_expired_wpcom_plan_is_named_and_flagged() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->given_woa( true );
+		$this->given_site(
+			array(
+				$this->jetpack_ai_purchase(),
+				(object) array(
+					'product_slug'  => 'business-bundle',
+					'product_name'  => 'WordPress.com Business',
+					'expiry_status' => 'expired',
+					'expiry_date'   => '2026-08-27T00:00:00+00:00',
+				),
+			),
+			'business-bundle'
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( 'Business', $settings['planName'] );
+		$this->assertTrue( $settings['planExpired'] );
+	}
+
+	/**
+	 * A cache written before the flag existed must not read as expired.
+	 */
+	public function test_a_cache_without_the_flag_is_not_expired() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		set_transient(
+			'jetpack_ai_overview_plan_info',
+			array(
+				'name'      => 'Cached',
+				'renews_on' => '2027-03-15T00:00:00+00:00',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['planExpired'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* Fix the empty plan cell on the Overview when the site's plan has expired.
* Add "Expired on \<date\>", in red, matching how My Jetpack shows a lapsed purchase.
* Update `Jetpack_AI_Page` to pass a `planExpired` flag, instead of blanking the plan name and date.
* Keep "Free" plus Upgrade once the tier drops to free — the usage endpoint still owns the tier.

## Related product discussion/links

* Reported in the Jetpack AI Hub Call for Testing: pdtkmj-4Vi-p2

## Before / after

Atomic site, plan faked as expired per the steps below.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-overview-expired-plan/before-expired-plan.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-overview-expired-plan/after-expired-plan.png) |

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs a site with a paid plan, proxied. Steps 2 to 4 fake an expired plan.

1. Go to **Jetpack → Jetpack AI → Overview**. The Plan cell, right of the requests card, reads "Renews on \<date\>" — or "Expires on \<date\>" if auto-renew is off.

2. Run over WP-CLI:

```
wp eval '
$plan = (array) get_option( "jetpack_active_plan" );
set_transient( "my-jetpack-purchases", array(
  (object) array(
    "product_slug"  => "jetpack_ai_yearly",
    "product_name"  => "Jetpack AI Assistant",
    "expiry_status" => "expired",
    "expiry_date"   => "2026-08-27T00:00:00+00:00",
  ),
  (object) array(
    "product_slug"  => $plan["product_slug"],
    "product_name"  => "WordPress.com Business",
    "expiry_status" => "expired",
    "expiry_date"   => "2026-08-27T00:00:00+00:00",
  ),
), HOUR_IN_SECONDS );
delete_transient( "jetpack_ai_overview_plan_info" );'
```

Self-hosted: drop the second purchase. A WordPress.com site names itself by its own plan, so it needs both.

3. Reload the page. The Plan cell names the plan and reads **Expired on August 27, 2026**, in red. On trunk the same step leaves the cell empty apart from the "Plan" heading.

If you checked trunk first, re-run step 2 before this one: trunk caches an empty result for an hour, so the branch still renders an empty cell until that cache is cleared.

4. Put it back: `wp transient delete my-jetpack-purchases jetpack_ai_overview_plan_info`.

5. On a free site, go to the same page. The cell reads "Free" with an Upgrade button, and no plan name from step 2.
