### PR TITLE
Backup: stop an offline read reading as a settled "no"

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2490-2491-paused-queries
+++ b/projects/packages/backup/changelog/jetpack-2490-2491-paused-queries
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: an offline browser no longer reads as an answer. React Query parks a request instead of failing it, so the plan check showed a paying site the upgrade screen and the Overview showed an established site the first-backup panel. Both now wait, and pick up where they left off once the browser is back. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -219,19 +219,21 @@ export function useDefaultBackupRewindId(): string | null {
  * is paginated over the full retention window and does not have that
  * blind spot.
  *
- * `isError` is reported separately from `isLoading` because callers must
- * treat the two the same way and React Query does not. A failed query is
- * not loading and holds no rows, so `hasRestorePoints` comes back a
+ * `isError` and `isPaused` are reported separately from `isLoading`
+ * because callers must treat all three the same way and React Query does
+ * not. A query that failed, and one parked because the browser is offline,
+ * are both not loading and hold no rows, so `hasRestorePoints` comes back a
  * confident `false` for a question that was never actually answered —
  * which is indistinguishable, to a caller reading only the first two
  * values, from a site that genuinely has no restore points.
  *
- * @return Whether a restore point is visible, whether the answer has loaded, and whether asking failed.
+ * @return Whether a restore point is visible, whether the answer has loaded, and whether asking failed or was parked.
  */
 export function useHasRestorePoints(): {
 	hasRestorePoints: boolean;
 	isLoading: boolean;
 	isError: boolean;
+	isPaused: boolean;
 } {
 	const query = useActivityPageQuery( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, ACTIVITY_LOG_NEWEST_FIRST );
 	const hasRestorePoints = useMemo(
@@ -241,7 +243,12 @@ export function useHasRestorePoints(): {
 			),
 		[ query.data ]
 	);
-	return { hasRestorePoints, isLoading: query.isLoading, isError: query.isError };
+	return {
+		hasRestorePoints,
+		isLoading: query.isLoading,
+		isError: query.isError,
+		isPaused: query.isPaused,
+	};
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -221,8 +221,8 @@ export function useDefaultBackupRewindId(): string | null {
  *
  * `isError` and `isPaused` are reported separately from `isLoading`
  * because callers must treat all three the same way and React Query does
- * not. A query that failed, and one parked because the browser is offline,
- * are both not loading and hold no rows, so `hasRestorePoints` comes back a
+ * not. A query that failed, and a first read parked because the browser is
+ * offline, are both not loading and hold no rows, so `hasRestorePoints` comes back a
  * confident `false` for a question that was never actually answered —
  * which is indistinguishable, to a caller reading only the first two
  * values, from a site that genuinely has no restore points.
@@ -247,7 +247,9 @@ export function useHasRestorePoints(): {
 		hasRestorePoints,
 		isLoading: query.isLoading,
 		isError: query.isError,
-		isPaused: query.isPaused,
+		// `isPending` too: a parked *refetch* still holds its rows, and reporting
+		// that as unanswered would pull the first-run panel off a genuinely empty site.
+		isPaused: query.isPending && query.isPaused,
 	};
 }
 

--- a/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-capabilities.ts
@@ -50,6 +50,10 @@ export function useCapabilities( { enabled = true }: Args = {} ): Result {
 	// in the same render as the click — and this is the query whose error
 	// screen wraps the entire dashboard body.
 	const error = useStickyError( query.error ?? null, query.isFetching );
+	// `networkMode: 'online'` parks an offline request rather than failing it, so
+	// the first read sits pending with nothing to show and the gate reads that as
+	// an answered "no plan". `isPending` spares a paused refetch, which has data.
+	const isParkedOffline = query.isPending && query.isPaused;
 
 	return {
 		data: query.data,
@@ -58,7 +62,7 @@ export function useCapabilities( { enabled = true }: Args = {} ): Result {
 		// so on its own it would replace the error screen with a spinner
 		// for the whole round trip. The sticky error is what separates
 		// "nothing has ever been shown" from "we are asking again".
-		isLoading: query.isLoading && error === null,
+		isLoading: ( query.isLoading || isParkedOffline ) && error === null,
 		error,
 		// Not `query.isRefetching`: that is `isFetching && ! isPending`,
 		// and the rewind makes a retry pending, so it stays false exactly

--- a/projects/packages/backup/src/dashboard/screens/overview.tsx
+++ b/projects/packages/backup/src/dashboard/screens/overview.tsx
@@ -166,9 +166,9 @@ function OverviewBody() {
 	// briefly showing the two-pane view is a milder error than briefly
 	// telling an established customer they have no backups.
 	//
-	// A failed request is "still unknown" too, and that is the whole
-	// point of reading `isError` here. React Query reports an errored
-	// query as not-loading with no rows, so without this the veto lifts
+	// A failed request is "still unknown" too, and so is one React Query
+	// parked because the browser is offline — that is what `isError` and
+	// `isPaused` are for: neither loads nor has rows, so without them the veto lifts
 	// on a question nobody managed to ask: the first-run panel takes the
 	// body over and takes the activity log's own error report down with
 	// it, and a 5xx reads as "your first backup is on its way".
@@ -176,6 +176,7 @@ function OverviewBody() {
 		hasRestorePoints,
 		isLoading: restorePointsLoading,
 		isError: restorePointsError,
+		isPaused: restorePointsPaused,
 	} = useHasRestorePoints();
 
 	const overviewRef = useRef< HTMLDivElement >( null );
@@ -210,7 +211,7 @@ function OverviewBody() {
 		replacesOverview(
 			backupsState,
 			isInitialBackup,
-			restorePointsLoading || restorePointsError || hasRestorePoints
+			restorePointsLoading || restorePointsError || restorePointsPaused || hasRestorePoints
 		)
 	) {
 		return <BackupStatusPanel state={ backupsState } progress={ progress } />;

--- a/projects/packages/backup/tests/gate-decision.test.tsx
+++ b/projects/packages/backup/tests/gate-decision.test.tsx
@@ -13,7 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factory above.
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor, within } from '@testing-library/react';
 import BackupNowButton from '../src/dashboard/components/backup-now-button';
 import Gates from '../src/dashboard/components/gates';
@@ -144,6 +144,25 @@ function renderButtonAlone() {
 }
 
 /**
+ * Render the gate alone, with the client a test needs to drive a refetch.
+ *
+ * @return The client and the render container.
+ */
+function renderGateAlone() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const { container } = render(
+		<QueryClientProvider client={ client }>
+			<Gates>
+				<div>{ BODY }</div>
+			</Gates>
+		</QueryClientProvider>
+	);
+	return { client, container };
+}
+
+/**
  * Wait until the capabilities query has settled.
  *
  * @param client - The client the tree is rendering against.
@@ -162,6 +181,12 @@ beforeEach( () => {
 		...window.JP_CONNECTION_INITIAL_STATE,
 		connectionStatus: CONNECTED,
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+afterEach( () => {
+	// `onlineManager` is a module singleton, so an offline test leaves every
+	// later one in this file parking its requests.
+	onlineManager.setOnline( true );
 } );
 
 describe( 'Gate decision — what the gate and the header button each show', () => {
@@ -247,6 +272,44 @@ describe( 'Gate decision — what the gate and the header button each show', () 
 		await expect( view.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 		expect( view.queryByText( BODY ) ).not.toBeInTheDocument();
 		expect( headerSlot() ).toBeEmptyDOMElement();
+	} );
+
+	// JETPACK-2490 — `networkMode: 'online'` parks the read for an offline
+	// browser rather than failing it. The query is then pending but not
+	// fetching and not errored, so every flag the gate reads says "answered,
+	// with nothing", and a paying customer was sold an upgrade.
+	it( 'never sells an upgrade over a read it never managed to make', async () => {
+		onlineManager.setOnline( false );
+
+		const view = within( renderShell() );
+
+		// Parked, not sent: nothing failed, so there is no request to await.
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+		expect( view.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
+		expect( skeleton() ).not.toBeNull();
+
+		// And it is a wait, not a dead end: the parked read resumes by itself.
+		onlineManager.setOnline( true );
+		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
+	} );
+
+	// The narrowing the fix above needs. A paused query keeps whatever it
+	// cached, so a read parked mid-session must not blank a dashboard that
+	// already has its answer.
+	it( 'keeps a loaded dashboard up when a later read is parked', async () => {
+		const { client, container } = renderGateAlone();
+		const view = within( container );
+		await expect( view.findByText( BODY ) ).resolves.toBeInTheDocument();
+
+		onlineManager.setOnline( false );
+		// Not awaited: a parked refetch never settles until the browser is back.
+		void client.invalidateQueries( { queryKey: keys.capabilities() } );
+		await waitFor( () =>
+			expect( client.getQueryState( keys.capabilities() )?.fetchStatus ).toBe( 'paused' )
+		);
+
+		expect( view.getByText( BODY ) ).toBeInTheDocument();
+		expect( skeleton() ).toBeNull();
 	} );
 
 	it( 'shows the dashboard body and the button when everything passes', async () => {

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -23,9 +23,10 @@ jest.mock( '@wordpress/route', () => ( {
 } ) );
 
 // Imports must come after the jest.mock factories above.
+import { onlineManager } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
-import { queryClient } from '../src/dashboard/data/query-client';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
@@ -122,6 +123,12 @@ beforeEach( () => {
 	} as typeof window.JP_CONNECTION_INITIAL_STATE;
 } );
 
+afterEach( () => {
+	// `onlineManager` is a module singleton, so an offline test leaves every
+	// later one in this file parking its requests.
+	onlineManager.setOnline( true );
+} );
+
 describe( 'Overview takeover', () => {
 	it( 'replaces the body on a genuinely empty site', async () => {
 		mockEndpoints( { backups: [], activity: [] } );
@@ -152,6 +159,32 @@ describe( 'Overview takeover', () => {
 		expect(
 			screen.queryByText( 'Your first cloud backup will be ready soon' )
 		).not.toBeInTheDocument();
+	} );
+
+	// JETPACK-2491 — `networkMode: 'online'` parks the activity read for an
+	// offline browser rather than failing it, so it is neither loading nor
+	// errored and holds no rows. The veto lifted on a question nobody asked,
+	// and an established site was told its first backup was on its way.
+	it( 'does not take over when the activity request was parked, not answered', async () => {
+		mockEndpoints( { backups: [] } );
+		// Warmed so the gate and the backup state both have an answer, leaving
+		// the activity log as the only read the offline browser parks.
+		queryClient.setQueryData( keys.capabilities(), { hasBackupPlan: true, hasScan: false } );
+		queryClient.setQueryData( keys.backups(), [] );
+		onlineManager.setOnline( false );
+
+		render( <OverviewStage /> );
+
+		// The header renders above the body either way, so waiting on it
+		// settles the render without deciding what this test asserts.
+		await expect(
+			screen.findByRole( 'button', { name: 'Back up now' } )
+		).resolves.toBeInTheDocument();
+
+		expect(
+			screen.queryByText( 'Your first cloud backup will be ready soon' )
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'group', { name: 'Backup activity' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'still takes over when the activity log holds no backup rows', async () => {

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -24,9 +24,10 @@ jest.mock( '@wordpress/route', () => ( {
 
 // Imports must come after the jest.mock factories above.
 import { onlineManager } from '@tanstack/react-query';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { keys, queryClient } from '../src/dashboard/data/query-client';
+import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activity-log';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
@@ -202,11 +203,16 @@ describe( 'Overview takeover', () => {
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
 		} );
-		// The parked state reaches the observer a tick after the invalidation
-		// settles, so asserting straight away would pass without looking.
-		await act( async () => {
-			await new Promise( resolve => setTimeout( resolve, 50 ) );
-		} );
+		// The parked state reaches the observer after the invalidation settles, so
+		// asserting straight away passes without looking. Wait on the state itself,
+		// not a delay: this file's SETTLE exists because CI blows past fixed windows.
+		await waitFor( () =>
+			expect(
+				queryClient.getQueryState(
+					keys.activityLogPage( 1, ACTIVITY_LOG_DEFAULT_PER_PAGE, 'desc' )
+				)?.fetchStatus
+			).toBe( 'paused' )
+		);
 
 		expect( screen.getByText( 'Your first cloud backup will be ready soon' ) ).toBeInTheDocument();
 	} );

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -24,7 +24,7 @@ jest.mock( '@wordpress/route', () => ( {
 
 // Imports must come after the jest.mock factories above.
 import { onlineManager } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { stage as OverviewStage } from '../routes/dashboard/stage';
 import { keys, queryClient } from '../src/dashboard/data/query-client';
 
@@ -185,6 +185,30 @@ describe( 'Overview takeover', () => {
 			screen.queryByText( 'Your first cloud backup will be ready soon' )
 		).not.toBeInTheDocument();
 		expect( screen.getByRole( 'group', { name: 'Backup activity' } ) ).toBeInTheDocument();
+	} );
+
+	// The other half of JETPACK-2491: a parked *refetch* still holds its rows, so
+	// reporting it as unanswered would pull the panel off a site that really is empty.
+	it( 'still takes over when a refetch parks on an already-empty site', async () => {
+		mockEndpoints( { backups: [], activity: [] } );
+
+		render( <OverviewStage /> );
+		await expect(
+			screen.findByText( 'Your first cloud backup will be ready soon' )
+		).resolves.toBeInTheDocument();
+
+		// Offline after the answer landed, then something asks again.
+		onlineManager.setOnline( false );
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
+		} );
+		// The parked state reaches the observer a tick after the invalidation
+		// settles, so asserting straight away would pass without looking.
+		await act( async () => {
+			await new Promise( resolve => setTimeout( resolve, 50 ) );
+		} );
+
+		expect( screen.getByText( 'Your first cloud backup will be ready soon' ) ).toBeInTheDocument();
 	} );
 
 	it( 'still takes over when the activity log holds no backup rows', async () => {


### PR DESCRIPTION
Fixes JETPACK-2490, JETPACK-2491

## Proposed changes

Two gates in the modernized Backup dashboard treat an **offline** request as an answered "no".

React Query's default `networkMode: 'online'` does not fail an offline request — it parks it: `status: 'pending'`, `fetchStatus: 'paused'`. So `isLoading` is false, `error` is null and there are no rows, all at once. Code reading "not loading, no error, no rows" as "the answer is empty" is wrong; it is also "never asked".

* **JETPACK-2490** — `use-capabilities.ts` reported a parked read as settled, so `useGateState` fell through to `! hasBackupPlan`. A **paying customer whose connection drops during load was shown the "This site doesn't have an active Backup plan" upsell**, with a price and an upgrade button.
* **JETPACK-2491** — `useHasRestorePoints` reported a parked read as `isLoading: false, isError: false` with no rows, lifting the Overview's veto. A **customer with years of restore points was shown "Your first cloud backup will be ready soon"**, and the two-pane body disappeared.

Both self-heal on reconnect without a reload; both are modernized-dashboard only, so they are invisible today and become visible at flag flip.

`isPending && isPaused` in the capabilities fix is deliberate: bare `isPaused` would drop a warm, working dashboard to a skeleton whenever a background refetch parked.

## Related product discussion/links

* JETPACK-2490, JETPACK-2491

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`; no-op when off.

Automated, from `projects/packages/backup`:

* `npx jest --config=tests/jest.config.js` → **75 suites / 743 tests**. Trunk is 75 / 740; the 3 added are in `tests/gate-decision.test.tsx` and `tests/overview-takeover.test.tsx`.
* Both fixes are mutation-killed. Revert `isLoading: ( query.isLoading || isParkedOffline ) && error === null` to `query.isLoading && error === null` → `never sells an upgrade over a read it never managed to make` fails on the found `<h2>This site doesn't have an active Backup plan</h2>`. Revert `restorePointsPaused ||` in `screens/overview.tsx` → `does not take over when the activity request was parked, not answered` fails on the found `<h2>Your first cloud backup will be ready soon</h2>`.
* Drop the `isPending` narrowing → `keeps a loaded dashboard up when a later read is parked` fails, which is what stops the fix regressing a warm dashboard.

Manual, with the filter on:

1. Open Backup. Let it render.
2. DevTools → Network → **Offline**.
3. Console: clear the query cache.
4. Click into Download, then **Back to overview** (client-side, no page load).
5. **Before:** the no-plan upsell. **After:** the dashboard holds its loading state.
6. Network → **Online**. The parked read resumes and the dashboard renders, no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2J2i9Tn1Wyfb4UwHCwKAF
