### PR TITLE
Backup: stop the Overview claiming an unloaded row is gone

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2326-item-not-found
+++ b/projects/packages/backup/changelog/jetpack-2326-item-not-found
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the Overview's detail pane now offers a Clear selection button once the activity log has answered and the chosen row is genuinely gone, so a stale ?selected= is no longer a dead end that survives a reload. A log still in flight or one that failed is reported as itself rather than as a missing row, so the button never discards a valid selection. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the Overview's detail pane now offers a Clear selection button when the chosen row is not among the activity-log rows loaded, so a stale ?selected= is no longer a dead end that survives a reload. Only loaded pages are searched, so the pane says the row may be on another page rather than claiming it is gone, and clearing leaves a history entry so Back restores the selection. A log still in flight or one that failed is reported as itself. No-op when the filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -126,23 +126,22 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
  * selections that are not clicks — a bookmarked `?selected=` on a page nothing
  * has loaded, and the newest-backup default pinned by the hook below.
  *
- * A null item alone cannot be reported as "no such row": it is equally the
- * answer while the page query is in flight and after it failed. Callers that
- * act on the absence — not merely describe it — need `isResolved` and `error`
- * to tell those three apart.
+ * A null item never means "no such row": it is equally the answer while the page
+ * query is in flight, after it failed, and while the row sits on a page nothing
+ * has loaded — `hasAnswered` is the list's page verdict, not the whole log's.
  *
  * @param id        - Selection id: `rewindId` for backup items, `activity_id` otherwise.
  * @param page      - The page currently shown in the list.
  * @param pageSize  - The per-page setting currently shown in the list.
  * @param sortOrder - The sort direction currently shown in the list.
- * @return The matching item or null, whether the page query has answered, and its failure if it did.
+ * @return The matching item or null, whether the list's page query has answered, and its failure if it did.
  */
 export function useActivityById(
 	id: string | null,
 	page: number,
 	pageSize: number,
 	sortOrder: ActivitySortOrder
-): { item: ActivityItem | null; isResolved: boolean; error: Error | null } {
+): { item: ActivityItem | null; hasAnswered: boolean; error: Error | null } {
 	// Follows the list's `sortOrder`: it is part of the cache key, so pinning it
 	// here would open a second query for rows already on screen.
 	const query = useActivityPageQuery( page, pageSize, sortOrder );
@@ -174,7 +173,7 @@ export function useActivityById(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ id, query.data ] );
 
-	return { item, isResolved: query.isSuccess, error: query.error };
+	return { item, hasAnswered: query.isSuccess, error: query.error };
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -191,8 +191,8 @@ function OverviewBody() {
 		[ navigate ]
 	);
 
-	// The stale id lives in the URL, so the dead end survives a reload without
-	// this; `replace` keeps the Back button from returning to it either.
+	// The stale id lives in the URL, so the dead end survives a reload without this.
+	// A new history entry, not a replacement: the selection may be fine, so Back must restore it.
 	const clearSelected = useCallback( () => {
 		overviewRef.current?.focus();
 		navigate( {
@@ -201,9 +201,8 @@ function OverviewBody() {
 				delete next.selected;
 				return next;
 			},
-			replace: true,
 			// A single assertion, not `as unknown as`: the updater form stays
-			// comparable, so a typo in `replace` is still a build error.
+			// comparable, so a typo in the key is still a build error.
 		} as Parameters< typeof navigate >[ 0 ] );
 	}, [ navigate ] );
 
@@ -342,8 +341,8 @@ function OverviewBody() {
  * Resolves the URL-driven `selectedId` to an activity item and renders the
  * matching detail card: `<BackupDetail>` for backup rows and `<ActivityDetail>`
  * for everything else. A selection that resolves to nothing is reported three
- * ways — the log failed, the log has not answered yet, or the row is gone — and
- * only the last of those offers to drop the selection.
+ * ways — the log failed, the log has not answered yet, or nothing loaded holds
+ * the row — and only the last of those offers to drop the selection.
  *
  * @param props                 - Component props.
  * @param props.selectedId      - Currently selected row id, or null when nothing is selected.
@@ -367,7 +366,7 @@ function RightPane( {
 	onClearSelected: () => void;
 } ) {
 	// All four must match the list's arguments — this reads its cache entry.
-	const { item, isResolved, error } = useActivityById( selectedId, page, pageSize, sortOrder );
+	const { item, hasAnswered, error } = useActivityById( selectedId, page, pageSize, sortOrder );
 	if ( ! selectedId ) {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">
@@ -387,7 +386,7 @@ function RightPane( {
 			</div>
 		);
 	}
-	if ( ! item && ! isResolved ) {
+	if ( ! item && ! hasAnswered ) {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">
 				{ /* `Spinner` is `role="presentation"` with no text, so on its own this branch is silent. */ }
@@ -400,7 +399,13 @@ function RightPane( {
 		return (
 			<div className="jpb-overview__detail jpb-overview__detail--empty">
 				<Stack direction="column" gap="sm" align="center">
-					<Text>{ __( 'That item is no longer in the activity log.', 'jetpack-backup-pkg' ) }</Text>
+					{ /* Only loaded pages were searched, so "gone" is not ours to claim. */ }
+					<Text>
+						{ __(
+							"That item isn't on this page of the activity log. It may be on another page, or no longer available.",
+							'jetpack-backup-pkg'
+						) }
+					</Text>
 					<Button variant="outline" onClick={ onClearSelected }>
 						{ __( 'Clear selection', 'jetpack-backup-pkg' ) }
 					</Button>

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -1,10 +1,10 @@
-// A `?selected=` pointing at a row the activity log no longer holds rendered
-// "Item not found." and nothing else. The id lives in the URL, so a reload
-// returned the reader to the same dead end — the empty state had to offer a
-// way out of it.
+// A `?selected=` the pane cannot resolve rendered "Item not found." and nothing
+// else. The id lives in the URL, so a reload returned the reader to the same
+// dead end — the empty state had to offer a way out of it.
 //
-// That message answered for two other things as well, so the way out is offered
-// only once the log has actually said the row is gone.
+// That message also answered for a log in flight and a log that failed, which get
+// their own states here. It could never answer "the row is gone": only loaded
+// pages are searched, so the way out has to stay recoverable.
 
 const mockApiFetch = jest.fn();
 const mockSearch = jest.fn< Record< string, unknown >, [] >();
@@ -52,8 +52,12 @@ const SETTLE = { timeout: 10000 };
 
 const REWIND_ID = '1786644531.100';
 const STALE_ID = '1700000000.999';
+const PAGE_TWO_ID = '1786558131.200';
 
-const NOT_FOUND = 'That item is no longer in the activity log.';
+const NOT_FOUND =
+	"That item isn't on this page of the activity log. It may be on another page, or no longer available.";
+// The claim the pane must not make while pages of the log are still unread.
+const GONE_CLAIM = 'That item is no longer in the activity log.';
 const NO_SELECTION = 'Select an item from the list to see details.';
 const CLEAR = /^Clear selection$/;
 const GROUP_LABEL = 'Backup activity';
@@ -83,6 +87,20 @@ function backupEntry() {
 		actor: { type: 'Application', name: 'Jetpack' },
 		content: { text: '10 plugins, 4 themes' },
 		name: 'rewind__backup_complete_full',
+	};
+}
+
+/**
+ * A completed backup on the log's second page, which the list never requests.
+ *
+ * @return A raw activity entry.
+ */
+function pageTwoEntry() {
+	return {
+		...backupEntry(),
+		activity_id: `act-${ PAGE_TWO_ID }`,
+		rewind_id: PAGE_TWO_ID,
+		summary: 'Backup complete (page 2)',
 	};
 }
 
@@ -125,22 +143,27 @@ function finishedBackup() {
 	};
 }
 
-/** What the activity log does: answer with these rows, never answer, or fail. */
-type ActivityAnswer = ReturnType< typeof backupEntry | typeof postEntry >[] | 'pending' | 'error';
+type ActivityRows = ReturnType< typeof backupEntry | typeof postEntry >[];
+
+/** What the activity log does: answer per page, never answer, or fail. */
+type ActivityAnswer = ActivityRows | ( ( page: number ) => ActivityRows ) | 'pending' | 'error';
 
 /**
  * Point every route the Overview reads at a fixed set of answers.
  *
- * @param options          - Fixture options.
- * @param options.activity - Rows the log returns, or how it fails to return any.
- * @param options.backups  - Raw entries `/jetpack/v4/backups` returns.
+ * @param options            - Fixture options.
+ * @param options.activity   - Rows the log returns, or how it fails to return any.
+ * @param options.backups    - Raw entries `/jetpack/v4/backups` returns.
+ * @param options.totalPages - Pages the log reports holding.
  */
 function mockEndpoints( {
 	activity,
 	backups,
+	totalPages = 1,
 }: {
 	activity: ActivityAnswer;
 	backups: ReturnType< typeof finishedBackup >[];
+	totalPages?: number;
 } ) {
 	mockApiFetch.mockImplementation( ( o: { path?: string } ) => {
 		const path = o?.path ?? '';
@@ -154,10 +177,12 @@ function mockEndpoints( {
 			if ( activity === 'error' ) {
 				return Promise.reject( { code: 'activity_log_fetch_failed', message: FAILURE_REASON } );
 			}
+			const requested = Number( /[?&]page=(\d+)/.exec( path )?.[ 1 ] ?? 1 );
+			const rows = typeof activity === 'function' ? activity( requested ) : activity;
 			return Promise.resolve( {
-				current: { orderedItems: activity },
-				totalItems: activity.length,
-				totalPages: 1,
+				current: { orderedItems: rows },
+				totalItems: rows.length * totalPages,
+				totalPages,
 			} );
 		}
 		if ( path.includes( '/site/backup/size' ) ) {
@@ -202,21 +227,18 @@ describe( 'A selection the activity log cannot resolve', () => {
 		expect( screen.getByRole( 'button', { name: CLEAR } ) ).toBeInTheDocument();
 	} );
 
-	it( 'drops only `selected`, through the router, replacing the entry', async () => {
+	it( 'drops only `selected`, through the router', async () => {
 		render( <OverviewStage /> );
 		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
 
 		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
 		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {
 			search: ( previous: Record< string, unknown > ) => Record< string, unknown >;
-			replace?: boolean;
 		};
 		// `@wordpress/boot` nests the whole router href inside wp-admin's own
 		// `?p=`, so the param can only be dropped by the router itself.
 		expect( typeof options.search ).toBe( 'function' );
 		expect( options.search( { selected: STALE_ID, page: '3' } ) ).toEqual( { page: '3' } );
-		// Otherwise Back returns to the dead end the reader just left.
-		expect( options.replace ).toBe( true );
 	} );
 
 	it( 'leaves the dead end once the router applies it', async () => {
@@ -237,7 +259,7 @@ describe( 'A selection the activity log cannot resolve', () => {
 		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'hands focus to the two-pane region instead of dropping it', async () => {
+	it( 'hands focus to the two-pane region, so the next Tab is in the list', async () => {
 		render( <OverviewStage /> );
 		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
 
@@ -245,6 +267,58 @@ describe( 'A selection the activity log cannot resolve', () => {
 		// without naming where it went.
 		const region = screen.getByRole( 'group', { name: GROUP_LABEL } );
 		await waitFor( () => expect( region ).toHaveFocus() );
+
+		// The claim the comment on `.jpb-overview` makes: Tab lands on the list's own
+		// first control, which is DataViews' cog.
+		await userEvent.tab();
+		expect( screen.getByRole( 'button', { name: 'View options' } ) ).toHaveFocus();
+	} );
+} );
+
+// The list's page is React state seeded from `INITIAL_VIEW`, and only `selected`
+// is in the URL — so every reload of a selection made off page 1 lands here.
+describe( 'A selection on a page nothing has loaded', () => {
+	beforeEach( () => {
+		mockEndpoints( {
+			activity: page => ( page === 2 ? [ pageTwoEntry() ] : [ backupEntry() ] ),
+			backups: [],
+			totalPages: 2,
+		} );
+		mockSearch.mockReturnValue( { selected: PAGE_TWO_ID } );
+	} );
+
+	it( 'does not report the row as gone', async () => {
+		render( <OverviewStage /> );
+
+		// The button is the positive control: it renders in this branch either
+		// way, so a missing claim below cannot be a pane that never rendered.
+		await expect(
+			screen.findByRole( 'button', { name: CLEAR }, SETTLE )
+		).resolves.toBeInTheDocument();
+		// Page 1 answering says nothing about page 2, which holds this row and
+		// which nothing has fetched.
+		expect( screen.queryByText( GONE_CLAIM ) ).not.toBeInTheDocument();
+		expect( screen.getByText( NOT_FOUND ) ).toBeInTheDocument();
+	} );
+
+	// The control for the two above: without it they rest on a fixture nothing
+	// checks, and would read the same way if page 2 held no such row.
+	it( 'resolves the row once the list reaches the page holding it', async () => {
+		render( <OverviewStage /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Next page' }, SETTLE ) );
+
+		await expect(
+			screen.findByRole( 'heading', { name: 'Backup complete (page 2)' }, SETTLE )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'leaves the cleared selection on the back stack', async () => {
+		render( <OverviewStage /> );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+
+		// The selection may be perfectly good, so Back has to bring it back.
+		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as { replace?: boolean };
+		expect( options.replace ).not.toBe( true );
 	} );
 } );
 
@@ -283,9 +357,8 @@ describe( 'No selection yet', () => {
 } );
 
 // The pane reads one nullable item, and null is also the answer while the log
-// is in flight and after it failed. Both of those name a row that is fine, so
-// offering to discard it there throws away a valid selection — and `replace`
-// means Back cannot bring it back.
+// is in flight and after it failed. Neither says anything about the row, so
+// neither is a place to offer to drop it.
 describe( 'A selection the activity log has not answered for', () => {
 	beforeEach( () => {
 		// Valid: this id is in the fixture the first suite resolves from, which is


### PR DESCRIPTION
Fixes #

Follow-up to #51886, which merged before this correction was pushed.

## Proposed changes

* Stop the Overview's detail pane stating as fact that a selected row is gone when only the currently-shown page has been checked.

`useActivityById` resolves `item` by scanning **every cached page**, but reported `isResolved` as `query.isSuccess` — the verdict of the page the list happens to be showing. Those are different questions, so a `?selected=` naming a row on a page nothing has fetched returned `item: null, isResolved: true, error: null`, and the pane fell through to its last branch and claimed *"That item is no longer in the activity log."*

That is reachable on an ordinary reload: `?selected=` lives in the URL but the list's page does not, so reopening a bookmarked selection made off page 1 resets the list to page 1 and the row resolves from nothing. #51886 also hung a `replace: true` navigate off that branch, so "Clear selection" discarded a still-valid selection with no way back.

Three changes:

* `isResolved` → `hasAnswered`, with a docblock that names the fourth state instead of describing three.
* The copy hedges to what the code actually knows: *"That item isn't on this page of the activity log. It may be on another page, or no longer available."*
* `replace: true` dropped, so clearing leaves a history entry and Back restores the selection.

The escape hatch itself is unchanged — that was the point of #51886 and it stays.

### Why not resolve the id properly

There is no single-activity lookup to resolve against. `src/rest/class-activity-log-bridge.php` declares exactly `number`, `page` and `sort_order`, and the package's whole route surface has nothing that fetches one row. Proving a row is gone would mean walking every page.

A narrower variant was considered and rejected: keep the definite wording when `totalPages <= 1`, since one page then holds the whole log. It only improves single-page logs, and on a multi-page log the hedge is still the only honest copy — so it is a possible follow-up, not part of this fix.

## Related product discussion/links

* JETPACK-2326

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Modernized dashboard only, behind the `rsm_jetpack_ui_modernization_backup` filter. No-op when the filter is off.

Automated — run from `projects/packages/backup`:

* `npx jest --config=tests/jest.config.js` → **75 suites / 740 tests** passing. Trunk is 75 / 737; the 3 added tests are the `A selection on a page nothing has loaded` suite in `tests/stale-selection-recovery.test.tsx`.
* To see the tests are load-bearing, revert any one change and re-run:
  * restore `'That item is no longer in the activity log.'` → 2 failures (`does not report the row as gone`, `offers a way out beside the message`)
  * restore `replace: true` → 1 failure (`leaves the cleared selection on the back stack`)

Manual, on a site with more than one page of activity:

1. Open Backup → Overview. Click **Next page**, then click any row. The URL gains `?selected=<id>`.
2. Reload the page. The list returns to page 1; the selected row is on page 2.
3. **Before this change:** the pane reads "That item is no longer in the activity log." — untrue, the row is one click away.
   **After:** it reads "That item isn't on this page of the activity log. It may be on another page, or no longer available."
4. Click **Next page**. The row is there, and the detail pane renders it.
5. Repeat steps 1–2, click **Clear selection**, then press **Back**. The selection is restored. Before this change it was gone for good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2J2i9Tn1Wyfb4UwHCwKAF
