### PR TITLE
wpcomsh: bump wc-calypso-bridge to 2.11.8

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-bump_wc-calypso-bridge-2.11.8
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-bump_wc-calypso-bridge-2.11.8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update wc-calypso-bridge to 2.11.8.

--- a/projects/plugins/wpcomsh/composer.json
+++ b/projects/plugins/wpcomsh/composer.json
@@ -8,7 +8,7 @@
 		"automattic/custom-fonts": "^3.0",
 		"automattic/custom-fonts-typekit": "^2.0",
 		"automattic/text-media-widget-styles": "^2.0",
-		"automattic/wc-calypso-bridge": "^2.11.7",
+		"automattic/wc-calypso-bridge": "^2.11.8",
 		"wordpress/classic-editor-plugin": "1.6.7",
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d86e97be5937a9514188a45b11b07c1",
+    "content-hash": "322ae0393abf28902a8b7658c32ea20b",
     "packages": [
         {
             "name": "automattic/block-delimiter",
@@ -2827,16 +2827,16 @@
         },
         {
             "name": "automattic/wc-calypso-bridge",
-            "version": "v2.11.7",
+            "version": "v2.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/wc-calypso-bridge.git",
-                "reference": "ff8f1980da53ce4ad724edb3ca3e7188a7f1778e"
+                "reference": "0c058d67c384d15752691402dd8031824387b6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/ff8f1980da53ce4ad724edb3ca3e7188a7f1778e",
-                "reference": "ff8f1980da53ce4ad724edb3ca3e7188a7f1778e",
+                "url": "https://api.github.com/repos/Automattic/wc-calypso-bridge/zipball/0c058d67c384d15752691402dd8031824387b6da",
+                "reference": "0c058d67c384d15752691402dd8031824387b6da",
                 "shasum": ""
             },
             "require-dev": {
@@ -2878,7 +2878,7 @@
             "license": [
                 "GPL-2.0-or-later"
             ],
-            "time": "2026-08-21T15:43:09+00:00"
+            "time": "2026-09-03T14:06:44+00:00"
         },
         {
             "name": "automattic/woocommerce-analytics",


### PR DESCRIPTION
## Proposed changes

* Updates the `wc-calypso-bridge` dependency in wpcomsh from 2.11.7 to 2.11.8.
* Raises the constraint to `^2.11.8` in addition to moving the lockfile, so a fresh resolve settles on 2.11.8 as the minimum rather than merely the current pick.
* Includes the WooCommerce 11.1 compatibility update that avoids deprecated stable WooCommerce Admin feature flag lookups while preserving optional feature settings.

The lockfile change is scoped to this one package. No unrelated dependencies were updated, so the lock diff is 12 lines.

Upstream tag: https://github.com/Automattic/wc-calypso-bridge/tree/2.11.8

## Related product discussion/links

* https://github.com/Automattic/wc-calypso-bridge/pull/1646
* https://github.com/woocommerce/woocommerce/pull/65472
* https://developer.woocommerce.com/2026/08/31/retiring-stable-feature-flags/

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Simple site running wpcomsh and WooCommerce 11.1 or newer, confirm `vendor/automattic/wc-calypso-bridge` reports version 2.11.8.
* Enable debug logging and load **WooCommerce → Home**.
* Confirm the setup task list and the Customize Store and Launch Your Store functionality continue to load as expected.
* Disable and re-enable WooCommerce Analytics and marketplace suggestions, confirming those optional settings remain respected.
* Confirm no database errors, PHP notices, or feature-flag deprecation warnings appear in the logs.
