### PR TITLE
AI Hub: show the Jetpack AI turned-off notice on Overview tab

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/components/master-off-notice/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/master-off-notice/index.jsx
@@ -4,26 +4,9 @@ import { Link, Notice } from '@wordpress/ui';
 /**
  * Site-wide notice shown on every AI Hub view while the master switch is off.
  *
- * @param {object} props          - Component props.
- * @param {object} props.settings - Settings shape from the feature-settings endpoint; null while loading.
- * @return {object|null} Component markup, or null while the switch is on or another gate is the blocker.
+ * @return {object} Component markup.
  */
-export default function MasterOffNotice( { settings } ) {
-	// Jetpack is not connected.
-	if ( settings?.is_connected === false ) {
-		return null;
-	}
-
-	// The host doesn't allow AI. 
-	if ( settings?.host_allows_ai === false ) {
-		return null;
-	}
-
-	// The master switch is on.
-	if ( settings?.master_enabled !== false ) {
-		return null;
-	}
-
+export default function MasterOffNotice() {
 	return (
 		<Notice.Root intent="warning" className="jetpack-ai-admin__page-notice">
 			<Notice.Title>{ __( 'Jetpack AI is turned off for this site.', 'jetpack' ) }</Notice.Title>

--- a/projects/plugins/jetpack/_inc/client/ai/components/master-off-notice/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/master-off-notice/index.jsx
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import { Link, Notice } from '@wordpress/ui';
+
+/**
+ * Site-wide notice shown on every AI Hub view while the master switch is off.
+ *
+ * @param {object} props          - Component props.
+ * @param {object} props.settings - Settings shape from the feature-settings endpoint; null while loading.
+ * @return {object|null} Component markup, or null while the switch is on or another gate is the blocker.
+ */
+export default function MasterOffNotice( { settings } ) {
+	// Jetpack is not connected.
+	if ( settings?.is_connected === false ) {
+		return null;
+	}
+
+	// The host doesn't allow AI. 
+	if ( settings?.host_allows_ai === false ) {
+		return null;
+	}
+
+	// The master switch is on.
+	if ( settings?.master_enabled !== false ) {
+		return null;
+	}
+
+	return (
+		<Notice.Root intent="warning" className="jetpack-ai-admin__page-notice">
+			<Notice.Title>{ __( 'Jetpack AI is turned off for this site.', 'jetpack' ) }</Notice.Title>
+			<Notice.Description>
+				{ __(
+					'Your feature settings are saved and will apply again when AI is turned back on.',
+					'jetpack'
+				) }{ ' ' }
+				<Link href="admin.php?page=my-jetpack#/products" className="jetpack-ai-admin__notice-link">
+					{ __( 'Manage in My Jetpack', 'jetpack' ) }
+				</Link>
+			</Notice.Description>
+		</Notice.Root>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -213,9 +213,9 @@ function FeatureRow( {
  */
 export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 	const features = settings?.features ?? {};
-	// Children keep their saved values while the master switch is off — the
-	// page shows them greyed with a site-wide notice instead of misreporting
-	// the user's choices as off.
+	// Children keep their saved values while the master switch is off — they
+	// render greyed (under the page-level master-off notice main.jsx owns)
+	// instead of misreporting the user's choices as off.
 	const masterEnabled = settings?.master_enabled !== false;
 	// The connection gate sits outside the master switch: false covers both a
 	// site without a connected owner and one in offline mode, and in either
@@ -290,25 +290,6 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 						) }{ ' ' }
 						<Link href="admin.php?page=my-jetpack#/connection">
 							{ __( 'Connect Jetpack', 'jetpack' ) }
-						</Link>
-					</Notice.Description>
-				</Notice.Root>
-			) }
-			{ isConnected && ! masterEnabled && (
-				<Notice.Root intent="warning">
-					<Notice.Title>
-						{ __( 'Jetpack AI is turned off for this site.', 'jetpack' ) }
-					</Notice.Title>
-					<Notice.Description>
-						{ __(
-							'Your feature settings are saved and will apply again when AI is turned back on.',
-							'jetpack'
-						) }{ ' ' }
-						<Link
-							href="admin.php?page=my-jetpack#/products"
-							className="jetpack-ai-features__notice-link"
-						>
-							{ __( 'Manage in My Jetpack', 'jetpack' ) }
 						</Link>
 					</Notice.Description>
 				</Notice.Root>

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -73,11 +73,11 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.queryByRole( 'separator' ) ).not.toBeInTheDocument();
 	} );
 
-	test( 'the page notices survive the card disappearing', () => {
-		renderFeatures( { master_enabled: false, features: {} } );
+	test( 'the connect notice survives the card disappearing', () => {
+		renderFeatures( { is_connected: false, features: {} } );
 
-		// The notices live outside the card and must not go down with it.
-		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
+		// The notice lives outside the card and must not go down with it.
+		expect( screen.getByText( 'Jetpack is not connected to WordPress.com.' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'region' ) ).not.toBeInTheDocument();
 	} );
 
@@ -178,14 +178,14 @@ describe( 'AiFeatures rendering', () => {
 		).resolves.toBeInTheDocument();
 	} );
 
-	test( 'master off: notice with a My Jetpack link, toggles keep saved values but disable, links hidden', () => {
+	test( 'master off: toggles keep saved values but disable, links hidden', () => {
 		renderFeatures( { master_enabled: false } );
 
-		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'link', { name: 'Manage in My Jetpack' } ) ).toHaveAttribute(
-			'href',
-			'admin.php?page=my-jetpack#/products'
-		);
+		// The master-off notice is page-level (main.jsx owns it) — rendering it
+		// here too would double it up.
+		expect(
+			screen.queryByText( 'Jetpack AI is turned off for this site.' )
+		).not.toBeInTheDocument();
 
 		// The saved value stays visible — the toggle must not misreport it as off.
 		const toggle = screen.getByRole( 'checkbox', { name: /Writing Assistant/ } );
@@ -213,15 +213,6 @@ describe( 'AiFeatures rendering', () => {
 		// connection the plan is unknown, so no upgrade badge may show.
 		expect( screen.queryByText( 'Requires upgrade' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
-	} );
-
-	test( 'not connected takes precedence over the master-off notice', () => {
-		renderFeatures( { is_connected: false, master_enabled: false } );
-
-		expect( screen.getByText( 'Jetpack is not connected to WordPress.com.' ) ).toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Jetpack AI is turned off for this site.' )
-		).not.toBeInTheDocument();
 	} );
 
 	// A plan without paid Jetpack AI still has the free tier (every connected
@@ -271,12 +262,6 @@ describe( 'AiFeatures rendering', () => {
 		// AI Answers stays gated while the free-tier rows work.
 		expect( screen.getByText( 'Requires upgrade' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'checkbox', { name: /AI Answers/ } ) ).toBeDisabled();
-	} );
-
-	test( 'free plan AND master off: the master-off notice shows', () => {
-		renderFeatures( { is_connected: true, plan: { supports_ai: false }, master_enabled: false } );
-
-		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
 	} );
 
 	// Gated toggles must be inert, not merely styled disabled.

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -298,6 +298,7 @@ export default function App() {
 				<GlobalNotices />
 
 				{ ! masterEnabled &&
+					! isMcpContext &&
 					aiSettings?.is_connected !== false &&
 					aiSettings?.host_allows_ai !== false && <MasterOffNotice /> }
 
@@ -338,7 +339,6 @@ export default function App() {
 										savingToolIds={ savingToolIds }
 										onNavigate={ handleMcpNavigate }
 										onUpdate={ handleUpdate }
-										masterEnabled={ masterEnabled }
 										// The activity log has exactly one home: Overview owns the
 										// row whenever the Overview tab exists; the MCP hub keeps
 										// it in the ungated MCP-only shape.

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -40,6 +40,10 @@ const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 // test request. MCP and Connectors ships publicly, so it is not in here.
 const GATED_VIEWS = [ 'overview', 'features' ];
 
+// Views the master switch governs. MCP and Scheduled tasks are not gated by
+// it, so they never show the master-off notice.
+const MASTER_SWITCH_VIEWS = [ 'overview', 'features' ];
+
 // Read at call time, not module scope, so the flag reflects the injected page data.
 const getTabViews = () => {
 	const views = [];
@@ -298,7 +302,7 @@ export default function App() {
 				<GlobalNotices />
 
 				{ ! masterEnabled &&
-					! isMcpContext &&
+					MASTER_SWITCH_VIEWS.includes( view ) &&
 					aiSettings?.is_connected !== false &&
 					aiSettings?.host_allows_ai !== false && <MasterOffNotice /> }
 

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -168,6 +168,8 @@ export default function App() {
 		updateSettings: updateAiSettings,
 	} = useFeatureSettings( showFeaturesView );
 
+	const masterEnabled = aiSettings?.master_enabled !== false;
+
 	// The hash is the single source of truth for the current view: popstate
 	// covers back/forward, hashchange covers direct hash edits and links.
 	useEffect( () => {
@@ -295,7 +297,9 @@ export default function App() {
 			>
 				<GlobalNotices />
 
-				<MasterOffNotice settings={ aiSettings } />
+				{ ! masterEnabled &&
+					aiSettings?.is_connected !== false &&
+					aiSettings?.host_allows_ai !== false && <MasterOffNotice /> }
 
 				{ isMcpContext && (
 					<>
@@ -334,6 +338,7 @@ export default function App() {
 										savingToolIds={ savingToolIds }
 										onNavigate={ handleMcpNavigate }
 										onUpdate={ handleUpdate }
+										masterEnabled={ masterEnabled }
 										// The activity log has exactly one home: Overview owns the
 										// row whenever the Overview tab exists; the MCP hub keeps
 										// it in the ungated MCP-only shape.

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -16,6 +16,7 @@ import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
+import MasterOffNotice from './components/master-off-notice';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
 import McpConnectCallout from './mcp/connect-callout';
@@ -293,6 +294,8 @@ export default function App() {
 				}` }
 			>
 				<GlobalNotices />
+
+				<MasterOffNotice settings={ aiSettings } />
 
 				{ isMcpContext && (
 					<>

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -100,20 +100,18 @@ function BadgeWithIcon( { badge } ) {
  * A tappable row that navigates to a sub-view, visually similar to calypso's
  * RouterLinkSummaryButton.
  *
- * @param {object}                            props          - Component props.
- * @param {*}                                 props.icon     - WordPress icon.
- * @param {string}                            props.title    - Row label.
- * @param {{ text: string, intent?: string }} props.badge    - Optional badge.
- * @param {Function}                          props.onClick  - Click handler.
- * @param {boolean}                           props.disabled - Whether the row is inert.
+ * @param {object}                            props         - Component props.
+ * @param {*}                                 props.icon    - WordPress icon.
+ * @param {string}                            props.title   - Row label.
+ * @param {{ text: string, intent?: string }} props.badge   - Optional badge.
+ * @param {Function}                          props.onClick - Click handler.
  * @return {object} Component markup.
  */
-function SummaryRow( { icon, title, badge, onClick, disabled } ) {
+function SummaryRow( { icon, title, badge, onClick } ) {
 	return (
 		<Button
 			className="jetpack-ai-mcp__summary-row"
-			onClick={ disabled ? undefined : onClick }
-			disabled={ disabled }
+			onClick={ onClick }
 			variant="minimal"
 			tone="neutral"
 		>
@@ -123,7 +121,7 @@ function SummaryRow( { icon, title, badge, onClick, disabled } ) {
 					<Text>{ title }</Text>
 				</Stack>
 				<Stack direction="row" gap="sm" align="center" justify="flex-end">
-					{ ! disabled && badge && <BadgeWithIcon badge={ badge } /> }
+					{ badge && <BadgeWithIcon badge={ badge } /> }
 					<Icon icon={ chevronRight } size={ 20 } />
 				</Stack>
 			</Stack>
@@ -270,7 +268,7 @@ export default function McpHub( {
 					</Stack>
 				</CardBody>
 
-				{ isMcpEnabled && (
+				{ isMcpEnabled && masterEnabled && (
 					<>
 						<CardDivider />
 						<SummaryRow
@@ -278,7 +276,6 @@ export default function McpHub( {
 							title={ __( 'Read', 'jetpack' ) }
 							badge={ readBadge }
 							onClick={ navigateToRead }
-							disabled={ controlsDisabled }
 						/>
 						<CardDivider />
 						<SummaryRow
@@ -286,7 +283,6 @@ export default function McpHub( {
 							title={ __( 'Write', 'jetpack' ) }
 							badge={ writeBadge }
 							onClick={ navigateToWrite }
-							disabled={ controlsDisabled }
 						/>
 					</>
 				) }

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -100,18 +100,20 @@ function BadgeWithIcon( { badge } ) {
  * A tappable row that navigates to a sub-view, visually similar to calypso's
  * RouterLinkSummaryButton.
  *
- * @param {object}                            props         - Component props.
- * @param {*}                                 props.icon    - WordPress icon.
- * @param {string}                            props.title   - Row label.
- * @param {{ text: string, intent?: string }} props.badge   - Optional badge.
- * @param {Function}                          props.onClick - Click handler.
+ * @param {object}                            props          - Component props.
+ * @param {*}                                 props.icon     - WordPress icon.
+ * @param {string}                            props.title    - Row label.
+ * @param {{ text: string, intent?: string }} props.badge    - Optional badge.
+ * @param {Function}                          props.onClick  - Click handler.
+ * @param {boolean}                           props.disabled - Whether the row is inert.
  * @return {object} Component markup.
  */
-function SummaryRow( { icon, title, badge, onClick } ) {
+function SummaryRow( { icon, title, badge, onClick, disabled } ) {
 	return (
 		<Button
 			className="jetpack-ai-mcp__summary-row"
-			onClick={ onClick }
+			onClick={ disabled ? undefined : onClick }
+			disabled={ disabled }
 			variant="minimal"
 			tone="neutral"
 		>
@@ -121,7 +123,7 @@ function SummaryRow( { icon, title, badge, onClick } ) {
 					<Text>{ title }</Text>
 				</Stack>
 				<Stack direction="row" gap="sm" align="center" justify="flex-end">
-					{ badge && <BadgeWithIcon badge={ badge } /> }
+					{ ! disabled && badge && <BadgeWithIcon badge={ badge } /> }
 					<Icon icon={ chevronRight } size={ 20 } />
 				</Stack>
 			</Stack>
@@ -169,6 +171,7 @@ function ConnectRow( { title, description, onClick } ) {
  * @param {Set}      props.savingToolIds     - Set of toolIds currently being saved.
  * @param {Function} props.onNavigate        - Called with 'read' | 'write' | 'setup'.
  * @param {Function} props.onUpdate          - Called with partial mcp_abilities update.
+ * @param {boolean}  [props.masterEnabled]   - Whether the site-wide AI master switch is on.
  * @param {boolean}  [props.showActivityLog] - Whether this view owns the activity log row
  *                                           (false when the Overview tab renders it instead).
  * @return {object} Component markup.
@@ -180,6 +183,7 @@ export default function McpHub( {
 	savingToolIds,
 	onNavigate,
 	onUpdate,
+	masterEnabled = true,
 	showActivityLog = true,
 } ) {
 	const accountAbilities = getAccountMcpAbilities( mcpAbilities ?? {} );
@@ -238,6 +242,11 @@ export default function McpHub( {
 	const navigateToWrite = useCallback( () => onNavigate( 'write' ), [ onNavigate ] );
 	const navigateToSetup = useCallback( () => onNavigate( 'setup' ), [ onNavigate ] );
 
+	// Saved MCP access stays visible while master is off; the toggle is inert
+	// until AI is turned back on (same pattern as the Features rows).
+	const controlsDisabled = ! masterEnabled;
+	const isToggleDisabled = savingToolIds.has( '__site_level__' ) || controlsDisabled;
+
 	return (
 		<>
 			<Card className="jetpack-ai-mcp__access-card">
@@ -254,7 +263,7 @@ export default function McpHub( {
 						<ToggleControl
 							__nextHasNoMarginBottom
 							checked={ isMcpEnabled }
-							disabled={ savingToolIds.has( '__site_level__' ) }
+							disabled={ isToggleDisabled }
 							label={ __( 'Enable MCP access', 'jetpack' ) }
 							onChange={ handleMcpToggle }
 						/>
@@ -269,6 +278,7 @@ export default function McpHub( {
 							title={ __( 'Read', 'jetpack' ) }
 							badge={ readBadge }
 							onClick={ navigateToRead }
+							disabled={ controlsDisabled }
 						/>
 						<CardDivider />
 						<SummaryRow
@@ -276,12 +286,13 @@ export default function McpHub( {
 							title={ __( 'Write', 'jetpack' ) }
 							badge={ writeBadge }
 							onClick={ navigateToWrite }
+							disabled={ controlsDisabled }
 						/>
 					</>
 				) }
 			</Card>
 
-			{ isMcpEnabled && (
+			{ isMcpEnabled && masterEnabled && (
 				<Card className="jetpack-ai-mcp__action-card">
 					<ConnectRow
 						title={ __( 'Connect external AI agent', 'jetpack' ) }
@@ -294,7 +305,7 @@ export default function McpHub( {
 				</Card>
 			) }
 
-			{ showActivityLog && isMcpEnabled && activityLogUrl && (
+			{ showActivityLog && isMcpEnabled && activityLogUrl && masterEnabled && (
 				<Card className="jetpack-ai-mcp__action-card">
 					<a className="jetpack-ai-mcp__connect-row" href={ activityLogUrl }>
 						<span className="jetpack-ai-mcp__connect-row-icon">

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -169,7 +169,6 @@ function ConnectRow( { title, description, onClick } ) {
  * @param {Set}      props.savingToolIds     - Set of toolIds currently being saved.
  * @param {Function} props.onNavigate        - Called with 'read' | 'write' | 'setup'.
  * @param {Function} props.onUpdate          - Called with partial mcp_abilities update.
- * @param {boolean}  [props.masterEnabled]   - Whether the site-wide AI master switch is on.
  * @param {boolean}  [props.showActivityLog] - Whether this view owns the activity log row
  *                                           (false when the Overview tab renders it instead).
  * @return {object} Component markup.
@@ -181,7 +180,6 @@ export default function McpHub( {
 	savingToolIds,
 	onNavigate,
 	onUpdate,
-	masterEnabled = true,
 	showActivityLog = true,
 } ) {
 	const accountAbilities = getAccountMcpAbilities( mcpAbilities ?? {} );
@@ -240,11 +238,6 @@ export default function McpHub( {
 	const navigateToWrite = useCallback( () => onNavigate( 'write' ), [ onNavigate ] );
 	const navigateToSetup = useCallback( () => onNavigate( 'setup' ), [ onNavigate ] );
 
-	// Saved MCP access stays visible while master is off; the toggle is inert
-	// until AI is turned back on (same pattern as the Features rows).
-	const controlsDisabled = ! masterEnabled;
-	const isToggleDisabled = savingToolIds.has( '__site_level__' ) || controlsDisabled;
-
 	return (
 		<>
 			<Card className="jetpack-ai-mcp__access-card">
@@ -261,14 +254,14 @@ export default function McpHub( {
 						<ToggleControl
 							__nextHasNoMarginBottom
 							checked={ isMcpEnabled }
-							disabled={ isToggleDisabled }
+							disabled={ savingToolIds.has( '__site_level__' ) }
 							label={ __( 'Enable MCP access', 'jetpack' ) }
 							onChange={ handleMcpToggle }
 						/>
 					</Stack>
 				</CardBody>
 
-				{ isMcpEnabled && masterEnabled && (
+				{ isMcpEnabled && (
 					<>
 						<CardDivider />
 						<SummaryRow
@@ -288,7 +281,7 @@ export default function McpHub( {
 				) }
 			</Card>
 
-			{ isMcpEnabled && masterEnabled && (
+			{ isMcpEnabled && (
 				<Card className="jetpack-ai-mcp__action-card">
 					<ConnectRow
 						title={ __( 'Connect external AI agent', 'jetpack' ) }
@@ -301,7 +294,7 @@ export default function McpHub( {
 				</Card>
 			) }
 
-			{ showActivityLog && isMcpEnabled && activityLogUrl && masterEnabled && (
+			{ showActivityLog && isMcpEnabled && activityLogUrl && (
 				<Card className="jetpack-ai-mcp__action-card">
 					<a className="jetpack-ai-mcp__connect-row" href={ activityLogUrl }>
 						<span className="jetpack-ai-mcp__connect-row-icon">

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -161,8 +161,14 @@ body.jetpack_page_jetpack-ai {
 }
 
 // Keeps the notice link on one line, so it does not wrap mid-phrase.
-.jetpack-ai-features__notice-link {
+.jetpack-ai-admin__notice-link {
 	white-space: nowrap;
+}
+
+// Page-level notices render above whichever view is active; the views own no
+// spacing toward them, so the gap lives here.
+.jetpack-ai-admin__page-notice {
+	margin-block-end: 16px;
 }
 
 // Feature rows: the design aligns the action link with the label's text

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -129,6 +129,108 @@ describe( 'AI admin page (main.jsx)', () => {
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 
+	describe( 'master-off notice', () => {
+		const MASTER_OFF_TITLE = 'Jetpack AI is turned off for this site.';
+		const masterOffSettings = () => ( { ...enabledSettings(), master_enabled: false } );
+
+		test( 'features tab: notice with the My Jetpack link, rendered exactly once', async () => {
+			mockApiFetch( { featureGet: masterOffSettings() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Manage in My Jetpack' } ) ).toHaveAttribute(
+				'href',
+				'admin.php?page=my-jetpack#/products'
+			);
+			// One page-level notice — AiFeatures must not render a second copy.
+			expect( screen.getAllByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).toHaveLength( 1 );
+			expect( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) ).toBeDisabled();
+		} );
+
+		test( 'overview tab: the notice shows', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
+			window.location.hash = '#/overview';
+			mockApiFetch( { featureGet: masterOffSettings() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+		} );
+
+		test( 'MCP tab: the notice shows', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
+			window.location.hash = '#/mcp';
+			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+		} );
+
+		test( 'scheduled tasks tab: the notice shows', async () => {
+			window.jetpackAiSettings = {
+				showFeaturesView: true,
+				blogId: 1,
+				featureFlags: { 'ai-hub-scheduled-tasks': true },
+			};
+			window.location.hash = '#/scheduled-tasks';
+			window.__agentsManagerActions = {
+				isReady: true,
+				chatNavigate: jest.fn(),
+				setChatDocked: jest.fn(),
+				setChatOpen: jest.fn(),
+			};
+			mockApiFetch( { featureGet: masterOffSettings() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+		} );
+
+		test( 'not connected: the connect ask wins over the master-off notice', async () => {
+			mockApiFetch( { featureGet: { ...masterOffSettings(), is_connected: false } } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( 'Jetpack is not connected to WordPress.com.', IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'host off: only the host notice shows', async () => {
+			mockApiFetch( { featureGet: { ...masterOffSettings(), host_allows_ai: false } } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( 'AI has been turned off for this site.', IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'MCP sub-view: the notice shows there too', async () => {
+			window.location.hash = '#/read';
+			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByRole( 'button', { name: 'Jetpack AI' } )
+			).resolves.toBeInTheDocument();
+			expect( screen.getByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).toBeInTheDocument();
+		} );
+	} );
+
 	test( 'save-confirmation: a successful AI-settings save shows a success snackbar', async () => {
 		mockApiFetch( { featurePost: () => Promise.resolve( enabledSettings() ) } );
 

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -174,6 +174,39 @@ describe( 'AI admin page (main.jsx)', () => {
 			).resolves.toBeInTheDocument();
 		} );
 
+		test( 'MCP tab: master off disables the main toggle and hides action cards', async () => {
+			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
+			window.location.hash = '#/mcp';
+			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+
+			// Saved "on" value stays visible but the toggle is inert.
+			const mcpToggle = screen.getByRole( 'checkbox', { name: 'Enable MCP access' } );
+			expect( mcpToggle ).toBeChecked();
+			expect( mcpToggle ).toBeDisabled();
+
+			// Read / Write nav rows appear (MCP is saved on) but cannot be clicked.
+			// @wordpress/ui Button uses aria-disabled rather than the HTML disabled
+			// attribute, so toBeDisabled() does not match — check the attribute directly.
+			expect( screen.getByRole( 'button', { name: /Read/ } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
+			expect( screen.getByRole( 'button', { name: /Write/ } ) ).toHaveAttribute(
+				'aria-disabled',
+				'true'
+			);
+
+			// Action cards are hidden while master is off.
+			expect( screen.queryByText( 'Connect external AI agent' ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'link', { name: /Activity log/ } ) ).not.toBeInTheDocument();
+		} );
+
 		test( 'scheduled tasks tab: the notice shows', async () => {
 			window.jetpackAiSettings = {
 				showFeaturesView: true,

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -174,7 +174,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			).resolves.toBeInTheDocument();
 		} );
 
-		test( 'MCP tab: master off disables the main toggle and hides action cards', async () => {
+		test( 'MCP tab: master off disables the main toggle and hides the rest of the hub', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
 			window.location.hash = '#/mcp';
 			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
@@ -190,19 +190,8 @@ describe( 'AI admin page (main.jsx)', () => {
 			expect( mcpToggle ).toBeChecked();
 			expect( mcpToggle ).toBeDisabled();
 
-			// Read / Write nav rows appear (MCP is saved on) but cannot be clicked.
-			// @wordpress/ui Button uses aria-disabled rather than the HTML disabled
-			// attribute, so toBeDisabled() does not match — check the attribute directly.
-			expect( screen.getByRole( 'button', { name: /Read/ } ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
-			expect( screen.getByRole( 'button', { name: /Write/ } ) ).toHaveAttribute(
-				'aria-disabled',
-				'true'
-			);
-
-			// Action cards are hidden while master is off.
+			expect( screen.queryByRole( 'button', { name: /Read/ } ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: /Write/ } ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( 'Connect external AI agent' ) ).not.toBeInTheDocument();
 			expect( screen.queryByRole( 'link', { name: /Activity log/ } ) ).not.toBeInTheDocument();
 		} );

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -175,7 +175,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'scheduled tasks tab: the notice shows', async () => {
+		test( 'scheduled tasks tab: the notice does not show', async () => {
 			window.jetpackAiSettings = {
 				showFeaturesView: true,
 				blogId: 1,
@@ -193,8 +193,9 @@ describe( 'AI admin page (main.jsx)', () => {
 			render( <App /> );
 
 			await expect(
-				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
+				screen.findByRole( 'button', { name: 'Try again' } )
 			).resolves.toBeInTheDocument();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'not connected: the connect ask wins over the master-off notice', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -162,38 +162,17 @@ describe( 'AI admin page (main.jsx)', () => {
 			).resolves.toBeInTheDocument();
 		} );
 
-		test( 'MCP tab: the notice shows', async () => {
+		test( 'MCP tab: the notice does not show and the hub stays functional', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
 			window.location.hash = '#/mcp';
 			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
 
 			render( <App /> );
 
-			await expect(
-				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
-			).resolves.toBeInTheDocument();
-		} );
-
-		test( 'MCP tab: master off disables the main toggle and hides the rest of the hub', async () => {
-			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1 };
-			window.location.hash = '#/mcp';
-			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
-
-			render( <App /> );
-
-			await expect(
-				screen.findByText( MASTER_OFF_TITLE, IGNORE_A11Y )
-			).resolves.toBeInTheDocument();
-
-			// Saved "on" value stays visible but the toggle is inert.
-			const mcpToggle = screen.getByRole( 'checkbox', { name: 'Enable MCP access' } );
+			const mcpToggle = await screen.findByRole( 'checkbox', { name: 'Enable MCP access' } );
 			expect( mcpToggle ).toBeChecked();
-			expect( mcpToggle ).toBeDisabled();
-
-			expect( screen.queryByRole( 'button', { name: /Read/ } ) ).not.toBeInTheDocument();
-			expect( screen.queryByRole( 'button', { name: /Write/ } ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( 'Connect external AI agent' ) ).not.toBeInTheDocument();
-			expect( screen.queryByRole( 'link', { name: /Activity log/ } ) ).not.toBeInTheDocument();
+			expect( mcpToggle ).toBeEnabled();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
 		test( 'scheduled tasks tab: the notice shows', async () => {
@@ -240,7 +219,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'MCP sub-view: the notice shows there too', async () => {
+		test( 'MCP sub-view: the notice does not show there either', async () => {
 			window.location.hash = '#/read';
 			mockApiFetch( { featureGet: masterOffSettings(), mcpGet: connectedMcpGet() } );
 
@@ -249,7 +228,7 @@ describe( 'AI admin page (main.jsx)', () => {
 			await expect(
 				screen.findByRole( 'button', { name: 'Jetpack AI' } )
 			).resolves.toBeInTheDocument();
-			expect( screen.getByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).toBeInTheDocument();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
-Comment: AI Hub: show the Jetpack AI turned-off notice on every tab. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.
+Comment: AI Hub: show the Jetpack AI turned-off notice on the non-MCP tabs; MCP is not gated by the master switch. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.
 

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: AI Hub: show the Jetpack AI turned-off notice on every tab. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
@@ -1,3 +1,4 @@
 Significance: patch
 Type: other
 Comment: AI Hub: show the Jetpack AI turned-off notice on every tab. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.
+

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-disabled-notice-all-tabs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
-Comment: AI Hub: show the Jetpack AI turned-off notice on the non-MCP tabs; MCP is not gated by the master switch. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.
+Comment: AI Hub: show the Jetpack AI turned-off notice on the Overview and AI Features tabs; MCP and Scheduled tasks are not gated by the master switch. The gated tabs have not shipped in a stable release, so there is nothing for users to be told about.
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Ensure the  "Jetpack AI is turned off for this site." notice appears both on the AI Features page and the Overview page (previously only on the AI features page)
* The notice only renders when the master switch is the actual blocker.  The not-connected and host-disallowed states keep their own dedicated notices and take precedence.
* Since MCP is not affected by the AI "Master Switch", the notice is omitted there. Quick start links are also not disabled since these are MCP as well.

## Related product discussion/links
pdtkmj-4Vi

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to Jetpack → AI, open the **AI Features** tab, and turn the master Jetpack AI switch off (or turn Jetpack AI off from My Jetpack → Products).
* Verify the warning notice "Jetpack AI is turned off for this site." with a working "Manage in My Jetpack" link appears at the top of Overview, AI Features, Scheduled tasks (needs the `ai-hub-scheduled-tasks` flag), and appears exactly once on the AI Features tab (it used to render inside that view).
* On the AI Features tab, confirm the feature toggles still show their saved values but are disabled.
* On the MCP and Connectors tab, confirm there is no notice, and MCP controls work as usual.
* Turn the master switch back on and confirm the notice disappears.
* Sanity-check precedence: with the site not connected (or on a host that disallows AI), the existing connection/host notices show instead of this one.

| Feature On | Feature Off |
|--------|--------|
| <img width="655" height="498" alt="image" src="https://github.com/user-attachments/assets/971abfcb-6668-4057-9241-75039c1b5f30" /> | <img width="664" height="561" alt="image" src="https://github.com/user-attachments/assets/c095a0b3-cfe1-450c-960d-60d76a947292" /> |
| <img width="651" height="785" alt="image" src="https://github.com/user-attachments/assets/53c5b961-2d62-4c3e-83c6-97da56757463" /> | <img width="661" height="785" alt="image" src="https://github.com/user-attachments/assets/0a3d3aac-e67a-4374-a6b7-4d1c1fbb3977" />| 
