### PR TITLE
Backup: stop the file browser calling a parked read an empty one

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2494-file-browser-paused-reads
+++ b/projects/packages/backup/changelog/jetpack-2494-file-browser-paused-reads
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: an offline browser no longer makes the file browser lie. React Query parks a request instead of failing it, so the backup's file tree rendered empty and an expanded folder announced itself as Empty to a screen reader. Both now wait, and pick up where they left off once the browser is back. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -139,10 +139,15 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 	// when it refetches after a failure, so without this the reason
 	// disappears the moment the reader clicks the retry button.
 	const error = useStickyError( query.error, query.isFetching );
+	// `networkMode: 'online'` parks an offline request rather than failing it, so
+	// the first read is neither loading nor errored and holds no children — which
+	// the tree read as an answered "empty". `isPending` spares a parked refetch,
+	// which still has its children.
+	const isParkedOffline = query.isPending && query.isPaused;
 
 	return {
 		children,
-		isLoading: query.isLoading,
+		isLoading: query.isLoading || isParkedOffline,
 		isFetching: query.isFetching,
 		error,
 		refetch: retry,

--- a/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-file-tree.ts
@@ -135,15 +135,15 @@ export function useFileTree( rewindId: string, folderPath: string | null ): Resu
 		refetch();
 	}, [ refetch ] );
 
-	// Held across the retry: React Query rewinds this query to `pending`
-	// when it refetches after a failure, so without this the reason
-	// disappears the moment the reader clicks the retry button.
-	const error = useStickyError( query.error, query.isFetching );
 	// `networkMode: 'online'` parks an offline request rather than failing it, so
 	// the first read is neither loading nor errored and holds no children — which
 	// the tree read as an answered "empty". `isPending` spares a parked refetch,
 	// which still has its children.
 	const isParkedOffline = query.isPending && query.isPaused;
+	// Held across the retry: React Query rewinds this query to `pending` when it
+	// refetches after a failure, so without this the reason disappears the moment
+	// the reader clicks retry — and an offline retry parks rather than fetching.
+	const error = useStickyError( query.error, query.isFetching || isParkedOffline );
 
 	return {
 		children,

--- a/projects/packages/backup/tests/file-browser-paused-reads.test.tsx
+++ b/projects/packages/backup/tests/file-browser-paused-reads.test.tsx
@@ -1,0 +1,139 @@
+// React Query parks a request for an offline browser rather than failing it,
+// so the read is neither loading nor errored and holds no rows. The file
+// browser read that as an answer: an empty tree for the backup, and "Empty"
+// spoken aloud for a folder nobody managed to look inside.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { onlineManager } from '@tanstack/react-query';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+
+const REWIND_ID = '1786644531.123';
+
+/** Selection is irrelevant to these assertions; the rows render regardless. */
+const noop = () => {};
+
+const ROOT = {
+	'wp-content': { type: 'dir', has_children: true },
+	'wp-config.php': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-config.php' },
+};
+
+const WP_CONTENT = {
+	'style.css': { type: 'file', period: '1786644531', manifest_path: 'f5:/wp-content/style.css' },
+};
+
+/**
+ * Render the browser.
+ */
+function renderBrowser(): void {
+	render(
+		<QueryClientProvider>
+			<FileBrowser
+				rewindId={ REWIND_ID }
+				selection={ EMPTY_FILE_SELECTION }
+				onSelectionChange={ noop }
+			/>
+		</QueryClientProvider>
+	);
+}
+
+/**
+ * Let the parked state reach the observer. It arrives a tick after the
+ * invalidation settles, so asserting straight away passes without looking.
+ *
+ * @return Promise resolving once the tick has elapsed.
+ */
+async function settle(): Promise< void > {
+	await act( async () => {
+		await new Promise( resolve => setTimeout( resolve, 50 ) );
+	} );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+
+	mockApiFetch.mockReset();
+	mockApiFetch.mockImplementation( ( options: { data?: { path?: string } } ) =>
+		Promise.resolve( { contents: options.data?.path === '/wp-content' ? WP_CONTENT : ROOT } )
+	);
+} );
+
+afterEach( () => {
+	// `onlineManager` is a module singleton, so an offline test leaves every
+	// later one in this file parking its requests.
+	onlineManager.setOnline( true );
+} );
+
+describe( 'the root tree', () => {
+	it( 'keeps waiting when the root read was parked, not answered', async () => {
+		onlineManager.setOnline( false );
+
+		renderBrowser();
+		await settle();
+
+		// The selection header renders above the tree either way, so reading it
+		// proves the browser mounted without deciding what this test asserts.
+		expect( screen.getByRole( 'checkbox', { name: '0 items selected' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'presentation' ) ).toBeInTheDocument();
+	} );
+
+	// The other half: a parked *refetch* still holds its rows, so reporting it
+	// as unanswered would blank a tree that is on screen and working.
+	it( 'keeps its rows when a refetch parks on a loaded tree', async () => {
+		renderBrowser();
+		await expect(
+			screen.findByRole( 'button', { name: 'Folder: wp-content' } )
+		).resolves.toBeInTheDocument();
+
+		onlineManager.setOnline( false );
+		await act( async () => {
+			await queryClient.invalidateQueries( { queryKey: keys.fileTree( REWIND_ID, '/' ) } );
+		} );
+		await settle();
+
+		expect( screen.getByRole( 'button', { name: 'Folder: wp-content' } ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'an expanded folder', () => {
+	it( 'does not announce a folder empty when its read was parked', async () => {
+		renderBrowser();
+		const toggle = await screen.findByRole( 'button', { name: 'Folder: wp-content' } );
+
+		onlineManager.setOnline( false );
+		await userEvent.click( toggle );
+		await settle();
+
+		// `role="status"` is a live region: whatever it holds is spoken as fact.
+		await expect( screen.findByRole( 'status' ) ).resolves.toBeEmptyDOMElement();
+	} );
+
+	it( 'keeps its children when a refetch parks on a loaded folder', async () => {
+		renderBrowser();
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Folder: wp-content' } ) );
+		await expect(
+			screen.findByRole( 'button', { name: 'File: style.css' } )
+		).resolves.toBeInTheDocument();
+
+		onlineManager.setOnline( false );
+		await act( async () => {
+			await queryClient.invalidateQueries( {
+				queryKey: keys.fileTree( REWIND_ID, '/wp-content' ),
+			} );
+		} );
+		await settle();
+
+		expect( screen.getByRole( 'button', { name: 'File: style.css' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/backup/tests/file-browser-paused-reads.test.tsx
+++ b/projects/packages/backup/tests/file-browser-paused-reads.test.tsx
@@ -88,6 +88,22 @@ describe( 'the root tree', () => {
 		expect( screen.getByRole( 'presentation' ) ).toBeInTheDocument();
 	} );
 
+	// The retry path: the sticky error is held across a refetch, but an offline
+	// retry parks instead of fetching — so without the guard the reason vanishes
+	// and the reader is left with a spinner and no way to ask again.
+	it( 'keeps the failure on screen when the retry parks offline', async () => {
+		mockApiFetch.mockRejectedValueOnce( new Error( 'Service unavailable' ) );
+
+		renderBrowser();
+		const retry = await screen.findByRole( 'button', { name: 'Try again' } );
+
+		onlineManager.setOnline( false );
+		await userEvent.click( retry );
+		await settle();
+
+		expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toBeInTheDocument();
+	} );
+
 	// The other half: a parked *refetch* still holds its rows, so reporting it
 	// as unanswered would blank a tree that is on screen and working.
 	it( 'keeps its rows when a refetch parks on a loaded tree', async () => {


### PR DESCRIPTION
Fixes JETPACK-2494 (two of its three items)

## Proposed changes

Two file-browser surfaces tell the reader something false when a read is **parked offline**.

React Query's default `networkMode: 'online'` does not fail an offline request — it parks it: `status: 'pending'`, `fetchStatus: 'paused'`. So `isLoading` is false, `error` is null and there are no rows, all at once. Reading that as "the answer is empty" is wrong; it is also "never asked".

* A parked **root** read rendered an **empty tree** under the "0 items selected" header.
* A parked **folder** read announced **"Empty"** in a `role="status"` region — spoken aloud, as fact, to a screen-reader user. That is the worst of the set.

Both now keep waiting, rendering the same spinner an in-flight read already shows. They self-heal on reconnect with no reload.

**One line, in the hook rather than the two render branches.** Both sites read `isLoading` / `error` from `useFileTree` and both want the same thing from a parked read, so the guard went where the state lives:

```ts
const isParkedOffline = query.isPending && query.isPaused;
isLoading: query.isLoading || isParkedOffline,
```

`useFileTree` has exactly one consumer, so nothing else sees the widened `isLoading`.

`isPending` is load-bearing and separately tested. A parked *first read* holds no rows; a parked *refetch* still holds all of them, so bare `isPaused` would blank a warm, working tree — turning the fix into a regression. Same narrowing as #51953, which had that exact bug caught in review.

## Related product discussion/links

* JETPACK-2494. Sibling: #51953 fixes the same root cause in the two gate hooks.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`; no-op when off.

Automated, from `projects/packages/backup`:

* `npx jest --config=tests/jest.config.js` → **76 suites / 744 tests**. Trunk is 75 / 740; the new file is `tests/file-browser-paused-reads.test.tsx` (4 tests).
* The two defect tests fail on trunk for the right reasons — add just the test file, leave the source alone: the root test reports `Unable to find an accessible element with the role "presentation"` over an empty `<div class="jpb-file-browser__tree" />`, and the folder test reports `expect(element).toBeEmptyDOMElement()` / `Received: "Empty"` on the `role="status"` node.
* Mutations, each killing exactly two tests: remove the guard (`isLoading: query.isLoading`) → the two defect tests fail; drop the narrowing (`const isParkedOffline = query.isPaused`) → the two "keeps its rows / children when a refetch parks" tests fail, reporting the tree and file rows gone.

Manual, with the filter on:

1. Open Backup → a backup → Browse files. Let the tree render.
2. DevTools → Network → **Offline**.
3. Clear the query cache from the console, then expand a folder.
4. **Before:** an empty tree, and "Empty" announced for the folder. **After:** the loading spinner, and nothing announced.
5. Network → **Online**. The parked read resumes and the tree renders, no reload.

## Note for the reviewer

JETPACK-2494's third item, `components/activity-list/index.tsx`, is deliberately **not** here — it needs `useActivityLog` to expose `isPaused`, which lives on the unmerged #51887 and would conflict. It follows once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2J2i9Tn1Wyfb4UwHCwKAF
