### PR TITLE
PayPal Payment Buttons: warn that deleting a link breaks published blocks

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-admin-delete-orphans
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-admin-delete-orphans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Say how many published posts embed a payment link before it is deleted from the admin.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
@@ -39,6 +39,84 @@ class PayPal_Admin_Page {
 	const CAPABILITY = 'manage_options';
 
 	/**
+	 * Most published posts scanned for embedded payment links.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var int
+	 */
+	const EMBED_SCAN_LIMIT = 100;
+
+	/**
+	 * The confirmation shown before a payment link is deleted from the admin.
+	 *
+	 * Deleting a link orphans every published block embedding it, so the
+	 * warning has to be at least as strong as the one the block itself shows.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $embed_count Published posts embedding the link, when known.
+	 * @return string Plain text; escape it for wherever it goes.
+	 */
+	public static function delete_confirm_text( $embed_count = 0 ) {
+		$text = __( 'This will permanently delete your payment link. Any links, QR codes, or embedded buttons using this payment will stop working and cannot be recovered.', 'jetpack-paypal-payments' );
+
+		if ( $embed_count > 0 ) {
+			$text .= ' ' . sprintf(
+				/* translators: %d: number of published posts embedding the payment link */
+				_n(
+					'It is embedded in %d published post, which will show a broken button.',
+					'It is embedded in %d published posts, which will show broken buttons.',
+					$embed_count,
+					'jetpack-paypal-payments'
+				),
+				$embed_count
+			);
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Count the published posts embedding each payment link.
+	 *
+	 * The id only exists inside the block comment in post_content, so this is
+	 * one search for the block across published posts rather than a query per
+	 * link. It is capped, so on a site with more block posts than the cap the
+	 * counts are a lower bound.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array<string,int> Post counts keyed by resource id.
+	 */
+	public static function count_published_embeds() {
+		$posts = get_posts(
+			array(
+				'post_type'              => 'any',
+				'post_status'            => 'publish',
+				'posts_per_page'         => self::EMBED_SCAN_LIMIT,
+				's'                      => 'wp:jetpack/paypal-payment-buttons',
+				'sentence'               => true,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		$counts = array();
+		foreach ( $posts as $post ) {
+			if ( ! preg_match_all( '/"resourceId":"(PLB-[A-Za-z0-9]+)"/', $post->post_content, $matches ) ) {
+				continue;
+			}
+			foreach ( array_unique( $matches[1] ) as $resource_id ) {
+				$counts[ $resource_id ] = ( $counts[ $resource_id ] ?? 0 ) + 1;
+			}
+		}
+
+		return $counts;
+	}
+
+	/**
 	 * Initialize admin hooks.
 	 */
 	public static function init() {
@@ -497,7 +575,7 @@ class PayPal_Admin_Page {
 		printf(
 			'<a href="%s" class="button paypal-delete-link" data-confirm="%s">%s</a>',
 			esc_url( $delete_url ),
-			esc_attr__( 'This will permanently delete your payment link. Any links, QR codes, or embedded buttons using this payment will stop working and cannot be recovered.', 'jetpack-paypal-payments' ),
+			esc_attr( self::delete_confirm_text( self::count_published_embeds()[ $resource_id ] ?? 0 ) ),
 			esc_html__( 'Delete', 'jetpack-paypal-payments' )
 		);
 		echo '</p>';

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
@@ -48,6 +48,13 @@ class PayPal_Payment_Links_List_Table extends \WP_List_Table {
 	public $next_page_token = null;
 
 	/**
+	 * Published posts embedding each link, keyed by resource id. Loaded once per table.
+	 *
+	 * @var array<string,int>|null
+	 */
+	private $embed_counts = null;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -213,10 +220,14 @@ class PayPal_Payment_Links_List_Table extends \WP_List_Table {
 				'delete_payment_link_' . $item['id']
 			);
 
+			if ( null === $this->embed_counts ) {
+				$this->embed_counts = PayPal_Admin_Page::count_published_embeds();
+			}
+
 			$actions['delete'] = sprintf(
 				'<a href="%s" class="submitdelete paypal-delete-link" data-confirm="%s">%s</a>',
 				esc_url( $delete_url ),
-				esc_attr__( 'This will permanently delete your payment link. Any links, QR codes, or embedded buttons using this payment will stop working and cannot be recovered.', 'jetpack-paypal-payments' ),
+				esc_attr( PayPal_Admin_Page::delete_confirm_text( $this->embed_counts[ $item['id'] ] ?? 0 ) ),
 				esc_html__( 'Delete', 'jetpack-paypal-payments' )
 			);
 		}

--- a/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
@@ -29,6 +29,7 @@ class PayPal_Admin_Page_Test extends TestCase {
 		delete_transient( PayPal_OAuth::TOKEN_TRANSIENT_KEY );
 		delete_transient( 'paypal_admin_notice_' . get_current_user_id() );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'posts_pre_query' );
 
 		// Clear detail view and list table API response caches.
 		delete_transient( 'paypal_resource_plb-abc123' );
@@ -116,6 +117,96 @@ class PayPal_Admin_Page_Test extends TestCase {
 
 		PayPal_Admin_Page::handle_actions();
 		$this->assertTrue( true );
+	}
+
+	// --- Delete confirmation ---
+
+	/**
+	 * Test the confirmation warns that embedded buttons break, even with no count.
+	 */
+	public function test_delete_confirm_text_warns_about_orphaned_blocks() {
+		$text = PayPal_Admin_Page::delete_confirm_text();
+
+		$this->assertStringContainsString( 'permanently delete your payment link', $text );
+		$this->assertStringContainsString( 'embedded buttons using this payment will stop working', $text );
+		$this->assertStringNotContainsString( 'published post', $text );
+	}
+
+	/**
+	 * Test the confirmation says how many published posts embed the link.
+	 */
+	public function test_delete_confirm_text_counts_embedding_posts() {
+		$this->assertStringContainsString(
+			'embedded in 1 published post, which will show a broken button.',
+			PayPal_Admin_Page::delete_confirm_text( 1 )
+		);
+		$this->assertStringContainsString(
+			'embedded in 3 published posts, which will show broken buttons.',
+			PayPal_Admin_Page::delete_confirm_text( 3 )
+		);
+	}
+
+	/**
+	 * Test that embeds are counted once per post, from the query that asks for published block posts.
+	 *
+	 * The test environment has no database behind WP_Query, so the posts are
+	 * fed through posts_pre_query, which also pins down what the query asks for.
+	 */
+	public function test_count_published_embeds_counts_posts_once_each() {
+		$block = '<!-- wp:jetpack/paypal-payment-buttons {"isApiManaged":true,"resourceId":"PLB-EMBED1","paymentLink":"https://www.paypal.com/ncp/payment/PLB-EMBED1"} /-->';
+		$posts = array(
+			$this->make_post( $block . $block ),
+			$this->make_post( $block, 'page' ),
+			$this->make_post( str_replace( 'PLB-EMBED1', 'PLB-EMBED2', $block ) ),
+			$this->make_post( 'No block here.' ),
+		);
+
+		add_filter(
+			'posts_pre_query',
+			function ( $pre, $query ) use ( $posts ) {
+				$this->assertSame( 'publish', $query->get( 'post_status' ) );
+				$this->assertSame( 'any', $query->get( 'post_type' ) );
+				$this->assertSame( 'wp:jetpack/paypal-payment-buttons', $query->get( 's' ) );
+				$this->assertSame( PayPal_Admin_Page::EMBED_SCAN_LIMIT, $query->get( 'posts_per_page' ) );
+				return $posts;
+			},
+			10,
+			2
+		);
+		$queries_before = did_filter( 'posts_pre_query' );
+
+		$counts = PayPal_Admin_Page::count_published_embeds();
+
+		$this->assertSame( $queries_before + 1, did_filter( 'posts_pre_query' ) );
+
+		$this->assertSame(
+			array(
+				'PLB-EMBED1' => 2,
+				'PLB-EMBED2' => 1,
+			),
+			$counts
+		);
+	}
+
+	/**
+	 * Build a post object with the given content.
+	 *
+	 * @param string $content   Post content.
+	 * @param string $post_type Post type.
+	 * @return \WP_Post The post.
+	 */
+	private function make_post( $content, $post_type = 'post' ) {
+		static $next_id = 1000;
+
+		return new \WP_Post(
+			(object) array(
+				'ID'           => $next_id++,
+				'post_type'    => $post_type,
+				'post_status'  => 'publish',
+				'post_content' => $content,
+				'filter'       => 'raw',
+			)
+		);
 	}
 
 	// --- render_page: disconnected state ---

--- a/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
@@ -28,6 +28,7 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 		delete_option( PayPal_OAuth::ENVIRONMENT_OPTION_KEY );
 		delete_transient( PayPal_OAuth::TOKEN_TRANSIENT_KEY );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'posts_pre_query' );
 
 		// Clear list table API response caches.
 		delete_transient( 'paypal_list_cache_' . md5( '' ) );
@@ -171,6 +172,32 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 		$this->assertStringContainsString( 'action=delete', $output );
 		$this->assertStringContainsString( 'PLB-ABC123', $output );
 		$this->assertStringContainsString( '_wpnonce', $output );
+	}
+
+	/**
+	 * Test the delete confirmation says how many published posts embed the link.
+	 */
+	public function test_column_name_delete_confirm_counts_published_embeds() {
+		$post = new \WP_Post(
+			(object) array(
+				'ID'           => 1000,
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:jetpack/paypal-payment-buttons {"isApiManaged":true,"resourceId":"PLB-ABC123"} /-->',
+				'filter'       => 'raw',
+			)
+		);
+		add_filter(
+			'posts_pre_query',
+			function () use ( $post ) {
+				return array( $post );
+			}
+		);
+
+		$table  = new PayPal_Payment_Links_List_Table();
+		$output = $table->column_name( $this->get_sample_items()[0] );
+
+		$this->assertStringContainsString( 'embedded in 1 published post', $output );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/fix-paypal-admin-delete-orphans
+++ b/projects/plugins/jetpack/changelog/fix-paypal-admin-delete-orphans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payment Buttons: say how many published posts embed a payment link before it is deleted from the admin.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-admin-delete-orphans
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-admin-delete-orphans
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Say how many published posts embed a payment link before it is deleted from the admin.


### PR DESCRIPTION
Fixes WOOPTP-472

## Proposed changes

Deleting a payment link from the Payment Links admin screen orphans every published block that embeds it: the page goes on rendering a complete, confident-looking buy button pointing at a dead PayPal link, and nothing tells the merchant. The two admin confirms (row action and detail view) already got the block's stronger wording on this branch, but as two separate literals in two files, and neither says how many posts are affected.

* **One source for the admin confirm.** `PayPal_Admin_Page::delete_confirm_text()` is a static method (it has to run `__()` at runtime, so not a constant) that both the list table row action and the detail view now call. The block's own `ConfirmDialog` copy is deliberately left alone, along with its "payment button" noun: that is WOOPTP-393's file and sprint.
* **The confirm says how many published posts embed the link.** The resource id only exists inside the block comment in `post_content`, so `count_published_embeds()` runs a single `get_posts()` search for the block name across published posts (any searchable type), capped at 100 posts, and counts distinct `resourceId`s per post. The list table loads that map once per table render rather than once per row; the detail view runs it once. When the count is zero the confirm reads exactly as before, so nothing regresses if the scan finds nothing.
* Wording when there are embeds, appended to the existing warning: "It is embedded in 3 published posts, which will show broken buttons."

The scan is a `LIKE` on `post_content`, which is what the ticket anticipated. It is bounded by the cap and runs only on the admin screen for `manage_options` users. On a site with more than 100 posts carrying the block the number is a lower bound. If reviewers think even that is too much for a confirm dialog, the wording-only half stands on its own.

## Related product discussion/links

* Linear: WOOPTP-472. The block-level confirm and its copy belong to WOOPTP-391 and WOOPTP-393.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a site with a PayPal connection and one published post carrying a PayPal Payment Buttons block. Only delete links you created.

1. Go to the Payment Links admin screen. Hover the row for the link that post embeds and click Delete. The confirm reads "This will permanently delete your payment link. Any links, QR codes, or embedded buttons using this payment will stop working and cannot be recovered. It is embedded in 1 published post, which will show a broken button." Cancel.
2. Open the same link's detail view and click Delete. Same text. Cancel.
3. A link no published post embeds shows the first two sentences only.
4. Check the count against `GET /wp/v2/posts?context=edit&search=PLB-XXXXXXXXXXXX`. A draft embedding the link is not counted.

The admin confirms are native `window.confirm()` dialogs, so browser automation cannot capture them; screenshots need a human.

Automated: `jp test php packages/paypal-payments` passes locally. The test environment has no database behind `WP_Query`, so the new count tests feed posts through `posts_pre_query` and assert what the query asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
