### PR TITLE
JSON API: avoid max_input_vars warning and silent truncation

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-json-api-max-input-vars-warning
+++ b/projects/plugins/jetpack/changelog/fix-json-api-max-input-vars-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+JSON API: avoid a PHP warning and silently-truncated input when a POST body exceeds max_input_vars.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -467,6 +467,24 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
+	 * Parse a query string without risking PHP's max_input_vars truncation warning.
+	 *
+	 * @param string $input  The query string to parse.
+	 * @param array  $result Parsed key/value pairs are written here.
+	 */
+	private function safe_parse_str( $input, &$result ) {
+		$max_input_vars = (int) ini_get( 'max_input_vars' );
+
+		// 0 is a real limit (allow zero vars) here, not a sentinel for "no limit".
+		if ( substr_count( $input, '&' ) >= $max_input_vars ) {
+			$result = array();
+			return;
+		}
+
+		wp_parse_str( $input, $result );
+	}
+
+	/**
 	 * Get POST body data.
 	 *
 	 * @param bool $return_default_values Whether to include default values in the response.
@@ -504,12 +522,12 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$return = json_decode( $input, true );
 
 				if ( $return === null ) {
-					wp_parse_str( $input, $return );
+					$this->safe_parse_str( $input, $return );
 				}
 
 				break;
 			default:
-				wp_parse_str( $input, $return );
+				$this->safe_parse_str( $input, $return );
 				break;
 		}
 


### PR DESCRIPTION
Fixes #46996

## Proposed changes

* `WPCOM_JSON_API_Endpoint::input()` calls `wp_parse_str()` directly for `application/x-www-form-urlencoded` (non-JSON) and unrecognized content types. Once the POST body has more variables than PHP's `max_input_vars` allows, `wp_parse_str()` emits an `E_WARNING` and silently truncates its result — a truncated-but-accepted result is worse than an empty one here, since callers would treat the missing fields as intentionally absent rather than the input having been rejected.
* Adds `safe_parse_str()`, which bails to an empty result instead of letting PHP guess which variables survive.
* `max_input_vars=0` is itself a real, PHP-honored "allow zero variables" setting (confirmed directly: `parse_str()` warns and truncates under it too), not a sentinel for "no limit" — so the guard checks it the same as any other configured value. (An earlier draft of this fix special-cased 0 as "disabled"; real execution caught that as wrong before it shipped.)

## Related product discussion/links

* None — found via #46996.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a pure, isolable function (no WordPress state involved), so it doesn't need the Docker/WP-core test harness to verify — I confirmed it with a standalone PHP script instead:

* Normal input (well under `max_input_vars`) parses unchanged.
* With `max_input_vars` genuinely exceeded (set via `-d max_input_vars=N` at PHP startup — `ini_set()` at runtime silently fails to change this `PERDIR` directive, confirmed separately), the pre-fix code path (`wp_parse_str()` directly) reproduces the exact real `E_WARNING` and truncated result described in the issue; the fixed path (`safe_parse_str()`) returns an empty array instead, with no warning.
* Boundary case (exactly at the limit) and `max_input_vars=0` are covered explicitly as their own scenarios.

To reproduce manually: send a request to any endpoint that calls `input()` with a form-urlencoded body containing more fields than the server's `max_input_vars` (e.g. set `max_input_vars=5` in `php.ini` and POST 10+ fields) — before this fix, PHP's warning fires and the parsed result silently drops fields past the limit; after, `input()` returns an empty array for that request instead.

Co-authored with Claude Code (Anthropic); reviewed by @si-kui-a before submission.
