### PR TITLE
PayPal Payment Buttons: take the lowest price from the primary option group only

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-non-primary-option-price
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-non-primary-option-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Take the displayed price from the option group PayPal is actually pricing.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
@@ -65,6 +65,24 @@ class PayPal_Attribute_Mapper {
 	);
 
 	/**
+	 * Maximum number of option groups (variant dimensions) per product.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var int
+	 */
+	const MAX_VARIANT_DIMENSIONS = 5;
+
+	/**
+	 * Maximum number of options per option group.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var int
+	 */
+	const MAX_VARIANT_OPTIONS = 10;
+
+	/**
 	 * Maximum product name length.
 	 *
 	 * @var int
@@ -321,6 +339,15 @@ class PayPal_Attribute_Mapper {
 			);
 		}
 
+		// Anything sanitize_variants() would drop must be rejected here instead,
+		// or the pricing checks below run against options PayPal never receives.
+		if ( ! empty( $attributes['variantsEnabled'] ) && ! empty( $attributes['variants']['dimensions'] ) ) {
+			$variant_structure_error = self::validate_variant_structure( $attributes['variants'] );
+			if ( is_wp_error( $variant_structure_error ) ) {
+				return $variant_structure_error;
+			}
+		}
+
 		// Required: price — unless the product options carry their own prices,
 		// in which case PayPal takes the amount from the options instead.
 		$uses_variant_pricing = ! empty( $attributes['variantsEnabled'] )
@@ -513,6 +540,62 @@ class PayPal_Attribute_Mapper {
 	}
 
 	/**
+	 * Validate the shape of a variants structure.
+	 *
+	 * Mirrors what sanitize_variants() discards, so a save cannot pass
+	 * validation on options that are then dropped before reaching PayPal.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $variants Variants structure (block or API shape).
+	 * @return true|WP_Error True when valid, WP_Error otherwise.
+	 */
+	private static function validate_variant_structure( array $variants ) {
+		$dimensions = $variants['dimensions'] ?? array();
+
+		if ( ! is_array( $dimensions ) || count( $dimensions ) > self::MAX_VARIANT_DIMENSIONS ) {
+			return new WP_Error(
+				'too_many_variant_dimensions',
+				/* translators: %d: maximum number of option groups */
+				sprintf( __( 'A product can have at most %d option groups.', 'jetpack-paypal-payments' ), self::MAX_VARIANT_DIMENSIONS ),
+				array( 'status' => 400 )
+			);
+		}
+
+		foreach ( $dimensions as $dimension ) {
+			if ( ! is_array( $dimension ) || '' === trim( sanitize_text_field( (string) ( $dimension['name'] ?? '' ) ) ) ) {
+				return new WP_Error(
+					'missing_variant_name',
+					__( 'Every option group needs a name.', 'jetpack-paypal-payments' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$options = $dimension['options'] ?? array();
+			if ( ! is_array( $options ) || count( $options ) > self::MAX_VARIANT_OPTIONS ) {
+				return new WP_Error(
+					'too_many_variant_options',
+					/* translators: %d: maximum number of options per group */
+					sprintf( __( 'An option group can have at most %d options.', 'jetpack-paypal-payments' ), self::MAX_VARIANT_OPTIONS ),
+					array( 'status' => 400 )
+				);
+			}
+
+			foreach ( $options as $option ) {
+				if ( ! is_array( $option ) || '' === trim( sanitize_text_field( (string) ( $option['label'] ?? '' ) ) ) ) {
+					return new WP_Error(
+						'missing_variant_label',
+						__( 'Every product option needs a label.', 'jetpack-paypal-payments' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Validate per-option pricing.
 	 *
 	 * Per-option prices replace the product-level price, so they are
@@ -572,7 +655,7 @@ class PayPal_Attribute_Mapper {
 		$count                = 0;
 
 		foreach ( $variants['dimensions'] as $dimension ) {
-			if ( ++$count > 5 ) {
+			if ( ++$count > self::MAX_VARIANT_DIMENSIONS ) {
 				break;
 			}
 
@@ -588,7 +671,7 @@ class PayPal_Attribute_Mapper {
 
 			$option_count = 0;
 			foreach ( ( $dimension['options'] ?? array() ) as $option ) {
-				if ( ++$option_count > 10 ) {
+				if ( ++$option_count > self::MAX_VARIANT_OPTIONS ) {
 					break;
 				}
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-buttons.php
@@ -475,7 +475,10 @@ class PayPal_Payment_Buttons {
 	}
 
 	/**
-	 * Find the cheapest per-option price in a variants structure.
+	 * Find the cheapest per-option price in the primary dimension.
+	 *
+	 * PayPal only prices the primary dimension, so an amount left on any other
+	 * dimension is not a price a buyer can pay and must not become the headline.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -490,7 +493,7 @@ class PayPal_Payment_Buttons {
 		$lowest = null;
 
 		foreach ( $variants['dimensions'] as $dimension ) {
-			if ( empty( $dimension['options'] ) || ! is_array( $dimension['options'] ) ) {
+			if ( empty( $dimension['primary'] ) || empty( $dimension['options'] ) || ! is_array( $dimension['options'] ) ) {
 				continue;
 			}
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/paypal-button-preview.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/paypal-button-preview.jsx
@@ -20,7 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { CURRENCY_SYMBOLS } from './currency-symbols';
 import { withPartnerAttribution } from './partner-attribution';
 import PayPalLogo from './paypal-logo';
-import { hasVariantPricing } from './variant-builder';
+import { getPrimaryDimension, hasVariantPricing } from './variant-builder';
 
 /**
  * Format a price with currency symbol.
@@ -35,7 +35,10 @@ function formatPrice( priceValue, currencyCode ) {
 }
 
 /**
- * Find the cheapest per-option price across the variant dimensions.
+ * Find the cheapest per-option price in the primary option group.
+ *
+ * PayPal only prices the primary group, so an amount left on another group is
+ * not a price a buyer can pay and must not become the headline.
  *
  * @param {object} variants - Variants data with dimensions.
  * @return {string|null} The lowest option price, or null when none are priced.
@@ -43,16 +46,14 @@ function formatPrice( priceValue, currencyCode ) {
 function getLowestVariantPrice( variants ) {
 	let lowest = null;
 
-	( variants?.dimensions || [] ).forEach( dim => {
-		( dim.options || [] ).forEach( opt => {
-			const value = `${ opt.unit_amount?.value ?? '' }`.trim();
-			if ( value === '' || isNaN( parseFloat( value ) ) ) {
-				return;
-			}
-			if ( lowest === null || parseFloat( value ) < parseFloat( lowest ) ) {
-				lowest = value;
-			}
-		} );
+	( getPrimaryDimension( variants )?.options || [] ).forEach( opt => {
+		const value = `${ opt.unit_amount?.value ?? '' }`.trim();
+		if ( value === '' || isNaN( parseFloat( value ) ) ) {
+			return;
+		}
+		if ( lowest === null || parseFloat( value ) < parseFloat( lowest ) ) {
+			lowest = value;
+		}
 	} );
 
 	return lowest;

--- a/projects/packages/paypal-payments/tests/js/paypal-button-preview.test.jsx
+++ b/projects/packages/paypal-payments/tests/js/paypal-button-preview.test.jsx
@@ -158,4 +158,33 @@ describe( 'PayPalButtonPreview', () => {
 		);
 		expect( screen.getByText( '$9.99' ) ).toBeInTheDocument();
 	} );
+
+	it( 'ignores a price left on a non-primary option group', () => {
+		// PayPal only prices the primary group, so $5.00 is not a price a buyer can pay.
+		render(
+			<PayPalButtonPreview
+				{ ...defaultProps }
+				price=""
+				variantsEnabled
+				variants={ {
+					dimensions: [
+						{
+							name: 'Size',
+							primary: true,
+							options: [
+								{ label: 'Small', unit_amount: { currency_code: 'USD', value: '12.50' } },
+							],
+						},
+						{
+							name: 'Color',
+							primary: false,
+							options: [ { label: 'Red', unit_amount: { currency_code: 'USD', value: '5.00' } } ],
+						},
+					],
+				} }
+			/>
+		);
+		expect( screen.getByText( 'From $12.50' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'From $5.00' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
@@ -725,6 +725,118 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 		$this->assertEquals( 'invalid_variant_price', $result->get_error_code() );
 	}
 
+	/**
+	 * Test that an option group without a name is rejected.
+	 *
+	 * The sanitizer drops such a group, so accepting it would validate prices
+	 * PayPal never receives.
+	 */
+	public function test_validate_rejects_unnamed_option_group() {
+		$variants                          = $this->variants_with_prices( array( '10.00', '20.00' ) );
+		$variants['dimensions'][0]['name'] = ' ';
+
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => 'USD',
+				'variantsEnabled' => true,
+				'variants'        => $variants,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_variant_name', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that an option without a label is rejected.
+	 */
+	public function test_validate_rejects_unlabeled_option() {
+		$variants = $this->variants_with_prices( array( '10.00', '20.00' ) );
+		$variants['dimensions'][0]['options'][1]['label'] = '';
+
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => 'USD',
+				'variantsEnabled' => true,
+				'variants'        => $variants,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'missing_variant_label', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that more option groups than the sanitizer keeps are rejected.
+	 */
+	public function test_validate_rejects_too_many_option_groups() {
+		$variants = array( 'dimensions' => array() );
+		for ( $i = 0; $i <= PayPal_Attribute_Mapper::MAX_VARIANT_DIMENSIONS; $i++ ) {
+			$variants['dimensions'][] = array(
+				'name'    => 'Group ' . $i,
+				'primary' => 0 === $i,
+				'options' => array( array( 'label' => 'Option' ) ),
+			);
+		}
+
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'price'           => '29.99',
+				'currencyCode'    => 'USD',
+				'variantsEnabled' => true,
+				'variants'        => $variants,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'too_many_variant_dimensions', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that more options than the sanitizer keeps are rejected.
+	 */
+	public function test_validate_rejects_too_many_options() {
+		$variants = $this->variants_with_prices( array_fill( 0, PayPal_Attribute_Mapper::MAX_VARIANT_OPTIONS + 1, '10.00' ) );
+
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => 'USD',
+				'variantsEnabled' => true,
+				'variants'        => $variants,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'too_many_variant_options', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a well-formed non-primary option group is accepted.
+	 */
+	public function test_validate_accepts_named_and_labeled_option_groups() {
+		$variants                 = $this->variants_with_prices( array( '10.00', '20.00' ) );
+		$variants['dimensions'][] = array(
+			'name'    => 'Color',
+			'primary' => false,
+			'options' => array( array( 'label' => 'Red' ) ),
+		);
+
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => 'USD',
+				'variantsEnabled' => true,
+				'variants'        => $variants,
+			)
+		);
+
+		$this->assertTrue( $result );
+	}
+
 	// --- Constants ---
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
+++ b/projects/packages/paypal-payments/tests/php/Paypal_Payment_Buttons_Test.php
@@ -679,6 +679,61 @@ class Paypal_Payment_Buttons_Test extends TestCase {
 	}
 
 	/**
+	 * Test that a price left on a non-primary option never becomes the headline.
+	 *
+	 * PayPal only prices the primary group, so the $5.00 here is not a price a
+	 * buyer can pay.
+	 */
+	public function test_render_block_ignores_prices_on_non_primary_options() {
+		$attributes = array(
+			'isApiManaged'    => true,
+			'resourceId'      => 'PLB-VAR7',
+			'paymentLink'     => 'https://www.paypal.com/ncp/payment/PLB-VAR7',
+			'productName'     => 'Widget',
+			'price'           => '',
+			'currencyCode'    => 'USD',
+			'variantsEnabled' => true,
+			'variants'        => array(
+				'dimensions' => array(
+					array(
+						'name'    => 'Size',
+						'primary' => true,
+						'options' => array(
+							array(
+								'label'       => 'Small',
+								'unit_amount' => array(
+									'currency_code' => 'USD',
+									'value'         => '12.50',
+								),
+							),
+						),
+					),
+					array(
+						'name'    => 'Color',
+						'primary' => false,
+						'options' => array(
+							array(
+								'label'       => 'Red',
+								'unit_amount' => array(
+									'currency_code' => 'USD',
+									'value'         => '5.00',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$this->set_up_block_render_context( $attributes );
+
+		$result = PayPal_Payment_Buttons::render_block( $attributes, '' );
+
+		$this->assertStringContainsString( 'jetpack-paypal-button__product-price">From $12.50</span>', $result );
+		$this->assertStringNotContainsString( 'From $5.00', $result );
+	}
+
+	/**
 	 * Test that render_block keeps the product price when the options are off.
 	 *
 	 * Whether the options have prices is a separate question from whether they

--- a/projects/plugins/jetpack/changelog/fix-paypal-non-primary-option-price
+++ b/projects/plugins/jetpack/changelog/fix-paypal-non-primary-option-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payment Buttons: take the displayed price from the option group PayPal is actually pricing.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-non-primary-option-price
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-non-primary-option-price
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Take the displayed price from the option group PayPal is actually pricing.


### PR DESCRIPTION
Fixes WOOPTP-478

## Proposed changes

A product with two option groups could show a "From" price taken from the group PayPal is not pricing. `variants_have_pricing()` and `hasVariantPricing()` only look at the primary group, but `get_lowest_variant_price()` and `getLowestVariantPrice()` scanned every group. A primary group priced at $12.50 next to a stale non-primary option at $5.00 printed "From $5.00" on the published page and in the editor preview, a price PayPal never holds.

* Scope both lowest-price helpers to the primary option group, so they ask the same question the pricing helpers ask. The PHP loop guard is copied from `variants_have_pricing()`; the preview reuses the exported `getPrimaryDimension()`.
* Close the second asymmetry in the same file: `validate_attributes()` checked the raw variants while the request builder checked the sanitized ones. The validator now rejects what `sanitize_variants()` would silently discard (an unnamed group, an unlabeled option, and more groups or options than the sanitizer keeps), mirroring the rules the JS validator already enforces. The magic numbers 5 and 10 become `MAX_VARIANT_DIMENSIONS` and `MAX_VARIANT_OPTIONS`.
* The `unit_amount.value !== $price` comparison in the option badge loop is deliberately kept. It still governs badge display for a priced non-primary option.

Not done: making `sanitize_variants()` drop a non-primary `unit_amount` loudly. It runs on merchant data at request time, so `_doing_it_wrong()` would fire on hand-edited block JSON rather than on developer misuse. Happy to add a logged notice if reviewers want one.

## Related product discussion/links

* Linear: WOOPTP-478. Follows WOOPTP-464 (the stale-price fix this builds on).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

No site needed for the headline fix; it is reachable only from hand-edited block JSON.

1. In the block editor, create a PayPal Payment Buttons block with one option group ("Size") priced per option at $12.50. Open the code editor and add a second, non-primary group with an option carrying `"unit_amount": { "currency_code": "USD", "value": "5.00" }`.
2. **Before:** the editor preview and the published page both read "From $5.00". **After:** both read "From $12.50".
3. `GET /wpcom/v2/paypal/buttons/PLB-XXXX` holds only the primary group's amounts either way.
4. An ordinary single-group product with priced options, and a product with a product-level price and no priced options, are unchanged.
5. Send a `POST /wpcom/v2/paypal/buttons` with a variant group whose `name` is empty (or an option whose `label` is empty). It is now rejected with a 400 and `missing_variant_name` / `missing_variant_label` instead of being sent to PayPal.

Automated: `jp test php packages/paypal-payments` (329 tests) and `jp test js packages/paypal-payments` (167 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
