### PR TITLE
PayPal Payment Buttons: show the payment a block points at, not the copy it was duplicated from

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-duplicated-block-resource
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-duplicated-block-resource
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the payment a duplicated block actually points at, so two blocks sharing one PayPal payment can no longer display different products or prices.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
@@ -231,6 +231,14 @@ class PayPal_Attribute_Mapper {
 			if ( ! empty( $line_item['variants']['dimensions'] ) ) {
 				$attributes['variantsEnabled'] = true;
 				$attributes['variants']        = $line_item['variants'];
+
+				// With per-option pricing the currency lives on the options.
+				if ( ! isset( $attributes['currencyCode'] ) ) {
+					$variant_currency = self::get_variant_currency( $line_item['variants'] );
+					if ( null !== $variant_currency ) {
+						$attributes['currencyCode'] = $variant_currency;
+					}
+				}
 			}
 
 			// Adjustable quantity (WOOPTP-170).
@@ -477,6 +485,26 @@ class PayPal_Attribute_Mapper {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Find the currency the per-option prices are in.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array|null $variants Variants structure (block or API shape).
+	 * @return string|null The first priced option's currency code, or null when none is priced.
+	 */
+	private static function get_variant_currency( $variants ) {
+		foreach ( ( $variants['dimensions'] ?? array() ) as $dimension ) {
+			foreach ( ( $dimension['options'] ?? array() ) as $option ) {
+				if ( ! empty( $option['unit_amount']['currency_code'] ) ) {
+					return sanitize_text_field( $option['unit_amount']['currency_code'] );
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -653,6 +653,10 @@ class PayPal_REST_Controller {
 			return self::api_error_to_rest_error( $result );
 		}
 
+		// The editor reads a payment back to line its block up with what PayPal
+		// holds, so hand it the block shape alongside the raw resource.
+		$result['attributes'] = PayPal_Attribute_Mapper::api_response_to_attributes( $result );
+
 		return new WP_REST_Response( $result, 200 );
 	}
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.jsx
@@ -20,6 +20,7 @@ import {
 	InspectorControls,
 	MediaUpload,
 	MediaUploadCheck,
+	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 import {
@@ -37,10 +38,12 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis -- Experimental API; stable ConfirmDialog not yet exported by @wordpress/components.
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useCallback, useMemo, useRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import metadata from './block.json';
 import PayPalButtonPreview from './paypal-button-preview';
+import { getResourceAttributeUpdates } from './resource-sync';
 import {
 	validatePrice,
 	validateProductName,
@@ -301,9 +304,14 @@ function FormatSwitcher( { value, onChange, disabled } ) {
  * @param {object}   props               - Block props.
  * @param {object}   props.attributes    - Block attributes.
  * @param {Function} props.setAttributes - Function to update block attributes.
+ * @param {string}   props.clientId      - The block's client ID (not the PayPal one).
  * @return {Element} Block editor UI.
  */
-export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } ) {
+export default function PayPalPaymentButtonsEdit( {
+	attributes,
+	setAttributes,
+	clientId: blockClientId,
+} ) {
 	const {
 		colorScheme,
 		isApiManaged,
@@ -553,6 +561,68 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 				setConnectionLoading( false );
 			} );
 	}, [] );
+
+	// Two blocks can share one PayPal payment — a duplicate, or one product
+	// shown as a button, a link and a QR code — and only the block that saved
+	// last has seen what PayPal holds. Read it back so every block agrees.
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( blockEditorStore );
+	const latestAttributes = useRef( attributes );
+	latestAttributes.current = attributes;
+
+	useEffect( () => {
+		if ( ! isConnected || ! isApiManaged || ! resourceId ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		apiFetch( { path: `${ API_BASE }/buttons/${ resourceId }` } )
+			.then( response => {
+				if ( cancelled || ! response?.attributes ) {
+					return;
+				}
+				const updates = getResourceAttributeUpdates(
+					latestAttributes.current,
+					response.attributes
+				);
+				if ( ! Object.keys( updates ).length ) {
+					return;
+				}
+				// Opening a post must not mark it dirty.
+				__unstableMarkNextChangeAsNotPersistent?.();
+				setAttributes( updates );
+			} )
+			// A payment deleted on PayPal is re-created when the merchant next saves the block.
+			.catch( () => {} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		isConnected,
+		isApiManaged,
+		resourceId,
+		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
+
+	// Other blocks on this page pointing at the same PayPal payment.
+	const sharedResourceCount = useSelect(
+		select => {
+			if ( ! resourceId || ! blockClientId ) {
+				return 0;
+			}
+			const { getClientIdsWithDescendants, getBlockName, getBlockAttributes } =
+				select( blockEditorStore );
+			return getClientIdsWithDescendants().filter(
+				id =>
+					id !== blockClientId &&
+					getBlockName( id ) === metadata.name &&
+					getBlockAttributes( id )?.resourceId === resourceId
+			).length;
+		},
+		[ blockClientId, resourceId ]
+	);
 
 	/**
 	 * Follow the site-wide connection state when another block changes it.
@@ -1877,6 +1947,23 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 		</Notice>
 	) : null;
 
+	const sharedResourceMessage = sprintf(
+		/* translators: %d: number of other blocks on this page using the same PayPal payment */
+		_n(
+			'%d other block on this page uses this PayPal payment. Changing the product or price here changes it there too. To sell something different, add a new block and create a new payment.',
+			'%d other blocks on this page use this PayPal payment. Changing the product or price here changes it there too. To sell something different, add a new block and create a new payment.',
+			sharedResourceCount,
+			'jetpack-paypal-payments'
+		),
+		sharedResourceCount
+	);
+	const sharedResourceNotice =
+		sharedResourceCount > 0 ? (
+			<Notice status="info" isDismissible={ false }>
+				{ sharedResourceMessage }
+			</Notice>
+		) : null;
+
 	const connectionStatus = (
 		<span
 			className={ `jetpack-paypal-payment-buttons__status-dot ${
@@ -1915,6 +2002,7 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 					</div>
 
 					{ disconnectedNotice }
+					{ sharedResourceNotice }
 
 					{ successMessage && (
 						<Notice status="success" isDismissible onDismiss={ () => setSuccessMessage( null ) }>
@@ -1964,6 +2052,7 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 				</div>
 
 				{ disconnectedNotice }
+				{ sharedResourceNotice }
 
 				<h3>{ hasButton ? labelEditHeading : labelCreateHeading }</h3>
 				{ ! hasButton && (

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/resource-sync.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/resource-sync.js
@@ -1,0 +1,141 @@
+/**
+ * Line a block's attributes up with the PayPal payment it points at.
+ *
+ * Two blocks can share one payment — a duplicate, or one product shown as a
+ * button, a link and a QR code — and only the block that saved last has seen
+ * what PayPal holds.
+ *
+ * @package
+ */
+
+import metadata from './block.json';
+
+/**
+ * Attributes the PayPal payment is the source of truth for. Everything else
+ * (image, format, colors, button text) belongs to the block.
+ */
+export const RESOURCE_ATTRIBUTES = [
+	'paymentLink',
+	'productName',
+	'price',
+	'currencyCode',
+	'productDescription',
+	'variantsEnabled',
+	'variants',
+	'adjustableQuantity',
+	'maxQuantity',
+	'customerNotes',
+	'taxEnabled',
+	'taxType',
+	'taxName',
+	'taxValue',
+	'returnUrl',
+];
+
+let nextKey = 1;
+
+/**
+ * Reduce a variants structure to what PayPal prices, so two copies compare on content.
+ *
+ * Editor-only `_key`s, the per-option currency and empty amounts are left out.
+ *
+ * @param {object} variants - Variants data with dimensions.
+ * @return {Array|null} Comparable dimensions, or null when there are none.
+ */
+function comparableVariants( variants ) {
+	const dimensions = variants?.dimensions;
+	if ( ! Array.isArray( dimensions ) || dimensions.length === 0 ) {
+		return null;
+	}
+
+	return dimensions.map( dim => ( {
+		name: dim.name ?? '',
+		primary: !! dim.primary,
+		options: ( dim.options || [] ).map( opt => ( {
+			label: opt.label ?? '',
+			value: `${ opt.unit_amount?.value ?? '' }`.trim(),
+		} ) ),
+	} ) );
+}
+
+/**
+ * Put a payment's variants into the shape the variant builder edits.
+ *
+ * Adds the `_key`s the builder uses for React keys, and infers `primary` from
+ * where the prices are when the payment does not carry the flag.
+ *
+ * @param {object} variants - Variants data from the payment.
+ * @return {object|null} Editable variants, or null when there are none.
+ */
+export function normalizeResourceVariants( variants ) {
+	const dimensions = variants?.dimensions;
+	if ( ! Array.isArray( dimensions ) || dimensions.length === 0 ) {
+		return null;
+	}
+
+	const hasPrimaryFlag = dimensions.some( dim => dim.primary );
+	const pricedIndex = dimensions.findIndex( dim =>
+		( dim.options || [] ).some( opt => `${ opt.unit_amount?.value ?? '' }`.trim() !== '' )
+	);
+	const primaryIndex = pricedIndex === -1 ? 0 : pricedIndex;
+
+	return {
+		dimensions: dimensions.map( ( dim, i ) => ( {
+			...dim,
+			_key: dim._key || `rs-${ nextKey++ }`,
+			primary: hasPrimaryFlag ? !! dim.primary : i === primaryIndex,
+			options: ( dim.options || [] ).map( opt => ( {
+				...opt,
+				_key: opt._key || `rs-${ nextKey++ }`,
+			} ) ),
+		} ) ),
+	};
+}
+
+/**
+ * Whether two attribute values mean the same thing.
+ *
+ * @param {string} key - Attribute name.
+ * @param {*}      a   - Current value.
+ * @param {*}      b   - Value from the payment.
+ * @return {boolean} True when no update is needed.
+ */
+function isSameValue( key, a, b ) {
+	if ( key === 'variants' ) {
+		return JSON.stringify( comparableVariants( a ) ) === JSON.stringify( comparableVariants( b ) );
+	}
+	if ( typeof a === 'object' || typeof b === 'object' ) {
+		return JSON.stringify( a ?? null ) === JSON.stringify( b ?? null );
+	}
+	return a === b;
+}
+
+/**
+ * Work out which block attributes differ from the payment PayPal holds.
+ *
+ * A field the payment no longer carries goes back to its block.json default,
+ * so a description or a per-option price removed elsewhere clears here too.
+ *
+ * @param {object} current      - The block's current attributes.
+ * @param {object} fromResource - Attributes mapped from the payment by the server.
+ * @return {object} The attributes to set, empty when the block already agrees.
+ */
+export function getResourceAttributeUpdates( current, fromResource ) {
+	const updates = {};
+
+	RESOURCE_ATTRIBUTES.forEach( key => {
+		const fallback = metadata.attributes[ key ]?.default;
+		const value = current?.[ key ] === undefined ? fallback : current[ key ];
+
+		let next = fromResource?.[ key ] === undefined ? fallback : fromResource[ key ];
+		if ( key === 'variants' ) {
+			next = normalizeResourceVariants( next );
+		}
+
+		if ( ! isSameValue( key, value, next ) ) {
+			updates[ key ] = next;
+		}
+	} );
+
+	return updates;
+}

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
@@ -33,14 +33,28 @@ jest.mock( '@wordpress/element', () => {
 jest.mock( '@wordpress/i18n', () => ( {
 	__: text => text,
 	_x: text => text,
+	_n: ( single, plural, count ) => ( count === 1 ? single : plural ),
 	sprintf: ( format, ...args ) => {
 		let i = 0;
 		return format.replace( /%[ds]/g, () => args[ i++ ] );
 	},
 } ) );
 
+// Block-editor store: the sibling count reads other blocks through useSelect.
+const mockBlockEditorSelect = {
+	getClientIdsWithDescendants: jest.fn( () => [] ),
+	getBlockName: jest.fn(),
+	getBlockAttributes: jest.fn(),
+};
+const mockMarkNotPersistent = jest.fn();
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: selector => selector( () => mockBlockEditorSelect ),
+	useDispatch: () => ( { __unstableMarkNextChangeAsNotPersistent: mockMarkNotPersistent } ),
+} ) );
+
 // Mock WordPress block-editor.
 jest.mock( '@wordpress/block-editor', () => ( {
+	store: { name: 'core/block-editor' },
 	useBlockProps: () => ( { className: 'wp-block-paypal-payment-buttons' } ),
 	BlockControls: ( { children } ) => <div data-testid="block-controls">{ children }</div>,
 	InspectorControls: ( { children } ) => <div data-testid="inspector-controls">{ children }</div>,
@@ -1370,6 +1384,110 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 					} ),
 				} )
 			);
+		} );
+	} );
+
+	describe( 'Shared payment resource', () => {
+		const attributes = {
+			isApiManaged: true,
+			resourceId: 'PLB-SHARED1',
+			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-SHARED1',
+			productName: 'original',
+			price: '9.99',
+			currencyCode: 'USD',
+		};
+		const resourcePath = '/wpcom/v2/paypal/buttons/PLB-SHARED1';
+
+		/**
+		 * Answer the connection check as connected and the payment read with the given attributes.
+		 *
+		 * @param {object} resourceAttributes - Block-shaped attributes the server maps from the payment.
+		 */
+		function mockResource( resourceAttributes ) {
+			apiFetch.mockImplementation( ( { path } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				if ( path === resourcePath ) {
+					return Promise.resolve( { id: 'PLB-SHARED1', attributes: resourceAttributes } );
+				}
+				return Promise.resolve( {} );
+			} );
+		}
+
+		beforeEach( () => {
+			mockMarkNotPersistent.mockClear();
+			mockBlockEditorSelect.getClientIdsWithDescendants.mockReturnValue( [] );
+		} );
+
+		it( 'corrects a stale copy from the payment PayPal holds, without dirtying the post', async () => {
+			mockResource( { ...attributes, productName: 'duplicate', price: '49.00' } );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+
+			await waitFor( () =>
+				expect( setAttributes ).toHaveBeenCalledWith( { productName: 'duplicate', price: '49.00' } )
+			);
+			expect( mockMarkNotPersistent ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'leaves a block alone when it already matches the payment', async () => {
+			mockResource( { ...attributes } );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+
+			await expect( screen.findByTestId( 'paypal-button-preview' ) ).resolves.toBeInTheDocument();
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { path: resourcePath } ) )
+			);
+			expect( setAttributes ).not.toHaveBeenCalled();
+			expect( mockMarkNotPersistent ).not.toHaveBeenCalled();
+		} );
+
+		it( 'keeps a payment deleted on PayPal for the save-time recovery path', async () => {
+			apiFetch.mockImplementation( ( { path } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				return Promise.reject( { code: 'paypal_api_resource_not_found', data: { status: 404 } } );
+			} );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+
+			await expect( screen.findByTestId( 'paypal-button-preview' ) ).resolves.toBeInTheDocument();
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { path: resourcePath } ) )
+			);
+			expect( setAttributes ).not.toHaveBeenCalled();
+			expect( screen.queryByTestId( 'notice' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not read the payment while PayPal is disconnected', async () => {
+			apiFetch.mockResolvedValue( { connected: false, environment: 'sandbox' } );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+
+			await expect( screen.findByTestId( 'paypal-button-preview' ) ).resolves.toBeInTheDocument();
+			expect( apiFetch ).not.toHaveBeenCalledWith(
+				expect.objectContaining( { path: resourcePath } )
+			);
+		} );
+
+		it( 'says when other blocks on the page use the same payment', async () => {
+			mockResource( { ...attributes } );
+			mockBlockEditorSelect.getClientIdsWithDescendants.mockReturnValue( [ 'a', 'b', 'c', 'd' ] );
+			mockBlockEditorSelect.getBlockName.mockImplementation( id =>
+				id === 'd' ? 'core/paragraph' : 'jetpack/paypal-payment-buttons'
+			);
+			mockBlockEditorSelect.getBlockAttributes.mockImplementation( id => ( {
+				resourceId: id === 'c' ? 'PLB-OTHER' : 'PLB-SHARED1',
+			} ) );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+
+			await expect(
+				screen.findByText( /1 other block on this page uses this PayPal payment/ )
+			).resolves.toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/packages/paypal-payments/tests/js/resource-sync.test.js
+++ b/projects/packages/paypal-payments/tests/js/resource-sync.test.js
@@ -1,0 +1,184 @@
+/**
+ * Tests for lining a block up with the PayPal payment it points at.
+ *
+ * @package
+ */
+
+import {
+	getResourceAttributeUpdates,
+	normalizeResourceVariants,
+} from '../../src/paypal-payment-buttons/resource-sync';
+
+const blockAttributes = {
+	isApiManaged: true,
+	resourceId: 'PLB-1',
+	paymentLink: 'https://www.paypal.com/ncp/payment/PLB-1',
+	productName: 'Widget',
+	price: '9.99',
+	currencyCode: 'USD',
+	productDescription: '',
+	variantsEnabled: false,
+	variants: null,
+	adjustableQuantity: false,
+	maxQuantity: 10,
+	customerNotes: [],
+	taxEnabled: false,
+	taxType: 'PERCENTAGE',
+	taxName: 'Sales Tax',
+	taxValue: '',
+	returnUrl: '',
+	imageUrl: 'https://example.com/widget.jpg',
+	format: 'QR',
+};
+
+const resourceAttributes = {
+	isApiManaged: true,
+	resourceId: 'PLB-1',
+	paymentLink: 'https://www.paypal.com/ncp/payment/PLB-1',
+	productName: 'Widget',
+	price: '9.99',
+	currencyCode: 'USD',
+};
+
+describe( 'getResourceAttributeUpdates', () => {
+	it( 'returns nothing when the block already matches the payment', () => {
+		expect( getResourceAttributeUpdates( blockAttributes, resourceAttributes ) ).toEqual( {} );
+	} );
+
+	it( 'picks up a product and price changed through another block', () => {
+		expect(
+			getResourceAttributeUpdates( blockAttributes, {
+				...resourceAttributes,
+				productName: 'duplicate',
+				price: '49.00',
+			} )
+		).toEqual( { productName: 'duplicate', price: '49.00' } );
+	} );
+
+	it( 'leaves block-only attributes alone', () => {
+		const updates = getResourceAttributeUpdates( blockAttributes, {
+			...resourceAttributes,
+			imageUrl: 'https://example.com/other.jpg',
+			format: 'BUTTON',
+		} );
+		expect( updates ).toEqual( {} );
+	} );
+
+	it( 'clears a field the payment no longer carries', () => {
+		expect(
+			getResourceAttributeUpdates(
+				{
+					...blockAttributes,
+					productDescription: 'Old copy',
+					returnUrl: 'https://example.com/thanks',
+				},
+				resourceAttributes
+			)
+		).toEqual( { productDescription: '', returnUrl: '' } );
+	} );
+
+	it( 'clears a leftover product price when the payment prices per option', () => {
+		const { price, ...perOptionResource } = resourceAttributes;
+		const updates = getResourceAttributeUpdates( blockAttributes, {
+			...perOptionResource,
+			variantsEnabled: true,
+			variants: {
+				dimensions: [
+					{
+						name: 'Size',
+						primary: true,
+						options: [ { label: 'Small', unit_amount: { currency_code: 'USD', value: '12.50' } } ],
+					},
+				],
+			},
+		} );
+
+		expect( price ).toBe( '9.99' );
+		expect( updates.price ).toBe( '' );
+		expect( updates.variantsEnabled ).toBe( true );
+		expect( updates.variants.dimensions[ 0 ].options[ 0 ].unit_amount.value ).toBe( '12.50' );
+	} );
+
+	it( 'treats editor keys and empty per-option amounts as no difference', () => {
+		const current = {
+			...blockAttributes,
+			variantsEnabled: true,
+			variants: {
+				dimensions: [
+					{
+						_key: 'vb-1',
+						name: 'Size',
+						primary: true,
+						options: [
+							{ _key: 'vb-2', label: 'Small', unit_amount: { currency_code: 'USD', value: '' } },
+							{ _key: 'vb-3', label: 'Large', unit_amount: { currency_code: 'USD', value: '' } },
+						],
+					},
+				],
+			},
+		};
+		const fromResource = {
+			...resourceAttributes,
+			variantsEnabled: true,
+			variants: {
+				dimensions: [
+					{ name: 'Size', primary: true, options: [ { label: 'Small' }, { label: 'Large' } ] },
+				],
+			},
+		};
+
+		expect( getResourceAttributeUpdates( current, fromResource ) ).toEqual( {} );
+	} );
+} );
+
+describe( 'normalizeResourceVariants', () => {
+	it( 'returns null when there are no option groups', () => {
+		expect( normalizeResourceVariants( null ) ).toBeNull();
+		expect( normalizeResourceVariants( { dimensions: [] } ) ).toBeNull();
+	} );
+
+	it( 'gives every group and option a key the variant builder can use', () => {
+		const normalized = normalizeResourceVariants( {
+			dimensions: [ { name: 'Size', primary: true, options: [ { label: 'Small' } ] } ],
+		} );
+
+		expect( normalized.dimensions[ 0 ]._key ).toEqual( expect.any( String ) );
+		expect( normalized.dimensions[ 0 ].options[ 0 ]._key ).toEqual( expect.any( String ) );
+	} );
+
+	it( 'infers the primary group from where the prices are when the flag is missing', () => {
+		const normalized = normalizeResourceVariants( {
+			dimensions: [
+				{ name: 'Color', options: [ { label: 'Red' } ] },
+				{
+					name: 'Size',
+					options: [ { label: 'Small', unit_amount: { currency_code: 'USD', value: '12.50' } } ],
+				},
+			],
+		} );
+
+		expect( normalized.dimensions.map( dim => dim.primary ) ).toEqual( [ false, true ] );
+	} );
+
+	it( 'falls back to the first group when nothing is priced or flagged', () => {
+		const normalized = normalizeResourceVariants( {
+			dimensions: [
+				{ name: 'Color', options: [ { label: 'Red' } ] },
+				{ name: 'Size', options: [ { label: 'Small' } ] },
+			],
+		} );
+
+		expect( normalized.dimensions.map( dim => dim.primary ) ).toEqual( [ true, false ] );
+	} );
+
+	it( 'keeps the flag when the payment carries one', () => {
+		const normalized = normalizeResourceVariants( {
+			dimensions: [
+				{ name: 'Color', primary: false, options: [ { label: 'Red' } ] },
+				{ name: 'Size', primary: true, options: [ { label: 'Small' } ] },
+			],
+		} );
+
+		expect( normalized.dimensions.map( dim => dim.primary ) ).toEqual( [ false, true ] );
+	} );
+} );

--- a/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
@@ -659,6 +659,32 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 	}
 
 	/**
+	 * Test that the currency comes from the priced options when there is no product price.
+	 */
+	public function test_api_response_to_attributes_takes_currency_from_priced_options() {
+		$variants = $this->variants_with_prices( array( '10.00', '20.00' ) );
+
+		$variants['dimensions'][0]['options'][0]['unit_amount']['currency_code'] = 'EUR';
+		$variants['dimensions'][0]['options'][1]['unit_amount']['currency_code'] = 'EUR';
+
+		$attributes = PayPal_Attribute_Mapper::api_response_to_attributes(
+			array(
+				'id'         => 'PLB-VAR',
+				'line_items' => array(
+					array(
+						'name'     => 'Widget',
+						'variants' => $variants,
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 'EUR', $attributes['currencyCode'] );
+		$this->assertArrayNotHasKey( 'price', $attributes );
+		$this->assertTrue( $attributes['variantsEnabled'] );
+	}
+
+	/**
 	 * Test that the product price is optional once the options carry their own.
 	 */
 	public function test_validate_allows_missing_price_with_variant_pricing() {

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -747,6 +747,51 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
+	 * Test that reading a button also returns it in block-attribute shape.
+	 *
+	 * The editor uses it to line a block up with the payment it points at.
+	 */
+	public function test_get_button_includes_block_attributes() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_routes(
+			array(
+				'/v1/checkout/payment-resources' => $this->http_response(
+					200,
+					array(
+						'id'         => 'PLB-42',
+						'line_items' => array(
+							array(
+								'name'        => 'Widget',
+								'unit_amount' => array(
+									'currency_code' => 'EUR',
+									'value'         => '49.00',
+								),
+							),
+						),
+						'links'      => array(
+							array(
+								'rel'  => 'payment_link',
+								'href' => 'https://www.paypal.com/ncp/payment/PLB-42',
+							),
+						),
+					)
+				),
+			)
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+
+		$data = PayPal_REST_Controller::handle_get_button( $request )->get_data();
+
+		$this->assertSame( 'PLB-42', $data['attributes']['resourceId'] );
+		$this->assertSame( 'Widget', $data['attributes']['productName'] );
+		$this->assertSame( '49.00', $data['attributes']['price'] );
+		$this->assertSame( 'EUR', $data['attributes']['currencyCode'] );
+		$this->assertSame( 'https://www.paypal.com/ncp/payment/PLB-42', $data['attributes']['paymentLink'] );
+	}
+
+	/**
 	 * Test that an API failure while listing is surfaced as a REST error.
 	 */
 	public function test_list_buttons_converts_api_error() {

--- a/projects/plugins/jetpack/changelog/fix-paypal-duplicated-block-resource
+++ b/projects/plugins/jetpack/changelog/fix-paypal-duplicated-block-resource
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payment Buttons: show the payment a duplicated block actually points at, so two blocks sharing one PayPal payment can no longer display different products or prices.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-duplicated-block-resource
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-duplicated-block-resource
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the payment a duplicated block actually points at, so two blocks sharing one PayPal payment can no longer display different products or prices.


### PR DESCRIPTION
Fixes WOOPTP-467

## Proposed changes

Duplicating a PayPal Payment Buttons block copies its `resourceId`, so both copies point at one PayPal payment. Editing either copy replaces that payment with a `PUT`, but the other copy keeps the product name and price it was duplicated with, and the frontend renders from block attributes alone. The page could say $9.99 while PayPal charged $49, with no error anywhere.

Sharing one payment between blocks is a feature (WOOPTP-389: one product as a button, a link and a QR code), so this does not prevent duplication or reset the id. It makes the blocks agree, and says so.

* **The payment is the source of truth.** When a block with a resource loads on a connected site, the editor reads `GET /wpcom/v2/paypal/buttons/{id}` and corrects the attributes PayPal owns (product, price, currency, description, options, quantity, notes, tax, return URL, payment link). The update goes through `__unstableMarkNextChangeAsNotPersistent()` from the block-editor store, the same shape VideoPress uses, so opening a post does not mark it dirty. A `GET` failure is ignored, which keeps the existing save-time 404 re-create path intact.
* **The GET route returns the block shape too.** `handle_get_button()` adds an `attributes` key computed by `PayPal_Attribute_Mapper::api_response_to_attributes()`, so the mapping lives in one place. That mapper now also takes the currency from the priced options when there is no product-level amount, otherwise a per-option JPY product would sync back as USD.
* **Blocks say when they share a payment.** The edit component now receives the block `clientId` (destructured as `blockClientId`, since `clientId` in this file is the PayPal REST client id) and counts other blocks on the page with the same `resourceId` through `useSelect`. A non-dismissible info notice tells the merchant that edits here change the other blocks too, and how to sell something different instead.
* The variants comparison ignores the editor-only `_key`s and empty per-option amounts, and synced variants get keys and a `primary` flag inferred from where the prices are, in case PayPal does not echo the flag.

Left alone on purpose: the delete confirm copy and scoping the delete to sibling blocks. Both belong with WOOPTP-391/393, which are in progress in that code. The Cancel reset is unchanged because it only runs when there is no resource.

## Related product discussion/links

* Linear: WOOPTP-467. Sharing is specified in WOOPTP-389; CHE-114 is the V1 inverse of this bug.

## Does this pull request change what data or activity we track or use?

No. The editor makes one extra read of a payment the site already created.

## Testing instructions

On a site with a PayPal connection (sandbox is fine).

1. New post. Insert PayPal Payment Buttons, create a button: product `original`, price `9.99`. Note the `PLB-` id.
2. Duplicate the block. Both copies should now show an info notice that one other block on the page uses this payment.
3. Edit the second copy: product `duplicate`, price `49.00`, update. Save the post.
4. Reload the editor. **Before:** the first copy still says `original` / `9.99`. **After:** both copies read `duplicate` / `49.00`, and the post is not marked dirty by the reload. Check with:
   ```js
   wp.data.select('core/block-editor').getBlocks()
     .filter(b => b.name === 'jetpack/paypal-payment-buttons')
     .map(b => ({ id: b.attributes.resourceId, name: b.attributes.productName, price: b.attributes.price }))
   ```
5. Publish and open the frontend: both blocks show the same price, matching `GET /wpcom/v2/paypal/buttons/PLB-XXXX`.
6. Delete the payment from one copy, then reload the editor. The other copy still loads, shows no error, and re-creates the payment when you next update it (the existing 404 path).
7. Three blocks on one payment, one Button / one Link / one QR, all agree.

Automated: `jp test js packages/paypal-payments` (182 tests, including a new `resource-sync` suite and four edit-component cases for two blocks on one id) and `jp test php packages/paypal-payments` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
