### PR TITLE
PayPal Payment Buttons: reject decimal prices for zero-decimal currencies

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-zero-decimal-currencies
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-zero-decimal-currencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop accepting prices with decimals for Japanese yen, Hungarian forint and New Taiwan dollar, which PayPal rejects, and remove the Indian rupee, which PayPal does not support.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
@@ -61,7 +61,6 @@ class PayPal_Attribute_Mapper {
 		'PHP',
 		'TWD',
 		'THB',
-		'INR',
 	);
 
 	/**
@@ -336,24 +335,27 @@ class PayPal_Attribute_Mapper {
 			);
 		}
 
-		if ( $has_price && ! self::is_valid_price( $attributes['price'] ) ) {
+		// The currency decides how many decimals a price may carry, so the
+		// price checks need it before it is itself validated below.
+		$currency = strtoupper( sanitize_text_field( (string) ( $attributes['currencyCode'] ?? 'USD' ) ) );
+
+		if ( $has_price && ! self::is_valid_price( $attributes['price'], $currency ) ) {
 			return new WP_Error(
 				'invalid_price',
-				__( 'Price must be a valid positive number (e.g., "29.99").', 'jetpack-paypal-payments' ),
+				self::get_invalid_price_message( $currency ),
 				array( 'status' => 400 )
 			);
 		}
 
 		if ( $uses_variant_pricing ) {
-			$variant_price_error = self::validate_variant_pricing( $attributes['variants'] );
+			$variant_price_error = self::validate_variant_pricing( $attributes['variants'], $currency );
 			if ( is_wp_error( $variant_price_error ) ) {
 				return $variant_price_error;
 			}
 		}
 
 		// Required: currency code.
-		$currency = $attributes['currencyCode'] ?? 'USD';
-		if ( ! in_array( strtoupper( $currency ), self::SUPPORTED_CURRENCIES, true ) ) {
+		if ( ! in_array( $currency, self::SUPPORTED_CURRENCIES, true ) ) {
 			return new WP_Error(
 				'invalid_currency',
 				__( 'Unsupported currency code.', 'jetpack-paypal-payments' ),
@@ -450,15 +452,53 @@ class PayPal_Attribute_Mapper {
 	}
 
 	/**
+	 * Whether PayPal prices a currency without decimals.
+	 *
+	 * PayPal rejects a decimal amount in these currencies outright rather than
+	 * rounding it. The legacy currency table already records which they are.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $currency ISO currency code.
+	 * @return bool True for JPY, HUF and TWD.
+	 */
+	public static function is_zero_decimal_currency( $currency ) {
+		$currency = strtoupper( (string) $currency );
+
+		return in_array( $currency, self::SUPPORTED_CURRENCIES, true )
+			&& isset( \PayPal_Payments_Currencies::CURRENCIES[ $currency ]['decimal'] )
+			&& 0 === \PayPal_Payments_Currencies::CURRENCIES[ $currency ]['decimal'];
+	}
+
+	/**
+	 * The message for a price PayPal would not accept in the given currency.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $currency ISO currency code.
+	 * @return string Translated message.
+	 */
+	private static function get_invalid_price_message( $currency ) {
+		if ( self::is_zero_decimal_currency( $currency ) ) {
+			/* translators: %s: currency code, e.g. JPY */
+			return sprintf( __( 'Prices in %s must be whole numbers (e.g., "1500").', 'jetpack-paypal-payments' ), $currency );
+		}
+
+		return __( 'Price must be a valid positive number (e.g., "29.99").', 'jetpack-paypal-payments' );
+	}
+
+	/**
 	 * Validate a price string.
 	 *
-	 * Ensures the price is a positive decimal number with up to 2 decimal places.
-	 * PayPal requires string format prices like "29.99".
+	 * The price must be a positive number with at most two decimal places, or
+	 * a whole number in a currency PayPal prices without decimals. PayPal
+	 * requires string format prices like "29.99".
 	 *
-	 * @param string $price The price string to validate.
+	 * @param string $price    The price string to validate.
+	 * @param string $currency ISO currency code the price is in.
 	 * @return bool True if valid.
 	 */
-	private static function is_valid_price( $price ) {
+	private static function is_valid_price( $price, $currency = 'USD' ) {
 		// Must be a string representation of a positive decimal number.
 		if ( ! is_string( $price ) && ! is_numeric( $price ) ) {
 			return false;
@@ -466,8 +506,8 @@ class PayPal_Attribute_Mapper {
 
 		$price = (string) $price;
 
-		// Match positive numbers with optional decimal places (up to 2).
-		if ( ! preg_match( '/^\d+(\.\d{1,2})?$/', $price ) ) {
+		$pattern = self::is_zero_decimal_currency( $currency ) ? '/^\d+$/' : '/^\d+(\.\d{1,2})?$/';
+		if ( ! preg_match( $pattern, $price ) ) {
 			return false;
 		}
 
@@ -522,9 +562,10 @@ class PayPal_Attribute_Mapper {
 	 * @since $$next-version$$
 	 *
 	 * @param array|null $variants Variants structure (block or API shape).
+	 * @param string     $currency ISO currency code the option prices are in.
 	 * @return true|WP_Error True when valid, WP_Error otherwise.
 	 */
-	private static function validate_variant_pricing( $variants ) {
+	private static function validate_variant_pricing( $variants, $currency = 'USD' ) {
 		foreach ( ( $variants['dimensions'] ?? array() ) as $dimension ) {
 			if ( empty( $dimension['primary'] ) ) {
 				continue;
@@ -541,12 +582,15 @@ class PayPal_Attribute_Mapper {
 					);
 				}
 
-				if ( ! self::is_valid_price( $value ) ) {
-					return new WP_Error(
-						'invalid_variant_price',
-						__( 'Product option prices must be valid positive numbers (e.g., "29.99").', 'jetpack-paypal-payments' ),
-						array( 'status' => 400 )
-					);
+				if ( ! self::is_valid_price( $value, $currency ) ) {
+					if ( self::is_zero_decimal_currency( $currency ) ) {
+						/* translators: %s: currency code, e.g. JPY */
+						$message = sprintf( __( 'Product option prices in %s must be whole numbers (e.g., "1500").', 'jetpack-paypal-payments' ), $currency );
+					} else {
+						$message = __( 'Product option prices must be valid positive numbers (e.g., "29.99").', 'jetpack-paypal-payments' );
+					}
+
+					return new WP_Error( 'invalid_variant_price', $message, array( 'status' => 400 ) );
 				}
 			}
 		}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/currency-symbols.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/currency-symbols.js
@@ -35,3 +35,20 @@ export const CURRENCY_SYMBOLS = {
 	TWD: 'NT$',
 	THB: '\u0E3F',
 };
+
+/**
+ * Currencies PayPal only accepts as whole numbers. A decimal amount is
+ * rejected outright, not rounded. Matches the `decimal` column of the PHP
+ * currency table.
+ */
+export const ZERO_DECIMAL_CURRENCIES = new Set( [ 'HUF', 'JPY', 'TWD' ] );
+
+/**
+ * The smallest step a price input should offer for a currency.
+ *
+ * @param {string} currencyCode - The ISO currency code.
+ * @return {string} '1' for a zero-decimal currency, '0.01' otherwise.
+ */
+export function getPriceStep( currencyCode ) {
+	return ZERO_DECIMAL_CURRENCIES.has( currencyCode ) ? '1' : '0.01';
+}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit.jsx
@@ -40,6 +40,7 @@ import {
 import { useState, useEffect, useCallback, useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import metadata from './block.json';
+import { getPriceStep } from './currency-symbols';
 import PayPalButtonPreview from './paypal-button-preview';
 import {
 	validatePrice,
@@ -226,7 +227,6 @@ const SUPPORTED_CURRENCIES = [
 	{ label: 'PHP — Philippine Peso', value: 'PHP' },
 	{ label: 'TWD — Taiwan Dollar', value: 'TWD' },
 	{ label: 'THB — Thai Baht', value: 'THB' },
-	{ label: 'INR — Indian Rupee', value: 'INR' },
 	{ label: 'CNY — Chinese Yuan', value: 'CNY' },
 ];
 
@@ -361,6 +361,10 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 		'Each product option sets its own price, so this value is ignored.',
 		'jetpack-paypal-payments'
 	);
+
+	// PayPal rejects any decimal in JPY, HUF and TWD, so the input must not offer one.
+	const priceStep = getPriceStep( currencyCode || 'USD' );
+	const pricePlaceholder = priceStep === '1' ? '1500' : '29.99';
 
 	// Connection state.
 	const [ isConnected, setIsConnected ] = useState( false );
@@ -500,7 +504,7 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 			// The product price is only required when the options aren't priced
 			// individually. A stray value is still validated so it can't be sent
 			// half-formed if the merchant clears the per-option prices later.
-			price: usesVariantPricing && ! price ? null : validatePrice( price ),
+			price: usesVariantPricing && ! price ? null : validatePrice( price, currencyCode || 'USD' ),
 			productDescription: validateDescription( productDescription ),
 			currencyCode:
 				currencyCode && ! VALID_CURRENCY_CODES.has( currencyCode )
@@ -514,8 +518,8 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 	 * Variant validation errors (empty array if valid or disabled).
 	 */
 	const variantErrors = useMemo(
-		() => validateVariants( variantsEnabled, variants ),
-		[ variantsEnabled, variants ]
+		() => validateVariants( variantsEnabled, variants, currencyCode || 'USD' ),
+		[ variantsEnabled, variants, currencyCode ]
 	);
 
 	/**
@@ -2018,9 +2022,9 @@ export default function PayPalPaymentButtonsEdit( { attributes, setAttributes } 
 							onBlur={ () => markTouched( 'price' ) }
 							disabled={ isCreating }
 							type="number"
-							min="0.01"
-							step="0.01"
-							placeholder="29.99"
+							min={ priceStep }
+							step={ priceStep }
+							placeholder={ pricePlaceholder }
 							help={
 								touchedFields.price && validationErrors.price
 									? validationErrors.price

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/validation.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/validation.js
@@ -10,6 +10,7 @@
  */
 
 import { __, sprintf } from '@wordpress/i18n';
+import { ZERO_DECIMAL_CURRENCIES } from './currency-symbols';
 
 /**
  * Validation constants — match server-side limits.
@@ -44,17 +45,44 @@ export const VALID_CURRENCY_CODES = new Set( [
 	'PHP',
 	'TWD',
 	'THB',
-	'INR',
 	'CNY',
 ] );
 
 /**
- * Validate a price string.
+ * Check the decimals a price carries against what PayPal accepts for the currency.
  *
- * @param {string} value - The price value.
+ * PayPal rejects any decimal for JPY, HUF and TWD; every other currency takes up to two.
+ *
+ * @param {string} value        - The price value.
+ * @param {string} currencyCode - The ISO currency code the price is in.
  * @return {string|null} Error message or null if valid.
  */
-export function validatePrice( value ) {
+export function getPriceFormatError( value, currencyCode = 'USD' ) {
+	const trimmed = `${ value ?? '' }`.trim();
+
+	if ( ZERO_DECIMAL_CURRENCIES.has( currencyCode ) ) {
+		return /^\d+$/.test( trimmed )
+			? null
+			: sprintf(
+					/* translators: %s: currency code, e.g. JPY */
+					__( 'Prices in %s are whole numbers (e.g., "1500").', 'jetpack-paypal-payments' ),
+					currencyCode
+			  );
+	}
+
+	return /^\d+(\.\d{1,2})?$/.test( trimmed )
+		? null
+		: __( 'Price can have at most 2 decimal places (e.g., "29.99").', 'jetpack-paypal-payments' );
+}
+
+/**
+ * Validate a price string.
+ *
+ * @param {string} value        - The price value.
+ * @param {string} currencyCode - The ISO currency code the price is in.
+ * @return {string|null} Error message or null if valid.
+ */
+export function validatePrice( value, currencyCode = 'USD' ) {
 	if ( ! value || value.trim() === '' ) {
 		return __( 'Price is required.', 'jetpack-paypal-payments' );
 	}
@@ -64,15 +92,7 @@ export function validatePrice( value ) {
 		return __( 'Price must be a positive number.', 'jetpack-paypal-payments' );
 	}
 
-	// Check max 2 decimal places.
-	if ( ! /^\d+(\.\d{1,2})?$/.test( value.trim() ) ) {
-		return __(
-			'Price can have at most 2 decimal places (e.g., "29.99").',
-			'jetpack-paypal-payments'
-		);
-	}
-
-	return null;
+	return getPriceFormatError( value, currencyCode );
 }
 
 /**

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/variant-builder.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/variant-builder.jsx
@@ -12,6 +12,8 @@
 import { Button, TextControl, ToggleControl } from '@wordpress/components';
 import { useRef, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { getPriceStep } from './currency-symbols';
+import { getPriceFormatError } from './validation';
 
 // Pre-extract translated strings used in ternaries to avoid i18n build errors.
 const placeholderColor = __( 'e.g., Color', 'jetpack-paypal-payments' );
@@ -115,11 +117,12 @@ export function hasVariantPricing( enabled, variants ) {
 /**
  * Validate variant data and return error messages.
  *
- * @param {boolean} enabled  - Whether variants are enabled.
- * @param {object}  variants - The variants data.
+ * @param {boolean} enabled      - Whether variants are enabled.
+ * @param {object}  variants     - The variants data.
+ * @param {string}  currencyCode - Product currency the option prices are in.
  * @return {Array} Array of error strings. Empty if valid.
  */
-export function validateVariants( enabled, variants ) {
+export function validateVariants( enabled, variants, currencyCode = 'USD' ) {
 	if ( ! enabled || ! variants?.dimensions?.length ) {
 		return [];
 	}
@@ -185,6 +188,20 @@ export function validateVariants( enabled, variants ) {
 							),
 							opt.label || `Option ${ j + 1 }`,
 							dim.name || `#${ i + 1 }`
+						)
+					);
+					return;
+				}
+
+				const formatError = getPriceFormatError( rawValue, currencyCode );
+				if ( formatError ) {
+					errors.push(
+						sprintf(
+							/* translators: 1: option label or number, 2: group name, 3: what is wrong with the price */
+							__( 'Price for "%1$s" in "%2$s": %3$s', 'jetpack-paypal-payments' ),
+							opt.label || `Option ${ j + 1 }`,
+							dim.name || `#${ i + 1 }`,
+							formatError
 						)
 					);
 				}
@@ -324,8 +341,8 @@ function GroupEditor( { group, index, currencyCode, onChange, onRemove, onSetPri
 									} )
 								}
 								type="number"
-								min="0.01"
-								step="0.01"
+								min={ getPriceStep( currencyCode ) }
+								step={ getPriceStep( currencyCode ) }
 								placeholder={ __( 'Same as product price', 'jetpack-paypal-payments' ) }
 								disabled={ disabled }
 								help={ helpOptionPrice }

--- a/projects/packages/paypal-payments/tests/js/validation.test.js
+++ b/projects/packages/paypal-payments/tests/js/validation.test.js
@@ -64,6 +64,23 @@ describe( 'validatePrice', () => {
 	it( 'returns null for the minimum valid price', () => {
 		expect( validatePrice( '0.01' ) ).toBeNull();
 	} );
+
+	it.each( [ 'JPY', 'HUF', 'TWD' ] )(
+		'rejects a decimal price in %s, which PayPal prices whole',
+		code => {
+			expect( validatePrice( '1500.50', code ) ).toBe(
+				`Prices in ${ code } are whole numbers (e.g., "1500").`
+			);
+		}
+	);
+
+	it.each( [ 'JPY', 'HUF', 'TWD' ] )( 'accepts a whole-number price in %s', code => {
+		expect( validatePrice( '1500', code ) ).toBeNull();
+	} );
+
+	it( 'still accepts two decimals in a currency PayPal prices with them', () => {
+		expect( validatePrice( '12.34', 'EUR' ) ).toBeNull();
+	} );
 } );
 
 describe( 'validateProductName', () => {

--- a/projects/packages/paypal-payments/tests/js/variant-pricing.test.js
+++ b/projects/packages/paypal-payments/tests/js/variant-pricing.test.js
@@ -97,6 +97,26 @@ describe( 'validateVariants', () => {
 		expect( errors[ 0 ] ).toContain( 'must be a positive number' );
 	} );
 
+	it( 'rejects more than two decimals on an option price', () => {
+		const errors = validateVariants( true, variantsWithPrices( [ '10.00', '10.005' ] ) );
+
+		expect( errors ).toHaveLength( 1 );
+		expect( errors[ 0 ] ).toContain( 'at most 2 decimal places' );
+	} );
+
+	it( 'rejects a decimal option price in a currency PayPal prices whole', () => {
+		const errors = validateVariants( true, variantsWithPrices( [ '1500', '1500.50' ] ), 'JPY' );
+
+		expect( errors ).toHaveLength( 1 );
+		expect( errors[ 0 ] ).toContain( 'Prices in JPY are whole numbers' );
+	} );
+
+	it( 'accepts whole-number option prices in a currency PayPal prices whole', () => {
+		expect( validateVariants( true, variantsWithPrices( [ '1500', '2000' ] ), 'JPY' ) ).toEqual(
+			[]
+		);
+	} );
+
 	it( 'still requires group names and option labels', () => {
 		const errors = validateVariants( true, {
 			dimensions: [ { name: '', primary: true, options: [ { label: '' } ] } ],

--- a/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
@@ -197,14 +197,16 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 	}
 
 	/**
-	 * Test that all 26 supported currencies are accepted.
+	 * Test that every supported currency is accepted.
+	 *
+	 * A whole-number price, because three of them refuse decimals.
 	 */
 	public function test_validate_accepts_all_supported_currencies() {
 		foreach ( PayPal_Attribute_Mapper::SUPPORTED_CURRENCIES as $currency ) {
 			$result = PayPal_Attribute_Mapper::validate_attributes(
 				array(
 					'productName'  => 'Widget',
-					'price'        => '10.00',
+					'price'        => '10',
 					'currencyCode' => $currency,
 				)
 			);
@@ -212,7 +214,143 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 			$this->assertTrue( $result, "Currency $currency should be accepted" );
 		}
 
-		$this->assertCount( 25, PayPal_Attribute_Mapper::SUPPORTED_CURRENCIES );
+		$this->assertCount( 24, PayPal_Attribute_Mapper::SUPPORTED_CURRENCIES );
+	}
+
+	// --- validate_attributes: zero-decimal currencies ---
+
+	/**
+	 * Data provider for the currencies PayPal prices without decimals.
+	 *
+	 * @return array[] Test cases.
+	 */
+	public static function zero_decimal_currency_provider(): array {
+		return array(
+			'JPY' => array( 'JPY' ),
+			'HUF' => array( 'HUF' ),
+			'TWD' => array( 'TWD' ),
+		);
+	}
+
+	/**
+	 * Test that is_zero_decimal_currency knows the three currencies and nothing else.
+	 */
+	public function test_is_zero_decimal_currency() {
+		$this->assertTrue( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'JPY' ) );
+		$this->assertTrue( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'huf' ) );
+		$this->assertTrue( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'TWD' ) );
+		$this->assertFalse( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'USD' ) );
+		$this->assertFalse( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'EUR' ) );
+		// The legacy table lists INR as zero-decimal, but PayPal does not support it at all.
+		$this->assertFalse( PayPal_Attribute_Mapper::is_zero_decimal_currency( 'INR' ) );
+	}
+
+	/**
+	 * Test that a decimal price is rejected in a currency PayPal prices whole.
+	 *
+	 * @param string $currency Zero-decimal currency code.
+	 * @dataProvider zero_decimal_currency_provider
+	 */
+	#[DataProvider( 'zero_decimal_currency_provider' )]
+	public function test_validate_rejects_decimal_price_for_zero_decimal_currency( $currency ) {
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'  => 'Widget',
+				'price'        => '1500.50',
+				'currencyCode' => $currency,
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'invalid_price', $result->get_error_code() );
+		$this->assertStringContainsString( 'whole numbers', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that a whole-number price is accepted in a currency PayPal prices whole.
+	 *
+	 * @param string $currency Zero-decimal currency code.
+	 * @dataProvider zero_decimal_currency_provider
+	 */
+	#[DataProvider( 'zero_decimal_currency_provider' )]
+	public function test_validate_accepts_whole_price_for_zero_decimal_currency( $currency ) {
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'  => 'Widget',
+				'price'        => '1500',
+				'currencyCode' => $currency,
+			)
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a decimal option price is rejected in a currency PayPal prices whole.
+	 *
+	 * @param string $currency Zero-decimal currency code.
+	 * @dataProvider zero_decimal_currency_provider
+	 */
+	#[DataProvider( 'zero_decimal_currency_provider' )]
+	public function test_validate_rejects_decimal_option_price_for_zero_decimal_currency( $currency ) {
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => $currency,
+				'variantsEnabled' => true,
+				'variants'        => $this->variants_with_prices( array( '1500', '1500.50' ) ),
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertEquals( 'invalid_variant_price', $result->get_error_code() );
+		$this->assertStringContainsString( 'whole numbers', $result->get_error_message() );
+	}
+
+	/**
+	 * Test that whole-number option prices are accepted in a currency PayPal prices whole.
+	 *
+	 * @param string $currency Zero-decimal currency code.
+	 * @dataProvider zero_decimal_currency_provider
+	 */
+	#[DataProvider( 'zero_decimal_currency_provider' )]
+	public function test_validate_accepts_whole_option_prices_for_zero_decimal_currency( $currency ) {
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'     => 'Widget',
+				'currencyCode'    => $currency,
+				'variantsEnabled' => true,
+				'variants'        => $this->variants_with_prices( array( '1500', '2000' ) ),
+			)
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that a two-decimal currency still takes decimals, on the product and on its options.
+	 */
+	public function test_validate_accepts_decimal_prices_for_two_decimal_currency() {
+		$this->assertTrue(
+			PayPal_Attribute_Mapper::validate_attributes(
+				array(
+					'productName'  => 'Widget',
+					'price'        => '12.34',
+					'currencyCode' => 'EUR',
+				)
+			)
+		);
+
+		$this->assertTrue(
+			PayPal_Attribute_Mapper::validate_attributes(
+				array(
+					'productName'     => 'Widget',
+					'currencyCode'    => 'EUR',
+					'variantsEnabled' => true,
+					'variants'        => $this->variants_with_prices( array( '12.34', '56.78' ) ),
+				)
+			)
+		);
 	}
 
 	// --- validate_attributes: optional field length limits ---

--- a/projects/plugins/jetpack/changelog/fix-paypal-zero-decimal-currencies
+++ b/projects/plugins/jetpack/changelog/fix-paypal-zero-decimal-currencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payment Buttons: stop accepting prices with decimals for Japanese yen, Hungarian forint and New Taiwan dollar, which PayPal rejects, and remove the Indian rupee, which PayPal does not support.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-zero-decimal-currencies
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-zero-decimal-currencies
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop accepting prices with decimals for Japanese yen, Hungarian forint and New Taiwan dollar, which PayPal rejects, and remove the Indian rupee, which PayPal does not support.


### PR DESCRIPTION
Fixes WOOPTP-477

## Proposed changes

PayPal prices JPY, HUF and TWD without decimals and rejects a decimal amount outright (`DECIMALS_NOT_SUPPORTED`), but both our validators shared one currency-blind regex and the price inputs offered `step="0.01"` whatever the currency. A JPY button at `1500.50` passed our checks, went to PayPal, and came back as a 422 in PayPal's own words. Worse, a failed update leaves the block attributes at `1500.50` while PayPal still holds `1500`, so the published page could show a price checkout does not charge.

* **Validators are currency-aware.** `is_valid_price()` takes the currency and requires a whole number for a zero-decimal one, with a message that says so. The same applies to every per-option price through `validate_variant_pricing()`. On the JS side `validatePrice()` takes the currency and a new `getPriceFormatError()` is shared with `validateVariants()`, which previously did not check decimals on option prices at all.
* **The inputs stop offering decimals.** The product price and per-option price inputs use `step="1"` and `min="1"` for JPY, HUF and TWD (`getPriceStep()`), with a whole-number placeholder, so the merchant cannot type a decimal in the first place. The validator is the backstop.
* **One source of truth on the PHP side.** `is_zero_decimal_currency()` reads the `decimal` column of the existing legacy currency table rather than adding a third list. It also requires the currency to be one we support, which keeps the table's unexplained `INR => 0` row out of it. The JS side needs its own three-entry set in `currency-symbols.js`, next to the symbol map that already mirrors PHP.
* **INR is removed from the selector and both validators.** PayPal does not support it at all, so no existing payment can be in it.

Not in this PR, deliberately:

* Reverting the block attributes when a `PUT` fails. That is a separate, WOOPTP-464-shaped problem and deserves its own ticket; with this change a decimal never reaches PayPal, so this route to it is closed.
* RUB (supported by PayPal, missing from our list) and the in-country-only note on CNY, MYR and BRL. Worth a follow-up.

## Related product discussion/links

* Linear: WOOPTP-477. PayPal's currency-codes reference, footnote 1, and the supported-currencies report page both document the rule.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a site with a PayPal connection.

1. Insert a PayPal Payment Buttons block, set the currency to JPY. The price field now steps in whole numbers and the placeholder reads `1500`.
2. Paste `1500.50` into it. **Before:** the request went out and PayPal returned a 422. **After:** the field shows "Prices in JPY are whole numbers" and the Create button stays disabled. No request is sent.
3. Type `1500` and create. It saves and reads ¥1500 on the page, in the editor and at checkout.
4. Turn on product options with per-option pricing and repeat steps 2 and 3 on an option price.
5. Repeat with HUF and TWD.
6. Switch to USD or EUR: `12.34` is accepted everywhere, as before.
7. Send `{ "unit_amount": { "currency_code": "JPY", "value": "1500.50" } }` straight to `POST /wpcom/v2/paypal/buttons`. It is rejected with a 400 and `invalid_price` before any call to PayPal.
8. INR is no longer in the currency dropdown.

Automated: `jp test php packages/paypal-payments` and `jp test js packages/paypal-payments` (176 tests) pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
