### PR TITLE
Backup: hoist the scrollIntoView jsdom stub into jest setup

### DIFF
--- a/projects/packages/backup/changelog/update-backup-hoist-scrollintoview-stub
+++ b/projects/packages/backup/changelog/update-backup-hoist-scrollintoview-stub
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Hoist the shared scrollIntoView jsdom stub into jest setup.
+
+

--- a/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
+++ b/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
@@ -39,13 +39,6 @@ const SETTLE = { timeout: 10000 };
 const OLD_REWIND = '1786644531.100';
 const NEW_REWIND = '1786644532.200';
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * One rewindable-activity entry, in WPCOM's shape.
  *

--- a/projects/packages/backup/tests/error-persists-during-retry.test.tsx
+++ b/projects/packages/backup/tests/error-persists-during-retry.test.tsx
@@ -94,13 +94,6 @@ function Harness() {
 	);
 }
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -114,14 +114,6 @@ function failFileTree( error: { code: string; message: string } ) {
 	} );
 }
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row. Defined rather than spied on:
-// `jest.spyOn` requires the property to already exist.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );

--- a/projects/packages/backup/tests/jest.setup.js
+++ b/projects/packages/backup/tests/jest.setup.js
@@ -5,3 +5,12 @@ window.JP_CONNECTION_INITIAL_STATE = {
 		},
 	},
 };
+
+// jsdom implements no scrolling, and DataViews' list layout calls
+// `scrollIntoView` on the selected row.
+// Defined rather than spied on: `jest.spyOn` needs the property to already
+// exist, and `defineProperty` keeps `jest/prefer-spy-on` from rewriting it.
+Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
+	value: () => {},
+	writable: true,
+} );

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -42,13 +42,6 @@ const SITE = 'example.wordpress.com';
 // taken well over Testing Library's 1s default on a loaded runner.
 const SETTLE = { timeout: 10000 };
 
-// jsdom implements no scrolling, and DataViews calls `scrollIntoView`. Defined rather
-// than spied on: `jest.spyOn` needs the property to already exist.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 // Everything Jest's fake timers can replace *except* `Date`. Faking the timer functions
 // too would take Testing Library's polling with it — `waitFor` switches implementation
 // the moment it sees a mocked `setTimeout` — and the suite would hang on the first

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -113,13 +113,6 @@ let hasBackupPlan = false;
 /** Flipped per test; whether the site has a restore for the Restore screen to adopt. */
 let restoreRunning = false;
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * How many times `apiFetch` has been asked for a route, ignoring query args.
  *

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -34,20 +34,6 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 // coverage has taken well over that for the same work locally-green here.
 const SETTLE = { timeout: 10000 };
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row — which only happens here because
-// these are the first tests to render the list with a row in it.
-//
-// Defined rather than spied on: `jest.spyOn` requires the property to
-// already exist, and in jsdom it does not, so spying throws
-// "Property `scrollIntoView` does not exist in the provided object".
-// `defineProperty` also keeps `jest/prefer-spy-on` from rewriting this
-// back into a spy, which is how it broke the first time.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * One rewindable-activity entry, in WPCOM's shape.
  *

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -52,13 +52,6 @@ const BACKUPS_QUESTION = 'Do you enjoy the peace of mind of having backups?';
 // wording rather than to ours.
 const CTA = /Please leave a review and help us spread the word!/;
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * One rewindable-activity entry, so the list has a row to render and the
  * first-run panel does not take the body over.

--- a/projects/packages/backup/tests/stale-rows-feedback.test.tsx
+++ b/projects/packages/backup/tests/stale-rows-feedback.test.tsx
@@ -105,13 +105,6 @@ function list() {
 	return document.querySelector( '.jpb-activity-list' ) as HTMLElement;
 }
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -65,13 +65,6 @@ const FAILURE_REASON = 'Service unavailable';
 const LOADING = 'Loading item details…';
 const LOAD_FAILED = "We couldn't load this item.";
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * One completed backup, in WPCOM's rewindable-activity shape.
  *

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -53,13 +53,6 @@ const SETTLE = { timeout: 10000 };
 const REWIND_A = '1786644531.100';
 const REWIND_B = '1786644532.200';
 
-// jsdom implements no scrolling, and DataViews' list layout calls
-// `scrollIntoView` on the selected row.
-Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', {
-	value: () => {},
-	writable: true,
-} );
-
 /**
  * One rewindable-activity entry, in WPCOM's shape.
  *


### PR DESCRIPTION
Fixes #

## Proposed changes

* `projects/packages/backup/tests/` held **ten byte-identical copies** of the same jsdom stub for `scrollIntoView`. jsdom implements no scrolling, and DataViews' list layout calls `scrollIntoView` on the selected row, so every suite that renders a selected row needs the stub.
* Move the stub into `tests/jest.setup.js` and delete all ten copies. Tests only — no production code changes.
* `tests/jest.config.js` already wires `jest.setup.js` through `setupFilesAfterEnv`, which runs after jsdom exists and before each test module body. That is the same point the ten copies sat at, so the seam does not move. Nothing sets `restoreMocks`, and `Object.defineProperty` is not a Jest mock, so a per-test reset cannot undo it.
* Three of the ten copies were already dead code: `stale-rows-feedback`, `error-persists-during-retry` and `no-plan-quiet` never render a selected row. They are removed either way, and the shared stub covers them if they ever grow one.

Suggested by @dhasilva in review of #51886 — it was finding 5 there, and was deliberately left out of that PR to keep its diff narrow.

### All ten copies removed

#51886 and #51942 have both landed, so `tests/stale-selection-recovery.test.tsx` is on trunk and this branch now removes its copy too — ten in total, no loose end. The shared setup covers that suite: with the stub deleted from `jest.setup.js`, `stale-selection-recovery` fails alongside the others.

## Related product discussion/links

* #51886 — the review that suggested this cleanup (finding 5).

## Does this pull request change what data or activity we track or use?

No. Test-only change.

## Testing instructions

Both commands below were run on this branch, rebased onto trunk at `ca583a09d03`.

**1. The suite passes as-is.**

```
cd projects/packages/backup
nvm use
npx jest --config=tests/jest.config.js
```

Expect:

```
Test Suites: 75 passed, 75 total
Tests:       740 passed, 740 total
```

Those are the same counts trunk gives at `ca583a09d03` — I ran the suite there too and got `75 passed` / `740 passed`. So hoisting the stub changes no test count and drops no coverage.

**2. The stub is load-bearing.**

Delete the `Object.defineProperty( window.HTMLElement.prototype, 'scrollIntoView', … )` block, and its comment, from `tests/jest.setup.js`. Re-run the same command.

Expect **7 suites / 38 tests** to fail:

```
Test Suites: 7 failed, 68 passed, 75 total
Tests:       38 failed, 702 passed, 740 total
```

The failures are all `TypeError: itemRef.current?.scrollIntoView is not a function`, raised from `ListItem` in `@wordpress/dataviews`' list layout, in these seven suites:

* `overview-takeover`
* `error-surfacing`
* `next-scheduled-backup`
* `activity-refresh-on-backup-complete`
* `review-request`
* `switching-backups-resets-detail`
* `stale-selection-recovery`

That last one is the copy this branch newly removes, and its failure here is what confirms the copy was load-bearing rather than dead code.

Restore the block and the suite returns to 75 / 740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2J2i9Tn1Wyfb4UwHCwKAF

