### PR TITLE
Backup: gate the modernized file preview on a pattern family, not one literal path

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers any wp-config copy, .env file, and Bedrock's config/application.php. No-op when the filter is off.
+
+

--- a/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers wp-config, .env and Bedrock config/application.php files at any depth, including hand-made copies of them. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the reveal click that already hid wp-config.php now also covers .env files, Bedrock config/application.php, database dumps and log files at any depth, including hand-made copies of them. No-op when the filter is off.

--- a/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/packages/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,5 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers any wp-config copy, .env file, and Bedrock's config/application.php. No-op when the filter is off.
-
-
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers wp-config, .env and Bedrock config/application.php files at any depth, including hand-made copies of them. No-op when the filter is off.

--- a/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
@@ -68,19 +68,18 @@ function mimeFromName( name: string ): string {
 }
 
 /**
- * Files whose preview waits for a deliberate second click, matched against
- * the lowercased manifest path once its volume prefix is dropped.
+ * Files whose preview waits for a deliberate second click: anything that can
+ * hold credentials, plus any hand-made copy of one that still previews.
  *
- * A family rather than the single `wp-config.php` Calypso names, so a
- * hand-made copy that still previews is gated too; `(^|\/)` is what keeps
- * `mywp-config.php` out.
+ * Matched against the lowercased manifest path once its volume prefix is
+ * dropped, and `[^/]*$` confines every pattern to the file's own name.
  */
 const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
 	/(^|\/)wp-config[^/]*$/,
-	/(^|\/)\.env[^/]*$/,
-	/(^|\/)config\/application\.php$/,
+	/(^|\/)config\/application[^/]*$/,
+	/\.env[^/]*$/,
+	/\.log[^/]*$/,
 	/\.sql[^/]*$/,
-	/debug\.log[^/]*$/,
 ];
 
 /**

--- a/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
@@ -21,6 +21,10 @@ import type { FileNodeFile } from '../../types/file-tree';
  * an opaque binary. Calypso reaches the same conclusion and keeps its
  * own extension map for exactly this decision, using `data_type` only
  * to drive granular download.
+ *
+ * `sql` and `log` are deliberately absent: a database dump and a debug
+ * log are pure secret, and nobody previews one to decide whether to
+ * restore it.
  */
 const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	css: 'text/css',
@@ -29,12 +33,10 @@ const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	html: 'text/html',
 	js: 'application/javascript',
 	json: 'application/json',
-	log: 'text/plain',
 	md: 'text/markdown',
 	php: 'application/x-php',
 	po: 'text/plain',
 	pot: 'text/plain',
-	sql: 'application/sql',
 	svg: 'image/svg+xml',
 	txt: 'text/plain',
 	xml: 'application/xml',
@@ -66,19 +68,26 @@ function mimeFromName( name: string ): string {
 }
 
 /**
- * The one filename whose preview waits for a deliberate second click:
- * `wp-config.php`, which carries `DB_PASSWORD` and the salts. Same single
- * file Calypso hides, so the two surfaces agree.
+ * Files whose preview waits for a deliberate second click, matched against
+ * the lowercased manifest path once its volume prefix is dropped.
+ *
+ * A family rather than the single `wp-config.php` Calypso names, so a
+ * hand-made copy that still previews is gated too; `(^|\/)` is what keeps
+ * `mywp-config.php` out.
  */
-const SENSITIVE_NAME = 'wp-config.php';
+const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
+	/(^|\/)wp-config[^/]*$/,
+	/(^|\/)\.env[^/]*$/,
+	/(^|\/)config\/application\.php$/,
+	/\.sql[^/]*$/,
+	/debug\.log[^/]*$/,
+];
 
 /**
- * Whether the given manifest path names the file above, at any depth.
+ * Whether the given manifest path matches one of the patterns above.
  *
- * Three ways to fail open, all closed: the volume prefix is dropped (the `5`
- * in `f5:` is a data-type code, not identity), the compare is lowercased, and
- * the name matches at any depth, so a second install under `/staging/` is
- * covered. The `/` in the suffix keeps `mywp-config.php` out.
+ * Two ways to fail open, both closed: the volume prefix is dropped (the `5`
+ * in `f5:` is a data-type code, not identity) and the compare is lowercased.
  *
  * @param manifestPath - The volume-prefixed manifest path, e.g. `f5:/wp-config.php`.
  * @return True when the preview needs a reveal.
@@ -88,7 +97,7 @@ function isSensitivePath( manifestPath: string | undefined ): boolean {
 		return false;
 	}
 	const path = manifestPath.slice( manifestPath.indexOf( ':' ) + 1 ).toLowerCase();
-	return path === SENSITIVE_NAME || path.endsWith( `/${ SENSITIVE_NAME }` );
+	return SENSITIVE_PATH_PATTERNS.some( pattern => pattern.test( path ) );
 }
 
 /**

--- a/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
@@ -22,8 +22,8 @@ import type { FileNodeFile } from '../../types/file-tree';
  * own extension map for exactly this decision, using `data_type` only
  * to drive granular download.
  *
- * `sql` and `log` are deliberately absent: a dump and a debug log are
- * pure secret, and previewing one decides nothing about restoring it.
+ * `sql` and `log` never preview unprompted despite being here: every
+ * pattern below matches them, so they arrive behind the reveal click.
  */
 const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	css: 'text/css',
@@ -32,10 +32,12 @@ const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	html: 'text/html',
 	js: 'application/javascript',
 	json: 'application/json',
+	log: 'text/plain',
 	md: 'text/markdown',
 	php: 'application/x-php',
 	po: 'text/plain',
 	pot: 'text/plain',
+	sql: 'application/sql',
 	svg: 'image/svg+xml',
 	txt: 'text/plain',
 	xml: 'application/xml',
@@ -70,8 +72,9 @@ function mimeFromName( name: string ): string {
  * Files whose preview waits for a deliberate second click: anything that can
  * hold credentials, plus any hand-made copy of one that still previews.
  *
- * Matched against the lowercased, prefix-stripped manifest path; `[^/]*$`
- * confines every pattern to the file's own name.
+ * Matched against the lowercased, prefix-stripped manifest path. The trailing
+ * `[^/]*$` keeps a match inside one filename; `config/application` is the only
+ * pattern that also pins a parent directory.
  */
 const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
 	/(^|\/)wp-config[^/]*$/,

--- a/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/use-file-info.ts
@@ -22,9 +22,8 @@ import type { FileNodeFile } from '../../types/file-tree';
  * own extension map for exactly this decision, using `data_type` only
  * to drive granular download.
  *
- * `sql` and `log` are deliberately absent: a database dump and a debug
- * log are pure secret, and nobody previews one to decide whether to
- * restore it.
+ * `sql` and `log` are deliberately absent: a dump and a debug log are
+ * pure secret, and previewing one decides nothing about restoring it.
  */
 const PREVIEWABLE_TEXT_TYPES: Record< string, string > = {
 	css: 'text/css',
@@ -71,8 +70,8 @@ function mimeFromName( name: string ): string {
  * Files whose preview waits for a deliberate second click: anything that can
  * hold credentials, plus any hand-made copy of one that still previews.
  *
- * Matched against the lowercased manifest path once its volume prefix is
- * dropped, and `[^/]*$` confines every pattern to the file's own name.
+ * Matched against the lowercased, prefix-stripped manifest path; `[^/]*$`
+ * confines every pattern to the file's own name.
  */
 const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
 	/(^|\/)wp-config[^/]*$/,
@@ -85,8 +84,7 @@ const SENSITIVE_PATH_PATTERNS: readonly RegExp[] = [
 /**
  * Whether the given manifest path matches one of the patterns above.
  *
- * Two ways to fail open, both closed: the volume prefix is dropped (the `5`
- * in `f5:` is a data-type code, not identity) and the compare is lowercased.
+ * The `5` in `f5:` is a data-type code, not identity, so the prefix goes.
  *
  * @param manifestPath - The volume-prefixed manifest path, e.g. `f5:/wp-config.php`.
  * @return True when the preview needs a reveal.

--- a/projects/packages/backup/tests/file-preview-integrity.test.tsx
+++ b/projects/packages/backup/tests/file-preview-integrity.test.tsx
@@ -16,11 +16,11 @@ import type { FileNodeFile } from '../src/dashboard/types/file-tree';
 const noop = () => {};
 
 const FILE: FileNodeFile = {
-	name: 'error.log',
-	path: '/error.log',
+	name: 'error.txt',
+	path: '/error.txt',
 	type: 'file',
 	period: '1786644531',
-	manifestPath: 'f5:/error.log',
+	manifestPath: 'f5:/error.txt',
 };
 
 const UNAVAILABLE = 'Preview unavailable for this file.';

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -255,8 +255,10 @@ describe( 'sensitive preview gate', () => {
 		[ '/config/application.php.txt' ],
 		[ '/.env.txt' ],
 		[ '/production.env.txt' ],
+		[ '/dump.sql' ],
 		[ '/dump.sql.txt' ],
 		[ '/wp-content/uploads/db-backup.sql.txt' ],
+		[ '/wp-content/debug.log' ],
 		[ '/wp-content/debug.log.txt' ],
 		[ '/wp-content/error.log.txt' ],
 	] )( 'hides %s and never fetches it', async path => {
@@ -318,20 +320,15 @@ describe( 'sensitive preview gate', () => {
 		expect( fetchedContent() ).toBe( false );
 	} );
 
-	it.each( [ [ '/dump.sql' ], [ '/wp-content/debug.log' ] ] )(
-		'refuses %s with no reveal to click',
-		async path => {
-			mockEndpoints( SECRET );
+	it( 'shows a database dump once the reader asks', async () => {
+		mockEndpoints( SECRET );
+		renderCard( fileAt( '/dump.sql' ) );
 
-			renderCard( fileAt( path ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
 
-			await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
-			expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
-			expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
-			expect( screen.queryByRole( 'button', { name: SHOW } ) ).not.toBeInTheDocument();
-			expect( fetchedContent() ).toBe( false );
-		}
-	);
+		await expect( screen.findByText( SECRET ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( UNAVAILABLE ) ).not.toBeInTheDocument();
+	} );
 
 	it( 'hands focus to the preview it just revealed', async () => {
 		mockEndpoints( SECRET );

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -1,6 +1,6 @@
 // JETPACK-2353 — clicking `wp-config.php` printed `DB_PASSWORD` and the salts
-// straight into the `<pre>`. Calypso already hides the same single file behind
-// a "Show preview" click; this is that gate, ported.
+// straight into the `<pre>`. JETPACK-2474 widened that literal path into a
+// pattern family, because a hand-made copy of it previewed just as freely.
 
 const mockRecordEvent = jest.fn();
 
@@ -113,6 +113,22 @@ function renderCard( file: FileNodeFile ) {
 	);
 }
 
+/**
+ * A file node for the given path below the backup root.
+ *
+ * @param path - Path below the root, e.g. `/wp-config.old.php`.
+ * @return The file node the tree would hand the card.
+ */
+function fileAt( path: string ): FileNodeFile {
+	return {
+		name: path.slice( path.lastIndexOf( '/' ) + 1 ),
+		path,
+		type: 'file',
+		period: '1786644531',
+		manifestPath: `f5:${ path }`,
+	};
+}
+
 beforeEach( () => {
 	queryClient.clear();
 	queryClient.setDefaultOptions( { queries: { retry: false } } );
@@ -213,21 +229,38 @@ describe( 'sensitive preview gate', () => {
 		expect( fetchedContent() ).toBe( false );
 	} );
 
-	// The leading `/` in the compare is what stops the basename match
-	// swallowing every name that merely ends in the same letters.
-	it( 'leaves a file whose name only ends in wp-config.php alone', async () => {
+	// Each pattern is anchored to the start of a path segment, so a name that
+	// merely ends in — or merely contains — the same letters is not swallowed.
+	it.each( [
+		[ '/wp-content/mywp-config.php' ],
+		[ '/wp-content/env.php' ],
+		[ '/config/app.php' ],
+	] )( 'leaves %s alone', async path => {
 		mockEndpoints( PLAIN );
 
-		renderCard( {
-			name: 'mywp-config.php',
-			path: '/wp-content/mywp-config.php',
-			type: 'file',
-			period: '1786644531',
-			manifestPath: 'f5:/wp-content/mywp-config.php',
-		} );
+		renderCard( fileAt( path ) );
 
 		await expect( screen.findByText( PLAIN ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
+	} );
+
+	// `config/application.php` is Bedrock's, where the credentials live instead.
+	it.each( [
+		[ '/wp-config-backup.php' ],
+		[ '/wp-config.old.php' ],
+		[ '/wp-config.php.txt' ],
+		[ '/.env.txt' ],
+		[ '/config/application.php' ],
+		[ '/dump.sql.txt' ],
+		[ '/wp-content/debug.log.txt' ],
+	] )( 'hides %s and never fetches it', async path => {
+		mockEndpoints( SECRET );
+
+		renderCard( fileAt( path ) );
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
 	} );
 
 	// Two gated files in one tree is what makes the stale-reveal render
@@ -267,23 +300,33 @@ describe( 'sensitive preview gate', () => {
 		expect( screen.queryByRole( 'button', { name: SHOW } ) ).not.toBeInTheDocument();
 	} );
 
-	// Why the gate names one path instead of a family: a stray backup copy is
-	// already unpreviewable, because `bak` is not in the extension map.
-	it( 'needs no entry for a wp-config.php.bak, which never previews at all', async () => {
+	// The pattern matches this one too, and the map still wins.
+	it( 'refuses a wp-config.php.bak outright rather than offering a reveal', async () => {
 		mockEndpoints( SECRET );
 
-		renderCard( {
-			name: 'wp-config.php.bak',
-			path: '/wp-config.php.bak',
-			type: 'file',
-			period: '1786644531',
-			manifestPath: 'f5:/wp-config.php.bak',
-		} );
+		renderCard( fileAt( '/wp-config.php.bak' ) );
 
 		await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: SHOW } ) ).not.toBeInTheDocument();
 		expect( fetchedContent() ).toBe( false );
 	} );
+
+	it.each( [ [ '/dump.sql' ], [ '/wp-content/debug.log' ] ] )(
+		'refuses %s with no reveal to click',
+		async path => {
+			mockEndpoints( SECRET );
+
+			renderCard( fileAt( path ) );
+
+			await expect( screen.findByText( UNAVAILABLE ) ).resolves.toBeInTheDocument();
+			expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( HIDDEN ) ).not.toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: SHOW } ) ).not.toBeInTheDocument();
+			expect( fetchedContent() ).toBe( false );
+		}
+	);
+
 	it( 'hands focus to the preview it just revealed', async () => {
 		mockEndpoints( SECRET );
 		renderCard( WP_CONFIG );

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -229,12 +229,14 @@ describe( 'sensitive preview gate', () => {
 		expect( fetchedContent() ).toBe( false );
 	} );
 
-	// Each pattern is anchored to the start of a path segment, so a name that
-	// merely ends in — or merely contains — the same letters is not swallowed.
+	// Near-misses on all five: the two name-anchored patterns need a segment to
+	// start with the name, and the three extension patterns need the dot.
 	it.each( [
 		[ '/wp-content/mywp-config.php' ],
-		[ '/wp-content/env.php' ],
 		[ '/config/app.php' ],
+		[ '/wp-content/env.php' ],
+		[ '/changelog.txt' ],
+		[ '/wp-content/uploads/mysql.txt' ],
 	] )( 'leaves %s alone', async path => {
 		mockEndpoints( PLAIN );
 
@@ -249,10 +251,15 @@ describe( 'sensitive preview gate', () => {
 		[ '/wp-config-backup.php' ],
 		[ '/wp-config.old.php' ],
 		[ '/wp-config.php.txt' ],
-		[ '/.env.txt' ],
 		[ '/config/application.php' ],
+		[ '/config/application.old.php' ],
+		[ '/config/application.php.txt' ],
+		[ '/.env.txt' ],
+		[ '/production.env.txt' ],
 		[ '/dump.sql.txt' ],
+		[ '/wp-content/uploads/db-backup.sql.txt' ],
 		[ '/wp-content/debug.log.txt' ],
+		[ '/wp-content/error.log.txt' ],
 	] )( 'hides %s and never fetches it', async path => {
 		mockEndpoints( SECRET );
 

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -1,6 +1,5 @@
 // JETPACK-2353 — clicking `wp-config.php` printed `DB_PASSWORD` and the salts
-// straight into the `<pre>`. JETPACK-2474 widened that literal path into a
-// pattern family, because a hand-made copy of it previewed just as freely.
+// straight into the `<pre>`. JETPACK-2474 widened the gate to a pattern family.
 
 const mockRecordEvent = jest.fn();
 

--- a/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Backup: the modernized file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers any wp-config copy, .env file, and Bedrock's config/application.php. No-op when the modernization filter is off.
+
+

--- a/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,5 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Backup: the modernized file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers any wp-config copy, .env file, and Bedrock's config/application.php. No-op when the modernization filter is off.
-
-
+Comment: Backup: the modernized file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers wp-config, .env and Bedrock config/application.php files at any depth, including hand-made copies of them. No-op when the modernization filter is off.

--- a/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
+++ b/projects/plugins/backup/changelog/jetpack-2474-backup-preview-secret-file-gate
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Backup: the modernized file browser no longer previews .sql or .log files at all, and the reveal click that already hid wp-config.php now covers wp-config, .env and Bedrock config/application.php files at any depth, including hand-made copies of them. No-op when the modernization filter is off.
+Comment: Backup: in the modernized file browser, the reveal click that already hid wp-config.php now also covers .env files, Bedrock config/application.php, database dumps and log files at any depth, including hand-made copies of them. No-op when the modernization filter is off.


### PR DESCRIPTION
Fixes JETPACK-2474

Follow-up to #51868, which gated `wp-config.php` behind a reveal click and recorded that rule as **provisional**. This settles it.

## Proposed changes

Both halves of the fix, in `projects/packages/backup/src/dashboard/components/file-info-card/index.tsx`:

* **The reveal gate keys on a pattern family instead of one literal path.** `SENSITIVE_NAME` / `isSensitivePath` matched exactly `wp-config.php`, so a hand-made copy with a previewable extension — `wp-config-backup.php`, `wp-config.old.php`, `wp-config.php.txt` — previewed in full. `SENSITIVE_PATH_PATTERNS` replaces it, matched against the lowercased manifest path with its volume prefix dropped:

  | Pattern | Covers |
  | --- | --- |
  | `/(^\|\/)wp-config[^/]*$/` | `wp-config.php` and every hand-made copy of it |
  | `/(^\|\/)config\/application[^/]*$/` | Bedrock's credential file, and copies of it |
  | `/\.env[^/]*$/` | `.env`, `production.env`, `.env.txt` — previously safe only by accident, because `mimeFromName` requires the dot at index > 0 |
  | `/\.log[^/]*$/` | logs, and copies like `error.log.txt` |
  | `/\.sql[^/]*$/` | dumps, and copies like `dump.sql.txt` |

* **`sql` and `log` join `PREVIEWABLE_TEXT_TYPES`, which puts them behind that gate.** On trunk a root `dump.sql` or a `debug.log` printed in full and unprompted — user rows, password hashes, session tokens, every API key in `wp_options`, plus whatever a plugin logged. They now arrive behind the same reveal click as `wp-config.php`, with the same no-fetch property. The patterns above already matched them, so the map entry is the whole change.

**The membership rule, written down** so it is decided here rather than inherited from Calypso (which still matches `wp-config.php` alone — this deliberately diverges): *anything that can hold credentials, plus any hand-made copy of one that still previews.* That clause is the docblock on the constant, and it is the criterion for adding a sixth pattern.

The first two patterns are anchored to a path-segment start, so the file's name has to *begin* with `wp-config` / `config/application`. The last three key on the dot, so they match mid-name — which is what covers `db-backup.sql.txt` and `error.log.txt`. `changelog.txt` and `mysql.txt` have no dot before `log` / `sql` and stay ungated; there are tests for both.

### Why a reveal rather than a refusal

An earlier revision of this PR removed `sql` and `log` from the extension map outright, so those files hit "Preview unavailable for this file." with no way through, ever. [@CGastrell](https://github.com/CGastrell) pointed out the asymmetry in review: `wp-config.php`, strictly more secret, still got a click.

The deciding factor is who is on the other side of this screen. The modernized dashboard is registered with `manage_options` (`packages/backup/src/class-jetpack-backup.php`), and `Admin_Menu` skips the registration entirely for anyone without it, so `admin.php?page=jetpack-backup` is refused rather than merely hidden. Every bridge route behind it — `file-list`, `path-info`, `file-content` — goes through `Rest_Controller::permission_check()`, which is stricter still: `manage_options` **and** an individually WordPress.com-linked account. Only the `administrator` role holds `manage_options` among core roles.

So every reader of this preview is already entitled to these bytes, and this gate is not a privilege boundary — it is protection against shoulder-surfing, screen sharing, and screenshots pasted into support tickets. Against that threat a reveal click is worth exactly as much as a refusal, and "no reveal, ever" is pure loss of function: reading a `debug.log` to work out what broke before choosing a restore point is a fair reason to open one.

### Judgement calls

* **`.sql` and `.log` now have one guard where they had two.** With the extensions out of the map they were protected both by the map and by the patterns, so a careless edit to either still failed safe. Now the pattern is the only thing standing between a dump and the `<pre>`. That is the same posture `wp-config.php` has always had — `php` is previewable, so its pattern is its sole guard — and dropping the two patterns costs 7 test failures (control C below). Uniform risk rather than a new class of it, but worth stating.
* **The real cost of over-gating is `wp-config-sample.php`, not an exotic filename.** It ships in every WordPress root, holds no secrets, and now reads "contains sensitive information." That is one extra click on a file present in essentially every backup — a worse trade than the earlier draft of this section implied by naming `my.logo.svg`, which almost nobody has. It stays gated because the alternative is a negative-lookahead carve-out that a `wp-config-sample.old.php` would walk straight through, and the failure direction here is asymmetric: an extra click versus a secret printed unprompted.
* **`.env` and `.log` are slightly wider than the issue's literal wording** (`.env*`, `*debug.log`), and that is deliberate. `<stage>.env` is a normal dotenv convention, so `production.env.txt` has to be covered and a leading-dot anchor would miss it; and a log is not always named `debug.log`, so `\.log` matches the `\.sql` treatment of dumps rather than keying on one filename.
* **`wp-config.php.bak` stays refused outright rather than gated.** `bak` is not in the extension map, and the map is checked first — so the pattern matching it is belt-and-braces, not the thing doing the work.
* **The reveal withholds the fetch, not just the render** — the property #51868 established. `awaitingReveal` drives `showPreview`, which drives `useFileContents`'s `enabled`. Every gated case asserts zero `/file-content` requests before the click.
* **The bridge is unchanged.** It enforces no mime check by design and says so in `src/rest/class-file-browser-bridge.php`; this rule is client-side, exactly as the `wp-config.php` gate was.

### Not in scope

* Bedrock's `config/environments/*.php` — not gated. Only `config/application*` is, per the issue.
* `"Preview unavailable for this file."` now does double duty: an extension outside the map, and a previewable file whose bytes turned out not to be text. Splitting the two strings is a follow-up, not this PR.
* No server-side enforcement. The bridge remains advisory-only.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-2474/backup-the-file-preview-prints-database-dumps-and-debug-logs-in-the
* #51868 — the `wp-config.php` gate this widens

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_backup_browser_preview_file_sensitive_click` event still fires on a reveal; it now fires for more filenames, but no new event and no new property.

## Testing instructions

This is behind the `rsm_jetpack_ui_modernization_backup` filter, which is off, so there is nothing to see on a stock install.

**Automated (what I actually ran):**

```
cd projects/packages/backup
pnpm test          # 75 suites, 759 tests, all passing
pnpm run typecheck # clean
```

`pnpm run lint-changed` from the repo root is clean.

Coverage is in `projects/packages/backup/tests/sensitive-preview-gate.test.tsx` (31 tests, up from 12 on trunk):

* Gated, and issuing **no** `/file-content` request: `/wp-config-backup.php`, `/wp-config.old.php`, `/wp-config.php.txt`, `/config/application.php`, `/config/application.old.php`, `/config/application.php.txt`, `/.env.txt`, `/production.env.txt`, `/dump.sql`, `/dump.sql.txt`, `/wp-content/uploads/db-backup.sql.txt`, `/wp-content/debug.log`, `/wp-content/debug.log.txt`, `/wp-content/error.log.txt`.
* Revealed on click, body rendered: `wp-config.php` and `/dump.sql`. The dump case is what proves the map entry rather than just the pattern — without it the file would show "Preview unavailable" and there would be no button to click.
* Refused outright — "Preview unavailable for this file.", no reveal button, no fetch: `/wp-config.php.bak`.
* Preview normally, proving the patterns don't over-match: `/wp-content/mywp-config.php`, `/config/app.php`, `/wp-content/env.php`, `/changelog.txt`, `/wp-content/uploads/mysql.txt`.

I verified the tests actually guard this rather than trusting green, by reverting the source three ways and re-running:

| Control | Expected failures | Result |
| --- | --- | --- |
| A — patterns → trunk's literal `wp-config.php` | every family case | **17 failed**, 14 passed |
| B — `sql`/`log` removed from the extension map | the two dumps/logs that only the map makes previewable, plus the reveal case | **3 failed**, 28 passed |
| C — the `\.sql` and `\.log` patterns removed | every dump and log, gated and copy alike | **7 failed**, 24 passed |

B and C together are the point: B fails if the files stop being previewable at all, C fails if they preview without the gate. Neither half is redundant.

`tests/file-preview-integrity.test.tsx` used an `error.log` fixture purely as "some previewable file"; it is now `error.txt`, since `.log` is gated and that suite needs a file that renders straight away. No assertion changed.

**Manual (with the filter forced on), if you want to confirm in the browser:**

1. Force the modernized dashboard on, open **Jetpack → Backup**, and expand a backup's file browser.
2. Click a `.sql` or `.log` file. Expect the hidden-preview notice and a "Show preview" button, and in the Network tab **no** `rewind/backup/file-content` request until you click it.
3. Click `wp-config.php`, or a copy such as `wp-config.old.php`. Same behaviour.
4. Click an ordinary `.txt` or `.php` file and confirm it still previews immediately.

**What I did not test:** I did not run this against a real backup in a browser — all verification is the Jest suite, which renders the real component against a mocked `apiFetch`. In particular the Bedrock case is untested against an actual Bedrock backup, matching the issue's own note that it is unverified; the patterns are exercised only against synthesized file nodes. There is no e2e coverage of the preview gate, and I did not add any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtKuZ5cXZGbMF95xaNZpnB
