### PR TITLE
AI Hub: rename the MCP Settings tab to MCP and Connectors

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -1,9 +1,9 @@
 /**
  * Root component for the Jetpack AI admin page.
  *
- * Four top-level tabs (Overview | AI Features | Scheduled tasks | MCP Settings) with hash-based
- * routing. The MCP tab owns the read | write | setup sub-views, which render
- * with breadcrumbs in place of the tab bar.
+ * Four top-level tabs (Overview | AI Features | Scheduled tasks | MCP and Connectors)
+ * with hash-based routing. The MCP tab owns the read | write | setup sub-views,
+ * which render with breadcrumbs in place of the tab bar.
  *
  * Overview and AI Features share an internal-testing gate. Scheduled tasks
  * is controlled independently by the ai-hub-scheduled-tasks server-side feature
@@ -35,7 +35,7 @@ const SETTINGS_REF = 'jetpack-ai-mcp-settings';
 
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 
-// Views that only exist in internal testing environments. MCP Settings ships
+// Views that only exist in internal testing environments. MCP and Connectors ships
 // publicly, so it is not in here.
 const GATED_VIEWS = [ 'overview', 'features' ];
 
@@ -64,7 +64,7 @@ const VIEW_TITLES = {
 	overview: __( 'Overview', 'jetpack' ),
 	features: __( 'AI Features', 'jetpack' ),
 	'scheduled-tasks': __( 'Scheduled tasks', 'jetpack' ),
-	mcp: __( 'MCP Settings', 'jetpack' ),
+	mcp: __( 'MCP and Connectors', 'jetpack' ),
 	read: __( 'Read', 'jetpack' ),
 	write: __( 'Write', 'jetpack' ),
 	setup: __( 'Connect external AI agent', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -1,5 +1,5 @@
 /**
- * MCP Settings hub — main view shown at wp-admin/admin.php?page=jetpack-ai.
+ * MCP and Connectors hub — main view shown at wp-admin/admin.php?page=jetpack-ai.
  * Shows the enable/disable toggle and navigation to Read, Write, and Setup sub-views.
  */
 

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -460,7 +460,7 @@ describe( 'AI admin page (main.jsx)', () => {
 
 		// No Features UI and no tab bar (a single tab renders no tabs at all).
 		expect( screen.queryByText( 'AI Features' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'MCP Settings' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'MCP and Connectors' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Writing Assistant/ } )
 		).not.toBeInTheDocument();
@@ -500,7 +500,7 @@ describe( 'AI admin page (main.jsx)', () => {
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Overview' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'AI Features' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'MCP Settings' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'MCP and Connectors' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Writing Assistant/ } )
 		).not.toBeInTheDocument();

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-mcp-tab-name
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-hub-mcp-tab-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: AI Hub: rename the "MCP Settings" tab to "MCP and Connectors". The tab has not shipped in a stable release, so there is nothing for users to be told about.
+


### PR DESCRIPTION
## Proposed changes

* Renames the Jetpack AI Hub's **MCP Settings** tab to **MCP and Connectors**. Label only — the tab's contents, the `#/mcp` route and the Read / Write / Connect sub-pages are untouched.

The name is not settled. JETPACK-1912 renames this tab to "Agent access" per the i2 designs, and "External AI Apps" was proposed on the UX post. This PR carries the name agreed in the release thread; it is one string, so say the word and I'll change it here.

## Related product discussion/links

* JETPACK-1912 — Build the Agent access page (renamed from MCP)
* p1HpG7-yDZ-p2 — tab-name discussion, comment 78544 onward

## Does this pull request change what data or activity we track or use?

No. The Tracks `ref` stays `jetpack-ai-mcp-settings`, so event continuity is preserved.

## Testing instructions

* Go to **Jetpack → Jetpack AI** on an Atomic or self-hosted site, proxied.
* The third tab reads **MCP and Connectors**. Nothing on the tab itself changes.
* Open it, then a sub-page (Read, Write, Connect) and go back — all still work, and `#/mcp` still lands here.
