### PR TITLE
Fix WooCommerce thumbnail carousel JS concatenation issue

### DIFF
--- a/projects/plugins/boost/changelog/fix-woocommerce-thumbnail-carousel-concatenation
+++ b/projects/plugins/boost/changelog/fix-woocommerce-thumbnail-carousel-concatenation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Prevent WooCommerce product thumbnail carousels from breaking.

--- a/projects/plugins/boost/compatibility/js-concatenate.php
+++ b/projects/plugins/boost/compatibility/js-concatenate.php
@@ -18,6 +18,8 @@ function maybe_do_not_concat( $do_concat, $handle ) {
 		'wc-bookings-booking-form',
 		// WooCommerce Analytics
 		'woocommerce-analytics-client',
+		// Plugin: `woocommerce`
+		'wc-single-product',
 	);
 
 	if ( in_array( $handle, $excluded_handles, true ) ) {

--- a/projects/plugins/boost/tests/php/compatibility/JS_Concatenate_Test.php
+++ b/projects/plugins/boost/tests/php/compatibility/JS_Concatenate_Test.php
@@ -22,6 +22,7 @@ class JS_Concatenate_Test extends Base_TestCase {
 		$fn = 'Automattic\Jetpack_Boost\Compatibility\JS_Concatenate\maybe_do_not_concat';
 		$this->assertFalse( $fn( true, 'tribe-tickets-block' ) );
 		$this->assertFalse( $fn( true, 'woocommerce-analytics-client' ) );
+		$this->assertFalse( $fn( true, 'wc-single-product' ) );
 	}
 
 	public function test_other_handles_pass_through_unchanged() {


### PR DESCRIPTION
Fixes BOOST-664

This pull request addresses the issue with the WooCommerce thumbnail carousel breaking due to JavaScript concatenation. The following changes were made:

- **Changelog Entry**: Added a new entry to document the fix for the WooCommerce thumbnail carousel concatenation issue.
- **JS Concatenation**: Updated the `js-concatenate.php` file to exclude the `wc-single-product` handle from concatenation, ensuring that the thumbnail carousel functions correctly without interference from concatenated scripts.
- **Regression Test**: Added a regression test in `JS_Concatenate_Test.php` to verify that the exclusion works as intended and prevents future issues.

This fix is a targeted approach to resolve the immediate problem while maintaining the integrity of the existing JavaScript loading strategies.

## Why this breaks

`Concatenate_JS::do_items()` builds each `<script>` tag by hand:

```php
$tag = "<script type='text/javascript' src='" . esc_url( $href ) . "'></script>\n";
```

That path never goes through `WP_Scripts::do_item()`, which is where core resolves a script's
loading strategy — so **a concatenated script loses its `defer`**. (`script_loader_tag` is
re-applied just below, but only for single-handle groups, and core has already been skipped by
then, so the attribute is not added back.)

WooCommerce registers `wc-single-product` with `'strategy' => 'defer'`. Botiga — and any theme
that hooks the gallery init events — enqueues its gallery script **blocking**. Unconcatenated,
that ordering works: the blocking theme script executes during parse and binds its handlers,
then the deferred `wc-single-product` runs after parsing and fires
`wc-product-gallery-before-init` / `-after-init` into handlers that already exist.

Concatenated, `wc-single-product` loses `defer` and lands in an earlier bundle than the theme
script, so it fires those events before anything has bound to them. The thumbnail carousel is
never initialised and renders as a flat static grid.

Excluding the *theme's* handles does not help — they had no loading strategy to lose. Excluding
`wc-single-product` restores it, because an excluded handle is emitted through `do_item()`.

## Testing instructions

### Set up a store with a product gallery

Any WordPress site with WooCommerce works. On Jurassic Ninja, launch with the **WooCommerce**
and **Import sample product data** features, then:

1. Install a theme that hooks the WooCommerce gallery init events. The free
   [Botiga](https://wordpress.org/themes/botiga/) theme is the one from the original report and
   needs no premium add-on — its `assets/js/botiga-gallery.min.js` listens for
   `wc-product-gallery-before-init` and `wc-product-gallery-after-init`:

   ```bash
   wp theme install botiga --activate
   ```

2. Turn off WooCommerce's coming-soon mode, which is on by default on a fresh install and hides
   every product page:

   ```bash
   wp option update woocommerce_coming_soon no
   ```

3. Give a product a gallery. The sample-data products ship with a featured image but an empty
   `_product_image_gallery`, so there is no thumbnail carousel to break until you add one. Use
   any 4+ attachment IDs from `wp post list --post_type=attachment`:

   ```bash
   wp post meta update <product_id> _product_image_gallery "46,47,48,49,50"
   ```

4. Install Jetpack Boost and turn on Concatenate JS:

   ```bash
   wp plugin install jetpack-boost --activate
   wp jetpack-boost module activate minify_js
   ```

### Reproduce the bug (trunk)

Open the product page **logged out** (or in a private window — Boost's page cache is bypassed
for logged-in users, which is fine either way).

- ❌ The gallery thumbnails render as a **flat static grid**, all of them at once, with no
  next/prev arrow.
- Compare against the same URL with `?jb-disable-modules=minify_js`, which turns concatenation
  off for that request only: ✅ the thumbnails become a **horizontal carousel** with a `›` arrow.

In the browser console, on either URL:

```js
document.querySelectorAll( '.botiga-flex-viewport, .botiga-flex-direction-nav' ).length
// 0 = carousel never initialised (bug), 2 = carousel working
```

### Confirm the cause

Add `define( 'WP_DEBUG', true );` to `wp-config.php`. Boost then stamps each bundle with the
handles it contains, which makes the ordering visible:

```bash
curl -s 'https://<site>/product/<slug>/' | grep -oE "<script [^>]*data-handles[^>]*>"
```

On trunk, `wc-single-product` sits in the *first* bundle and the theme's gallery script in the
*second* — and neither tag carries `defer`:

```
data-handles='jquery-migrate,…,wc-zoom,wc-flexslider,wc-photoswipe,wc-photoswipe-ui-default,wc-single-product,wc-js-cookie,woocommerce'
data-handles='botiga-custom,botiga-gallery,comment-reply,…,wc-cart-fragments'
```

Without concatenation those same scripts each render as
`<script data-wp-strategy="defer" defer id="wc-single-product-js" …>`.

### Verify the fix

Apply this branch (or, for a no-deploy preview of exactly the same code path, load the product
page as an admin with `?jb-minify-js-excludes=wc-single-product` — that per-request debug
parameter feeds the same exclude list this PR's filter feeds).

- ✅ The thumbnail carousel works **with Concatenate JS still enabled** — identical to the
  `?jb-disable-modules=minify_js` control.
- `wc-single-product` is now emitted on its own, with its strategy intact:

  ```
  <script data-wp-strategy="defer" defer id="wc-single-product-js" src=".../single-product.min.js?ver=11.1.0">
  ```

- The console check above now returns `2`.

Flipping the two added lines out of `compatibility/js-concatenate.php` and reloading re-breaks
the carousel, so the exclusion is doing the work.

|Before|After|
|---|---|
|<img width="1166" height="250" alt="before-trunk-carousel-broken" src="https://github.com/user-attachments/assets/4ed6b159-9627-40d0-94a7-bca7a27575f6" />|<img width="1166" height="250" alt="after-pr51950-carousel-works" src="https://github.com/user-attachments/assets/69492b83-f377-48bd-809d-af07d0d28822" />|

### Regression test

```bash
jp test php plugins/boost
```

`JS_Concatenate_Test::test_excluded_handle_is_not_concatenated` covers the new handle.

### Scope note for reviewers

This fixes the one handle behind BOOST-664, but the underlying defect is broader: the concat
path drops the loading strategy from **every** script it emits, not just this one. A quick way
to see that on the same page is `wc-cart-fragments`, which is also registered `defer` and also
loses it. Worth a follow-up issue against `Concatenate_JS::do_items()`; a theme that binds to any
other WooCommerce init event will hit the same wall.
