### PR TITLE
Feature gating: extend all features from new feature gating to legacy sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-new-default-feature-gating
+++ b/projects/plugins/wpcomsh/changelog/add-new-default-feature-gating
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+
+Sync features list with WPCOM to enable access to new features for legacy sites.
+

--- a/projects/plugins/wpcomsh/phpunit.11.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.11.xml.dist
@@ -25,6 +25,7 @@
 			<exclude>tests/FrontendNoticesTest.php</exclude>
 			<exclude>tests/FunctionsTest.php</exclude>
 			<exclude>tests/PlanNoticesTest.php</exclude>
+			<exclude>tests/WpcomFeaturesMapTest.php</exclude>
 			<exclude>tests/WpcomFeaturesTest.php</exclude>
 			<exclude>tests/WpcomSitePurchaseTest.php</exclude>
 			<exclude>tests/WpcomshPremiumAnalyticsTest.php</exclude>
@@ -34,6 +35,7 @@
 			<file>tests/FrontendNoticesTest.php</file>
 			<file>tests/FunctionsTest.php</file>
 			<file>tests/PlanNoticesTest.php</file>
+			<file>tests/WpcomFeaturesMapTest.php</file>
 			<file>tests/WpcomFeaturesTest.php</file>
 			<file>tests/WpcomSitePurchaseTest.php</file>
 			<file>tests/WpcomshPremiumAnalyticsTest.php</file>

--- a/projects/plugins/wpcomsh/phpunit.9.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.9.xml.dist
@@ -16,6 +16,7 @@
 			<exclude>tests/FrontendNoticesTest.php</exclude>
 			<exclude>tests/FunctionsTest.php</exclude>
 			<exclude>tests/PlanNoticesTest.php</exclude>
+			<exclude>tests/WpcomFeaturesMapTest.php</exclude>
 			<exclude>tests/WpcomFeaturesTest.php</exclude>
 			<exclude>tests/WpcomSitePurchaseTest.php</exclude>
 			<exclude>tests/WpcomshPremiumAnalyticsTest.php</exclude>
@@ -25,6 +26,7 @@
 			<file>tests/FrontendNoticesTest.php</file>
 			<file>tests/FunctionsTest.php</file>
 			<file>tests/PlanNoticesTest.php</file>
+			<file>tests/WpcomFeaturesMapTest.php</file>
 			<file>tests/WpcomFeaturesTest.php</file>
 			<file>tests/WpcomSitePurchaseTest.php</file>
 			<file>tests/WpcomshPremiumAnalyticsTest.php</file>

--- a/projects/plugins/wpcomsh/tests/WpcomFeaturesLegacyGatingTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomFeaturesLegacyGatingTest.php
@@ -10,7 +10,7 @@
 /**
  * Covers the sticker plumbing WPCOM_Features uses on Atomic: `is_legacy_gating_site()`, the single
  * predicate that decides whether a site stays on the pre-2026 feature gating, and the
- * `required_sticker` / `sticker_not_present` keys in the products map that read the same helper.
+ * `legacy_gating` key in the products map that reads the same helper.
  *
  * Ported from the wpcom-side LegacyGatingSiteTest, with the differences that matter on Atomic:
  *
@@ -44,8 +44,8 @@ class WpcomFeaturesLegacyGatingTest extends WP_UnitTestCase {
 		if ( ! self::stickers_are_writable() ) {
 			$this->markTestSkipped(
 				'These tests write blog stickers into Atomic Persistent Data, which only the mock in tests/lib/mocks supports. '
-				. 'On a real Atomic host the platform defines Atomic_Persistent_Data first and its stickers are read-only, so this test '
-				. 'is skipped there. Run it in the monorepo instead: '
+				. 'On a real Atomic host the platform defines Atomic_Persistent_Data first and its stickers are read-only, which is '
+				. 'why this file is excluded from the "wpcloud" suite. Run it in the monorepo instead: '
 				. 'jp docker phpunit wpcomsh -- --filter=WpcomFeaturesLegacyGatingTest'
 			);
 		}
@@ -247,34 +247,36 @@ class WpcomFeaturesLegacyGatingTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `required_sticker` in the products map goes through the same helper, so a plan that only
-	 * unlocks a feature for stickered sites has to stay locked without the sticker.
+	 * The additive half of the 2026 flip, on Atomic.
 	 *
-	 * ADVANCED_SEO grants Premium plans access only behind `gating-business-q1`; Premium appears
-	 * nowhere else in that feature's map.
+	 * ADVANCED_SEO used to grant Premium only behind `gating-business-q1`. It is now unconditional
+	 * at Premium, so both cohorts have it -- which is what makes the legacy set a union of the old
+	 * and new gating rather than a freeze.
 	 */
-	public function test_required_sticker_gates_a_purchase_on_atomic() {
+	public function test_advanced_seo_is_unconditional_at_premium_on_atomic() {
 		$purchases = array( (object) array( 'product_slug' => 'value_bundle' ) );
 
-		$this->assertFalse(
+		$this->assertTrue(
 			WPCOM_Features::has_feature( WPCOM_Features::ADVANCED_SEO, $purchases, 'wpcom' ),
-			'Without the sticker a Premium plan must not unlock Advanced SEO.'
+			'A legacy Premium site must gain Advanced SEO.'
 		);
 
-		$this->add_sticker( WPCOM_Features::STICKER_GATING_BUSINESS_Q1 );
+		$this->add_sticker( WPCOM_Features::STICKER_FEATURE_GATING_2026 );
 
 		$this->assertTrue(
-			WPCOM_Features::has_feature( WPCOM_Features::ADVANCED_SEO, $purchases, 'wpcom' )
+			WPCOM_Features::has_feature( WPCOM_Features::ADVANCED_SEO, $purchases, 'wpcom' ),
+			'A Premium site on the 2026 gating must have Advanced SEO too.'
 		);
 	}
 
 	/**
-	 * The mirror image: `sticker_not_present` withdraws a legacy grant once the site is stickered.
+	 * The subtractive half: `legacy_gating` withdraws a pre-2026 grant once the site is off legacy.
 	 *
-	 * DONATIONS is available to Personal and higher only while `gating-business-q1` is absent;
-	 * under the new gating it starts at Premium.
+	 * DONATIONS is available to Personal and higher only while the site is legacy; under the 2026
+	 * gating it starts at Premium. `gating-business-q1` is one of the three markers the predicate
+	 * reads, so a site carrying it is already on the new gating.
 	 */
-	public function test_sticker_not_present_gates_a_purchase_on_atomic() {
+	public function test_legacy_gating_withdraws_a_purchase_grant_on_atomic() {
 		$purchases = array( (object) array( 'product_slug' => 'personal-bundle' ) );
 
 		$this->assertTrue(

--- a/projects/plugins/wpcomsh/tests/WpcomFeaturesMapTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomFeaturesMapTest.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * WPCOM Features products-map test file.
+ *
+ * @package wpcomsh
+ */
+
+// @phan-file-suppress PhanUndeclaredStaticMethod -- Atomic_Persistent_Data::set()/delete() only exist in the test mock in tests/lib/mocks, which Phan does not parse.
+
+/**
+ * Covers `WPCOM_Features::purchase_in_products_map()` rule by rule, and
+ * `get_site_gating_cache_suffix()`, the cache-key fragment that has to vary on every per-site input
+ * those rules consult.
+ *
+ * The map cases use synthetic product definitions rather than real feature slugs, so each rule is
+ * exercised in isolation and the cases survive the next verbatim sync of the map from wpcom.
+ */
+class WpcomFeaturesMapTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * A WordPress.com blog ID below the 2026 cutoff, so the fixture site starts out legacy.
+	 *
+	 * @var int
+	 */
+	const LEGACY_BLOG_ID = 123456789;
+
+	/**
+	 * Pin the WordPress.com blog ID, which on Atomic lives in `jetpack_options` rather than in
+	 * `$blog_id`, and is what the gating predicate compares against the cutoff.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$options       = (array) get_option( 'jetpack_options', array() );
+		$options['id'] = self::LEGACY_BLOG_ID;
+
+		update_option( 'jetpack_options', $options );
+	}
+
+	/**
+	 * A leaked sticker is the dangerous direction: it turns assertions here and elsewhere in the
+	 * suite into confusing passes.
+	 */
+	public function tear_down() {
+		foreach ( self::map_sticker_slugs() as $slug ) {
+			$this->remove_sticker( $slug );
+		}
+
+		$this->remove_sticker( WPCOM_Features::STICKER_FEATURE_GATING_2026 );
+		$this->remove_sticker( WPCOM_Features::STICKER_PRE_FEATURE_GATING_2026 );
+		$this->remove_sticker( WPCOM_Features::STICKER_GATING_BUSINESS_Q1 );
+
+		parent::tear_down();
+	}
+
+	public function test_a_definition_without_rules_matches_on_slug_alone() {
+		$map = array( array( 'business-bundle', 'ecommerce-bundle' ) );
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'personal-bundle' ), $map ) );
+	}
+
+	public function test_before_rule_admits_only_purchases_made_before_the_cutoff() {
+		$map = array(
+			array(
+				'before' => '2020-01-01',
+				'business-bundle',
+			),
+		);
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2019-06-01' ), $map ) );
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2021-06-01' ), $map ) );
+	}
+
+	public function test_after_rule_admits_only_purchases_made_after_the_cutoff() {
+		$map = array(
+			array(
+				'after' => '2020-01-01',
+				'business-bundle',
+			),
+		);
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2021-06-01' ), $map ) );
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2019-06-01' ), $map ) );
+	}
+
+	public function test_both_date_bounds_admit_only_purchases_inside_the_range() {
+		$map = array(
+			array(
+				'after'  => '2020-01-01',
+				'before' => '2021-01-01',
+				'business-bundle',
+			),
+		);
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2020-06-01' ), $map ) );
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2019-06-01' ), $map ) );
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle', '2021-06-01' ), $map ) );
+	}
+
+	/**
+	 * A purchase with no `subscribed_date` cannot be placed in a date range, so a dated rule has to
+	 * fail closed rather than treat the missing date as passing.
+	 */
+	public function test_a_dated_rule_rejects_a_purchase_with_no_subscribed_date() {
+		$map = array(
+			array(
+				'before' => '2020-01-01',
+				'business-bundle',
+			),
+		);
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	/**
+	 * The excluded plan is also listed in the definition below it, so the second assertion is what
+	 * proves the exclusion is targeted rather than rejecting the whole map.
+	 */
+	public function test_an_excluded_plan_is_rejected_even_when_a_later_definition_lists_it() {
+		$map = array(
+			WPCOM_Features::EXCLUDE_PLANS => array( 'ecommerce-trial-bundle-monthly' ),
+			array( 'ecommerce-trial-bundle-monthly', 'business-bundle' ),
+		);
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'ecommerce-trial-bundle-monthly' ), $map ) );
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	public function test_product_type_rule_matches_on_the_type() {
+		$map      = array( array( 'product_type' => array( 'bundle' ) ) );
+		$purchase = $this->purchase( 'a-slug-not-in-the-map' );
+
+		$purchase->product_type = 'bundle';
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $purchase, $map ) );
+	}
+
+	/**
+	 * A `product_type` definition `continue`s on a miss, so slugs sitting alongside it are never
+	 * consulted -- worth pinning, because the definition reads as if they would be.
+	 */
+	public function test_product_type_rule_never_falls_through_to_its_slug_list() {
+		$map      = array(
+			array(
+				'product_type' => array( 'bundle' ),
+				'business-bundle',
+			),
+		);
+		$purchase = $this->purchase( 'business-bundle' );
+
+		$purchase->product_type = 'domain';
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $purchase, $map ) );
+	}
+
+	public function test_required_sticker_gates_the_definition() {
+		$map = array(
+			array(
+				'required_sticker' => 'flex-cache-site',
+				'business-bundle',
+			),
+		);
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+
+		$this->add_sticker( 'flex-cache-site' );
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	public function test_sticker_not_present_withdraws_the_definition_once_the_sticker_lands() {
+		$map = array(
+			array(
+				'sticker_not_present' => 'flex-cache-site',
+				'business-bundle',
+			),
+		);
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+
+		$this->add_sticker( 'flex-cache-site' );
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	public function test_before_feature_gating_2026_grants_only_while_the_site_is_legacy() {
+		$map = array(
+			array(
+				'before_feature_gating_2026' => true,
+				'business-bundle',
+			),
+		);
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+
+		$this->add_sticker( WPCOM_Features::STICKER_FEATURE_GATING_2026 );
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	/**
+	 * The map only ever sets this key to true today, but the comparison is written to accept either
+	 * value, so the false arm is reachable the moment someone writes it.
+	 */
+	public function test_before_feature_gating_2026_false_grants_only_off_legacy() {
+		$map = array(
+			array(
+				'before_feature_gating_2026' => false,
+				'business-bundle',
+			),
+		);
+
+		$this->assertFalse( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+
+		$this->add_sticker( WPCOM_Features::STICKER_FEATURE_GATING_2026 );
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $this->purchase( 'business-bundle' ), $map ) );
+	}
+
+	public function test_cache_suffix_names_the_gating_cohort() {
+		$blog_id = _wpcom_get_current_blog_id();
+
+		$this->assertSame( '_pre_gating_2026', WPCOM_Features::get_site_gating_cache_suffix( $blog_id ) );
+
+		$this->add_sticker( WPCOM_Features::STICKER_FEATURE_GATING_2026 );
+
+		$this->assertSame( '_gating_2026', WPCOM_Features::get_site_gating_cache_suffix( $blog_id ) );
+	}
+
+	/**
+	 * The whole point of the suffix: two sites the map answers differently for must not share a
+	 * cache key. A sticker the map gates on that does not reach the suffix serves one site's feature
+	 * list to the other.
+	 */
+	public function test_cache_suffix_varies_on_every_sticker_the_map_gates_on() {
+		$blog_id = _wpcom_get_current_blog_id();
+		$slugs   = self::map_sticker_slugs();
+		$base    = WPCOM_Features::get_site_gating_cache_suffix( $blog_id );
+
+		$this->assertNotEmpty( $slugs, 'Without slugs this test asserts nothing at all.' );
+
+		foreach ( $slugs as $slug ) {
+			$this->add_sticker( $slug );
+			$suffix = WPCOM_Features::get_site_gating_cache_suffix( $blog_id );
+			$this->remove_sticker( $slug );
+
+			$this->assertNotSame( $base, $suffix, "Setting '$slug' must change the cache suffix." );
+			$this->assertStringContainsString( $slug, $suffix );
+		}
+	}
+
+	/**
+	 * The suffix goes into a key in the global `site_purchases` cache group, so it has to be a
+	 * function of which stickers are set, never of the order they were written in.
+	 */
+	public function test_cache_suffix_is_ordered_independently_of_when_stickers_were_added() {
+		$blog_id = _wpcom_get_current_blog_id();
+		$slugs   = self::map_sticker_slugs();
+		$sorted  = $slugs;
+		sort( $sorted );
+
+		$this->assertSame( $sorted, $slugs, 'The slug list has to be sorted, or the key changes shape between requests.' );
+		$this->assertSame( array_unique( $slugs ), $slugs, 'A duplicated slug would be appended twice.' );
+
+		foreach ( $slugs as $slug ) {
+			$this->add_sticker( $slug );
+		}
+		$forward = WPCOM_Features::get_site_gating_cache_suffix( $blog_id );
+
+		foreach ( $slugs as $slug ) {
+			$this->remove_sticker( $slug );
+		}
+		foreach ( array_reverse( $slugs ) as $slug ) {
+			$this->add_sticker( $slug );
+		}
+
+		$this->assertSame( $forward, WPCOM_Features::get_site_gating_cache_suffix( $blog_id ) );
+	}
+
+	public function test_add_free_plan_purchase_appends_a_synthetic_purchase() {
+		$purchases = array( $this->purchase( 'business-bundle' ) );
+
+		WPCOM_Features::add_free_plan_purchase( $purchases, 'wpcom', '2020-05-04 01:02:03' );
+
+		$this->assertCount( 2, $purchases );
+		$this->assertSame( 'wpcom-all-sites', $purchases[1]->product_slug );
+		$this->assertSame( '2020-05-04 01:02:03', $purchases[1]->subscribed_date );
+	}
+
+	/**
+	 * Why the synthetic purchase carries the registration date: a free site can only clear a dated
+	 * all-sites rule if it has a date to be judged on.
+	 */
+	public function test_free_plan_purchase_can_satisfy_a_dated_all_sites_rule() {
+		$map       = array(
+			array(
+				'before' => '2021-01-01',
+				'wpcom-all-sites',
+			),
+		);
+		$purchases = array();
+
+		WPCOM_Features::add_free_plan_purchase( $purchases, 'wpcom', '2020-05-04' );
+
+		$this->assertTrue( WPCOM_Features::purchase_in_products_map( $purchases[0], $map ) );
+	}
+
+	public function test_in_array_recursive_finds_needles_at_any_depth() {
+		$haystack = array( 'a', array( 'b', array( 'c' ) ) );
+
+		$this->assertTrue( WPCOM_Features::in_array_recursive( 'a', $haystack ) );
+		$this->assertTrue( WPCOM_Features::in_array_recursive( 'c', $haystack ) );
+		$this->assertFalse( WPCOM_Features::in_array_recursive( 'd', $haystack ) );
+	}
+
+	/**
+	 * Comparison is strict, which is what stops a numeric-looking product slug from matching an
+	 * unrelated integer in the map.
+	 */
+	public function test_in_array_recursive_compares_strictly() {
+		$this->assertFalse( WPCOM_Features::in_array_recursive( '0', array( 0 ) ) );
+		$this->assertFalse( WPCOM_Features::in_array_recursive( 1, array( '1' ) ) );
+	}
+
+	public function test_an_unknown_feature_is_never_granted() {
+		$this->assertFalse( WPCOM_Features::feature_exists( 'not-a-real-feature' ) );
+		$this->assertTrue( WPCOM_Features::feature_exists( WPCOM_Features::PREMIUM_THEMES ) );
+
+		$this->assertFalse(
+			WPCOM_Features::has_feature( 'not-a-real-feature', array( $this->purchase( 'business-bundle' ) ), 'wpcom' )
+		);
+	}
+
+	public function test_get_feature_slugs_lists_mapped_features() {
+		$slugs = WPCOM_Features::get_feature_slugs();
+
+		$this->assertNotEmpty( $slugs );
+		$this->assertContains( WPCOM_Features::PREMIUM_THEMES, $slugs );
+		$this->assertContains( WPCOM_Features::FREE_BLOG, $slugs );
+	}
+
+	/**
+	 * Build a purchase in the shape `purchase_in_products_map()` reads.
+	 *
+	 * @param string      $slug            Product slug.
+	 * @param string|null $subscribed_date Subscription date, or null to leave the property unset.
+	 *
+	 * @return stdClass
+	 */
+	private function purchase( $slug, $subscribed_date = null ) {
+		$purchase               = new stdClass();
+		$purchase->product_slug = $slug;
+
+		if ( null !== $subscribed_date ) {
+			$purchase->subscribed_date = $subscribed_date;
+		}
+
+		return $purchase;
+	}
+
+	/**
+	 * The sticker slugs the products map gates on, read from the private helper that builds them.
+	 *
+	 * Reflection rather than a hard-coded list so a sticker added upstream is covered by the cases
+	 * above on the next sync instead of silently going untested.
+	 *
+	 * @return string[]
+	 */
+	private static function map_sticker_slugs() {
+		return ( new ReflectionMethod( 'WPCOM_Features', 'get_map_sticker_slugs' ) )->invoke( null );
+	}
+
+	/**
+	 * Add a blog sticker the way the Atomic platform does, by writing its persistent-data key.
+	 *
+	 * @param string $sticker Sticker slug.
+	 */
+	private function add_sticker( $sticker ) {
+		Atomic_Persistent_Data::set( 'site_sticker_' . $sticker, '1' );
+	}
+
+	/**
+	 * Remove a blog sticker written by `add_sticker()`.
+	 *
+	 * @param string $sticker Sticker slug.
+	 */
+	private function remove_sticker( $sticker ) {
+		Atomic_Persistent_Data::delete( 'site_sticker_' . $sticker );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/WpcomFeaturesMapTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomFeaturesMapTest.php
@@ -6,6 +6,7 @@
  */
 
 // @phan-file-suppress PhanUndeclaredStaticMethod -- Atomic_Persistent_Data::set()/delete() only exist in the test mock in tests/lib/mocks, which Phan does not parse.
+// @phan-file-suppress PhanPluginMixedKeyNoKey -- The synthetic product definitions mirror FEATURES_MAP, which pairs a rule key with unkeyed slugs; class-wpcom-features.php is baselined for the same issue.
 
 /**
  * Covers `WPCOM_Features::purchase_in_products_map()` rule by rule, and

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -101,10 +101,6 @@ class WPCOM_Features {
 	private const WPCOM_WOOEXPRESS_MEDIUM_BUNDLE_YEARLY       = 'wooexpress-medium-bundle-yearly'; // 1055
 	private const WPCOM_WOOEXPRESS_SMALL_BUNDLE_MONTHLY       = 'wooexpress-small-bundle-monthly'; // 1054
 	private const WPCOM_WOOEXPRESS_SMALL_BUNDLE_YEARLY        = 'wooexpress-small-bundle-yearly'; // 1056
-	private const WOO_HOSTED_BASIC_PLAN_MONTHLY               = 'woo_hosted_basic_plan_monthly'; // 4001
-	private const WOO_HOSTED_BASIC_PLAN_YEARLY                = 'woo_hosted_basic_plan_yearly'; // 4002
-	private const WOO_HOSTED_PRO_PLAN_MONTHLY                 = 'woo_hosted_pro_plan_monthly'; // 4003
-	private const WOO_HOSTED_PRO_PLAN_YEARLY                  = 'woo_hosted_pro_plan_yearly'; // 4004
 	private const WPCOM_MIGRATION_TRIAL_BUNDLE_MONTHLY        = 'wp_bundle_migration_trial_monthly'; // 1057
 	private const WPCOM_HOSTING_TRIAL_BUNDLE_MONTHLY          = 'wp_bundle_hosting_trial_monthly'; // 1058
 	private const WPCOM_STAGING_PRODUCT                       = 'wp_staging_site_lifetime'; // 1060
@@ -263,6 +259,10 @@ class WPCOM_Features {
 	private const A4A_JETPACK_SOCIAL_V1_MONTHLY               = 'a4a_jetpack_social_v1_monthly'; // 3339
 	private const A4A_JETPACK_CREATOR_YEARLY                  = 'a4a_jetpack_creator_yearly'; // 3340
 	private const A4A_JETPACK_CREATOR_MONTHLY                 = 'a4a_jetpack_creator_monthly'; // 3341
+	private const WOO_HOSTED_BASIC_PLAN_MONTHLY               = 'woo_hosted_basic_plan_monthly'; // 4001
+	private const WOO_HOSTED_BASIC_PLAN_YEARLY                = 'woo_hosted_basic_plan_yearly'; // 4002
+	private const WOO_HOSTED_PRO_PLAN_MONTHLY                 = 'woo_hosted_pro_plan_monthly'; // 4003
+	private const WOO_HOSTED_PRO_PLAN_YEARLY                  = 'woo_hosted_pro_plan_yearly'; // 4004
 
 	// WPCOM "Level 2": Groups of level 1s.
 	private const WPCOM_BLOGGER_PLANS           = array( self::BLOGGER_BUNDLE, self::BLOGGER_BUNDLE_2Y );
@@ -418,9 +418,9 @@ class WPCOM_Features {
 	public const BACKUPS                           = 'backups';
 	public const BACKUPS_DAILY                     = 'backups-daily';
 	public const BACKUPS_RESTORE                   = 'restore';
+	public const BIG_SKY                           = 'big-sky';
 	public const BACKUPS_SELF_SERVE                = 'backups-self-serve';
 	public const BACKUP_ONE_TIME                   = 'backup-one-time';
-	public const BIG_SKY                           = 'big-sky';
 	public const BLAZE_CREDITS_VOUCHER             = 'blaze-credits-voucher';
 	public const BLOG_DOMAIN_ONLY                  = 'blog-domain-only';
 	public const CALENDLY                          = 'calendly';
@@ -682,12 +682,14 @@ class WPCOM_Features {
 		),
 		self::BLAZE_CREDITS_VOUCHER             => array(
 			array(
-				// Business (Excluding Monthly).
+				// Business.
 				self::BUSINESS_BUNDLE,
+				self::BUSINESS_BUNDLE_MONTHLY,
 				self::BUSINESS_BUNDLE_2Y,
 				self::BUSINESS_BUNDLE_3Y,
-				// Ecommerce (Excluding Monthly).
+				// Ecommerce.
 				self::ECOMMERCE_BUNDLE,
+				self::ECOMMERCE_BUNDLE_MONTHLY,
 				self::ECOMMERCE_BUNDLE_2Y,
 				self::ECOMMERCE_BUNDLE_3Y,
 			),

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -577,11 +577,8 @@ class WPCOM_Features {
 			self::JETPACK_COMPLETE_PLANS,
 		),
 		self::AI_SEO_ENHANCER                   => array(
+			self::WPCOM_PREMIUM_PLANS,
 			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
-			array(
-				'required_sticker' => 'gating-business-q1',
-				self::WPCOM_PREMIUM_PLANS,
-			),
 			self::JETPACK_COMPLETE_PLANS,
 		),
 		self::AD_CREDIT_VOUCHERS                => array(
@@ -593,17 +590,12 @@ class WPCOM_Features {
 		 * ADVANCED_SEO - Called seo-tools in Jetpack.
 		 *
 		 * Active for:
-		 * - Simple and Atomic sites with Business or up plan.
+		 * - Simple and Atomic sites with Premium or up plan.
 		 * - Jetpack sites with any plan.
 		 * - Not VIP sites.
 		 */
 		self::ADVANCED_SEO                      => array(
-			array(
-				'required_sticker' => 'gating-business-q1',
-				self::WPCOM_PREMIUM_PLANS,
-			),
-			self::WPCOM_PRO_PLANS,
-			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,
 		),
 		self::AKISMET                           => array(
@@ -690,7 +682,6 @@ class WPCOM_Features {
 		),
 		self::BLAZE_CREDITS_VOUCHER             => array(
 			array(
-				'required_sticker' => 'gating-business-q1',
 				// Business (Excluding Monthly).
 				self::BUSINESS_BUNDLE,
 				self::BUSINESS_BUNDLE_2Y,
@@ -803,11 +794,11 @@ class WPCOM_Features {
 		),
 		self::DONATIONS                         => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_ALL_SITES,
 			),
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			),
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
@@ -867,7 +858,7 @@ class WPCOM_Features {
 		// See: https://github.com/Automattic/jetpack/pull/43177 / https://github.a8c.com/Automattic/wpcom/pull/179247
 		self::FIELD_FILE                        => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_PLANS,
 				self::WPCOM_PREMIUM_PLANS,
 			),
@@ -877,7 +868,7 @@ class WPCOM_Features {
 		),
 		self::FORM_INTEGRATIONS                 => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			),
 			self::WPCOM_PRO_PLANS,
@@ -1022,10 +1013,7 @@ class WPCOM_Features {
 			self::WPCOM_PRO_PLANS,
 		),
 		self::MAILPOET_BUSINESS                 => array(
-			array(
-				'required_sticker' => 'gating-business-q1',
-				self::WPCOM_BUSINESS_PLANS,
-			),
+			self::WPCOM_BUSINESS_PLANS,
 			self::WPCOM_ECOMMERCE_PLANS,
 			self::WPCOM_WOOEXPRESS_PLANS,
 			self::WOO_HOSTED_PLANS,
@@ -1067,7 +1055,7 @@ class WPCOM_Features {
 		),
 		self::MULTISTEP_FORM                    => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_PLANS,
 				self::WPCOM_PREMIUM_PLANS,
 			),
@@ -1095,7 +1083,7 @@ class WPCOM_Features {
 		),
 		self::PAYMENTS                          => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_PLANS,
 			),
 			self::WPCOM_STARTER_PLANS,
@@ -1103,11 +1091,11 @@ class WPCOM_Features {
 		),
 		self::PAYMENT_BUTTONS                   => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_ALL_SITES,
 			),
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			),
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
@@ -1115,11 +1103,11 @@ class WPCOM_Features {
 		),
 		self::PAYPAL_PAYMENT_BUTTONS            => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_ALL_SITES,
 			),
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PERSONAL_AND_HIGHER_PLANS,
 			),
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
@@ -1328,14 +1316,9 @@ class WPCOM_Features {
 			),
 		),
 		self::SEO_PREVIEW_TOOLS                 => array(
-			array(
-				'required_sticker' => 'gating-business-q1',
-				self::WPCOM_PREMIUM_PLANS,
-			),
+			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::BUNDLE_ENTERPRISE,
 			self::JETPACK_ALL_SITES,
-			self::WPCOM_BUSINESS_AND_HIGHER_PLANS,
-			self::WPCOM_PRO_PLANS,
 			self::WPCOM_FLEX_CACHE_SITE_FREE_PLANS,
 		),
 		self::SEND_A_MESSAGE                    => array(
@@ -1559,7 +1542,6 @@ class WPCOM_Features {
 		),
 		self::TITAN_MAIL_1YEAR_TRIAL            => array(
 			array(
-				'required_sticker' => 'gating-business-q1',
 				self::WPCOM_BUSINESS_PLANS,
 				self::WPCOM_ECOMMERCE_PLANS,
 			),
@@ -1676,7 +1658,7 @@ class WPCOM_Features {
 		 */
 		self::VIDEO_HOSTING                     => array(
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PREMIUM_PLANS,
 			),
 			self::WPCOM_PRO_PLANS,
@@ -1693,7 +1675,7 @@ class WPCOM_Features {
 			self::JETPACK_PREMIUM_PLANS,
 			self::JETPACK_VIDEOPRESS_PLANS,
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PREMIUM_PLANS,
 			),
 			self::WPCOM_PRO_PLANS,
@@ -1732,7 +1714,7 @@ class WPCOM_Features {
 		self::VIDEOPRESS_VIDEO                  => array(
 			self::WP_P2_PLUS_MONTHLY,
 			array(
-				'sticker_not_present' => 'gating-business-q1',
+				'before_feature_gating_2026' => true,
 				self::WPCOM_PREMIUM_PLANS,
 			),
 			self::WPCOM_PRO_PLANS,
@@ -2020,6 +2002,61 @@ class WPCOM_Features {
 	}
 
 	/**
+	 * Every blog sticker the products map gates on, in a stable order.
+	 *
+	 * @return string[]
+	 */
+	private static function get_map_sticker_slugs() {
+		static $slugs = null;
+
+		if ( null !== $slugs ) {
+			return $slugs;
+		}
+
+		$found = array();
+		$walk  = static function ( $node ) use ( &$walk, &$found ) {
+			foreach ( $node as $key => $value ) {
+				if ( 'required_sticker' === $key || 'sticker_not_present' === $key ) {
+					foreach ( (array) $value as $slug ) {
+						$found[ $slug ] = true;
+					}
+				} elseif ( is_array( $value ) ) {
+					$walk( $value );
+				}
+			}
+		};
+		$walk( self::FEATURES_MAP );
+
+		$slugs = array_keys( $found );
+		sort( $slugs );
+
+		return $slugs;
+	}
+
+	/**
+	 * A cache-key fragment covering every per-site input the products map consults.
+	 *
+	 * Feature resolution for a given product is not the same for every site, so anything caching it
+	 * outside a per-site key has to vary on this. The inputs are: before_feature_gating_2026 and
+	 * required_sticker / sticker_not_present.
+	 *
+	 * @param int $blog_id Blog ID to describe.
+	 *
+	 * @return string
+	 */
+	public static function get_site_gating_cache_suffix( $blog_id ) {
+		$suffix = self::is_legacy_gating_site( $blog_id ) ? '_pre_gating_2026' : '_gating_2026';
+
+		foreach ( self::get_map_sticker_slugs() as $slug ) {
+			if ( self::site_has_sticker( $slug, $blog_id ) ) {
+				$suffix .= '_' . $slug;
+			}
+		}
+
+		return $suffix;
+	}
+
+	/**
 	 * The products definition array ($products_map) may contain 1st-level sub-arrays with 'before' and/or 'after' keys
 	 * used to restrict access to a feature based on when the purchase was made. If the $purchase is included in
 	 * $products_map, and it was purchased within the defined date range (if a date range is defined), return true.
@@ -2076,6 +2113,14 @@ class WPCOM_Features {
 				$purchase_eligible_by_sticker = $purchase_eligible_by_sticker && ! $has_sticker;
 				// Remove the sticker key so $product_definition is clean for in_array_recursive search.
 				unset( $product_definition['sticker_not_present'] );
+			}
+
+			// Check if the site has legacy/current features, previously use gating-business-q1 sticker
+			if ( isset( $product_definition['before_feature_gating_2026'] ) ) {
+				$purchase_eligible_by_sticker = $purchase_eligible_by_sticker
+					&& (bool) $product_definition['before_feature_gating_2026'] === self::is_legacy_gating_site( self::resolve_blog_id( $blog_id ) );
+				// Remove the key so $product_definition is clean for in_array_recursive search.
+				unset( $product_definition['before_feature_gating_2026'] );
 			}
 
 			// If 'before' & 'after' are empty, this is not a legacy feature.

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -488,26 +488,20 @@ function wpcom_get_product_features( $product ) {
 	$cache_group = 'site_purchases';
 	$cache_found = false;
 
-	// Include sticker status in cache key only for Personal and Premium plans since they're affected by feature gating experiments.
-	$sticker_cache_suffix = '';
-	// @phan-suppress-next-line PhanRedundantCondition
-	if ( function_exists( 'has_blog_sticker' ) && $purchase ) {
-		// Use existing WPCOM_Store helper methods to check plan types
-		$is_personal_or_premium_plan = false;
-		if ( isset( $purchase->product_id ) ) {
-			$is_personal_or_premium_plan = WPCOM_Store::is_wpcom_personal_plan( $purchase->product_id ) || WPCOM_Store::is_wpcom_premium_plan( $purchase->product_id );
-		}
+	/*
+	Adjust the cache key to include site legacy/gating_2026 status. Applying it to all plans
+	 * and not just Personal/Premium to make it future-proof and avoid issue like
+	 * WPCOM_Store::get_wpcom_personal_plans() not returning the Personal trial plan.
+	 *
+	 * The cohort is not the only per-site input: `required_sticker` branches read stickers too, and
+	 * `site_purchases` is a global cache group. WPCOM_Features builds the whole suffix because it
+	 * owns the map that decides what varies.
+	 */
+	$cache_key = $purchase->product_slug
+		. WPCOM_Features::get_site_gating_cache_suffix( _wpcom_get_current_blog_id() )
+		. filemtime( __DIR__ . '/class-wpcom-features.php' );
 
-		if ( $is_personal_or_premium_plan ) {
-			$current_blog_id = get_current_blog_id();
-			if ( has_blog_sticker( 'gating-business-q1', $current_blog_id ) ) {
-				$sticker_cache_suffix .= '_gatingbq1';
-			}
-		}
-	}
-
-	$cache_key = $purchase->product_slug . $sticker_cache_suffix . filemtime( __DIR__ . '/class-wpcom-features.php' );
-	$features  = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
+	$features = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
 
 	if ( false === $cache_found ) {
 		$features = array();

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -507,7 +507,6 @@ function wpcom_get_product_features( $product ) {
 		$features = array();
 
 		foreach ( WPCOM_Features::get_feature_slugs() as $feature ) {
-			// @phan-suppress-next-line PhanTypeMismatchArgumentNullable
 			if ( wpcom_purchase_has_feature( $purchase, $feature ) ) {
 				$features[] = $feature;
 			}

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -496,12 +496,26 @@ function wpcom_get_product_features( $product ) {
 	 * The cohort is not the only per-site input: `required_sticker` branches read stickers too, and
 	 * `site_purchases` is a global cache group. WPCOM_Features builds the whole suffix because it
 	 * owns the map that decides what varies.
+	 *
+	 * method_exists() covers the deploy window, when this file can land before the class does. The
+	 * class that lacks the method still carries the pre-2026 map, which varies only on
+	 * `gating-business-q1`, so the fallback keys on that rather than dropping the cohort from the
+	 * key entirely -- an empty suffix would let two Personal/Premium sites in different cohorts
+	 * share one entry. Drop the guard once the class change is fully deployed.
 	 */
-	$cache_key = $purchase->product_slug
-		. WPCOM_Features::get_site_gating_cache_suffix( _wpcom_get_current_blog_id() )
-		. filemtime( __DIR__ . '/class-wpcom-features.php' );
+	$blog_id_for_gating = _wpcom_get_current_blog_id();
+	if ( method_exists( 'WPCOM_Features', 'get_site_gating_cache_suffix' ) ) {
+		$gating_cache_suffix = WPCOM_Features::get_site_gating_cache_suffix( $blog_id_for_gating );
+	} elseif ( function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'gating-business-q1', $blog_id_for_gating ) ) {
+		$gating_cache_suffix = '_gatingbq1';
+	} else {
+		$gating_cache_suffix = '';
+	}
 
-	$features = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
+	$cache_key = $purchase->product_slug
+		. $gating_cache_suffix
+		. filemtime( __DIR__ . '/class-wpcom-features.php' );
+	$features  = wp_cache_get( $cache_key, $cache_group, false, $cache_found );
 
 	if ( false === $cache_found ) {
 		$features = array();


### PR DESCRIPTION
Fixes MARTECH-3025

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Update the gating rules to stop using gating-business-q1 sticker.
* Extend all the new features (previously available with the sticker) to the legacy sites without the sticker, without taking away existing features from the legacy sites.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Follow the instructions from 239117-ghe-Automattic/wpcom
