### PR TITLE
Premium Analytics: read the reporting timezone from one accessor

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1978-single-source-reporting-timezone
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1978-single-source-reporting-timezone
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor: the reporting timezone is now read from one accessor.
+
+

--- a/projects/packages/premium-analytics/packages/data/README.md
+++ b/projects/packages/premium-analytics/packages/data/README.md
@@ -363,42 +363,39 @@ WordPress site settings:
 
 ### `localTZDate( value?, timezone? )`
 
-Creates a timezone-aware date using the site's configured timezone by
-default.
+Creates a timezone-aware date in the reporting timezone by default.
 
 ```typescript
 import { localTZDate } from '@jetpack-premium-analytics/data';
 
-const now = localTZDate(); // Current time in site timezone
+const now = localTZDate(); // Current time in the reporting timezone
 const custom = localTZDate( '2024-01-15', 'America/New_York' );
 ```
 
 **Parameters:**
 
 - `value` (optional): `number | string | Date` - Date value to convert
-- `timezone` (optional): `string` - Target timezone (defaults to site
-  timezone)
+- `timezone` (optional): `string` - Target timezone (defaults to the
+  reporting timezone)
 
 **Returns:** `TZDate` - Timezone-aware date object
 
-### `dateToISOStringWithLocalTZ( date, timezone? )`
+### `dateToISOStringWithLocalTZ( date )`
 
-Converts a date to ISO string with the site's timezone offset applied.
+Converts a date to ISO string with the reporting timezone's offset applied.
 
 ```typescript
 const withTZ = dateToISOStringWithLocalTZ( new Date() );
-// Returns: "2024-01-15T14:30:00.000-05:00" (with site timezone offset)
+// Returns: "2024-01-15T14:30:00.000-05:00" (with the reporting timezone's offset)
 ```
 
 **Parameters:**
 
 - `date`: `Date` - Date to convert
-- `timezone` (optional): `string` - Target timezone (defaults to site
-  timezone)
 
 **Returns:** `string` - ISO string with timezone offset
 
-**Note:** The site timezone comes from `siteTimeZone()` in
+**Note:** The reporting timezone comes from `reportingTimeZone()` in
 `@jetpack-premium-analytics/datetime`, which reads the WordPress date
 settings that ship with the page. It needs no await.
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
@@ -1,5 +1,5 @@
 import { tz } from '@date-fns/tz';
-import { siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { format, fromUnixTime } from 'date-fns';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsRecord } from './utils';
@@ -15,7 +15,7 @@ export function sanitizeStatsStreakResponse( response: unknown ): StatsStreakRes
 	const data = coerceStatsRecord( coerceStatsRecord( response ).data );
 	// Keyed by instant, not by day, so the calendar day is resolved here. By zone
 	// rather than by offset: a fixed offset is a day out either side of a DST change.
-	const zone = tz( siteTimeZone() );
+	const zone = tz( reportingTimeZone() );
 	const streak: StatsStreakResponse = {};
 
 	for ( const [ timestamp, count ] of Object.entries( data ) ) {

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/date.test.ts
@@ -6,7 +6,7 @@ import { format } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { dateToISOStringWithLocalTZ, formatToTimezoneNaiveString, localTZDate } from '../date';
+import { dateToISOStringWithLocalTZ, localTZDate } from '../date';
 
 const DEFAULTS = getSettings();
 
@@ -44,14 +44,6 @@ describe( 'localTZDate', () => {
 
 		expect( localTZDate( '2026-06-29', '+00:00' ).toISOString() ).toBe(
 			'2026-06-29T00:00:00.000Z'
-		);
-	} );
-
-	it( 'formats a naive string in the site zone', () => {
-		siteOn( 'America/New_York', -4 );
-
-		expect( formatToTimezoneNaiveString( localTZDate( '2026-06-29T13:30:00Z' ) ) ).toBe(
-			'2026-06-29T09:30:00.000'
 		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/utils/date.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/date.ts
@@ -4,24 +4,15 @@
 import { type TZDate } from '@date-fns/tz';
 import {
 	toLocalTZ,
-	siteTimeZone,
-	formatToTimezoneNaiveString as _formatNaive,
+	reportingTimeZone,
 	dateToISOStringWithTZ as _toISOWithTZ,
 } from '@jetpack-premium-analytics/datetime';
 
 export function localTZDate( value?: number | string | Date, timezone?: string ): TZDate {
-	const tz = timezone ?? siteTimeZone();
-	return toLocalTZ( value, tz );
-}
-
-/** TZ-aware Date -> timezone-naive `YYYY-MM-DDTHH:mm:ss.SSS`. */
-export function formatToTimezoneNaiveString( date: Date, timezone?: string ): string {
-	const tz = timezone ?? siteTimeZone();
-	return _formatNaive( date, tz );
+	return toLocalTZ( value, timezone ?? reportingTimeZone() );
 }
 
 /** TZ-aware Date -> ISO with offset `YYYY-MM-DDTHH:mm:ss.SSSxxx`. */
-export function dateToISOStringWithLocalTZ( date: Date, timezone?: string ): string {
-	const tz = timezone ?? siteTimeZone();
-	return _toISOWithTZ( date, tz );
+export function dateToISOStringWithLocalTZ( date: Date ): string {
+	return _toISOWithTZ( date, reportingTimeZone() );
 }

--- a/projects/packages/premium-analytics/packages/data/src/utils/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { localTZDate, dateToISOStringWithLocalTZ, formatToTimezoneNaiveString } from './date';
+export { localTZDate, dateToISOStringWithLocalTZ } from './date';
 export {
 	getApiErrorCode,
 	getApiErrorStatus,

--- a/projects/packages/premium-analytics/packages/data/src/utils/preset-date-range.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/preset-date-range.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { computePrimaryRange, siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { computePrimaryRange, reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { dateToISOStringWithLocalTZ } from './date';
 import type { ComputablePresetId } from '@jetpack-premium-analytics/datetime';
 
@@ -13,7 +13,7 @@ import type { ComputablePresetId } from '@jetpack-premium-analytics/datetime';
 export function computeDateRangeFromPreset(
 	presetId: ComputablePresetId
 ): { from: string; to: string } | undefined {
-	const range = computePrimaryRange( presetId, siteTimeZone() );
+	const range = computePrimaryRange( presetId, reportingTimeZone() );
 	if ( ! range?.from || ! range?.to ) {
 		return undefined;
 	}

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -11,7 +11,7 @@ for analytics widgets and date-range pickers.
 
 ### Timezone Utilities
 
-#### `createTZDateFromParts( dateParts: number[], timezone? )`
+#### `createTZDateFromParts( parts: number[], timezone? )`
 
 Creates a timezone-aware date in the specified timezone using the provided date parts.
 **Important:** Months are zero-based (0 = January, 11 = December).
@@ -23,18 +23,23 @@ const date = createTZDateFromParts( [ 2025, 9, 9 ], 'America/New_York' );
 
 **Parameters:**
 
-- `dateParts` : `number[]` - Date value to convert
+- `parts` : `number[]` - Wall-clock parts to convert
 - `timezone` (optional): `string` - Target timezone, default is GMT
 
 **Returns:** `TZDate` - Timezone-aware date object
 
-#### `siteTimeZone()`
+#### `reportingTimeZone()`
 
-The site's timezone, as an identifier `Intl` accepts. Reads the WordPress
-date settings that ship with the page, so it needs no await.
+The timezone reports are read in, as an identifier `Intl` accepts. Today that
+is the site's own timezone, read from the WordPress date settings that ship
+with the page, so it needs no await.
+
+Every layer asks here — request dates, bucket anchoring, display — so moving
+reports off the site's zone stays a one-line change. Nothing outside this
+package reads the site timezone directly.
 
 ```typescript
-siteTimeZone(); // 'America/New_York', or '+05:30' on an offset-configured site
+reportingTimeZone(); // 'America/New_York', or '+05:30' on an offset-configured site
 ```
 
 **Returns:** `string` - An IANA zone name, or a `±HH:MM` offset

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/reporting-time-zone.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/reporting-time-zone.test.ts
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { getSettings, setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { reportingTimeZone } from '../reporting-time-zone';
+
+/** The package defaults before tests override them. */
+const DEFAULTS = getSettings();
+
+const siteOn = ( timezone: { offset: number; string: string } ) =>
+	setSettings( {
+		...DEFAULTS,
+		timezone: { ...timezone, offsetFormatted: String( timezone.offset ), abbr: '' },
+	} );
+
+describe( 'reportingTimeZone', () => {
+	it( 'reports in the site timezone', () => {
+		siteOn( { offset: 9, string: 'Asia/Tokyo' } );
+
+		expect( reportingTimeZone() ).toBe( 'Asia/Tokyo' );
+	} );
+
+	it( 'reports in the site offset when the site has no named zone', () => {
+		siteOn( { offset: 5.5, string: '' } );
+
+		expect( reportingTimeZone() ).toBe( '+05:30' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/tz.test.ts
@@ -5,7 +5,7 @@ import { format } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { toLocalTZ } from '../tz';
+import { formatToTimezoneNaiveString, toLocalTZ } from '../tz';
 
 /**
  * The calendar day and clock time the value resolves to in its own zone.
@@ -151,5 +151,17 @@ describe( 'toLocalTZ', () => {
 
 		expect( now ).toBeGreaterThanOrEqual( before );
 		expect( now ).toBeLessThanOrEqual( Date.now() );
+	} );
+} );
+
+describe( 'formatToTimezoneNaiveString', () => {
+	it( 'writes an instant as the wall time it names in the zone', () => {
+		expect(
+			formatToTimezoneNaiveString( new Date( '2026-06-29T13:30:00Z' ), 'America/New_York' )
+		).toBe( '2026-06-29T09:30:00.000' );
+	} );
+
+	it( 'refuses an invalid date', () => {
+		expect( () => formatToTimezoneNaiveString( new Date( NaN ), 'America/New_York' ) ).toThrow();
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/datetime/src/bucket-start.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/bucket-start.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { siteTimeZone } from './site-time-zone';
+import { reportingTimeZone } from './reporting-time-zone';
 import { readSiteTimestamp } from './site-timestamp';
 import { createTZDateFromParts } from './tz';
 
@@ -25,7 +25,7 @@ export function parseBucketStart( value: unknown ): Date | undefined {
 		return undefined;
 	}
 
-	const date = createTZDateFromParts( timestamp.parts, siteTimeZone() );
+	const date = createTZDateFromParts( timestamp.parts, reportingTimeZone() );
 
 	return isNaN( date.getTime() ) ? undefined : date;
 }

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -30,7 +30,7 @@ export { parseSiteDateTime } from './site-datetime';
 
 export { readSiteTimestamp, type SiteTimestamp, type TimestampParts } from './site-timestamp';
 
-export { siteTimeZone } from './site-time-zone';
+export { reportingTimeZone } from './reporting-time-zone';
 
 export {
 	formatDatePartWithTime,

--- a/projects/packages/premium-analytics/packages/datetime/src/reporting-time-zone.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/reporting-time-zone.ts
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { siteTimeZone } from './site-time-zone';
+
+/**
+ * The timezone Premium Analytics reports in.
+ *
+ * The single place that decision is made, so moving reports off the site's own
+ * zone stays a one-line change instead of a hunt across every layer.
+ *
+ * @return An IANA zone name, or a `±HH:MM` offset.
+ */
+export function reportingTimeZone(): string {
+	return siteTimeZone();
+}

--- a/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/site-datetime.ts
@@ -1,18 +1,15 @@
 /**
- * External dependencies
- */
-import { getDate } from '@wordpress/date';
-/**
  * Internal dependencies
  */
+import { reportingTimeZone } from './reporting-time-zone';
 import { readSiteTimestamp } from './site-timestamp';
+import { toLocalTZ } from './tz';
 
 /**
- * Parse a timestamp in the WordPress site timezone.
+ * Parse a timestamp in the timezone reports are read in.
  *
- * `getDate` anchors offset-less Stats API values to the WordPress site timezone
- * while preserving the instant of offset-bearing values. It shares `toLocalTZ`'s
- * reading of validity, so the two cannot disagree.
+ * Offset-less Stats API values are anchored to that zone; offset-bearing ones
+ * already name an instant and keep it.
  *
  * @param value - The raw timestamp, or a `Date`.
  * @return The instant, or `undefined` when the value is missing or malformed.
@@ -32,7 +29,8 @@ export function parseSiteDateTime( value: unknown ): Date | undefined {
 		return undefined;
 	}
 
-	const parsed = getDate( timestamp.value );
+	const parsed = toLocalTZ( timestamp.value, reportingTimeZone() );
 
-	return isNaN( parsed.getTime() ) ? undefined : parsed;
+	// A plain `Date`, so callers keep reading its parts in their own zone as they did.
+	return isNaN( parsed.getTime() ) ? undefined : new Date( parsed.getTime() );
 }

--- a/projects/packages/premium-analytics/packages/datetime/src/tz.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/tz.ts
@@ -65,23 +65,13 @@ function wallPartsToTimestamp( parts: number[], timeZone: string ): number {
 /**
  * Build a TZDate from `DateParts` in the given timezone, UTC when omitted.
  *
- * @param root0
- * @param root0."0"
- * @param root0."1"
- * @param root0."2"
- * @param root0."3"
- * @param root0."4"
- * @param root0."5"
- * @param root0."6"
- * @param timeZone
+ * @param parts    - Wall-clock parts, `[ year, month, ...rest ]` as `Date.UTC` reads them.
+ * @param timeZone - The timezone the wall time belongs to.
+ * @return The zoned date.
  */
-export function createTZDateFromParts(
-	[ year, month, day, hours, minutes, seconds, milliseconds ]: DateParts,
-	timeZone?: string
-): TZDate {
+export function createTZDateFromParts( parts: DateParts, timeZone?: string ): TZDate {
 	const tzid = timeZone ?? '+00:00';
-
-	const dateParts = [ year, month, day, hours, minutes, seconds, milliseconds ];
+	const dateParts: ( number | undefined )[] = [ ...parts ];
 
 	// Trim until first undefined, to match one of the DateParts types.
 	const idx = dateParts.indexOf( undefined );

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -18,7 +18,7 @@ import {
 	isPrimaryPreset,
 	QUICK_SURFACE_PRESETS,
 	type QuickSurfacePresetId,
-	siteTimeZone,
+	reportingTimeZone,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
@@ -205,7 +205,7 @@ function ReportParamsControl( {
 				patch.from = encodeDateToSearchParam( nextRange.from );
 				patch.to = encodeDateToSearchParam(
 					// The site's day boundary, not the visitor's (see build-range-patch).
-					endOfDayTZ( nextRange.to, siteTimeZone() )
+					endOfDayTZ( nextRange.to, reportingTimeZone() )
 				);
 			}
 
@@ -295,7 +295,7 @@ function ReportParamsControl( {
 				onApply={ commit }
 				canApply={ isDateRangeDirty }
 				onCancel={ revert }
-				timeZone={ siteTimeZone() }
+				timeZone={ reportingTimeZone() }
 				presetIds={ presetIds }
 				withIntervalControl={ withIntervalControl }
 				interval={ interval }

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -99,6 +99,25 @@ describe( 'formatDate', () => {
 
 		expect( formatDate( JUNE_21, 'dateTime' ) ).toBe( 'June 21, 2025 12:00 am' );
 	} );
+
+	it( 'renders the calendar day the instant falls on in the reporting timezone', () => {
+		setSettings( {
+			...EN_US_SETTINGS,
+			timezone: { offset: -4, offsetFormatted: '-4', string: 'America/New_York', abbr: 'EDT' },
+		} );
+
+		// 22:00 the evening before, in New York.
+		expect( formatDate( new Date( '2025-06-21T02:00:00Z' ), 'medium' ) ).toBe( 'June 20, 2025' );
+	} );
+
+	it( 'renders in a site zone configured as a bare offset', () => {
+		setSettings( {
+			...EN_US_SETTINGS,
+			timezone: { offset: 5.5, offsetFormatted: '5.5', string: '', abbr: '' },
+		} );
+
+		expect( formatDate( new Date( '2025-06-20T20:00:00Z' ), 'medium' ) ).toBe( 'June 21, 2025' );
+	} );
 } );
 
 describe( 'formatMondayFirstWeekday', () => {

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { getSettings } from '@wordpress/date';
 /**
  * Internal dependencies
@@ -111,7 +111,7 @@ function buildRangeFormatter( name: RangeFormatName ): Intl.DateTimeFormat | und
 	try {
 		formatter = new Intl.DateTimeFormat( locale, {
 			...RANGE_PARTS[ name ],
-			timeZone: siteTimeZone(),
+			timeZone: reportingTimeZone(),
 		} );
 	} catch {
 		// An unusable locale, or an offset identifier this runtime will not take
@@ -163,7 +163,7 @@ export function elideRange(
 	}
 
 	const settings = getSettings();
-	const key = `${ settings.l10n.locale }|${ settings.formats.date }|${ siteTimeZone() }`;
+	const key = `${ settings.l10n.locale }|${ settings.formats.date }|${ reportingTimeZone() }`;
 	const cached = cache.get( name );
 
 	if ( cached?.key !== key ) {

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { dateI18n, getSettings } from '@wordpress/date';
 /**
  * Internal dependencies
@@ -84,7 +85,7 @@ function formatFor( name: DateFormatName ): string {
 }
 
 /**
- * Format a date in the site's locale and timezone.
+ * Format a date in the site's locale and the reporting timezone.
  *
  * Month and weekday names come from WordPress's translation tables and the
  * ordering from `date_format`, so dates match wp-admin rather than the browser.
@@ -94,7 +95,7 @@ function formatFor( name: DateFormatName ): string {
  * @return The formatted date.
  */
 export const formatDate = ( date: DateInput, name: DateFormatName = 'medium' ): string =>
-	dateI18n( formatFor( name ), date );
+	dateI18n( formatFor( name ), date, reportingTimeZone() );
 
 /**
  * Return a full weekday name in the site's locale.

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/build-range-patch.test.ts
@@ -1,11 +1,11 @@
 /**
- * Pin the site timezone to UTC for deterministic day-bound math. Stubs
- * `siteTimeZone()` directly rather than the `datetime` barrel: the interval
+ * Pin the reporting timezone to UTC for deterministic day-bound math. Stubs
+ * `reportingTimeZone()` directly rather than the `datetime` barrel: the interval
  * rules import `localTZDate` via a relative path a barrel stub can't reach.
  */
 jest.mock( '@jetpack-premium-analytics/datetime', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/datetime' ),
-	siteTimeZone: () => '+00:00',
+	reportingTimeZone: () => '+00:00',
 } ) );
 /**
  * External dependencies

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
@@ -5,7 +5,7 @@ import { resolveIntervalForRange, type ReportQueryParams } from '@jetpack-premiu
 import {
 	endOfDayTZ,
 	isSelectablePreset,
-	siteTimeZone,
+	reportingTimeZone,
 	type ComparisonPresetId,
 	type DateRange,
 	type PrimaryPresetId,
@@ -76,7 +76,7 @@ export function buildRangePatch( {
 		const rangeTo = encodeDateToSearchParam(
 			exactRange || isSelectablePreset( nextPresetId )
 				? nextRange.to
-				: endOfDayTZ( nextRange.to, siteTimeZone() )
+				: endOfDayTZ( nextRange.to, reportingTimeZone() )
 		);
 		patch.from = rangeFrom;
 		patch.to = rangeTo;

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/use-report-date-filters.tsx
@@ -9,7 +9,7 @@ import {
 import {
 	drillDateRange,
 	PRESET_CUSTOM,
-	siteTimeZone,
+	reportingTimeZone,
 	stepDateRange,
 	toLocalTZ,
 } from '@jetpack-premium-analytics/datetime';
@@ -133,7 +133,7 @@ export function useReportDateFilters< TFrom extends string >( from?: TFrom ): Re
 		TFrom
 	>( { from } );
 
-	const timeZone = siteTimeZone();
+	const timeZone = reportingTimeZone();
 
 	const presetId = useMemo( () => effective.preset ?? undefined, [ effective.preset ] );
 	const range = useMemo(

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/__tests__/derive-comparison-range.test.ts
@@ -4,14 +4,14 @@
  * so the anchoring under test is the production one.
  */
 jest.mock( '@jetpack-premium-analytics/data', () => {
-	const { toLocalTZ, dateToISOStringWithTZ, siteTimeZone } = jest.requireActual(
+	const { toLocalTZ, dateToISOStringWithTZ, reportingTimeZone } = jest.requireActual(
 		'@jetpack-premium-analytics/datetime'
 	);
 	return {
 		localTZDate: ( value?: number | string | Date, timezone?: string ) =>
-			toLocalTZ( value, timezone ?? siteTimeZone() ),
+			toLocalTZ( value, timezone ?? reportingTimeZone() ),
 		dateToISOStringWithLocalTZ: ( date: Date, timezone?: string ) =>
-			dateToISOStringWithTZ( date, timezone ?? siteTimeZone() ),
+			dateToISOStringWithTZ( date, timezone ?? reportingTimeZone() ),
 	};
 } );
 /**

--- a/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/comparison/derive-comparison-range.ts
@@ -9,7 +9,7 @@ import {
 import {
 	getComparisonOptions,
 	isComparisonPresetId,
-	siteTimeZone,
+	reportingTimeZone,
 	type ComparisonPresetId,
 } from '@jetpack-premium-analytics/datetime';
 
@@ -54,7 +54,7 @@ export function deriveComparisonRange( opts: ReportParams ):
 	 * site zone here too — a raw instant would put a date-only deep link on UTC
 	 * midnight, a different calendar day than the picker shows.
 	 */
-	const timezone = siteTimeZone();
+	const timezone = reportingTimeZone();
 	const reference = {
 		from: localTZDate( opts.from, timezone ),
 		to: localTZDate( opts.to, timezone ),

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { siteTimeZone, toLocalTZ } from '@jetpack-premium-analytics/datetime';
+import { reportingTimeZone, toLocalTZ } from '@jetpack-premium-analytics/datetime';
 import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { __, sprintf } from '@wordpress/i18n';
 import { format } from 'date-fns';
@@ -106,7 +106,7 @@ function formatPublishDate( date: string ): string {
 
 	// Read the instant in the site's zone: a plain `Date` would format in the
 	// visitor's, showing a late-evening post on the next day east of the site.
-	const parsed = toLocalTZ( date, siteTimeZone() );
+	const parsed = toLocalTZ( date, reportingTimeZone() );
 	const formatted = Number.isNaN( parsed.getTime() ) ? date : format( parsed, 'PP' );
 
 	return sprintf(

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/site-chart-formatting.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/site-chart-formatting.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { siteTimeZone } from '@jetpack-premium-analytics/datetime';
+import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { intlLocale } from '@jetpack-premium-analytics/formatters';
 
 /**
@@ -10,5 +10,5 @@ import { intlLocale } from '@jetpack-premium-analytics/formatters';
  * @return The formatting context.
  */
 export function siteChartFormatting() {
-	return { locale: intlLocale(), timeZone: siteTimeZone() };
+	return { locale: intlLocale(), timeZone: reportingTimeZone() };
 }

--- a/projects/packages/premium-analytics/routes/detail-header.ts
+++ b/projects/packages/premium-analytics/routes/detail-header.ts
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { format, isValid } from 'date-fns';
 import {
 	parseSiteDateTime,
-	siteTimeZone,
+	reportingTimeZone,
 	toLocalTZ,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
@@ -23,7 +23,7 @@ const DATE_FORMAT = 'MMM d, yyyy';
 export function formatPublishedDate( publishedDate: string | undefined ): string | undefined {
 	const parsed = parseSiteDateTime( publishedDate );
 
-	return parsed ? format( toLocalTZ( parsed, siteTimeZone() ), DATE_FORMAT ) : undefined;
+	return parsed ? format( toLocalTZ( parsed, reportingTimeZone() ), DATE_FORMAT ) : undefined;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/__tests__/annual-highlights.test.tsx
@@ -38,7 +38,7 @@ const mockApiFetch = apiFetch as unknown as jest.Mock;
 
 // Built relative to today: hardcoded years would silently move the no-attribute
 // default off the data after New Year. The package test script pins TZ=UTC, which
-// is what the widget's `siteTimeZone()` also resolves to under jsdom.
+// is what the widget's `reportingTimeZone()` also resolves to under jsdom.
 const CURRENT_YEAR = new Date().getFullYear();
 const PREVIOUS_YEAR = CURRENT_YEAR - 1;
 

--- a/projects/packages/premium-analytics/widgets/annual-highlights/years.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/years.ts
@@ -10,7 +10,7 @@ import {
 	PRESET_ALL_TIME,
 	getPresetYear,
 	getYearSurfacePresets,
-	siteTimeZone,
+	reportingTimeZone,
 	toLocalTZ,
 	type YearPresetId,
 } from '@jetpack-premium-analytics/datetime';
@@ -43,7 +43,7 @@ function findStartYear( data: StatsInsightsResponse | undefined ): number | unde
 export async function getYearElements(): Promise< Option[] > {
 	const data = await queryClient.fetchQuery( statsInsightsQuery() ).catch( () => undefined );
 
-	return getYearSurfacePresets( siteTimeZone(), { startYear: findStartYear( data ) } )
+	return getYearSurfacePresets( reportingTimeZone(), { startYear: findStartYear( data ) } )
 		.filter( preset => preset.id !== PRESET_ALL_TIME )
 		.map( preset => ( { value: preset.id, label: preset.label } ) );
 }
@@ -53,5 +53,5 @@ export async function getYearElements(): Promise< Option[] > {
  * reads as the current year, which the dropdown lists first.
  */
 export function resolveSelectedYear( year: YearPresetId | undefined ): number {
-	return getPresetYear( year ) ?? toLocalTZ( undefined, siteTimeZone() ).getFullYear();
+	return getPresetYear( year ) ?? toLocalTZ( undefined, reportingTimeZone() ).getFullYear();
 }


### PR DESCRIPTION
Fixes WOOA7S-1978

## Proposed changes
* Add `reportingTimeZone()` and stop exporting `siteTimeZone` from the `datetime` barrel, so nothing outside that package can ask the site directly.
* Point the 18 existing call sites at it — request dates, bucket anchoring, display.
* Close two readers that bypassed it entirely: `parseSiteDateTime()` (through `@wordpress/date`'s `getDate()`) and `formatDate()` (through `dateI18n()` with no zone argument).
* Delete the dead `formatToTimezoneNaiveString` wrapper in `data` and the never-passed `timezone` argument on `dateToISOStringWithLocalTZ`, moving the wrapper's coverage to `datetime`.
* Replace `createTZDateFromParts`'s generated `@param root0."0"`…`"6"` docblock by dropping the signature destructuring that forced it.

No behaviour change: `reportingTimeZone()` returns `siteTimeZone()` today. What it buys is that moving reports off the site's own zone becomes a one-line change instead of a hunt across 20 call sites.

## Related product discussion/links
* WOOA7S-1978

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Automated, from `projects/packages/premium-analytics`:

* `pnpm run test` — the package suite passes unchanged.
* `pnpm run test-tz` — the timezone-sensitive suites pass under `America/Los_Angeles` and `Asia/Tokyo`.
* `pnpm run typecheck`.

Manual, to confirm nothing moved:

* Set the site's timezone (Settings → General) to somewhere far from your own, e.g. `Pacific/Auckland`.
* Open the Premium Analytics dashboard and compare against trunk: chart labels and axis ticks, the date-range picker and its comparison ranges, Most popular day, Posting activity, and post publish dates on the detail pages should all read in the site's timezone, exactly as before.
