### PR TITLE
Profile settings: reword redirection link and add to username field also

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/profile-wpcom-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/profile-wpcom-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Profile Settings: add a link to manage your username on WordPress.com to the username row on wp-admin/profile.php.

--- a/projects/packages/jetpack-mu-wpcom/changelog/profile-wpcom-links-text
+++ b/projects/packages/jetpack-mu-wpcom/changelog/profile-wpcom-links-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Profile Settings: reword the WordPress.com links on wp-admin/profile.php to "Edit account settings on WordPress.com".

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php
@@ -24,34 +24,40 @@ function wpcom_profile_settings_add_links_to_wpcom() {
 
 	$is_wpcom_atomic = is_woa_site();
 
+	$wpcom_profile_settings_text = __( 'Edit account settings on WordPress.com ↗', 'jetpack-mu-wpcom' );
+
 	wp_localize_script(
 		'wpcom-profile-settings-link-to-wpcom',
 		'wpcomProfileSettingsLinkToWpcom',
 		array(
 			'language'      => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $wpcom_profile_settings_text,
+			),
+			'username'      => array(
+				'link' => esc_url( 'https://wordpress.com/me/account' ),
+				'text' => $wpcom_profile_settings_text,
 			),
 			'name'          => array(
 				'link'  => esc_url( 'https://wordpress.com/me' ),
-				'text'  => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text'  => $wpcom_profile_settings_text,
 				'title' => __( 'Name', 'jetpack-mu-wpcom' ),
 			),
 			'website'       => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $wpcom_profile_settings_text,
 			),
 			'bio'           => array(
 				'link' => esc_url( 'https://wordpress.com/me' ),
-				'text' => __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $wpcom_profile_settings_text,
 			),
 			'email'         => array(
 				'link' => esc_url( 'https://wordpress.com/me/account' ),
-				'text' => $is_wpcom_atomic ? __( 'Or manage your WP.com account email ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage your WordPress.com account email ↗', 'jetpack-mu-wpcom' ) : $wpcom_profile_settings_text,
 			),
 			'password'      => array(
 				'link' => esc_url( 'https://wordpress.com/me/security' ),
-				'text' => $is_wpcom_atomic ? __( 'Or manage your WP.com account password ↗', 'jetpack-mu-wpcom' ) : __( 'Manage on WP.com ↗', 'jetpack-mu-wpcom' ),
+				'text' => $is_wpcom_atomic ? __( 'Or manage your WordPress.com account password ↗', 'jetpack-mu-wpcom' ) : $wpcom_profile_settings_text,
 			),
 			'isWpcomAtomic' => $is_wpcom_atomic,
 		)

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-profile-settings/profile-settings-link-to-wpcom.ts
@@ -12,6 +12,24 @@ const wpcom_profile_settings_modify_language_section = () => {
 	}
 };
 
+const wpcom_profile_settings_modify_username_section = () => {
+	const section = document.querySelector( '.user-user-login-wrap' )?.querySelector( 'td' );
+	const settingsLink = window.wpcomProfileSettingsLinkToWpcom?.username?.link;
+	const settingsLinkText = window.wpcomProfileSettingsLinkToWpcom?.username?.text;
+	if ( section && settingsLink && settingsLinkText ) {
+		const notice = document.createElement( 'p' );
+		notice.className = 'description';
+		notice.innerHTML = `<a href="${ settingsLink }">${ settingsLinkText }</a>`;
+		section.appendChild( notice );
+	}
+
+	const field = section?.querySelector( 'input' );
+	if ( field ) {
+		field.classList.add( 'hidden' );
+	}
+	section?.querySelector( 'span.description' )?.remove();
+};
+
 const wpcom_profile_settings_modify_name_section = () => {
 	const table = document.querySelector( '.user-user-login-wrap' )?.parentElement;
 
@@ -40,7 +58,6 @@ const wpcom_profile_settings_modify_name_section = () => {
 	}
 
 	[
-		'.user-user-login-wrap',
 		'.user-first-name-wrap',
 		'.user-last-name-wrap',
 		'.user-nickname-wrap',
@@ -133,6 +150,7 @@ const wpcom_profile_settings_modify_password_section = () => {
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	wpcom_profile_settings_modify_language_section();
+	wpcom_profile_settings_modify_username_section();
 	wpcom_profile_settings_modify_name_section();
 	wpcom_profile_settings_modify_email_section();
 	wpcom_profile_settings_modify_website_section();

--- a/projects/plugins/wpcomsh/changelog/profile-wpcom-links
+++ b/projects/plugins/wpcomsh/changelog/profile-wpcom-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Profile Settings: add a link to manage your username on WordPress.com to the username row on wp-admin/profile.php.

--- a/projects/plugins/wpcomsh/changelog/profile-wpcom-links-text
+++ b/projects/plugins/wpcomsh/changelog/profile-wpcom-links-text
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Profile Settings: reword the WordPress.com links on wp-admin/profile.php to "Edit account settings on WordPress.com".


### PR DESCRIPTION
Fixes DOTSITE-156
Fixes DOTSITE-157

## Proposed changes

- Unhide the username field and show the same link to manage it on WordPress.com.
   - This gives users at least a pointer on how to change their username. Previously, they got confused as the field is not even there.
- Reword the link text.

| Before | After |
| - | - | 
| <img width="735" height="611" alt="image" src="https://github.com/user-attachments/assets/d728aefe-992b-473d-93ae-ec294f2c6fa8" /> |  <img width="643" height="598" alt="image" src="https://github.com/user-attachments/assets/7998a693-d9c3-41ba-829c-4889659980a6" /> |


## Related product discussion/links

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Patch this PR.
2. Go to `wp-admin/profile.php`.
3. Verify the username field and the link text as shown above.
