### PR TITLE
Podcast: open the stats date range calendar on the selected range

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-stats-calendar-default-month
+++ b/projects/packages/podcast/changelog/fix-podcast-stats-calendar-default-month
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Open the date range calendar on the selected range.

--- a/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
@@ -212,6 +212,7 @@ const PeriodControl = ( { value, onChange }: PeriodControlProps ) => {
 					</Stack>
 					<RangeCalendar
 						value={ draft }
+						defaultMonth={ draft?.from }
 						onValueChange={ handleCalendarChange }
 						locale={ document.documentElement.lang }
 						numberOfMonths={ isSmall ? 1 : 2 }

--- a/projects/plugins/jetpack/changelog/fix-podcast-stats-calendar-default-month
+++ b/projects/plugins/jetpack/changelog/fix-podcast-stats-calendar-default-month
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Podcast: Open the stats date range calendar on the selected range.

--- a/projects/plugins/jetpack/changelog/fix-podcast-stats-calendar-default-month
+++ b/projects/plugins/jetpack/changelog/fix-podcast-stats-calendar-default-month
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Podcast: Open the stats date range calendar on the selected range.


### PR DESCRIPTION
Follow-up to #51902.

## Proposed changes

* The stats date range calendar opened on the current month regardless of the selected range, so any range older than a couple of months was off-screen when the popover opened.
* Pass `defaultMonth` from the selected range so the calendar opens where the selection is.

## Related product discussion/links

* WOOPRD-3717

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Podcast dashboard, Stats tab, and pick a custom range a few months back.
* Reopen the date range button. The calendar should show the months of the selected range, not today's month.
* Pick "Last 7 days" and reopen. Should show last month and this month.

https://claude.ai/code/session_01APxsSQeDgarKucb8UNrDyp
