### PR TITLE
jetpack-mu-wpcom: skip the pre-launch modal on trial sites

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2925,8 +2925,8 @@ importers:
         specifier: 1.2.2
         version: 1.2.2(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(@wordpress/data@10.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/element@8.6.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/i18n@6.27.0)(debug@4.4.3)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automattic/site-launch-modals':
-        specifier: 1.0.2
-        version: 1.0.2(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 1.0.3
+        version: 1.0.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@automattic/typography':
         specifier: 1.0.0
         version: 1.0.0
@@ -7228,8 +7228,8 @@ packages:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
 
-  '@automattic/site-launch-modals@1.0.2':
-    resolution: {integrity: sha512-nKi7qg0WcmsLpL1qBe7PYY2YppHUJPQpzv5Xkc6brD29EYCQ31rDkWhy92K9kXXXJMXrtQkHTAMUBF06Ind2pQ==}
+  '@automattic/site-launch-modals@1.0.3':
+    resolution: {integrity: sha512-8iOLZ/aX6KrllOP+OYnez4fOtfwdhfODjoI4tlmm+RT9NLnhkKSNuRoJaJOhxNADnfDqeTxQWp87G1R+QuIuuw==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
@@ -19137,7 +19137,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@automattic/site-launch-modals@1.0.2(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@automattic/site-launch-modals@1.0.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@wordpress/base-styles': 9.1.0
       '@wordpress/components': 37.0.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-pre-launch-modal-skip-trials
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-pre-launch-modal-skip-trials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launch: Do not show the pre-launch confirmation modal on trial sites, which still need to choose a plan and domain.

--- a/projects/packages/jetpack-mu-wpcom/changelog/update-site-launch-modals-1.0.3
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-site-launch-modals-1.0.3
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update @automattic/site-launch-modals to 1.0.3.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -43,7 +43,7 @@
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/jetpack-shared-extension-utils": "workspace:*",
 		"@automattic/launchpad": "1.2.2",
-		"@automattic/site-launch-modals": "1.0.2",
+		"@automattic/site-launch-modals": "1.0.3",
 		"@automattic/typography": "1.0.0",
 		"@codemirror/autocomplete": "6.18.6",
 		"@codemirror/commands": "6.8.1",

--- a/projects/packages/jetpack-mu-wpcom/src/common/should-show-pre-launch-modal.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/should-show-pre-launch-modal.test.mts
@@ -17,6 +17,13 @@ describe( 'shouldShowPreLaunchModal', () => {
 		assert.equal( shouldShowPreLaunchModal( { sitePlan: null, hasCustomDomain: true } ), false );
 	} );
 
+	it( 'is false for a trial despite plan and custom-domain entitlements', () => {
+		assert.equal(
+			shouldShowPreLaunchModal( { sitePlan: plan, hasCustomDomain: true, isTrial: true } ),
+			false
+		);
+	} );
+
 	it( 'is false when both are missing', () => {
 		assert.equal( shouldShowPreLaunchModal( {} ), false );
 	} );

--- a/projects/packages/jetpack-mu-wpcom/src/common/should-show-pre-launch-modal.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/should-show-pre-launch-modal.ts
@@ -6,6 +6,7 @@ interface SitePlan {
 interface PreLaunchEligibility {
 	sitePlan?: SitePlan | null;
 	hasCustomDomain?: boolean;
+	isTrial?: boolean;
 }
 
 /**
@@ -16,11 +17,20 @@ interface PreLaunchEligibility {
  * other site redirects straight to the launch flow, preserving today's
  * behavior.
  *
+ * Trials are excluded: they carry the plan and custom-domain feature
+ * entitlements without having purchased a plan or registered a domain, so
+ * they still need Calypso's upsell steps.
+ *
  * @param site                 - The site's launch eligibility inputs.
  * @param site.sitePlan        - The site's paid plan, if any.
  * @param site.hasCustomDomain - Whether the site has a custom domain.
+ * @param site.isTrial         - Whether the site is on a trial plan.
  * @return Whether the pre-launch modal should be shown.
  */
-export function shouldShowPreLaunchModal( { sitePlan, hasCustomDomain }: PreLaunchEligibility ) {
-	return !! sitePlan && !! hasCustomDomain;
+export function shouldShowPreLaunchModal( {
+	sitePlan,
+	hasCustomDomain,
+	isTrial,
+}: PreLaunchEligibility ) {
+	return !! sitePlan && !! hasCustomDomain && ! isTrial;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -172,6 +172,7 @@ function wpcom_enqueue_launch_button_assets() {
 			'siteDomain'      => wp_parse_url( home_url(), PHP_URL_HOST ),
 			'sitePlan'        => $current_plan,
 			'hasCustomDomain' => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'custom-domain' ),
+			'isTrial'         => function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'trial' ),
 		),
 		JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 	);

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.jsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/launch-button.jsx
@@ -37,6 +37,7 @@ export function LaunchButton() {
 	const qualifiesForPreLaunch = shouldShowPreLaunchModal( {
 		sitePlan: launchButtonData.sitePlan,
 		hasCustomDomain: launchButtonData.hasCustomDomain,
+		isTrial: launchButtonData.isTrial,
 	} );
 
 	// Site launch gating: 'semi_gated_site_launch' is the shipped default. The other

--- a/projects/plugins/wpcomsh/changelog/fix-pre-launch-modal-skip-trials
+++ b/projects/plugins/wpcomsh/changelog/fix-pre-launch-modal-skip-trials
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Launch: Do not show the pre-launch confirmation modal on trial sites, which still need to choose a plan and domain.


### PR DESCRIPTION
Part of DOTPROD-77

<img width="1250" height="1303" alt="Screenshot 2026-09-03 at 17 20 36" src="https://github.com/user-attachments/assets/e1477d29-899c-4653-8aad-4ffd30b19b6c" />


## Proposed changes
* Do not show the pre-launch confirmation modal on trial sites. The gate previously required only a plan and a custom domain, but trial plans (e.g. the e-commerce trial) carry both the plan **and** the custom-domain feature as entitlements without the site having purchased a plan or registered a domain. Such sites were incorrectly shown the pre-launch modal instead of being sent straight to Calypso's launch flow, where they hit the plan/domain upsell.
* Thread an `isTrial` signal (`wpcom_site_has_feature( 'trial' )`) from the launch-button data into `shouldShowPreLaunchModal`, which now returns `true` only for a paid, non-trial plan with a custom domain. This covers all trial types, not just the e-commerce trial.
* Bump `@automattic/site-launch-modals` from 1.0.2 to 1.0.3.

## Related product discussion/links
* DOTPROD-77

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a WordPress.com **e-commerce trial** site (unlaunched), open wp-admin.
* Click the **Launch site** button in the admin bar.
* **Before:** the pre-launch confirmation modal appears.
* **After:** the button redirects straight to the Calypso launch flow (`wordpress.com/start/launch-site`), where the plan/domain upsell is presented.
* Regression check on a **paid plan + custom domain** (non-trial) site: the pre-launch confirmation modal should still appear as before.
* Unit tests: `jp test js packages/jetpack-mu-wpcom` (covers `shouldShowPreLaunchModal`, including the new trial case).
