### PR TITLE
jetpack-mu-wpcom: Fix handling of non-array response in `wp_ajax_wpcom_generate_site_preview_link`

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-replace-site-visibility-error
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-replace-site-visibility-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix handling of non-array response in `wp_ajax_wpcom_generate_site_preview_link`

--- a/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/replace-site-visibility/replace-site-visibility.php
@@ -45,7 +45,7 @@ function wp_ajax_wpcom_generate_site_preview_link() {
 
 	$response = json_decode( wp_remote_retrieve_body( $body ) );
 	// @phan-suppress-next-line PhanTypeMismatchArgumentProbablyReal -- It takes null, but its phpdoc only says int.
-	wp_send_json( $response[0] ?? $response, null, JSON_UNESCAPED_SLASHES );
+	wp_send_json( is_array( $response ) ? $response[0] ?? null : $response, null, JSON_UNESCAPED_SLASHES );
 }
 add_action( 'wp_ajax_wpcom_generate_site_preview_link', 'wp_ajax_wpcom_generate_site_preview_link' );
 
@@ -101,7 +101,7 @@ function wpcom_get_site_preview_link() {
 	if ( ! is_array( $response ) ) {
 		return $response;
 	}
-	return $response[0];
+	return $response[0] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
`??` (and, for that matter, `isset()`) suppress some errors but not "Cannot use object of type stdClass as array". Add an explicit array check, since apparently objects can be returned there.

This restores the behavior from before #45002, where any array returns element 0 (null if there is none, but now without an "Undefined array key 0" warning) and the response for anything else.

It also applies a fix to `wpcom_get_site_preview_link` to avoid the same "Undefined array key 0" warning in that case.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1788378479106549-slack-C0299DMPG

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Verify things still work? 🤷