### PR TITLE
Premium Analytics: keep the dashboard off while the Stats module is inactive

### DIFF
--- a/projects/plugins/jetpack/changelog/atlas-wooa7s-2087-premium-analytics-stats-module-gate
+++ b/projects/plugins/jetpack/changelog/atlas-wooa7s-2087-premium-analytics-stats-module-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the dashboard off while the Stats module is inactive.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -858,8 +858,8 @@ class Jetpack {
 	 * flag while it rolls out (WOOA7S-1595). When enabled it adds its own admin
 	 * menu alongside the existing Stats UI; it never replaces or hides the
 	 * legacy Stats menu, admin-bar entries, post-list column, or WP dashboard
-	 * widget. The Stats module's tracking is unaffected either way — Stats v2
-	 * depends on it.
+	 * widget. The Stats module's tracking is unaffected either way, and Stats v2
+	 * reads what that module collects, so it stays off while the module is off.
 	 *
 	 * The package has to be loadable for this to be true, so a site with the
 	 * flag on but a missing package answers false here and never adds the
@@ -887,14 +887,21 @@ class Jetpack {
 		 */
 		$flag = (bool) apply_filters( 'jetpack_premium_analytics_enabled', (bool) get_option( 'jetpack_premium_analytics_enabled' ) );
 
-		self::$premium_analytics_enabled = $flag && class_exists( 'Automattic\Jetpack\PremiumAnalytics\Analytics' );
+		if ( ! $flag ) {
+			self::$premium_analytics_enabled = false;
+			return false;
+		}
 
-		if ( $flag && ! self::$premium_analytics_enabled ) {
+		if ( ! class_exists( 'Automattic\Jetpack\PremiumAnalytics\Analytics' ) ) {
 			wp_trigger_error(
 				__METHOD__,
 				'The jetpack_premium_analytics_enabled flag is on but the Premium Analytics package is not loadable; keeping the Stats UI in place.'
 			);
+			self::$premium_analytics_enabled = false;
+			return false;
 		}
+
+		self::$premium_analytics_enabled = self::is_module_active( 'stats' );
 
 		return self::$premium_analytics_enabled;
 	}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -859,7 +859,8 @@ class Jetpack {
 	 * menu alongside the existing Stats UI; it never replaces or hides the
 	 * legacy Stats menu, admin-bar entries, post-list column, or WP dashboard
 	 * widget. The Stats module's tracking is unaffected either way, and Stats v2
-	 * reads what that module collects, so it stays off while the module is off.
+	 * reads what that module collects, so while the module is off the plugin
+	 * answers false here before even reading the flag.
 	 *
 	 * The package has to be loadable for this to be true, so a site with the
 	 * flag on but a missing package answers false here and never adds the
@@ -872,6 +873,11 @@ class Jetpack {
 	public static function is_premium_analytics_enabled() {
 		if ( null !== self::$premium_analytics_enabled ) {
 			return self::$premium_analytics_enabled;
+		}
+
+		if ( ! self::is_module_active( 'stats' ) ) {
+			self::$premium_analytics_enabled = false;
+			return false;
 		}
 
 		/**
@@ -887,21 +893,14 @@ class Jetpack {
 		 */
 		$flag = (bool) apply_filters( 'jetpack_premium_analytics_enabled', (bool) get_option( 'jetpack_premium_analytics_enabled' ) );
 
-		if ( ! $flag ) {
-			self::$premium_analytics_enabled = false;
-			return false;
-		}
+		self::$premium_analytics_enabled = $flag && class_exists( 'Automattic\Jetpack\PremiumAnalytics\Analytics' );
 
-		if ( ! class_exists( 'Automattic\Jetpack\PremiumAnalytics\Analytics' ) ) {
+		if ( $flag && ! self::$premium_analytics_enabled ) {
 			wp_trigger_error(
 				__METHOD__,
 				'The jetpack_premium_analytics_enabled flag is on but the Premium Analytics package is not loadable; keeping the Stats UI in place.'
 			);
-			self::$premium_analytics_enabled = false;
-			return false;
 		}
-
-		self::$premium_analytics_enabled = self::is_module_active( 'stats' );
 
 		return self::$premium_analytics_enabled;
 	}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -883,9 +883,10 @@ class Jetpack {
 		/**
 		 * Filters whether the bundled Premium Analytics dashboard is enabled.
 		 *
-		 * Resolved once, from `Jetpack::configure()` on `plugins_loaded`. Register
-		 * this from a mu-plugin or a plugin's main file — a callback added on
-		 * `plugins_loaded` or later runs too late to be seen.
+		 * Resolved once, from `Jetpack::configure()` on `plugins_loaded`, and only
+		 * while the Stats module is active. Register this from a mu-plugin or a
+		 * plugin's main file — a callback added on `plugins_loaded` or later runs
+		 * too late to be seen.
 		 *
 		 * @since 16.1
 		 *

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Premium_Analytics_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Premium_Analytics_Test.php
@@ -24,6 +24,7 @@ class Jetpack_Premium_Analytics_Test extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );
 		self::reset_flag_cache();
 	}
 
@@ -33,6 +34,7 @@ class Jetpack_Premium_Analytics_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		delete_option( 'jetpack_premium_analytics_enabled' );
 		unregister_setting( 'general', 'jetpack_premium_analytics_enabled' );
+		Jetpack_Options::delete_option( 'active_modules' );
 		self::reset_flag_cache();
 		remove_action( 'jetpack_admin_menu', 'stats_admin_menu' );
 		parent::tear_down();
@@ -122,6 +124,21 @@ class Jetpack_Premium_Analytics_Test extends WP_UnitTestCase {
 		update_option( 'jetpack_premium_analytics_enabled', 0 );
 
 		$this->assertFalse( Jetpack::is_premium_analytics_enabled() );
+	}
+
+	/**
+	 * Off while the Stats module is inactive, back once it is active again.
+	 */
+	public function test_follows_the_stats_module() {
+		update_option( 'jetpack_premium_analytics_enabled', 1 );
+		Jetpack_Options::update_option( 'active_modules', array() );
+
+		$this->assertFalse( Jetpack::is_premium_analytics_enabled() );
+
+		self::reset_flag_cache();
+		Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );
+
+		$this->assertTrue( Jetpack::is_premium_analytics_enabled() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Premium_Analytics_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Premium_Analytics_Test.php
@@ -127,13 +127,22 @@ class Jetpack_Premium_Analytics_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Off while the Stats module is inactive, back once it is active again.
+	 * Off while the Stats module is inactive, without even consulting the flag; back once it is active again.
 	 */
 	public function test_follows_the_stats_module() {
 		update_option( 'jetpack_premium_analytics_enabled', 1 );
 		Jetpack_Options::update_option( 'active_modules', array() );
 
-		$this->assertFalse( Jetpack::is_premium_analytics_enabled() );
+		$not_consulted = function () {
+			$this->fail( 'The flag must not be consulted while the Stats module is inactive.' );
+		};
+		add_filter( 'jetpack_premium_analytics_enabled', $not_consulted );
+
+		try {
+			$this->assertFalse( Jetpack::is_premium_analytics_enabled() );
+		} finally {
+			remove_filter( 'jetpack_premium_analytics_enabled', $not_consulted );
+		}
 
 		self::reset_flag_cache();
 		Jetpack_Options::update_option( 'active_modules', array( 'stats' ) );


### PR DESCRIPTION
Fixes WOOA7S-2087

## Why

Site owners who switched the Stats module off were still getting a "Stats v2" menu (and the whole Premium Analytics boot behind it) as soon as the opt-in was on, even though there is nothing for the dashboard to show without the module collecting data. Now the dashboard just stays off while the module is inactive and comes back by itself once the module is turned on again.

## Proposed changes

The PR proposes to make `Jetpack::is_premium_analytics_enabled()` also require the Stats module to be active, so the Jetpack plugin doesn't boot Premium Analytics when the module is off.

* `is_premium_analytics_enabled()` now checks the `stats` module first and answers false straight away while it is inactive, before reading the flag, the filter or the package. It's the single gate the plugin boots from, and My Jetpack's Stats card builds its URLs from the same answer so that falls back to the legacy Stats page on its own. Atomic goes through the same gate because wpcomsh only supplies the filter.
* The flag / filter / package lines below the module check are exactly what trunk has, so with the module on nothing changes, warning included. With the module off none of it runs.
* The opt-in setting stays registered regardless, same as before, since it is what flips the flag.
* Tests: the suite never runs `activate_default_modules()`, so `set_up()` now switches the module on, plus a new test for the module-off case.

Simple sites and the standalone premium-analytics plugin are not touched: `Modules::is_active()` is always true under `IS_WPCOM`, and the standalone plugin never goes through this gate.

Known issue: the answer is still resolved once per request (that's the existing contract), so when you activate Stats from My Jetpack with the opt-in already on, that one request still builds its redirect from the "module off" answer and you land on the legacy Stats page, with the Stats v2 menu right there on that load. Next request is all Stats v2. I think that's acceptable for now given the module auto-activates anyway, but happy to reset the cached answer on the module hooks if folks feel strongly about it.

## Screenshots

Stats module inactive + opt-in on, on trunk vs this branch. Same page and viewport, only the PHP gate differs.

![Before/after: Stats v2 menu with the Stats module inactive](https://github.com/user-attachments/assets/b3933995-1784-46fe-a08a-daef37673f43)

## Verification

Checked on a local docker site with the option on, toggling the module with wp-cli and reading the public REST index in between.

<details>
<summary>Output</summary>

```text
# option on, module active (trunk and this branch behave the same)
$ curl -sk https://<site>/wp-json/ | jq -r '.namespaces[]' | grep -iE 'premium|stats'
jetpack-premium-analytics/v1
jetpack/v4/stats-app

$ wp jetpack module deactivate stats
Success: Jetpack Stats has been deactivated.

# module off, trunk: the namespace is still registered
$ curl -sk https://<site>/wp-json/ | jq -r '.namespaces[]' | grep -iE 'premium'
jetpack-premium-analytics/v1

# module off, this branch
$ curl -sk https://<site>/wp-json/ | jq -r '.namespaces[]' | grep -iE 'premium|stats'
jetpack/v4/stats-app

$ wp eval 'do_action("rest_api_init"); echo "enabled=", var_export( Jetpack::is_premium_analytics_enabled(), true ), " setting_registered=", var_export( isset( get_registered_settings()["jetpack_premium_analytics_enabled"] ), true ), PHP_EOL;'
enabled=false setting_registered=true

$ wp eval 'echo Automattic\Jetpack\My_Jetpack\Products\Stats::get_manage_url(), PHP_EOL;'
http://localhost/wp-admin/admin.php?page=stats

$ wp jetpack module activate stats
Success: Jetpack Stats has been activated.

$ wp eval 'echo "enabled=", var_export( Jetpack::is_premium_analytics_enabled(), true ), " manage_url=", Automattic\Jetpack\My_Jetpack\Products\Stats::get_manage_url(), PHP_EOL;'
enabled=true manage_url=http://localhost/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin

$ curl -sk https://<site>/wp-json/ | jq -r '.namespaces[]' | grep -iE 'premium'
jetpack-premium-analytics/v1

$ jp docker phpunit jetpack -- --filter=Jetpack_Premium_Analytics_Test
OK (13 tests, 19 assertions)
```

</details>

## Related product discussion/links

* WOOA7S-2087
* WOOA7S-1595 (the rollout flag this gate belongs to)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a Jetpack-connected site with `jetpack_premium_analytics_enabled` on (`wp option update jetpack_premium_analytics_enabled 1`):

* Deactivate the Stats module (Jetpack → Settings → Traffic, or `wp jetpack module deactivate stats`) and reload wp-admin.
* Ensure there is no "Stats v2" menu, `Jetpack::is_premium_analytics_enabled()` answers false, and `/wp-json/` lists no `jetpack-premium-analytics/v1` namespace.
* Ensure My Jetpack's Stats card links to `admin.php?page=stats` while the module is off.
* Ensure the opt-in still shows up in `wp option get` / `GET /wp-json/wp/v2/settings` (as `jetpack_premium_analytics_enabled`) while the module is off.
* Activate the module again and ensure the Stats v2 menu, the REST namespace, and the My Jetpack link to `page=jetpack-premium-analytics-wp-admin` all come back on the next request.
* Ensure the "flag on but package not loadable" warning behaves exactly as before while the module is on.
* Ensure a Simple site and the standalone Premium Analytics plugin are not affected.
* `jp docker phpunit jetpack -- --filter=Jetpack_Premium_Analytics_Test` passes.

