### PR TITLE
Expiry notices: add the plan-expiry notice to the block editors

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16616-add-expiration-notice-to-gutenberg-editor-for-sites
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotcom-16616-add-expiration-notice-to-gutenberg-editor-for-sites
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Expiry notices: show the plan-expiry notice inside the block editor, the site editor, and the block widgets screen.

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-banner.php
@@ -11,18 +11,36 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
 
 /**
  * Resolve the data needed to render the banner, or null if it shouldn't show.
- * Shared by the enqueue and render hooks.
+ * Shared by the enqueue and render hooks, and by the block-editor notice.
  *
+ * Memoized: each read costs a user-meta lookup, a site-slug resolution, and
+ * post-grace a sticker lookup, and three hooks ask per pageview.
+ *
+ * @param bool $flush Drop the memo. For tests, which move the fixture or the
+ *                    screen under a process that has already answered once.
  * @return array{state:array,is_early_warning:bool,is_dismissible:bool,urls:array}|null
  */
-function wpcom_expiry_notices_admin_banner_data(): ?array {
-	$state = wpcom_expiry_notices_eligible_state();
-	if ( null === $state ) {
+function wpcom_expiry_notices_admin_banner_data( bool $flush = false ): ?array {
+	// Distinct from null, which is a real answer worth remembering.
+	static $memo = false;
+
+	if ( $flush ) {
+		$memo = false;
 		return null;
 	}
 
+	if ( false !== $memo ) {
+		return $memo;
+	}
+
+	$memo  = null;
+	$state = wpcom_expiry_notices_eligible_state();
+	if ( null === $state ) {
+		return $memo;
+	}
+
 	if ( ! Expiry_Notice_Dismiss::should_show_banner( $state ) ) {
-		return null;
+		return $memo;
 	}
 
 	// Scope progression: the gentle pre-window reminder shows on the Dashboard
@@ -32,16 +50,18 @@ function wpcom_expiry_notices_admin_banner_data(): ?array {
 	if ( $is_early_warning ) {
 		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 		if ( ! $screen || 'dashboard' !== $screen->id ) {
-			return null;
+			return $memo;
 		}
 	}
 
-	return array(
+	$memo = array(
 		'state'            => $state,
 		'is_early_warning' => $is_early_warning,
 		'is_dismissible'   => Expiry_Notice_Dismiss::is_dismissible( $state ),
 		'urls'             => wpcom_expiry_notices_admin_banner_urls( $state ),
 	);
+
+	return $memo;
 }
 
 /**
@@ -86,8 +106,15 @@ function wpcom_expiry_notices_is_early_warning( array $state ): bool {
 /**
  * Enqueue + localize the banner's JS/CSS on admin_enqueue_scripts so the
  * stylesheet lands in <head>.
+ *
+ * Not on block-editor screens: core hides the banner there, the editor notice
+ * carries its message, and the script would still count an impression.
  */
 function wpcom_expiry_notices_enqueue_admin_banner_assets() {
+	if ( wpcom_expiry_notices_is_block_editor_screen() ) {
+		return;
+	}
+
 	$data = wpcom_expiry_notices_admin_banner_data();
 	if ( null === $data ) {
 		return;
@@ -115,6 +142,10 @@ add_action( 'admin_enqueue_scripts', 'wpcom_expiry_notices_enqueue_admin_banner_
  * Render the banner markup on admin_notices.
  */
 function wpcom_expiry_notices_render_admin_banner() {
+	if ( wpcom_expiry_notices_is_block_editor_screen() ) {
+		return;
+	}
+
 	$data = wpcom_expiry_notices_admin_banner_data();
 	if ( null === $data ) {
 		return;

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/admin-modal.php
@@ -163,13 +163,7 @@ function wpcom_expiry_notices_enqueue_admin_modal_assets() {
 		'wpcomExpiryModal',
 		array_merge(
 			$data,
-			array(
-				'trackProps' => array(
-					'state'          => $state['state'],
-					'days_remaining' => isset( $state['days_remaining'] ) ? (int) $state['days_remaining'] : 0,
-					'product_slug'   => isset( $state['product_slug'] ) ? (string) $state['product_slug'] : '',
-				),
-			)
+			array( 'trackProps' => wpcom_expiry_notices_track_props( $state ) )
 		)
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/class-expiry-data.php
@@ -320,8 +320,10 @@ class Expiry_Data {
 			'label' => __( 'Renew now', 'jetpack-mu-wpcom' ),
 			'url'   => sprintf( 'https://wordpress.com/checkout/%s/%s', $slug, $domain ),
 		);
+		// add_query_arg() does not encode values, so a redirect with a query of
+		// its own would hand checkout the second half as parameters of its own.
 		if ( '' !== $redirect_to ) {
-			$primary['url'] = add_query_arg( 'redirect_to', $redirect_to, $primary['url'] );
+			$primary['url'] = add_query_arg( 'redirect_to', rawurlencode( $redirect_to ), $primary['url'] );
 		}
 
 		$secondary = array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/editor-notice.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/editor-notice.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Block-editor notice for plans in their final week, in grace, or post-grace.
+ *
+ * Core hides legacy admin notices on block-editor screens, so the banner's
+ * message is carried into the editor's own notices store instead.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Data;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+
+/**
+ * Resolve the data the editor notice renders from, or null if it shouldn't show.
+ *
+ * The banner's own answer: an editor screen is never the Dashboard, so the
+ * early reminder is already excluded.
+ *
+ * @return array<string,mixed>|null
+ */
+function wpcom_expiry_notices_editor_notice_data(): ?array {
+	$data = wpcom_expiry_notices_admin_banner_data();
+	if ( null === $data ) {
+		return null;
+	}
+
+	$state  = $data['state'];
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+	return array(
+		'metaKey'       => Expiry_Notice_Dismiss::META_BANNER,
+		'content'       => sprintf(
+			/* translators: %1$s is the notice heading (e.g. "Your plan has expired"), %2$s is the rest of the notice. */
+			__( '%1$s. %2$s', 'jetpack-mu-wpcom' ),
+			wpcom_expiry_notices_admin_banner_heading( $state ),
+			wpcom_expiry_notices_admin_banner_body( $state )
+		),
+		'primary'       => $data['urls']['primary'],
+		'secondary'     => Expiry_Data::STATE_EXPIRED_GRACE === $state['state'] ? $data['urls']['secondary'] : null,
+		'isDismissible' => $data['is_dismissible'],
+		'context'       => wpcom_expiry_notices_editor_context( $screen ? $screen->id : '' ),
+		'trackProps'    => wpcom_expiry_notices_track_props( $state ),
+	);
+}
+
+/**
+ * The Tracks `context` naming the editor the notice showed in.
+ *
+ * @param string $screen_id Current screen id.
+ */
+function wpcom_expiry_notices_editor_context( string $screen_id ): string {
+	switch ( $screen_id ) {
+		case 'site-editor':
+			return 'site-editor';
+		case 'widgets':
+			return 'widgets';
+		default:
+			return 'post-editor';
+	}
+}
+
+/**
+ * Enqueue the editor notice's JS with its data inlined.
+ *
+ * The Customizer fires enqueue_block_editor_assets too but renders no store
+ * notices, hence the positive screen check.
+ */
+function wpcom_expiry_notices_enqueue_editor_notice_assets() {
+	if ( ! wpcom_expiry_notices_is_block_editor_screen() ) {
+		return;
+	}
+
+	$data = wpcom_expiry_notices_editor_notice_data();
+	if ( null === $data ) {
+		return;
+	}
+
+	// Not wp_localize_script(), which casts every top-level scalar to a string
+	// and would hand the client "" for a false `isDismissible`.
+	$json = wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_HEX_APOS );
+	if ( false === $json ) {
+		return;
+	}
+
+	$asset_handle = jetpack_mu_wpcom_enqueue_assets( 'expiry-notices-editor-notice', array( 'js' ) );
+	// Atomic wp-admin loads no Tracks transport of its own, so without this the
+	// notice's events would accumulate in a plain array and be dropped on unload.
+	\Automattic\Jetpack\Jetpack_Mu_Wpcom\Common\wpcom_enqueue_tracking_scripts( $asset_handle );
+	wp_add_inline_script( $asset_handle, 'window.wpcomExpiryEditorNotice = ' . $json . ';', 'before' );
+}
+add_action( 'enqueue_block_editor_assets', 'wpcom_expiry_notices_enqueue_editor_notice_assets' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/expiry-notices.php
@@ -62,9 +62,9 @@ function wpcom_expiry_notices_is_enabled_for_site(): bool {
 /**
  * The expiry state this user should be shown something about, or null.
  *
- * The audience test the banner and the modal share. Memoized because four hooks
- * reach it per admin pageview -- each surface enqueues and renders -- and
- * nothing can change the answer mid-request.
+ * The audience test every surface shares. Memoized because several hooks reach
+ * it per admin pageview -- each surface enqueues and renders -- and nothing can
+ * change the answer mid-request.
  *
  * @param bool $flush Drop the memo. For tests, which move the purchase fixture
  *                    under a process that has already answered once.
@@ -175,16 +175,41 @@ function wpcom_expiry_notices_support_cta( array $state ): array {
 }
 
 /**
- * Load the wp-admin banner and modal, unless something has held this site back.
+ * The Tracks props every surface's events carry.
+ *
+ * @param array<string,mixed> $state Expiry state.
+ * @return array{state:string,days_remaining:int,product_slug:string}
+ */
+function wpcom_expiry_notices_track_props( array $state ): array {
+	return array(
+		'state'          => (string) ( $state['state'] ?? '' ),
+		'days_remaining' => isset( $state['days_remaining'] ) ? (int) $state['days_remaining'] : 0,
+		'product_slug'   => isset( $state['product_slug'] ) ? (string) $state['product_slug'] : '',
+	);
+}
+
+/**
+ * Whether the current screen is a block editor: post editor, site editor, or
+ * block widgets.
+ */
+function wpcom_expiry_notices_is_block_editor_screen(): bool {
+	$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+	return $screen ? $screen->is_block_editor() : false;
+}
+
+/**
+ * Load the wp-admin banner, modal, and editor notice, unless something has held
+ * this site back.
  *
  * On `init` rather than at file load. This file is required on `plugins_loaded`,
- * and every hook either surface registers fires later still, so waiting keeps
- * the requires off the bootstrap at no cost.
+ * and every hook any surface registers fires later still, so waiting keeps the
+ * requires off the bootstrap at no cost.
  */
 function wpcom_expiry_notices_maybe_load_admin_banner() {
 	if ( is_admin() && wpcom_expiry_notices_is_enabled_for_site() ) {
 		require_once __DIR__ . '/admin-banner.php';
 		require_once __DIR__ . '/admin-modal.php';
+		require_once __DIR__ . '/editor-notice.php';
 	}
 }
 add_action( 'init', 'wpcom_expiry_notices_maybe_load_admin_banner' ); // @codeCoverageIgnore

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-banner.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-banner.ts
@@ -1,6 +1,7 @@
-import apiFetch from '@wordpress/api-fetch';
 import { wpcomTrackEvent } from '../../../common/tracks';
+import { recordDismissal } from './dismiss.ts';
 import { openHelpCenterWithMessage } from './help-center.ts';
+import { trackOncePerSession } from './track-once.ts';
 
 interface ExpiryBannerData {
 	metaKey: string;
@@ -15,22 +16,6 @@ declare global {
 	}
 }
 
-// sessionStorage can throw in private browsing / sandboxed iframes.
-const safeSessionGet = ( key: string ): string | null => {
-	try {
-		return sessionStorage.getItem( key );
-	} catch {
-		return null;
-	}
-};
-const safeSessionSet = ( key: string, value: string ): void => {
-	try {
-		sessionStorage.setItem( key, value );
-	} catch {
-		// Storage unavailable; the impression may fire more than once.
-	}
-};
-
 document.addEventListener( 'DOMContentLoaded', () => {
 	const banner = document.getElementById( 'wpcom-expiry-banner' );
 	const data = window.wpcomExpiryBanner;
@@ -44,13 +29,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		product_slug: data.productSlug,
 	};
 
-	// Fire impression once per browser session — the banner re-renders on
-	// every load in the non-dismissible states but we count unique sessions.
-	const impressionKey = `${ data.metaKey }_impression_fired`;
-	if ( safeSessionGet( impressionKey ) !== '1' ) {
-		wpcomTrackEvent( 'jetpack_expiry_banner_impression', trackProps );
-		safeSessionSet( impressionKey, '1' );
-	}
+	// Once per browser session: the banner re-renders on every load in the
+	// non-dismissible states but we count unique sessions.
+	trackOncePerSession(
+		`${ data.metaKey }_impression_fired`,
+		'jetpack_expiry_banner_impression',
+		trackProps
+	);
 
 	const primaryCta = banner.querySelector< HTMLAnchorElement >( '.button-primary' );
 	primaryCta?.addEventListener( 'click', ( e: Event ) => {
@@ -73,11 +58,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		banner.style.display = 'none';
 
 		try {
-			await apiFetch( {
-				path: '/wp/v2/users/me',
-				method: 'POST',
-				data: { meta: { [ data.metaKey ]: 1 } },
-			} );
+			await recordDismissal( data.metaKey );
 			wpcomTrackEvent( 'jetpack_expiry_banner_dismiss', trackProps );
 		} catch ( err ) {
 			// Re-show the banner so the user can see something went wrong

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/admin-modal.tsx
@@ -1,17 +1,10 @@
-import apiFetch from '@wordpress/api-fetch';
 import { Button, Modal } from '@wordpress/components';
 import { createRoot, useState } from '@wordpress/element';
 import { wpcomTrackEvent } from '../../../common/tracks';
+import { recordDismissal } from './dismiss.ts';
 import { openHelpCenterWithMessage } from './help-center.ts';
+import type { Cta } from './types.ts';
 import type { MouseEvent } from 'react';
-
-interface Cta {
-	label: string;
-	url: string;
-	// Present only on the reverted state's CTA, which opens the Help Center with
-	// this typed in rather than following its href.
-	message?: string;
-}
 
 interface ExpiryModalData {
 	metaKey: string;
@@ -38,17 +31,6 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 		return null;
 	}
 
-	const recordDismissal = ( keepalive: boolean ) =>
-		apiFetch( {
-			path: '/wp/v2/users/me',
-			method: 'POST',
-			data: { meta: { [ data.metaKey ]: 1 } },
-			// Survives the page unload a CTA starts. Without it the browser is
-			// free to cancel the write as it navigates, and the modal returns to
-			// someone who did what it asked.
-			keepalive,
-		} );
-
 	// Closing is the dismissal however it was reached, so the record matches what
 	// the user saw happen. Writing only from the button would let Escape hide a
 	// modal that then came straight back on the next page load.
@@ -56,7 +38,7 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 		setIsOpen( false );
 
 		try {
-			await recordDismissal( false );
+			await recordDismissal( data.metaKey );
 			wpcomTrackEvent( 'jetpack_expiry_modal_dismiss', data.trackProps );
 		} catch ( err ) {
 			wpcomTrackEvent( 'jetpack_expiry_modal_dismiss_failed', {
@@ -85,7 +67,9 @@ const ExpiryModal = ( { data }: { data: ExpiryModalData } ) => {
 			...data.trackProps,
 			cta: target.message ? 'support' : cta,
 		} );
-		recordDismissal( ! openedHere ).catch( () => {
+		// Keepalive survives the page unload a CTA starts; without it the browser
+		// may cancel the write as it navigates, and the modal returns.
+		recordDismissal( data.metaKey, ! openedHere ).catch( () => {
 			// Nothing useful to do while the page is leaving; at worst the modal
 			// shows once more.
 		} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/dismiss.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/dismiss.ts
@@ -1,0 +1,17 @@
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Record a notice dismissal for the current user. The server stamps its own
+ * time; the value sent is only a trigger.
+ *
+ * @param metaKey   - The notice's dismissal meta key.
+ * @param keepalive - Let the write survive a page unload the caller is starting.
+ * @return The pending write.
+ */
+export const recordDismissal = ( metaKey: string, keepalive = false ): Promise< unknown > =>
+	apiFetch( {
+		path: '/wp/v2/users/me',
+		method: 'POST',
+		data: { meta: { [ metaKey ]: 1 } },
+		keepalive,
+	} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice-content.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice-content.test.mts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { noticeActions } from './editor-notice-content.ts';
+
+const primary = {
+	label: 'Renew now',
+	url: 'https://wordpress.com/checkout/business-bundle/example.com',
+};
+const secondary = { label: 'View other plans', url: 'https://wordpress.com/plans/example.com' };
+const click = {} as Parameters< ReturnType< typeof noticeActions >[ 0 ][ 'onClick' ] >[ 0 ];
+
+describe( 'noticeActions', () => {
+	it( 'offers only the primary CTA outside the grace period', () => {
+		const actions = noticeActions( { primary, secondary: null }, () => {} );
+		assert.deepEqual(
+			actions.map( ( { label, url, variant } ) => ( { label, url, variant } ) ),
+			[ { label: 'Renew now', url: primary.url, variant: 'primary' } ]
+		);
+	} );
+
+	it( 'adds the other-plans link in the grace period', () => {
+		const actions = noticeActions( { primary, secondary }, () => {} );
+		assert.deepEqual(
+			actions.map( ( { label, url } ) => ( { label, url } ) ),
+			[
+				{ label: 'Renew now', url: primary.url },
+				{ label: 'View other plans', url: secondary.url },
+			]
+		);
+	} );
+
+	it( 'routes each click to its CTA', () => {
+		const clicks: Array< [ string, { label: string } ] > = [];
+		const actions = noticeActions( { primary, secondary }, ( cta, target ) =>
+			clicks.push( [ cta, target ] )
+		);
+		actions[ 1 ].onClick( click );
+		actions[ 0 ].onClick( click );
+		assert.deepEqual( clicks, [
+			[ 'secondary', secondary ],
+			[ 'primary', primary ],
+		] );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice-content.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice-content.ts
@@ -1,0 +1,51 @@
+import type { Cta } from './types.ts';
+import type { MouseEvent } from 'react';
+
+export interface NoticeCtas {
+	primary: Cta;
+	secondary: Cta | null;
+}
+
+export type CtaClickHandler = (
+	cta: 'primary' | 'secondary',
+	target: Cta,
+	event: MouseEvent
+) => void;
+
+export interface NoticeAction {
+	label: string;
+	url: string;
+	variant?: 'primary';
+	onClick: ( event: MouseEvent ) => void;
+}
+
+/**
+ * The notice's action links.
+ *
+ * @param ctas           - The CTAs the state offers.
+ * @param ctas.primary   - Always present.
+ * @param ctas.secondary - Only in the grace period.
+ * @param onCtaClick     - Receives which CTA was clicked, its target, and the click.
+ * @return The actions, primary first.
+ */
+export const noticeActions = (
+	{ primary, secondary }: NoticeCtas,
+	onCtaClick: CtaClickHandler
+): NoticeAction[] => {
+	const actions: NoticeAction[] = [
+		{
+			label: primary.label,
+			url: primary.url,
+			variant: 'primary',
+			onClick: event => onCtaClick( 'primary', primary, event ),
+		},
+	];
+	if ( secondary ) {
+		actions.push( {
+			label: secondary.label,
+			url: secondary.url,
+			onClick: event => onCtaClick( 'secondary', secondary, event ),
+		} );
+	}
+	return actions;
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/editor-notice.tsx
@@ -1,0 +1,113 @@
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { registerPlugin } from '@wordpress/plugins';
+// Direct import: the hooks barrel drags the router and private-apis bundles in.
+import useCanvasMode from '../../../common/hooks/use-canvas-mode';
+import { wpcomTrackEvent } from '../../../common/tracks';
+import { recordDismissal } from './dismiss.ts';
+import { noticeActions } from './editor-notice-content.ts';
+import { openHelpCenterWithMessage } from './help-center.ts';
+import { trackOncePerSession } from './track-once.ts';
+import type { Cta } from './types.ts';
+import type { MouseEvent } from 'react';
+
+const NOTICE_ID = 'wpcom-expiry-notices/editor-notice';
+
+interface EditorNoticeData {
+	metaKey: string;
+	content: string;
+	primary: Cta;
+	secondary: Cta | null;
+	isDismissible: boolean;
+	context: string;
+	trackProps: Record< string, string | number >;
+}
+
+declare global {
+	interface Window {
+		wpcomExpiryEditorNotice?: EditorNoticeData;
+	}
+}
+
+const ExpiryEditorNotice = ( { data }: { data: EditorNoticeData } ) => {
+	const { createNotice, removeNotice } = useDispatch( noticesStore );
+	const canvasMode = useCanvasMode();
+
+	// The site editor renders store notices in its edit canvas only; browse mode
+	// gets nothing yet, so the notice waits rather than counting an impression
+	// nobody could see.
+	const isVisible = data.context !== 'site-editor' || canvasMode === 'edit';
+
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		let mounted = true;
+		const trackProps = { ...data.trackProps, context: data.context };
+
+		const onCtaClick = ( cta: string, target: Cta, event: MouseEvent ) => {
+			// The support CTA opens the Help Center over the editor; its href is
+			// only the fallback for a Help Center that never loaded.
+			const openedHere = target.message ? openHelpCenterWithMessage( target.message ) : false;
+			if ( openedHere ) {
+				event.preventDefault();
+			}
+			wpcomTrackEvent( 'jetpack_expiry_editor_notice_cta_click', {
+				...trackProps,
+				cta: target.message ? 'support' : cta,
+			} );
+		};
+
+		// Closing the notice writes the banner's own key, so dismissing here
+		// dismisses the wp-admin banner too, and vice versa.
+		const onDismiss = async () => {
+			try {
+				await recordDismissal( data.metaKey );
+				wpcomTrackEvent( 'jetpack_expiry_editor_notice_dismiss', trackProps );
+			} catch ( err ) {
+				// Put it back, so a failed write reads as something going wrong
+				// rather than as a notice that returns on the next load.
+				if ( mounted ) {
+					show();
+				}
+				wpcomTrackEvent( 'jetpack_expiry_editor_notice_dismiss_failed', {
+					...trackProps,
+					error_message: err instanceof Error ? err.message : String( err ),
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to record expiry editor notice dismiss', err );
+			}
+		};
+
+		const show = () =>
+			createNotice( 'error', data.content, {
+				id: NOTICE_ID,
+				isDismissible: data.isDismissible,
+				actions: noticeActions( data, onCtaClick ),
+				onDismiss,
+			} );
+
+		show();
+		trackOncePerSession(
+			`${ data.metaKey }_editor_impression_fired`,
+			'jetpack_expiry_editor_notice_impression',
+			trackProps
+		);
+
+		return () => {
+			mounted = false;
+			removeNotice( NOTICE_ID );
+		};
+	}, [ createNotice, data, isVisible, removeNotice ] );
+
+	return null;
+};
+
+const data = window.wpcomExpiryEditorNotice;
+if ( data ) {
+	registerPlugin( 'wpcom-expiry-editor-notice', {
+		render: () => <ExpiryEditorNotice data={ data } />,
+	} );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/track-once.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/track-once.ts
@@ -1,0 +1,38 @@
+import { wpcomTrackEvent } from '../../../common/tracks';
+
+// sessionStorage can throw in private browsing / sandboxed iframes, so a flag
+// that cannot be stored reads as unset and the event may fire again.
+const hasSessionFlag = ( key: string ): boolean => {
+	try {
+		return sessionStorage.getItem( key ) === '1';
+	} catch {
+		return false;
+	}
+};
+
+const setSessionFlag = ( key: string ): void => {
+	try {
+		sessionStorage.setItem( key, '1' );
+	} catch {
+		// Storage unavailable.
+	}
+};
+
+/**
+ * Record an event once per browser session.
+ *
+ * @param key       - Session flag the event is counted under.
+ * @param eventName - Tracks event name.
+ * @param props     - Event properties.
+ */
+export const trackOncePerSession = (
+	key: string,
+	eventName: string,
+	props: Record< string, string | number >
+): void => {
+	if ( hasSessionFlag( key ) ) {
+		return;
+	}
+	wpcomTrackEvent( eventName, props );
+	setSessionFlag( key );
+};

--- a/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/types.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/expiry-notices/js/types.ts
@@ -1,0 +1,7 @@
+export interface Cta {
+	label: string;
+	url: string;
+	// Present only on the reverted state's CTA, which opens the Help Center with
+	// this typed in rather than following its href.
+	message?: string;
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -97,9 +97,21 @@ class Admin_Banner_Test extends \WorDBless\BaseTestCase {
 	}
 
 	private function render(): string {
+		// Tests move the screen between renders, so never trust the memo.
+		wpcom_expiry_notices_admin_banner_data( true );
 		ob_start();
 		wpcom_expiry_notices_render_admin_banner();
 		return (string) ob_get_clean();
+	}
+
+	public function test_leaves_block_editor_screens_to_the_editor_notice(): void {
+		$this->set_purchase( 5 );
+		set_current_screen( 'post' );
+		get_current_screen()->is_block_editor( true );
+		$this->assertSame( '', $this->render() );
+
+		get_current_screen()->is_block_editor( false );
+		$this->assertStringContainsString( 'notice-error', $this->render() );
 	}
 
 	public function test_renders_for_approaching_state(): void {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Banner_Test.php
@@ -16,84 +16,20 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-banner.php';
+require_once __DIR__ . '/trait-expiry-notices-fixtures.php';
 
 class Admin_Banner_Test extends \WorDBless\BaseTestCase {
-
-	/**
-	 * @var int
-	 */
-	private $admin_id;
-
-	/**
-	 * @var int
-	 */
-	private $subscriber_id;
+	use Expiry_Notices_Fixtures;
 
 	public function set_up() {
 		parent::set_up();
-		// WorDBless resets the users table between tests, so recreate fixture
-		// users here rather than in set_up_before_class.
-		$this->admin_id      = wp_insert_user(
-			array(
-				'user_login' => 'banner_admin',
-				'user_pass'  => 'pass',
-				'user_email' => 'banner_admin@example.com',
-				'role'       => 'administrator',
-			)
-		);
-		$this->subscriber_id = wp_insert_user(
-			array(
-				'user_login' => 'banner_subscriber',
-				'user_pass'  => 'pass',
-				'user_email' => 'banner_subscriber@example.com',
-				'role'       => 'subscriber',
-			)
-		);
-		wp_set_current_user( $this->admin_id );
-		wpcom_expiry_notices_eligible_state( true );
+		$this->set_up_expiry_fixtures();
 		set_current_screen( 'dashboard' );
 	}
 
 	public function tear_down() {
-		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
-		unset( $GLOBALS['wpcom_is_vip_test_value'] );
-		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER );
-		Constants::clear_constants();
+		$this->tear_down_expiry_fixtures();
 		parent::tear_down();
-	}
-
-	/**
-	 * A site the revert has already happened to.
-	 *
-	 * `has_blog_sticker` is declared per test because other suites declare their
-	 * own, and a shared definition makes theirs a fatal redeclare -- hence the
-	 * separate process on every caller.
-	 */
-	private function pretend_reverted(): void {
-		Constants::set_constant( 'IS_ATOMIC', false );
-		if ( ! function_exists( 'has_blog_sticker' ) ) {
-			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
-		}
-	}
-
-	private function set_purchase( int $days_until_expiry, bool $auto_renew = false, string $slug = 'business-bundle' ): void {
-		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
-			(object) array(
-				'product_slug'           => $slug,
-				'product_type'           => 'bundle',
-				// Half a day of slack on top of the whole days: the banner
-				// computes `floor( ( expiry - now ) / DAY_IN_SECONDS )` at
-				// render time, so an expiry set to exactly N days collapses to
-				// N-1 the moment a single second elapses between this call and
-				// render() — which is a race this test loses on a slow runner.
-				// The cushion keeps every case in its intended day bucket for
-				// twelve hours instead of one second.
-				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
-				'user_allows_auto_renew' => $auto_renew,
-			),
-		);
-		// The eligible-state memo has already answered for the previous fixture.
-		wpcom_expiry_notices_eligible_state( true );
 	}
 
 	private function render(): string {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Admin_Modal_Test.php
@@ -15,42 +15,14 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-modal.php';
+require_once __DIR__ . '/trait-expiry-notices-fixtures.php';
 
 class Admin_Modal_Test extends \WorDBless\BaseTestCase {
-
-	/**
-	 * @var int
-	 */
-	private $admin_id;
-
-	/**
-	 * @var int
-	 */
-	private $subscriber_id;
+	use Expiry_Notices_Fixtures;
 
 	public function set_up() {
 		parent::set_up();
-		// WorDBless resets the users table between tests, so recreate fixture
-		// users here rather than in set_up_before_class.
-		$this->admin_id      = wp_insert_user(
-			array(
-				'user_login' => 'modal_admin',
-				'user_pass'  => 'pass',
-				'user_email' => 'modal_admin@example.com',
-				'role'       => 'administrator',
-			)
-		);
-		$this->subscriber_id = wp_insert_user(
-			array(
-				'user_login' => 'modal_subscriber',
-				'user_pass'  => 'pass',
-				'user_email' => 'modal_subscriber@example.com',
-				'role'       => 'subscriber',
-			)
-		);
-		wp_set_current_user( $this->admin_id );
-		wpcom_expiry_notices_eligible_state( true );
-		wpcom_expiry_notices_admin_modal_data( true );
+		$this->set_up_expiry_fixtures();
 		set_current_screen( 'dashboard' );
 		Constants::set_constant( 'IS_ATOMIC', true );
 		// The modal names the domain the site reverts to; resolving it is an HTTP
@@ -60,13 +32,9 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	}
 
 	public function tear_down() {
-		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
-		unset( $GLOBALS['wpcom_is_vip_test_value'] );
 		unset( $GLOBALS['wpcom_blog_details_domain_test_value'] );
-		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL );
-		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_MODAL_GRACE );
 		delete_transient( \Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Domain::CACHE_KEY );
-		Constants::clear_constants();
+		$this->tear_down_expiry_fixtures();
 		parent::tear_down();
 	}
 
@@ -82,21 +50,6 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * A site the revert has already moved back to Simple.
-	 *
-	 * `has_blog_sticker` is declared per test because other suites declare their
-	 * own, and a shared definition makes theirs a fatal redeclare -- hence the
-	 * separate process on every caller.
-	 */
-	private function pretend_reverted_to_simple(): void {
-		Constants::set_constant( 'IS_ATOMIC', false );
-		Constants::set_constant( 'IS_WPCOM', true );
-		if ( ! function_exists( 'has_blog_sticker' ) ) {
-			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
-		}
-	}
-
-	/**
 	 * Record a dismissal and clear the modal memo, which in production could not
 	 * change inside one request.
 	 *
@@ -105,23 +58,6 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	 */
 	private function set_dismissed( string $meta_key, int $when ): void {
 		update_user_meta( $this->admin_id, $meta_key, $when );
-		wpcom_expiry_notices_admin_modal_data( true );
-	}
-
-	private function set_purchase( int $days_until_expiry, string $slug = 'business-bundle' ): void {
-		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
-			(object) array(
-				'product_slug'           => $slug,
-				'product_type'           => 'bundle',
-				// Half a day of slack so a case can't slip into the neighbouring
-				// day bucket between this call and the read. Same reasoning as
-				// Admin_Banner_Test::set_purchase().
-				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
-				'user_allows_auto_renew' => false,
-			),
-		);
-		// Both memos have already answered for the previous fixture.
-		wpcom_expiry_notices_eligible_state( true );
 		wpcom_expiry_notices_admin_modal_data( true );
 	}
 
@@ -145,7 +81,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_shows_after_grace_with_the_post_revert_copy(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		$this->set_purchase( -45 );
 		$data = wpcom_expiry_notices_admin_modal_data();
 
@@ -184,7 +120,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	public function test_does_not_show_in_grace_on_a_reverted_site(): void {
 		// A site already reverted was reverted by an earlier lapse. This one has
 		// not reached the changes the pre-revert variant promises are coming.
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 
 		$this->set_purchase( -5 );
 		$this->assertNull( wpcom_expiry_notices_admin_modal_data() );
@@ -200,10 +136,10 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 		// WPCOM_Features::ATOMIC is granted to Personal and higher, so there is no
 		// paid tier whose lapse could not have produced this revert. Narrowing to
 		// Business would hide the modal from most of the sites it is meant for.
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 
 		foreach ( array( 'personal-bundle', 'value_bundle', 'business-bundle' ) as $slug ) {
-			$this->set_purchase( -45, $slug );
+			$this->set_purchase( -45, false, $slug );
 			$this->assertNotNull( wpcom_expiry_notices_admin_modal_data(), "expected a modal for {$slug}" );
 		}
 	}
@@ -245,7 +181,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_post_grace_dismissal_does_not_lapse(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		$this->set_purchase( -45 );
 		// Dismissed 10 days ago -- within this term, since the revert it reports
 		// happened at day 30, but far outside the grace TTL, which must not apply
@@ -261,7 +197,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_a_grace_dismissal_does_not_bury_the_post_grace_modal(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		// The two states dismiss to separate keys precisely so this can't happen:
 		// a grace dismissal is stamped after expiry and would otherwise satisfy
 		// the post-grace "belongs to this term" check.
@@ -277,7 +213,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_dismissal_of_an_earlier_term_shows_again(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		$this->set_purchase( -45 );
 		// Dismissed against a purchase that has since been renewed and lapsed
 		// again: this revert is news.
@@ -302,7 +238,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_names_the_domain_the_site_moved_to_after_the_revert(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		// WorDBless serves example.org, so a matching blogs-table domain is a site
 		// sitting on its own unmapped address -- the switch already happened.
 		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'example.org';
@@ -336,7 +272,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	public function test_omits_the_domain_when_a_reverted_site_kept_its_own(): void {
 		// Serving from example.org while the blogs table says otherwise: the
 		// custom domain survived the revert, so nothing was switched.
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		$GLOBALS['wpcom_blog_details_domain_test_value'] = 'unused.wordpress.com';
 
 		$this->set_purchase( -45 );
@@ -353,7 +289,7 @@ class Admin_Modal_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_the_support_cta_prefills_a_message(): void {
-		$this->pretend_reverted_to_simple();
+		$this->pretend_reverted();
 		$this->set_purchase( -45 );
 		$data = wpcom_expiry_notices_admin_modal_data();
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Editor_Notice_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Editor_Notice_Test.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Editor Notice Tests
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-banner.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/editor-notice.php';
+
+class Editor_Notice_Test extends \WorDBless\BaseTestCase {
+
+	const HANDLE = 'jetpack-mu-wpcom-expiry-notices-editor-notice';
+
+	/**
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * @var string|null
+	 */
+	private $request_uri;
+
+	public function set_up() {
+		parent::set_up();
+		// Restored rather than unset afterwards: cron reads it at shutdown, and a
+		// missing key there is a warning the process-isolated test reports as an error.
+		$this->request_uri   = $_SERVER['REQUEST_URI'] ?? null;
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'editor_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'editor_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'editor_subscriber',
+				'user_pass'  => 'pass',
+				'user_email' => 'editor_subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
+		$this->set_screen( 'post' );
+	}
+
+	public function tear_down() {
+		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
+		unset( $GLOBALS['wpcom_is_vip_test_value'] );
+		if ( null === $this->request_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $this->request_uri;
+		}
+		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER );
+		wp_dequeue_script( self::HANDLE );
+		wp_deregister_script( self::HANDLE );
+		Constants::clear_constants();
+		parent::tear_down();
+	}
+
+	/**
+	 * A site the revert has already happened to. Declared per test, in a
+	 * separate process, for the reason Admin_Banner_Test gives.
+	 */
+	private function pretend_reverted(): void {
+		Constants::set_constant( 'IS_ATOMIC', false );
+		if ( ! function_exists( 'has_blog_sticker' ) ) {
+			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		}
+	}
+
+	/**
+	 * Make a screen current, flagged as a block editor the way core flags the
+	 * post editor, site editor, and block widgets screen.
+	 */
+	private function set_screen( string $id, bool $is_block_editor = true ): void {
+		set_current_screen( $id );
+		get_current_screen()->is_block_editor( $is_block_editor );
+		$this->flush();
+	}
+
+	private function flush(): void {
+		wpcom_expiry_notices_eligible_state( true );
+		wpcom_expiry_notices_admin_banner_data( true );
+	}
+
+	private function set_purchase( int $days_until_expiry, bool $auto_renew = false, string $slug = 'business-bundle' ): void {
+		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
+			(object) array(
+				'product_slug'           => $slug,
+				'product_type'           => 'bundle',
+				// Same half-day cushion as the banner tests, for the same race.
+				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
+				'user_allows_auto_renew' => $auto_renew,
+			),
+		);
+		$this->flush();
+	}
+
+	/**
+	 * The notice data, failing the test rather than returning null.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function notice(): array {
+		$data = wpcom_expiry_notices_editor_notice_data();
+		if ( null === $data ) {
+			$this->fail( 'expected the editor notice to show' );
+		}
+		return $data;
+	}
+
+	public function test_early_warning_is_left_to_the_dashboard(): void {
+		$this->set_purchase( 45 );
+		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
+	}
+
+	public function test_final_week_reads_the_heading_into_the_body(): void {
+		$this->set_purchase( 5 );
+		$data = $this->notice();
+
+		$this->assertStringStartsWith( 'Your plan expires in 5 days. Your site will move to the Free plan', $data['content'] );
+		$this->assertStringContainsString( '50 GB of storage', $data['content'] );
+		$this->assertStringContainsString( '/checkout/business-bundle/', $data['primary']['url'] );
+		$this->assertNull( $data['secondary'] );
+		$this->assertFalse( $data['isDismissible'] );
+	}
+
+	public function test_grace_offers_the_other_plans(): void {
+		$this->set_purchase( -5 );
+		$data = $this->notice();
+
+		$this->assertSame( 'Renew now', $data['primary']['label'] );
+		$this->assertStringContainsString( '/plans/', $data['secondary']['url'] );
+		$this->assertFalse( $data['isDismissible'] );
+	}
+
+	public function test_post_grace_is_dismissible_to_the_banner_key(): void {
+		$this->set_purchase( -45 );
+		$data = $this->notice();
+
+		$this->assertTrue( $data['isDismissible'] );
+		$this->assertSame( Expiry_Notice_Dismiss::META_BANNER, $data['metaKey'] );
+		$this->assertSame( 'Restore site', $data['primary']['label'] );
+		$this->assertNull( $data['secondary'] );
+	}
+
+	public function test_a_banner_dismissal_hides_the_editor_notice_too(): void {
+		$this->set_purchase( -45 );
+		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER, time() - DAY_IN_SECONDS );
+		$this->flush();
+		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_a_reverted_site_is_sent_to_support(): void {
+		$this->pretend_reverted();
+		$this->set_purchase( -45 );
+		$data = $this->notice();
+
+		$this->assertSame( 'Contact support', $data['primary']['label'] );
+		$this->assertStringContainsString( 'need your help getting it restored', $data['primary']['message'] );
+	}
+
+	public function test_monthly_plans_wait_for_the_final_week(): void {
+		$this->set_purchase( 8, false, 'business-bundle-monthly' );
+		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
+
+		$this->set_purchase( 5, false, 'business-bundle-monthly' );
+		$this->assertNotNull( wpcom_expiry_notices_editor_notice_data() );
+	}
+
+	public function test_nothing_for_an_active_plan(): void {
+		$this->set_purchase( 200 );
+		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
+	}
+
+	public function test_nothing_for_non_admins(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->set_purchase( 5 );
+		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
+	}
+
+	public function test_track_props_describe_the_state(): void {
+		$this->set_purchase( 5 );
+		$data = $this->notice();
+
+		$this->assertSame(
+			array(
+				'state'          => 'approaching_expiry',
+				'days_remaining' => 5,
+				'product_slug'   => 'business-bundle',
+			),
+			$data['trackProps']
+		);
+	}
+
+	public function test_context_names_the_editor(): void {
+		$this->set_purchase( 5 );
+		$this->assertSame( 'post-editor', $this->notice()['context'] );
+
+		$this->set_screen( 'site-editor' );
+		$this->assertSame( 'site-editor', $this->notice()['context'] );
+
+		$this->set_screen( 'widgets' );
+		$this->assertSame( 'widgets', $this->notice()['context'] );
+	}
+
+	public function test_checkout_returns_to_the_editor_deep_link(): void {
+		$_SERVER['REQUEST_URI'] = '/wp-admin/site-editor.php?p=%2Fpage&canvas=edit';
+		$this->set_purchase( 5 );
+		$data = $this->notice();
+
+		$this->assertStringContainsString( 'redirect_to=', $data['primary']['url'] );
+		$this->assertStringContainsString( rawurlencode( 'site-editor.php?p=%2Fpage&canvas=edit' ), $data['primary']['url'] );
+	}
+
+	public function test_enqueues_and_inlines_the_data_on_an_editor_screen(): void {
+		$this->set_purchase( 5 );
+		wpcom_expiry_notices_enqueue_editor_notice_assets();
+
+		$this->assertTrue( wp_script_is( self::HANDLE, 'enqueued' ) );
+		$inline = wp_scripts()->get_inline_script_data( self::HANDLE, 'before' );
+		$this->assertStringContainsString( 'window.wpcomExpiryEditorNotice = {', $inline );
+		$this->assertStringContainsString( '"isDismissible":false', $inline );
+		$this->assertStringContainsString( '"context":"post-editor"', $inline );
+	}
+
+	public function test_enqueues_nothing_when_there_is_nothing_to_say(): void {
+		$this->set_purchase( 45 );
+		wpcom_expiry_notices_enqueue_editor_notice_assets();
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+
+	public function test_enqueues_nothing_off_block_editor_screens(): void {
+		$this->set_screen( 'customize', false );
+		$this->set_purchase( 5 );
+		wpcom_expiry_notices_enqueue_editor_notice_assets();
+		$this->assertFalse( wp_script_is( self::HANDLE, 'enqueued' ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Editor_Notice_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Editor_Notice_Test.php
@@ -7,7 +7,6 @@
 
 declare( strict_types = 1 );
 
-use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -16,20 +15,12 @@ use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/expiry-notices.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/admin-banner.php';
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/expiry-notices/editor-notice.php';
+require_once __DIR__ . '/trait-expiry-notices-fixtures.php';
 
 class Editor_Notice_Test extends \WorDBless\BaseTestCase {
+	use Expiry_Notices_Fixtures;
 
 	const HANDLE = 'jetpack-mu-wpcom-expiry-notices-editor-notice';
-
-	/**
-	 * @var int
-	 */
-	private $admin_id;
-
-	/**
-	 * @var int
-	 */
-	private $subscriber_id;
 
 	/**
 	 * @var string|null
@@ -40,51 +31,21 @@ class Editor_Notice_Test extends \WorDBless\BaseTestCase {
 		parent::set_up();
 		// Restored rather than unset afterwards: cron reads it at shutdown, and a
 		// missing key there is a warning the process-isolated test reports as an error.
-		$this->request_uri   = $_SERVER['REQUEST_URI'] ?? null;
-		$this->admin_id      = wp_insert_user(
-			array(
-				'user_login' => 'editor_admin',
-				'user_pass'  => 'pass',
-				'user_email' => 'editor_admin@example.com',
-				'role'       => 'administrator',
-			)
-		);
-		$this->subscriber_id = wp_insert_user(
-			array(
-				'user_login' => 'editor_subscriber',
-				'user_pass'  => 'pass',
-				'user_email' => 'editor_subscriber@example.com',
-				'role'       => 'subscriber',
-			)
-		);
-		wp_set_current_user( $this->admin_id );
+		$this->request_uri = $_SERVER['REQUEST_URI'] ?? null;
+		$this->set_up_expiry_fixtures();
 		$this->set_screen( 'post' );
 	}
 
 	public function tear_down() {
-		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
-		unset( $GLOBALS['wpcom_is_vip_test_value'] );
 		if ( null === $this->request_uri ) {
 			unset( $_SERVER['REQUEST_URI'] );
 		} else {
 			$_SERVER['REQUEST_URI'] = $this->request_uri;
 		}
-		delete_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER );
 		wp_dequeue_script( self::HANDLE );
 		wp_deregister_script( self::HANDLE );
-		Constants::clear_constants();
+		$this->tear_down_expiry_fixtures();
 		parent::tear_down();
-	}
-
-	/**
-	 * A site the revert has already happened to. Declared per test, in a
-	 * separate process, for the reason Admin_Banner_Test gives.
-	 */
-	private function pretend_reverted(): void {
-		Constants::set_constant( 'IS_ATOMIC', false );
-		if ( ! function_exists( 'has_blog_sticker' ) ) {
-			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
-		}
 	}
 
 	/**
@@ -94,25 +55,7 @@ class Editor_Notice_Test extends \WorDBless\BaseTestCase {
 	private function set_screen( string $id, bool $is_block_editor = true ): void {
 		set_current_screen( $id );
 		get_current_screen()->is_block_editor( $is_block_editor );
-		$this->flush();
-	}
-
-	private function flush(): void {
-		wpcom_expiry_notices_eligible_state( true );
-		wpcom_expiry_notices_admin_banner_data( true );
-	}
-
-	private function set_purchase( int $days_until_expiry, bool $auto_renew = false, string $slug = 'business-bundle' ): void {
-		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
-			(object) array(
-				'product_slug'           => $slug,
-				'product_type'           => 'bundle',
-				// Same half-day cushion as the banner tests, for the same race.
-				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
-				'user_allows_auto_renew' => $auto_renew,
-			),
-		);
-		$this->flush();
+		$this->flush_expiry_memos();
 	}
 
 	/**
@@ -166,7 +109,7 @@ class Editor_Notice_Test extends \WorDBless\BaseTestCase {
 	public function test_a_banner_dismissal_hides_the_editor_notice_too(): void {
 		$this->set_purchase( -45 );
 		update_user_meta( $this->admin_id, Expiry_Notice_Dismiss::META_BANNER, time() - DAY_IN_SECONDS );
-		$this->flush();
+		$this->flush_expiry_memos();
 		$this->assertNull( wpcom_expiry_notices_editor_notice_data() );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Data_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/Expiry_Data_Test.php
@@ -543,4 +543,19 @@ class Expiry_Data_Test extends \WorDBless\BaseTestCase {
 		$this->assertArrayHasKey( 'redirect_to', $query_args );
 		$this->assertSame( $redirect, $query_args['redirect_to'] );
 	}
+
+	public function test_get_cta_urls_keeps_a_redirect_with_its_own_query_intact(): void {
+		$state    = array(
+			'state'        => Expiry_Data::STATE_EXPIRED_GRACE,
+			'product_slug' => 'business-bundle',
+			'auto_renew'   => false,
+		);
+		$redirect = 'https://example.com/wp-admin/site-editor.php?p=%2Fpage&canvas=edit';
+		$urls     = Expiry_Data::get_cta_urls( $state, $redirect );
+
+		$parsed = wp_parse_url( $urls['primary']['url'] );
+		parse_str( $parsed['query'] ?? '', $query_args );
+		$this->assertSame( $redirect, $query_args['redirect_to'] );
+		$this->assertArrayNotHasKey( 'canvas', $query_args );
+	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/trait-expiry-notices-fixtures.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/expiry-notices/trait-expiry-notices-fixtures.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Fixtures shared by the expiry-notices surface tests.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+declare( strict_types = 1 );
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Expiry_Notices\Expiry_Notice_Dismiss;
+
+trait Expiry_Notices_Fixtures {
+
+	/**
+	 * @var int
+	 */
+	protected $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected $subscriber_id;
+
+	/**
+	 * Create the users the tests act as, and act as the admin.
+	 *
+	 * WorDBless resets the users table between tests, so this belongs in
+	 * set_up rather than set_up_before_class.
+	 */
+	protected function set_up_expiry_fixtures(): void {
+		$this->admin_id      = wp_insert_user(
+			array(
+				'user_login' => 'expiry_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'expiry_admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		$this->subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'expiry_subscriber',
+				'user_pass'  => 'pass',
+				'user_email' => 'expiry_subscriber@example.com',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $this->admin_id );
+		$this->flush_expiry_memos();
+	}
+
+	protected function tear_down_expiry_fixtures(): void {
+		unset( $GLOBALS['wpcom_get_site_purchases_test_value'] );
+		unset( $GLOBALS['wpcom_is_vip_test_value'] );
+		foreach ( array( Expiry_Notice_Dismiss::META_BANNER, Expiry_Notice_Dismiss::META_MODAL, Expiry_Notice_Dismiss::META_MODAL_GRACE ) as $meta_key ) {
+			delete_user_meta( $this->admin_id, $meta_key );
+		}
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Drop every per-request memo, for whichever surfaces this test loaded.
+	 */
+	protected function flush_expiry_memos(): void {
+		wpcom_expiry_notices_eligible_state( true );
+		if ( function_exists( 'wpcom_expiry_notices_admin_banner_data' ) ) {
+			wpcom_expiry_notices_admin_banner_data( true );
+		}
+		if ( function_exists( 'wpcom_expiry_notices_admin_modal_data' ) ) {
+			wpcom_expiry_notices_admin_modal_data( true );
+		}
+	}
+
+	/**
+	 * A site the revert has already moved back to Simple.
+	 *
+	 * `has_blog_sticker` is declared per test because other suites declare their
+	 * own, and a shared definition makes theirs a fatal redeclare -- hence the
+	 * separate process on every caller.
+	 */
+	protected function pretend_reverted(): void {
+		Constants::set_constant( 'IS_ATOMIC', false );
+		Constants::set_constant( 'IS_WPCOM', true );
+		if ( ! function_exists( 'has_blog_sticker' ) ) {
+			eval( 'namespace { function has_blog_sticker( $sticker, $blog_id = 0 ) { return "blog-transfer-reverted" === $sticker; } }' ); // phpcs:ignore Squiz.PHP.Eval.Discouraged,MediaWiki.Usage.ForbiddenFunctions.eval
+		}
+	}
+
+	/**
+	 * The site's one plan purchase, expiring the given number of days from now.
+	 *
+	 * Half a day of slack on top of the whole days: the state computes
+	 * `floor( ( expiry - now ) / DAY_IN_SECONDS )` at read time, so an expiry
+	 * set to exactly N days collapses to N-1 the moment a second elapses
+	 * between this call and the read -- a race a slow runner loses.
+	 *
+	 * @param int    $days_until_expiry Negative for a plan that has lapsed.
+	 * @param bool   $auto_renew        Whether the customer left auto-renew on.
+	 * @param string $slug              Product slug.
+	 */
+	protected function set_purchase( int $days_until_expiry, bool $auto_renew = false, string $slug = 'business-bundle' ): void {
+		$GLOBALS['wpcom_get_site_purchases_test_value'] = array(
+			(object) array(
+				'product_slug'           => $slug,
+				'product_type'           => 'bundle',
+				'expiry_date'            => gmdate( 'c', time() + ( $days_until_expiry * DAY_IN_SECONDS ) + ( 12 * HOUR_IN_SECONDS ) ),
+				'user_allows_auto_renew' => $auto_renew,
+			),
+		);
+		$this->flush_expiry_memos();
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/webpack.config.js
+++ b/projects/packages/jetpack-mu-wpcom/webpack.config.js
@@ -27,6 +27,7 @@ module.exports = async () => {
 					'./src/features/expiry-notices/js/admin-modal.tsx',
 					'./src/features/expiry-notices/css/admin-modal.scss',
 				],
+				'expiry-notices-editor-notice': [ './src/features/expiry-notices/js/editor-notice.tsx' ],
 				'holiday-snow': './src/features/holiday-snow/holiday-snow.scss',
 				'html-block-restricted-tags':
 					'./src/features/html-block-restricted-tags/html-block-restricted-tags.tsx',


### PR DESCRIPTION
Fixes DOTCOM-16616

## Proposed changes

| Post editor, final week | Site editor, grace period | Widgets screen, post-grace |
| --- | --- | --- |
| ![Post editor showing the expiry notice under the toolbar](https://github.com/Automattic/jetpack/raw/screenshots/dotcom-16616-add-expiration-notice-to-gutenberg-editor-for-sites/post-editor-final-week.png) | ![Site editor showing the expiry notice with two CTAs and the expired modal](https://github.com/Automattic/jetpack/raw/screenshots/dotcom-16616-add-expiration-notice-to-gutenberg-editor-for-sites/site-editor-grace.png) | ![Widgets screen showing the dismissible expiry notice](https://github.com/Automattic/jetpack/raw/screenshots/dotcom-16616-add-expiration-notice-to-gutenberg-editor-for-sites/widgets-post-grace.png) |

Adds the plan-expiry notice to the block editors: the post editor, the site editor's edit canvas, and the block widgets screen.

**Why a separate surface.** Core hides every legacy admin notice on block-editor screens (`#wpbody-content > div:not(.block-editor)` is `display: none`, with a stylesheet comment telling plugins to use the editor's own notices instead), so the wp-admin banner never reached the one place an owner in the final week is most likely to be. This dispatches the same message to the `core/notices` store from a registered editor plugin, which lands it under the toolbar in all three editors. Copy, CTAs, dismissibility, and the user-meta key a dismissal writes to all come from the banner's own PHP resolver, so the two surfaces cannot disagree: the editor notice is the banner in a different frame, not a second implementation.

**Scope follows wp-admin.** Final week, grace, and post-grace show in the editors; the early reminder (auto-renew off, more than a week out) stays Dashboard-only, as it does on every other wp-admin screen. The notice is dismissible only post-grace, and a dismissal in either place hides both.

**The site editor's browse mode is deliberately left out.** It renders no store notices, and the shipped `edit-site` package exposes no slot anywhere in that sidebar — its only extension points (`PluginTemplateSettingPanel`, `PluginSidebar`, and friends) all target the edit canvas. The alternative is injecting into the DOM next to the save hub, which is what the Global Styles gating notice does and is exactly as fragile as it sounds. Rather than add a second copy of that, the notice waits until the edit canvas opens, and records no impression before then. The expired modal already covers browse mode.

**The Customizer is excluded** through the screen's own `is_block_editor()` flag: it fires `enqueue_block_editor_assets` for its widgets editor but renders no notices, so the bundle would be dead weight there.

**The wp-admin banner now stays off block-editor screens.** It was still being enqueued and rendered there — invisibly — and its script was faithfully recording `jetpack_expiry_banner_impression` for a banner nobody saw, then setting the once-per-session flag so later real views in the same session went uncounted. Both banner hooks bail on block-editor screens now.

**One fix to the shipped CTAs rides along.** The checkout return URL was appended with `add_query_arg()`, which does not encode values, so any admin URL carrying its own query — a site editor deep link like `site-editor.php?p=%2Fpage&canvas=edit` — was split at the ampersand and handed to checkout as extra parameters. The value is now `rawurlencode()`d in the shared CTA builder, so the banner and the modal pick up the fix too.

**Smaller things worth knowing.**

* The payload is inlined as JSON via `wp_add_inline_script()` rather than `wp_localize_script()`, which stringifies every top-level scalar and would have handed the client `""` for a false `isDismissible`.
* The notice reads the banner's heading as the first sentence of its body (`Your Business plan has expired. If renewal doesn't go through…`). Store notices are a single plain paragraph: markup needs the store's `__unstableHTML` flag, which nothing in the monorepo uses and core's own editor notices avoid. The joiner is a translatable format string in PHP, since this package extracts PHP strings for translation and not JS.
* The CTAs are real links with an `onClick` for tracking; `@wordpress/components`' `Notice` passes both through, so middle-click and "open in new tab" keep working. The reverted-site "Contact support" CTA opens the Help Center in place, with its href as the fallback.
* The dismissal write, the once-per-session impression guard, the `Cta` type, and the Tracks-props projection were each about to exist three times across the banner, the modal, and this; they are now shared helpers (`dismiss.ts`, `track-once.ts`, `types.ts`, `wpcom_expiry_notices_track_props()`).

## Related product discussion/links

* DOTCOM-16616 (this), DOTCOM-16615 (the wp-admin banner), DOTCOM-16617 (the expired modal)

## Does this pull request change what data or activity we track or use?

Yes — new Tracks events: `jetpack_expiry_editor_notice_impression`, `jetpack_expiry_editor_notice_cta_click`, `jetpack_expiry_editor_notice_dismiss`, `jetpack_expiry_editor_notice_dismiss_failed`. Each carries the banner's `state`, `days_remaining`, and `product_slug`, plus `context` (`post-editor`, `site-editor`, or `widgets`); the click event adds `cta` (`primary`, `secondary`, or `support`).

Also, `jetpack_expiry_banner_impression` no longer fires on block-editor screens, where the banner was never visible.

## Testing instructions

Needs a test Atomic site whose plan expiration date you can change. The block widgets screen needs a classic theme active.

**Final week** — set the expiration date to 5 days from now, with auto-renew off:

* Open the post editor. A red notice sits under the toolbar: "Your {plan} plan expires in 5 days. …" with a `Renew now` link and no close button.
* `Renew now` goes to checkout, and the checkout URL's `redirect_to` is the editor URL you came from. Middle-clicking it opens a new tab.
* Open a template in the site editor: same notice. Go back to the site editor's home (no template open): no notice, on purpose.
* Appearance → Widgets: same notice.
* Any non-editor wp-admin screen still shows the banner as before.

**Grace period** — set the expiration date to 3 days ago:

* The editor notice reads "Your {plan} plan has expired. …" and gains a `View other plans` link.
* The expired modal still opens over the editor, as it did before this PR. Closing it leaves the notice in place.

**Post-grace** — set the expiration date to 33 days ago:

* The notice's CTA reads `Restore site` and the notice has a close button.
* Close it: it disappears and stays gone on reload, and the wp-admin banner is gone too. Dismissing the wp-admin banner instead hides the editor notice as well.

**Early reminder** — set the expiration date to 45 days from now, auto-renew off:

* The Dashboard shows the yellow banner; the editors show nothing.

**Tracks** — with the Tracks debugger open, an editor load records `jetpack_expiry_editor_notice_impression` once per browser session with a `context` prop, and no `jetpack_expiry_banner_impression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
