### PR TITLE
PayPal Payment Buttons: log when stored credentials cannot be decrypted

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-log-credential-decrypt-failure
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-log-credential-decrypt-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Log a notice when stored PayPal credentials cannot be decrypted and are removed, instead of removing them silently.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-oauth.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-oauth.php
@@ -280,7 +280,9 @@ class PayPal_OAuth {
 		$client_secret = self::decrypt( $credentials['encrypted_client_secret'] );
 
 		if ( false === $client_id || false === $client_secret ) {
-			// Decryption failed — likely AUTH_KEY changed or data corrupted.
+			// Decryption failed — likely AUTH_KEY changed or data corrupted. Deleting
+			// is by design (WOOPTP-189); the log is the only trace it ever happened.
+			error_log( 'PayPal Payment Buttons: stored credentials could not be decrypted; deleting them. AUTH_KEY may have changed.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			self::delete_credentials();
 			return false;
 		}

--- a/projects/packages/paypal-payments/tests/php/PayPal_OAuth_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_OAuth_Test.php
@@ -24,10 +24,27 @@ use PHPUnit\Framework\TestCase;
 class PayPal_OAuth_Test extends TestCase {
 
 	/**
+	 * The error_log destination before the test changed it.
+	 *
+	 * @var string|false
+	 */
+	private $previous_error_log;
+
+	/**
+	 * Remember where error_log went, so tests that redirect it can be undone.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->previous_error_log = ini_get( 'error_log' );
+	}
+
+	/**
 	 * Clean up after each test.
 	 */
 	protected function tearDown(): void {
 		parent::tearDown();
+
+		ini_set( 'error_log', $this->previous_error_log ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 
 		// Clean up all options and transients. disconnect() is used rather than
 		// deleting options directly because it also resets the request-scoped
@@ -186,11 +203,39 @@ class PayPal_OAuth_Test extends TestCase {
 		update_option( PayPal_OAuth::CREDENTIALS_OPTION_KEY, $credentials );
 
 		// Authenticated encryption should detect tampering and return false.
+		ini_set( 'error_log', '/dev/null' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		$result = PayPal_OAuth::get_credentials();
 		$this->assertFalse( $result );
 
 		// Should also clean up the corrupted data.
 		$this->assertFalse( PayPal_OAuth::has_credentials() );
+	}
+
+	/**
+	 * Test that a failed decrypt is logged before the credentials are deleted.
+	 *
+	 * The ciphertext is re-encrypted under a different key, which is what a
+	 * salt rotation leaves behind.
+	 */
+	public function test_undecryptable_credentials_are_logged() {
+		PayPal_OAuth::store_credentials( 'test_client_id', 'test_client_secret' );
+
+		$key   = sodium_crypto_generichash( 'some-other-auth-key', '', SODIUM_CRYPTO_SECRETBOX_KEYBYTES );
+		$nonce = random_bytes( SODIUM_CRYPTO_SECRETBOX_NONCEBYTES );
+
+		$credentials                        = get_option( PayPal_OAuth::CREDENTIALS_OPTION_KEY );
+		$credentials['encrypted_client_id'] = base64_encode( $nonce . sodium_crypto_secretbox( 'test_client_id', $nonce, $key ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		update_option( PayPal_OAuth::CREDENTIALS_OPTION_KEY, $credentials );
+
+		$log_file = tempnam( sys_get_temp_dir(), 'paypal-oauth-log' );
+		ini_set( 'error_log', $log_file ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
+		$this->assertFalse( PayPal_OAuth::get_credentials() );
+
+		$logged = file_get_contents( $log_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		unlink( $log_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+
+		$this->assertStringContainsString( 'stored credentials could not be decrypted', $logged );
 	}
 
 	/**
@@ -204,6 +249,7 @@ class PayPal_OAuth_Test extends TestCase {
 		$credentials['encrypted_client_id'] = base64_encode( 'short' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		update_option( PayPal_OAuth::CREDENTIALS_OPTION_KEY, $credentials );
 
+		ini_set( 'error_log', '/dev/null' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		$result = PayPal_OAuth::get_credentials();
 		$this->assertFalse( $result );
 	}

--- a/projects/plugins/jetpack/changelog/fix-paypal-log-credential-decrypt-failure
+++ b/projects/plugins/jetpack/changelog/fix-paypal-log-credential-decrypt-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+PayPal Payment Buttons: log a notice when stored PayPal credentials cannot be decrypted and are removed, instead of removing them silently.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-log-credential-decrypt-failure
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-log-credential-decrypt-failure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Log a notice when stored PayPal credentials cannot be decrypted and are removed, instead of removing them silently.


### PR DESCRIPTION
Fixes WOOPTP-466

## Proposed changes

When the stored PayPal credentials cannot be decrypted, `PayPal_OAuth::get_credentials()` deletes them. That fires from read-only paths: `get_connection_status()` runs on `GET /paypal/connection` and on the admin page, so opening the block editor or the Payment Links screen is enough. It has been silent since the original commit, so nobody can say how often it happens. The realistic trigger is a self-hosted site cloned or migrated with fresh `wp-config.php` salts, or `wp config shuffle-salts`.

This PR takes the part nobody designed and leaves the design decision alone:

* **Log the deletion.** One `error_log()` line before `delete_credentials()`, using the `phpcs:ignore` the connection, config and autoloader packages already use for deliberate logging. No new hook; this package emits none and this is not the place to start.
* **Test it.** The new test re-encrypts the stored client id under a different derived key, which is byte-for-byte what a salt rotation leaves behind, redirects `error_log` to a temp file for the call, and asserts the line lands. It does not assert the option survives, because it does not.

**Deliberately not done:** removing the delete. WOOPTP-189 specified "gracefully treats account as disconnected and clears stored data" as a checked acceptance criterion, and the code, its test and the v0.8.0 security-audit pass all agree. The strongest argument for changing it is in the same file: `get_access_token()` handles the same failure by clearing the cached token and requesting a fresh one rather than destroying anything. Overturning a Done ticket needs the original author's sign-off, not a reviewer's, and with this log line in place the question can be answered with data in a quarter. If it is approved, the change is two lines (drop the `delete_credentials()` call, keep `return false`) plus a test that a poisoned option survives `get_connection_status()`.

The other three `delete_credentials()` callers (`class-paypal-rest-controller.php` twice, `abandon_onboarding()`) are deliberate discards of a half-finished connection and are unchanged. `disconnect()` differs in that it also clears the environment and token expiry.

## Related product discussion/links

* Linear: WOOPTP-466. WOOPTP-189 is the design this argues with; WOOPTP-260's `AUTH_KEY` guard already sits above this code and is not touched.

## Does this pull request change what data or activity we track or use?

No. The log line carries no credential material, only that a decrypt failed.

## Testing instructions

Best done with the unit test:

```bash
jp test php packages/paypal-payments
```

End to end, on a throwaway Jurassic Ninja site (do not change `AUTH_KEY` on a shared sandbox): connect PayPal, change `AUTH_KEY` in `wp-config.php`, then open the block editor. The connection shows as disconnected, the credentials option is gone, and the PHP error log now carries "PayPal Payment Buttons: stored credentials could not be decrypted; deleting them. AUTH_KEY may have changed." Before this PR the first two happened with no third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
