### PR TITLE
Premium Analytics: keep the date picker on the range a chart drill-down applies

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2064-date-picker-drill-down
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2064-date-picker-drill-down
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the date picker on the range a chart drill-down applies.

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -630,6 +630,28 @@ describe( 'useReportDateFilters', () => {
 				to: '2026-07-26T23:59:59.999Z',
 			} );
 		} );
+
+		it( 'leaves the calendar on the drilled window when the picker closes after the drill', () => {
+			const { result, rerender } = renderDateFilters( {
+				from: '2026-07-01T00:00:00.000Z',
+				to: '2026-07-30T23:59:59.999Z',
+				preset: 'last-30-days',
+				interval: 'day',
+			} );
+
+			// The popover's queued close calls the handler from before the drill.
+			const cancelBeforeDrill = result.current.onCancel;
+
+			act( () => result.current.drillDown( new Date( '2026-07-21T13:45:00.000Z' ) ) );
+			rerender();
+
+			act( () => cancelBeforeDrill() );
+			rerender();
+
+			expect( result.current.range.from?.toISOString() ).toBe( '2026-07-21T00:00:00.000Z' );
+			expect( result.current.range.to?.toISOString() ).toBe( '2026-07-21T23:59:59.999Z' );
+			expect( result.current.presetId ).toBe( 'custom' );
+		} );
 	} );
 
 	it( 'steps a to-date preset by whole months and compares it with the months before', () => {

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/__tests__/use-report-date-filters.test.tsx
@@ -639,14 +639,12 @@ describe( 'useReportDateFilters', () => {
 				interval: 'day',
 			} );
 
-			// The popover's queued close calls the handler from before the drill.
 			const cancelBeforeDrill = result.current.onCancel;
 
 			act( () => result.current.drillDown( new Date( '2026-07-21T13:45:00.000Z' ) ) );
 			rerender();
 
 			act( () => cancelBeforeDrill() );
-			rerender();
 
 			expect( result.current.range.from?.toISOString() ).toBe( '2026-07-21T00:00:00.000Z' );
 			expect( result.current.range.to?.toISOString() ).toBe( '2026-07-21T23:59:59.999Z' );

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
@@ -195,6 +195,17 @@ describe( 'useStagedValue', () => {
 		expect( result.current.staged ).toBe( before );
 	} );
 
+	// The same rule on the path the picker takes most: it cancels on every close,
+	// staged or not, and a draft rebuilt each time would re-render every widget.
+	it( 'leaves the draft alone when reverting with nothing staged', () => {
+		const { result } = renderStagedValue();
+		const before = result.current.staged;
+
+		act( () => result.current.revert() );
+
+		expect( result.current.staged ).toBe( before );
+	} );
+
 	// Clearing a key staged earlier in the same draft is the same no-op reached
 	// the long way round: the draft is back to the committed value, so Apply
 	// must go back to disabled rather than commit an unchanged URL.

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/__tests__/use-staged-value.test.tsx
@@ -120,6 +120,20 @@ describe( 'useStagedValue', () => {
 		expect( commits ).toHaveLength( 0 );
 	} );
 
+	// The picker's queued close calls the `revert` from before the drill's commit.
+	it( 'reverts to the committed value the store holds now, not the one it held', () => {
+		const { result } = renderStagedValue();
+
+		const revertFromBeforeTheCommit = result.current.revert;
+
+		act( () => result.current.stage( { preset: 'custom', interval: 'hour' } ) );
+		act( () => result.current.commit() );
+		act( () => revertFromBeforeTheCommit() );
+
+		expect( result.current.staged ).toEqual( { preset: 'custom', interval: 'hour' } );
+		expect( result.current.isDirty ).toBe( false );
+	} );
+
 	// Without this the next commit puts the stale draft back over the change.
 	it( 'realigns the draft on a value arriving from outside', () => {
 		const { result, writeFromOutside } = renderStagedValue();

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
@@ -79,25 +79,28 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 ): UseStagedValueReturn< TValue, TCommitOptions > {
 	/*
 	 * The draft is a patch over the store, never a copy of it: a `revert` queued
-	 * before a commit lands would write the pre-commit value back over the
-	 * realign below, which only fires while `committed` changes (WOOA7S-2064).
+	 * before a commit lands must not write the pre-commit value back (WOOA7S-2064).
 	 */
 	const [ patch, setPatch ] = useState< Partial< TValue > >( {} );
 
 	/*
 	 * A control can stage and commit in the same tick — `DatePeriodDropdown` does
-	 * that to apply a quick preset — so `commit` reads these refs, not the state
-	 * React has only queued, which would leave the store a click behind.
+	 * that to apply a quick preset — so `stage` and `commit` read the patch from a
+	 * ref, not the state React has only queued, which would leave the store a
+	 * click behind.
 	 */
-	const patchRef = useRef< Partial< TValue > >( patch );
+	const patchRef = useRef< Partial< TValue > >( {} );
+
+	// Those callbacks hold no `committed` dep, so they read it here. Writing this
+	// during render is safe: the realign below never reads it.
 	const committedRef = useRef< TValue >( committed );
 	committedRef.current = committed;
 
 	/*
-	 * Drop the draft when a committed value arrives from outside, or the next
-	 * commit puts it back over the change. Held in state, not a ref: React may
-	 * run this render twice and throw the first away, and a ref written during
-	 * the discarded pass would swallow the realign it just decided on.
+	 * Realign when a committed value arrives from outside; otherwise the next
+	 * commit puts the stale draft back over it. Held in state, not a ref: React
+	 * may run this render twice and throw the first away, and a ref written
+	 * during the discarded pass would swallow the realign it just decided on.
 	 */
 	const [ lastCommitted, setLastCommitted ] = useState< TValue >( committed );
 	if ( ! sameValues( lastCommitted, committed ) ) {

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-staged-value/use-staged-value.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 type AnyObject = Record< string, unknown >;
 
@@ -78,37 +78,45 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 	onCommit: ( staged: TValue, patch: Partial< TValue >, options?: TCommitOptions ) => void
 ): UseStagedValueReturn< TValue, TCommitOptions > {
 	/*
+	 * The draft is a patch over the store, never a copy of it: a `revert` queued
+	 * before a commit lands would write the pre-commit value back over the
+	 * realign below, which only fires while `committed` changes (WOOA7S-2064).
+	 */
+	const [ patch, setPatch ] = useState< Partial< TValue > >( {} );
+
+	/*
 	 * A control can stage and commit in the same tick — `DatePeriodDropdown` does
 	 * that to apply a quick preset — so `commit` reads these refs, not the state
 	 * React has only queued, which would leave the store a click behind.
 	 */
-	const stagedRef = useRef< TValue >( committed );
-	const patchRef = useRef< Partial< TValue > >( {} );
-	const [ staged, setStaged ] = useState< TValue >( committed );
+	const patchRef = useRef< Partial< TValue > >( patch );
+	const committedRef = useRef< TValue >( committed );
+	committedRef.current = committed;
 
 	/*
-	 * Realign when a committed value arrives from outside, or the next commit
-	 * puts the stale draft back over it. Held in state, not a ref: React may run
-	 * this render twice and throw the first away, and a ref written during the
-	 * discarded pass would swallow the realign it just decided on.
+	 * Drop the draft when a committed value arrives from outside, or the next
+	 * commit puts it back over the change. Held in state, not a ref: React may
+	 * run this render twice and throw the first away, and a ref written during
+	 * the discarded pass would swallow the realign it just decided on.
 	 */
 	const [ lastCommitted, setLastCommitted ] = useState< TValue >( committed );
 	if ( ! sameValues( lastCommitted, committed ) ) {
 		setLastCommitted( committed );
-		stagedRef.current = committed;
 		patchRef.current = {};
-		setStaged( committed );
+		setPatch( patchRef.current );
 	}
+
+	const staged = useMemo( () => ( { ...committed, ...patch } ), [ committed, patch ] );
 
 	/*
 	 * A patch that only clears keys the draft does not carry changes nothing, so
 	 * dropping it here keeps `commit` from pushing a history entry for a no-op.
 	 */
-	const stage = useCallback( ( patch: Partial< TValue > ) => {
+	const stage = useCallback( ( next: Partial< TValue > ) => {
+		const draft = { ...committedRef.current, ...patchRef.current } as AnyObject;
 		const changes = Object.fromEntries(
-			Object.entries( patch ).filter(
-				( [ key, value ] ) =>
-					value !== undefined || ( stagedRef.current as AnyObject )[ key ] !== undefined
+			Object.entries( next ).filter(
+				( [ key, value ] ) => value !== undefined || draft[ key ] !== undefined
 			)
 		) as Partial< TValue >;
 
@@ -116,9 +124,8 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 			return;
 		}
 
-		stagedRef.current = { ...stagedRef.current, ...changes };
 		patchRef.current = { ...patchRef.current, ...changes };
-		setStaged( stagedRef.current );
+		setPatch( patchRef.current );
 	}, [] );
 
 	const commit = useCallback(
@@ -127,16 +134,19 @@ export function useStagedValue< TValue extends AnyObject, TCommitOptions = void 
 				return;
 			}
 
-			onCommit( stagedRef.current, patchRef.current, options );
+			onCommit( { ...committedRef.current, ...patchRef.current }, patchRef.current, options );
 		},
 		[ onCommit ]
 	);
 
 	const revert = useCallback( () => {
-		stagedRef.current = committed;
+		if ( Object.keys( patchRef.current ).length === 0 ) {
+			return;
+		}
+
 		patchRef.current = {};
-		setStaged( committed );
-	}, [ committed ] );
+		setPatch( patchRef.current );
+	}, [] );
 
 	const isDirty = Object.keys( patchRef.current ).length > 0 && ! sameValues( staged, committed );
 

--- a/projects/plugins/jetpack/changelog/wooa7s-2064-date-picker-drill-down
+++ b/projects/plugins/jetpack/changelog/wooa7s-2064-date-picker-drill-down
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Keep the date picker on the range a chart drill-down applies.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2064-date-picker-drill-down
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2064-date-picker-drill-down
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the date picker on the range a chart drill-down applies.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2064-date-picker-drill-down
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2064-date-picker-drill-down
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Keep the date picker on the range a chart drill-down applies.


### PR DESCRIPTION
Fixes WOOA7S-2064

## Proposed changes

* `useStagedValue` holds the draft as a patch over the store rather than a copy of it, so `staged` is derived from the current `committed` on every render.
* `revert` clears that patch instead of writing back the value it saw, and no-ops when nothing is staged.
* `commit` and `stage` build the draft from the committed value at call time, so neither acts on a snapshot the store has moved past.

The chart drills on its own `useReportDateFilters` instance, so it commits the drilled range while the header's instance still holds the pre-drill one. The popover closes on a queued focus-outside check, and its `onCancel` lands in that window: the old `revert` copied the value it could see, still pre-drill, into the staged state, and that write was applied after the realign had already taken the new range. `lastCommitted` was current by then, so the realign never fired again. Holding a patch removes the ordering hazard, since a late revert can only write an empty one.

## Related product discussion/links

* Linear: WOOA7S-2064
* Pre-existing, found in #51842

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Build the dashboard: `jetpack build --deps packages/premium-analytics`.

* Open a surface with a chart (Traffic) on a drillable window, e.g. 30 days at a daily interval.
* Open the period dropdown and leave it open.
* Click a bar in the chart. The chart and the widgets narrow to that day.
* Reopen the dropdown: the calendar shows the drilled day, not the previous 30 days.
* Drill with the dropdown closed, then open it: same result, as before.
* Change a period from the menu, and Apply and Cancel a custom range: all unchanged.

The interleaving that produces the bug is React scheduling between a queued revert and a render-phase realign, which jsdom does not reproduce, so the unit tests cover the invariants and the videos below cover the behaviour.

Before:

https://github.com/user-attachments/assets/8efa9711-8eef-4d18-a2d2-ff71ba700b27

After:

https://github.com/user-attachments/assets/5cf1e600-0729-41ef-8488-1079b0203c15



