### PR TITLE
jetpack: Fix WooCommerce tests

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-woocommerce-tests
+++ b/projects/plugins/jetpack/changelog/fix-woocommerce-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Load a now-used class in `WooCommerceTestTrait`.
+
+

--- a/projects/plugins/jetpack/tests/php/trait-woo-tests.php
+++ b/projects/plugins/jetpack/tests/php/trait-woo-tests.php
@@ -42,7 +42,7 @@ trait WooCommerceTestTrait {
 		require_once $woo_tests_dir . '/legacy/framework/class-wc-mock-payment-gateway.php';
 		require_once $woo_tests_dir . '/legacy/framework/class-wc-mock-enhanced-payment-gateway.php';
 		require_once $woo_tests_dir . '/legacy/framework/class-wc-payment-token-stub.php';
-		// commenting this out for now. require_once( $woo_tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php' );
+		require_once $woo_tests_dir . '/legacy/framework/vendor/class-wp-test-spy-rest-server.php';
 
 		// test cases
 		require_once $woo_tests_dir . '/legacy/includes/wp-http-testcase.php';


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Looks like woocommerce/woocommerce#66522 added a use of a `WP_Test_Spy_REST_Server` class we hadn't been loading. Load it now.

(No idea why that line was there but commented out since 4a1b5c02 in 2016 🤷)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1788443805905609-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy now?