### PR TITLE
Premium Analytics: also route the feedback action through the Stats feedback endpoint

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -95,7 +95,8 @@ Two local REST surfaces; almost all data comes from WordPress.com via one agnost
 | `analytics` (Woo store reports)                                   | `view_woocommerce_reports` | —                               |
 | `stats`                                                           | `view_stats`               | `stats/referrers/spam/`         |
 | `wordads`                                                         | `activate_wordads`         | —                               |
-| `subscribers` / `site-has-never-published-post` / `jetpack-stats` | `view_stats`               | —                               |
+| `subscribers` / `site-has-never-published-post`                    | `view_stats`               | —                               |
+| `jetpack-stats`                                                   | `view_stats`               | `jetpack-stats/user-feedback`   |
 | `jetpack-stats-dashboard`                                         | `view_stats`               | whole prefix (busts read cache) |
 | `commercial-classification`                                       | `view_stats`               | exact path                      |
 | `upgrades` (not under `/sites/`)                                  | `view_stats`               | —                               |
@@ -107,6 +108,10 @@ Writes column. Query params pass through except control params (`endpoint`, `ver
 `force_refresh` to bypass. `x-wp-total` / `x-wp-totalpages` are forwarded back. Errors:
 `403 no_connection`, `500`/`502 api_error`, `405 rest_read_only`, `401`/`403` on a failed cap.
 
+The `jetpack-stats` write is the one body the proxy rewrites: it gains the submitting user's
+`user_email` (`inject_user_email`), because the blog token names no user and WPCOM would
+otherwise attribute the feedback to the first administrator it finds.
+
 ### Notices
 
 `GET|POST /jetpack-premium-analytics/v1/notices` (`{ id, status, postponed_for }`). Not proxied
@@ -116,7 +121,7 @@ gets its own route outside `proxy/`, like this.
 ### Adding a proxied endpoint
 
 To add a transparent forward, add a key to `PREFIX_CONFIG` (at least `capability`; add
-`writes` / `cache_bust` as needed) and cover it in `data_endpoint_matrix()`.
+`writes` / `cache_bust` / `inject_user_email` as needed) and cover it in `data_endpoint_matrix()`.
 
 ### Migrating from Stats / Woo Analytics
 

--- a/projects/packages/premium-analytics/changelog/stats-460-feedback-endpoint
+++ b/projects/packages/premium-analytics/changelog/stats-460-feedback-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Send dashboard feedback on to Jetpack support, so it is not lost when analytics are blocked.

--- a/projects/packages/premium-analytics/packages/data/src/api/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/index.ts
@@ -57,4 +57,8 @@ export {
 	type StatsProxyParams,
 	type StatsProxyVersion,
 } from './stats-proxy-fetch';
-export { submitStatsUserFeedback, type StatsUserFeedback } from './stats-user-feedback';
+export {
+	submitStatsUserFeedback,
+	type StatsFeedbackRating,
+	type StatsUserFeedback,
+} from './stats-user-feedback';

--- a/projects/packages/premium-analytics/packages/data/src/api/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/index.ts
@@ -57,3 +57,4 @@ export {
 	type StatsProxyParams,
 	type StatsProxyVersion,
 } from './stats-proxy-fetch';
+export { submitStatsUserFeedback, type StatsUserFeedback } from './stats-user-feedback';

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
@@ -3,13 +3,10 @@
  */
 import { fetchStatsProxy } from './stats-proxy-fetch';
 
-// Reaches Happiness as the subject line of the feedback email ("Feedback received
-// from …"), so it has to name the surface without any further context.
-const PRODUCT_NAME = 'Jetpack Stats Traffic tab preview';
-
 export type StatsUserFeedback = {
 	rating: number;
 	comment: string;
+	productName: string;
 };
 
 /**
@@ -19,19 +16,21 @@ export type StatsUserFeedback = {
  * The endpoint requires a message, so a rating with no comment is not submittable here —
  * Tracks carries the rating either way.
  *
- * @param feedback         - The reader's submission.
- * @param feedback.rating  - Where the reader placed the new tab on the comparison scale, 1 to 5.
- * @param feedback.comment - The reader's message. Must not be empty.
+ * @param feedback             - The reader's submission.
+ * @param feedback.rating      - Where the reader placed the new tab on the comparison scale, 1 to 5.
+ * @param feedback.comment     - The reader's message. Must not be empty.
+ * @param feedback.productName - The surface being reviewed. Reaches Happiness as the email
+ *                             subject line, so it has to stand alone.
  * @return The endpoint's response.
  */
-export function submitStatsUserFeedback( { rating, comment }: StatsUserFeedback ) {
+export function submitStatsUserFeedback( { rating, comment, productName }: StatsUserFeedback ) {
 	return fetchStatsProxy( {
 		version: '2',
 		endpoint: 'jetpack-stats/user-feedback',
 		method: 'POST',
 		body: {
 			source_url: window.location.href,
-			product_name: PRODUCT_NAME,
+			product_name: productName,
 			feedback: comment,
 			rating,
 		},

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
@@ -19,6 +19,9 @@ export type StatsUserFeedback = {
  * The endpoint requires a message, so a rating with no comment is not submittable here —
  * Tracks carries the rating either way.
  *
+ * It also throttles per site per day rather than per user, so on a multi-author site a
+ * co-author's earlier submission silently drops this one. Tracks still has it.
+ *
  * @param feedback             - The reader's submission.
  * @param feedback.rating      - Where the reader placed the new tab on the comparison scale.
  * @param feedback.comment     - The reader's message. Must not be empty.

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { fetchStatsProxy } from './stats-proxy-fetch';
+
+// Reaches Happiness as the subject line of the feedback email ("Feedback received
+// from …"), so it has to name the surface without any further context.
+const PRODUCT_NAME = 'Jetpack Stats Traffic tab preview';
+
+export type StatsUserFeedback = {
+	rating: number;
+	comment: string;
+};
+
+/**
+ * Send dashboard feedback to the WPCOM Stats feedback endpoint, which emails it on and
+ * opens a Zendesk ticket.
+ *
+ * The endpoint requires a message, so a rating with no comment is not submittable here —
+ * Tracks carries the rating either way.
+ *
+ * @param feedback         - The reader's submission.
+ * @param feedback.rating  - Where the reader placed the new tab on the comparison scale, 1 to 5.
+ * @param feedback.comment - The reader's message. Must not be empty.
+ * @return The endpoint's response.
+ */
+export function submitStatsUserFeedback( { rating, comment }: StatsUserFeedback ) {
+	return fetchStatsProxy( {
+		version: '2',
+		endpoint: 'jetpack-stats/user-feedback',
+		method: 'POST',
+		body: {
+			source_url: window.location.href,
+			product_name: PRODUCT_NAME,
+			feedback: comment,
+			rating,
+		},
+	} );
+}

--- a/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
+++ b/projects/packages/premium-analytics/packages/data/src/api/stats-user-feedback.ts
@@ -3,8 +3,11 @@
  */
 import { fetchStatsProxy } from './stats-proxy-fetch';
 
+/** Where the reader placed the new tab on the comparison scale, worst to best. */
+export type StatsFeedbackRating = 1 | 2 | 3 | 4 | 5;
+
 export type StatsUserFeedback = {
-	rating: number;
+	rating: StatsFeedbackRating;
 	comment: string;
 	productName: string;
 };
@@ -17,7 +20,7 @@ export type StatsUserFeedback = {
  * Tracks carries the rating either way.
  *
  * @param feedback             - The reader's submission.
- * @param feedback.rating      - Where the reader placed the new tab on the comparison scale, 1 to 5.
+ * @param feedback.rating      - Where the reader placed the new tab on the comparison scale.
  * @param feedback.comment     - The reader's message. Must not be empty.
  * @param feedback.productName - The surface being reviewed. Reaches Happiness as the email
  *                             subject line, so it has to stand alone.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -74,6 +74,7 @@ export {
 	type StoreInfo,
 } from './defaults';
 export { downloadReport, exportReport, fetchStatsProxy, getStatsProxyPath } from './api';
+export { submitStatsUserFeedback, type StatsUserFeedback } from './api';
 export type {
 	DownloadReportParams,
 	DownloadReportResponse,

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -74,7 +74,7 @@ export {
 	type StoreInfo,
 } from './defaults';
 export { downloadReport, exportReport, fetchStatsProxy, getStatsProxyPath } from './api';
-export { submitStatsUserFeedback, type StatsUserFeedback } from './api';
+export { submitStatsUserFeedback, type StatsFeedbackRating, type StatsUserFeedback } from './api';
 export type {
 	DownloadReportParams,
 	DownloadReportResponse,

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -236,7 +236,7 @@ describe( 'the Happiness copy of the feedback', () => {
 				method: 'POST',
 				data: {
 					source_url: window.location.href,
-					product_name: 'Jetpack Stats Traffic tab preview',
+					product_name: 'Stats v2',
 					feedback: 'Missing the date picker',
 					rating: 2,
 				},

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -28,6 +28,14 @@ const mockGetScriptData = jest.fn();
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getScriptData: () => mockGetScriptData(),
+	isSimpleSite: () => false,
+} ) );
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
 } ) );
 
 beforeEach( () => {
@@ -37,6 +45,7 @@ beforeEach( () => {
 		site: { wpcom: { blog_id: 42 } },
 		user: { current_user: { wpcom: { ID: 7, login: 'reader' } } },
 	} );
+	mockApiFetch.mockResolvedValue( 'success' );
 } );
 
 /**
@@ -210,5 +219,54 @@ describe( 'the Tracks identity', () => {
 
 		expect( mockSetUser ).toHaveBeenCalledWith( 7, 'reader' );
 		expect( mockAssignSuperProps ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'the Happiness copy of the feedback', () => {
+	it( 'sends the message and the rating to the WPCOM feedback endpoint', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
+		await user.type( screen.getByRole( 'textbox' ), '  Missing the date picker  ' );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats/user-feedback',
+				method: 'POST',
+				data: {
+					source_url: window.location.href,
+					product_name: 'Jetpack Stats Traffic tab preview',
+					feedback: 'Missing the date picker',
+					rating: 2,
+				},
+			} )
+		);
+	} );
+
+	it( 'keeps a bare rating out of the support queue', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: 'Much better' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
+			'jetpack_premium_analytics_feedback_submit',
+			{ rating: 5, comment: '' }
+		);
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'still thanks the reader when the endpoint fails', async () => {
+		mockApiFetch.mockRejectedValue( new Error( 'throttled' ) );
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
+		await user.type( screen.getByRole( 'textbox' ), 'Charts load slowly' );
+		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
+
+		expect(
+			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you. This helps.' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-action.test.tsx
@@ -236,7 +236,7 @@ describe( 'the Happiness copy of the feedback', () => {
 				method: 'POST',
 				data: {
 					source_url: window.location.href,
-					product_name: 'Stats v2',
+					product_name: 'Jetpack Stats v2',
 					feedback: 'Missing the date picker',
 					rating: 2,
 				},

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -17,6 +17,10 @@ type Rating = 1 | 2 | 3 | 4 | 5;
 // cost us the rating too.
 const COMMENT_MAX_LENGTH = 1000;
 
+// Reaches Happiness as the subject line of the feedback email ("Feedback received
+// from …"), so it has to name the surface without any further context.
+const PRODUCT_NAME = 'Stats v2';
+
 /**
  * The comparison scale, worst to best. `value` is the score that reaches Tracks.
  *
@@ -93,10 +97,12 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 		// silently, so the message also goes to Happiness where delivery is not the reader's
 		// browser's decision. A rating alone would only open an empty ticket.
 		if ( message ) {
-			submitStatsUserFeedback( { rating, comment: message } ).catch( () => {
-				// The reader has already been thanked and Tracks may well have the submission;
-				// a second, contradictory message would cost more than the lost email.
-			} );
+			submitStatsUserFeedback( { rating, comment: message, productName: PRODUCT_NAME } ).catch(
+				() => {
+					// The reader has already been thanked and Tracks may well have the submission;
+					// a second, contradictory message would cost more than the lost email.
+				}
+			);
 		}
 
 		setHasSubmitted( true );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { submitStatsUserFeedback } from '@jetpack-premium-analytics/data';
 import { Button, Notice, Stack, Text } from '@jetpack-premium-analytics/externals';
 import { Modal, RadioControl, TextareaControl } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
@@ -83,10 +84,19 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 			return;
 		}
 
-		trackEvent( 'jetpack_premium_analytics_feedback_submit', {
-			rating,
-			comment: comment.trim(),
-		} );
+		const message = comment.trim();
+
+		trackEvent( 'jetpack_premium_analytics_feedback_submit', { rating, comment: message } );
+
+		// Second channel, deliberately not awaited: Tracks is a pixel and ad blockers drop it
+		// silently, so the message also goes to Happiness where delivery is not the reader's
+		// browser's decision. A rating alone would only open an empty ticket.
+		if ( message ) {
+			submitStatsUserFeedback( { rating, comment: message } ).catch( () => {
+				// The reader has already been thanked and Tracks may well have the submission;
+				// a second, contradictory message would cost more than the lost email.
+			} );
+		}
 
 		setHasSubmitted( true );
 	}, [ comment, rating, trackEvent ] );

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -53,7 +53,8 @@ type FeedbackModalProps = {
 };
 
 /**
- * Comparison rating with an optional comment, recorded as a single Tracks event.
+ * Comparison rating with an optional comment. Both reach Tracks as one event; a non-empty
+ * comment also goes to the Stats feedback endpoint.
  *
  * @param {FeedbackModalProps} props         - Component props.
  * @param {Function}           props.onClose - Called once the reader dismisses the modal.

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { submitStatsUserFeedback } from '@jetpack-premium-analytics/data';
+import { submitStatsUserFeedback, type StatsFeedbackRating } from '@jetpack-premium-analytics/data';
 import { Button, Notice, Stack, Text } from '@jetpack-premium-analytics/externals';
 import { Modal, RadioControl, TextareaControl } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
@@ -11,15 +11,13 @@ import { __ } from '@wordpress/i18n';
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
 
-type Rating = 1 | 2 | 3 | 4 | 5;
-
 // Tracks drops an event whose properties are oversized, so a pasted essay would
 // cost us the rating too.
 const COMMENT_MAX_LENGTH = 1000;
 
 // Reaches Happiness as the subject line of the feedback email ("Feedback received
 // from …"), so it has to name the surface without any further context.
-const PRODUCT_NAME = 'Stats v2';
+const PRODUCT_NAME = 'Jetpack Stats v2';
 
 /**
  * The comparison scale, worst to best. `value` is the score that reaches Tracks.
@@ -66,7 +64,7 @@ type FeedbackModalProps = {
  */
 export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	const trackEvent = useTrackEvent();
-	const [ rating, setRating ] = useState< Rating | null >( null );
+	const [ rating, setRating ] = useState< StatsFeedbackRating | null >( null );
 	const [ comment, setComment ] = useState( '' );
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
 
@@ -80,7 +78,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	);
 
 	const selectRating = useCallback(
-		( value: string ) => setRating( Number( value ) as Rating ),
+		( value: string ) => setRating( Number( value ) as StatsFeedbackRating ),
 		[]
 	);
 

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -455,8 +455,8 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 *
 	 * Mirrors what stats-admin's own `post_user_feedback()` does: the request is signed with the
 	 * blog token, so WPCOM sees no user and would attribute the submission to whichever
-	 * administrator it finds first. A body that is not a JSON object is returned untouched rather
-	 * than replaced, so a malformed request still fails at WPCOM's own validation.
+	 * administrator it finds first. A body that is neither empty nor a JSON object is returned
+	 * untouched rather than replaced, so a malformed request still fails at WPCOM's own validation.
 	 *
 	 * @param string               $body The request body to forward.
 	 * @param array<string, mixed> $opts The matched prefix config.

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -384,10 +384,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 			$request,
 			$this->build_data_path( $endpoint ),
 			array(
-				'version'         => $version,
-				'base'            => $this->base_for_version( $version ),
-				'bust_on_write'   => $this->busts_cache( $endpoint ),
-				'unauthenticated' => ! empty( $config['unauthenticated'] ),
+				'version'           => $version,
+				'base'              => $this->base_for_version( $version ),
+				'bust_on_write'     => $this->busts_cache( $endpoint ),
+				'unauthenticated'   => ! empty( $config['unauthenticated'] ),
+				'inject_user_email' => ! empty( $config['inject_user_email'] ),
 			)
 		);
 	}

--- a/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
+++ b/projects/packages/premium-analytics/src/REST/class-api-proxy-controller.php
@@ -100,6 +100,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 *                  → only `<id>/likes` and `<id>/replies`, never post content). Anchored on both ends and
 	 *                  enforced in the route regex AND in `validate_data_endpoint()` (the route
 	 *                  capture can be shadowed with `?endpoint=`). Omit to allow the whole group.
+	 *  - `inject_user_email` (bool, optional) Add the local user's email to the forwarded write body
+	 *                  as `user_email`. The blog token carries no user, so a WPCOM endpoint that
+	 *                  attributes a submission to a person cannot resolve one on its own (it falls
+	 *                  back to the site's first administrator). The only body rewrite this proxy
+	 *                  does; see `inject_user_email()`.
 	 *  - `unauthenticated` (bool, optional) Forward reads WITHOUT signing (plain HTTP, like
 	 *                  stats-admin's Odyssey proxy does for post likes). For WPCOM endpoints
 	 *                  that reject blog-token auth but serve public data without credentials.
@@ -113,8 +118,9 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	 *  - REMOVE a group: delete its key — the route stops matching it and it 404s.
 	 *  - Cover it with a row in `data_endpoint_matrix()` (capability / writable / WPCOM path).
 	 *  - NOTE: this is for transparent WPCOM forwards only. Endpoints needing local processing
-	 *    (DB reads, body rewrites, the Notices class, …) are NOT proxied — they get their own
-	 *    routes outside `proxy/`; do not add them here.
+	 *    (DB reads, the Notices class, …) are NOT proxied — they get their own routes outside
+	 *    `proxy/`; do not add them here. `inject_user_email` is the one exception, and stays one:
+	 *    a rewrite that cannot be expressed as a flag on this table belongs in its own route.
 	 *
 	 * @var array<string, array<string, mixed>>
 	 */
@@ -129,7 +135,11 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		'wordads'                       => array( 'capability' => 'activate_wordads' ),
 		'subscribers'                   => array( 'capability' => 'view_stats' ),
 		'site-has-never-published-post' => array( 'capability' => 'view_stats' ),
-		'jetpack-stats'                 => array( 'capability' => 'view_stats' ),
+		'jetpack-stats'                 => array(
+			'capability'        => 'view_stats',
+			'writes'            => array( 'jetpack-stats/user-feedback' ),
+			'inject_user_email' => true,
+		),
 		'jetpack-stats-dashboard'       => array(
 			'capability' => 'view_stats',
 			'writes'     => array( 'jetpack-stats-dashboard/' ),
@@ -439,6 +449,45 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Add the local user's email to a forwarded write body, for a group declaring
+	 * `inject_user_email`.
+	 *
+	 * Mirrors what stats-admin's own `post_user_feedback()` does: the request is signed with the
+	 * blog token, so WPCOM sees no user and would attribute the submission to whichever
+	 * administrator it finds first. A body that is not a JSON object is returned untouched rather
+	 * than replaced, so a malformed request still fails at WPCOM's own validation.
+	 *
+	 * @param string               $body The request body to forward.
+	 * @param array<string, mixed> $opts The matched prefix config.
+	 *
+	 * @return string
+	 */
+	private function inject_user_email( string $body, array $opts ): string {
+		if ( empty( $opts['inject_user_email'] ) ) {
+			return $body;
+		}
+
+		$email = wp_get_current_user()->user_email;
+		if ( ! $email ) {
+			return $body;
+		}
+
+		$decoded = '' === $body ? array() : json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return $body;
+		}
+
+		// A JSON list is not a param bag, and adding a string key would reshape it into an object.
+		if ( array() !== $decoded && array_keys( $decoded ) === range( 0, count( $decoded ) - 1 ) ) {
+			return $body;
+		}
+
+		$decoded['user_email'] = $email;
+
+		return (string) wp_json_encode( $decoded, JSON_UNESCAPED_SLASHES );
+	}
+
+	/**
 	 * Whether a successful write to this endpoint should invalidate the matching read cache.
 	 *
 	 * @param string $endpoint The validated sub-path.
@@ -502,7 +551,7 @@ class Api_Proxy_Controller extends WP_REST_Controller {
 		);
 		$body = null;
 		if ( ! $is_read ) {
-			$body            = $request->get_body();
+			$body            = $this->inject_user_email( $request->get_body(), $opts );
 			$args['headers'] = array( 'Content-Type' => 'application/json' );
 		}
 

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -395,13 +395,15 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 
 		$request = $this->build_data_request( 'POST', 'jetpack-stats/user-feedback' );
 		$request->set_body( '{"feedback":"slow"}' );
-		$response = $this->controller->handle_data_request( $request );
-
-		remove_all_filters( 'pre_http_request' );
-		\Jetpack_Options::delete_option( 'blog_token' );
-		\Jetpack_Options::delete_option( 'id' );
-		( new Connection_Manager() )->reset_connection_status();
-		Constants::clear_single_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		try {
+			$response = $this->controller->handle_data_request( $request );
+		} finally {
+			remove_all_filters( 'pre_http_request' );
+			\Jetpack_Options::delete_option( 'blog_token' );
+			\Jetpack_Options::delete_option( 'id' );
+			( new Connection_Manager() )->reset_connection_status();
+			Constants::clear_single_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+		}
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertStringContainsString( '/wpcom/v2/sites/4242/jetpack-stats/user-feedback', $captured['url'] );

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -21,6 +21,11 @@ use WP_REST_Server;
 class Api_Proxy_Controller_Test extends BaseTestCase {
 
 	/**
+	 * Email of the user the injection cases sign in as.
+	 */
+	private const FEEDBACK_USER_EMAIL = 'jpa_feedback@example.com';
+
+	/**
 	 * Controller under test.
 	 *
 	 * @var Api_Proxy_Controller
@@ -299,6 +304,68 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The blog token carries no user, so the endpoint that attributes a submission to a person
+	 * gets the local one added on the way out. Every other group's body is forwarded untouched.
+	 *
+	 * @dataProvider data_user_email_injection
+	 *
+	 * @param array<string, mixed> $opts     The matched prefix config.
+	 * @param string               $body     The incoming request body.
+	 * @param string               $expected The body that should be forwarded.
+	 */
+	#[DataProvider( 'data_user_email_injection' )]
+	public function test_inject_user_email( array $opts, string $body, string $expected ) {
+		wp_set_current_user(
+			wp_insert_user(
+				array(
+					'user_login' => 'jpa_feedback',
+					'user_pass'  => 'password',
+					'user_email' => self::FEEDBACK_USER_EMAIL,
+					'role'       => 'administrator',
+				)
+			)
+		);
+
+		$accessor = function ( string $b, array $o ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->inject_user_email( $b, $o );
+		};
+
+		$this->assertSame( $expected, $accessor->call( $this->controller, $body, $opts ) );
+	}
+
+	public function test_inject_user_email_leaves_the_body_alone_for_a_logged_out_request() {
+		wp_set_current_user( 0 );
+
+		$accessor = function ( string $b, array $o ) {
+			// @phan-suppress-next-line PhanUndeclaredMethod -- rebound to the controller via Closure::call() below.
+			return $this->inject_user_email( $b, $o );
+		};
+
+		$this->assertSame(
+			'{"feedback":"slow"}',
+			$accessor->call( $this->controller, '{"feedback":"slow"}', array( 'inject_user_email' => true ) )
+		);
+	}
+
+	/**
+	 * @return array<string, array{0: array<string, mixed>, 1: string, 2: string}>
+	 */
+	public static function data_user_email_injection(): array {
+		$on    = array( 'inject_user_email' => true );
+		$email = self::FEEDBACK_USER_EMAIL;
+
+		return array(
+			'adds to an object'        => array( $on, '{"feedback":"slow"}', '{"feedback":"slow","user_email":"' . $email . '"}' ),
+			'adds to an empty body'    => array( $on, '', '{"user_email":"' . $email . '"}' ),
+			'overwrites a claimed one' => array( $on, '{"user_email":"spoof@example.com"}', '{"user_email":"' . $email . '"}' ),
+			'leaves a list alone'      => array( $on, '[1,2]', '[1,2]' ),
+			'leaves malformed alone'   => array( $on, 'not json', 'not json' ),
+			'skips groups without it'  => array( array(), '{"feedback":"slow"}', '{"feedback":"slow"}' ),
+		);
+	}
+
+	/**
 	 * @return array<string, string[]>
 	 */
 	public static function data_data_paths(): array {
@@ -341,7 +408,9 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 			'commercial subpath' => array( 'commercial-classification/foo', false ),
 			'stats read'         => array( 'stats/top-posts', false ),
 			'subscribers read'   => array( 'subscribers/counts', false ),
+			'user feedback'      => array( 'jetpack-stats/user-feedback', true ),
 			'usage read'         => array( 'jetpack-stats/usage', false ),
+			'feedback subpath'   => array( 'jetpack-stats/user-feedback/foo', false ),
 			'wordads read'       => array( 'wordads/earnings', false ),
 		);
 	}
@@ -736,6 +805,7 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 			'subscribers counts'   => array( 'subscribers/counts', $stats, false, '/sites/%d/subscribers/counts' ),
 			'never published'      => array( 'site-has-never-published-post', $stats, false, '/sites/%d/site-has-never-published-post' ),
 			'plan usage'           => array( 'jetpack-stats/usage', $stats, false, '/sites/%d/jetpack-stats/usage' ),
+			'user feedback'        => array( 'jetpack-stats/user-feedback', $stats, true, '/sites/%d/jetpack-stats/user-feedback' ),
 			'dashboard modules'    => array( 'jetpack-stats-dashboard/modules', $stats, true, '/sites/%d/jetpack-stats-dashboard/modules' ),
 			'module settings'      => array( 'jetpack-stats-dashboard/module-settings', $stats, true, '/sites/%d/jetpack-stats-dashboard/module-settings' ),
 			'commercial class.'    => array( 'commercial-classification', $stats, true, '/sites/%d/commercial-classification' ),

--- a/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
+++ b/projects/packages/premium-analytics/tests/php/REST/Api_Proxy_Controller_Test.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics\REST;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -345,6 +347,67 @@ class Api_Proxy_Controller_Test extends BaseTestCase {
 		$this->assertSame(
 			'{"feedback":"slow"}',
 			$accessor->call( $this->controller, '{"feedback":"slow"}', array( 'inject_user_email' => true ) )
+		);
+	}
+
+	/**
+	 * The cases above call the injector directly. This one drives the whole route, so a config
+	 * flag that never reaches `forward()` fails here rather than shipping as a dead option.
+	 */
+	public function test_feedback_write_forwards_the_user_email_through_the_route() {
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		\Jetpack_Options::update_option( 'id', 4242 );
+		\Jetpack_Options::update_option( 'blog_token', 'blog_token.secret' );
+		( new Connection_Manager() )->reset_connection_status();
+
+		wp_set_current_user(
+			wp_insert_user(
+				array(
+					'user_login' => 'jpa_feedback_route',
+					'user_pass'  => 'password',
+					'user_email' => self::FEEDBACK_USER_EMAIL,
+					'role'       => 'administrator',
+				)
+			)
+		);
+
+		$captured = array(
+			'url'  => '',
+			'args' => array(),
+		);
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args, $url ) use ( &$captured ) {
+				$captured = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => wp_json_encode( array( 'success' => true ), JSON_UNESCAPED_SLASHES ),
+					'headers'  => array(),
+				);
+			},
+			10,
+			3
+		);
+
+		$request = $this->build_data_request( 'POST', 'jetpack-stats/user-feedback' );
+		$request->set_body( '{"feedback":"slow"}' );
+		$response = $this->controller->handle_data_request( $request );
+
+		remove_all_filters( 'pre_http_request' );
+		\Jetpack_Options::delete_option( 'blog_token' );
+		\Jetpack_Options::delete_option( 'id' );
+		( new Connection_Manager() )->reset_connection_status();
+		Constants::clear_single_constant( 'JETPACK__WPCOM_JSON_API_BASE' );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertStringContainsString( '/wpcom/v2/sites/4242/jetpack-stats/user-feedback', $captured['url'] );
+		$this->assertSame(
+			'{"feedback":"slow","user_email":"' . self::FEEDBACK_USER_EMAIL . '"}',
+			$captured['args']['body'] ?? null
 		);
 	}
 

--- a/projects/plugins/jetpack/changelog/stats-460-feedback-endpoint
+++ b/projects/plugins/jetpack/changelog/stats-460-feedback-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Send dashboard feedback on to Jetpack support, so it is not lost when analytics are blocked.

--- a/projects/plugins/premium-analytics/changelog/stats-460-feedback-endpoint
+++ b/projects/plugins/premium-analytics/changelog/stats-460-feedback-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Send dashboard feedback on to Jetpack support, so it is not lost when analytics are blocked.

--- a/projects/plugins/wpcomsh/changelog/stats-460-feedback-endpoint
+++ b/projects/plugins/wpcomsh/changelog/stats-460-feedback-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: Send dashboard feedback on to Jetpack support, so it is not lost when analytics are blocked.


### PR DESCRIPTION
Fixes STATS-460

Follows #51870, which added the feedback modal and Tracks event. That PR has landed; this one adds the fallback delivery channel.

## Proposed changes

* Send non-empty feedback to the WPCOM Stats feedback endpoint as well as Tracks, so it is delivered when an ad blocker drops the pixel.
* Extend the existing `jetpack-stats` proxy with `inject_user_email`, allowing WPCOM to attribute feedback to its submitting user.
* Send the request without waiting for it, so a failed endpoint request does not affect the confirmation UI.
* Include `rating`; the endpoint safely ignores it until its matching WPCOM change lands.

## Related product discussion/links

* STATS-460

## Does this pull request change what data or activity we track or use?

Yes. A non-empty comment is now also sent to the WPCOM Stats feedback endpoint, which emails it to Happiness and opens a Zendesk ticket. The proxy adds the submitting WordPress user's email address to that request, so the ticket is attributed to the right person rather than to the site's first administrator. Nothing new is collected in the browser.

This mirrors the existing Odyssey Stats path (`Stats_Admin\REST_Controller::post_user_feedback()`), which already sends the same fields to the same endpoint. The flow is not new to Jetpack; this PR adds a second surface for it.

## Testing instructions

WPCOM sandbox 238916-ghe-Automattic/wpcom

**The endpoint throttles per site per day, not per user.** A second submission from the same site on the same day is dropped, returning 500 today and 429 once the WPCOM change lands, while the modal still shows its confirmation. `is_testing: true` returns before the throttle, so it can be used to repeat step 2.

**Step 2 sends a real submission.** The dashboard does not pass `is_testing`, so a comment reaches Happiness and opens a Zendesk ticket. Either add `is_testing: true` to the body in `submitStatsUserFeedback()` while you test, or resolve the ticket afterwards.

1. Build the branch with `jetpack build --deps plugins/premium-analytics`, install it on a Jetpack-connected site, and open the Premium Analytics dashboard in wp-admin.
2. Open the browser network panel. Click **Any feedback?**, select a rating, enter a comment, and submit. Confirm the usual request to `pixel.wp.com` and a POST to `jetpack-premium-analytics/v1/proxy/v2/jetpack-stats/user-feedback`.
3. Submit a rating with no comment. Confirm that only the pixel request is sent.
4. Block the proxy POST in devtools and submit feedback. Confirm the modal still shows its confirmation and the browser console has no error.
5. For the WPCOM-side check, configure a sandbox with `define( 'JETPACK__SANDBOX_DOMAIN', '<your sandbox>' );` in `wp-config.php`; confirm the admin bar says “Sandboxing via …”.
6. Save this as `feedback.php` and run `wp eval-file feedback.php` to make a testing request without sending mail (the inline `wp eval` form mangles the quoting):

    ```php
    <?php
    wp_set_current_user( 1 );
    $request = new WP_REST_Request( "POST", "/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats/user-feedback" );
    $request->set_header( "content-type", "application/json" );
    $request->set_body( wp_json_encode( array(
      "source_url"   => home_url(),
      "product_name" => "Jetpack Stats v2",
      "feedback"     => "e2e dry run",
      "rating"       => 4,
      "is_testing"   => true,
    ) ) );
    $response = rest_do_request( $request );
    var_export( array( $response->get_status(), $response->get_data() ) );
    ```

7. Confirm the response is `200`. In the sandbox log, confirm the testing-mode entry resolves the email for user ID `1`, verifying `inject_user_email`.
8. Optionally, add a temporary sandbox `pre_wp_mail` filter that logs `$atts` and returns `true`. Repeat step 6 without `is_testing` to inspect the email without creating a ticket. Once the WPCOM `rating` parameter lands, the body includes `Rating: 4`.

Simple sites call the endpoint directly, so they do not exercise `inject_user_email`; test that path after this package version reaches WPCOM.





