### PR TITLE
Backup: record the upgrade click on the modernized no-plan gate

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2500-backup-upgrade-button-tracks
+++ b/projects/packages/backup/changelog/jetpack-2500-backup-upgrade-button-tracks
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: the no-plan gate's Get VaultPress Backup button now records the same jetpack_backup_plugin_upgrade_click Tracks event the legacy dashboard records, so the purchase path stays measurable across the rollout. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -24,9 +24,8 @@ export default function UpgradeButton() {
 	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
 	const recordClick = useCallback( () => {
-		// On the click rather than at checkout: the event measures the reader
-		// deciding to buy, and this page never sees the purchase. Legacy records
-		// the same name and payload from `no-backup-capabilities.jsx`.
+		// Legacy records the same name and payload from `no-backup-capabilities.jsx`.
+		// Click-time and the `undefined` arm are as in `addon-upsell.tsx`.
 		analytics.tracks.recordEvent(
 			'jetpack_backup_plugin_upgrade_click',
 			site ? { site } : undefined

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -24,8 +24,7 @@ export default function UpgradeButton() {
 	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
 	const recordClick = useCallback( () => {
-		// Legacy records the same name and payload from `no-backup-capabilities.jsx`.
-		// Click-time and the `undefined` arm are as in `addon-upsell.tsx`.
+		// Same name and payload legacy records from `no-backup-capabilities.jsx`.
 		analytics.tracks.recordEvent(
 			'jetpack_backup_plugin_upgrade_click',
 			site ? { site } : undefined

--- a/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
+++ b/projects/packages/backup/src/dashboard/components/gates/upgrade-button.tsx
@@ -1,6 +1,8 @@
 import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
 import { Button } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useAnalytics } from '../../hooks/use-analytics';
 import { useSiteSuffix } from '../../hooks/use-connection';
 
 /**
@@ -15,13 +17,24 @@ import { useSiteSuffix } from '../../hooks/use-connection';
  */
 export default function UpgradeButton() {
 	const site = useSiteSuffix();
+	const analytics = useAnalytics();
 	// The key is omitted rather than passed as undefined: `getRedirectUrl`
 	// walks its args with `for…in`, so a present-but-undefined `site` is
 	// encoded literally *and* suppresses the helper's own site fallback.
 	const upgradeUrl = getRedirectUrl( 'backup-plugin-upgrade-10gb', site ? { site } : {} );
 
+	const recordClick = useCallback( () => {
+		// On the click rather than at checkout: the event measures the reader
+		// deciding to buy, and this page never sees the purchase. Legacy records
+		// the same name and payload from `no-backup-capabilities.jsx`.
+		analytics.tracks.recordEvent(
+			'jetpack_backup_plugin_upgrade_click',
+			site ? { site } : undefined
+		);
+	}, [ analytics, site ] );
+
 	return (
-		<Button variant="primary" href={ upgradeUrl }>
+		<Button variant="primary" href={ upgradeUrl } onClick={ recordClick }>
 			{ __( 'Get VaultPress Backup', 'jetpack-backup-pkg' ) }
 		</Button>
 	);

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -391,9 +391,8 @@ describe( 'Upgrade from the no-plan gate', () => {
 		document.removeEventListener( 'click', cancelNavigation );
 	} );
 
-	// JETPACK-2500. Legacy records this from `no-backup-capabilities.jsx`, and
-	// the rollout is all-at-once — so a name or payload that drifted here would
-	// read in Tracks as conversions stopping rather than telemetry stopping.
+	// JETPACK-2500 — a name or payload that drifted from legacy's would read in
+	// Tracks as conversions stopping rather than telemetry stopping.
 	it( 'records the reader deciding to buy, with the site they came from', async () => {
 		await userEvent.click( await upgradeCta( SITE_SUFFIX ) );
 

--- a/projects/packages/backup/tests/tracks-events.test.tsx
+++ b/projects/packages/backup/tests/tracks-events.test.tsx
@@ -342,3 +342,88 @@ describe( 'Modify schedule', () => {
 		expect( mockRecordEvent ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'Upgrade from the no-plan gate', () => {
+	const SITE_SUFFIX = 'example.com';
+
+	let defaultPrevented: boolean | null = null;
+
+	/**
+	 * Stop jsdom trying to navigate, and note whether the click was already
+	 * cancelled by the time it got here.
+	 *
+	 * Bound on the document, so it runs after React's own handler — which is
+	 * what makes `defaultPrevented` a witness rather than a coincidence.
+	 *
+	 * @param event - The click on its way up from the anchor.
+	 */
+	function cancelNavigation( event: MouseEvent ) {
+		defaultPrevented = event.defaultPrevented;
+		event.preventDefault();
+	}
+
+	/**
+	 * Render the purchase button for a site, or for a global carrying no site.
+	 *
+	 * @param siteSuffix - The site to put on the connection global.
+	 * @return The purchase link.
+	 */
+	async function upgradeCta( siteSuffix: string | undefined ) {
+		window.JP_CONNECTION_INITIAL_STATE = {
+			...window.JP_CONNECTION_INITIAL_STATE,
+			siteSuffix,
+		} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+
+		const UpgradeButton = ( await import( '../src/dashboard/components/gates/upgrade-button' ) )
+			.default;
+
+		render( <UpgradeButton /> );
+
+		return screen.findByRole( 'link', { name: /^Get VaultPress Backup$/ } );
+	}
+
+	beforeEach( () => {
+		defaultPrevented = null;
+		document.addEventListener( 'click', cancelNavigation );
+	} );
+
+	afterEach( () => {
+		document.removeEventListener( 'click', cancelNavigation );
+	} );
+
+	// JETPACK-2500. Legacy records this from `no-backup-capabilities.jsx`, and
+	// the rollout is all-at-once — so a name or payload that drifted here would
+	// read in Tracks as conversions stopping rather than telemetry stopping.
+	it( 'records the reader deciding to buy, with the site they came from', async () => {
+		await userEvent.click( await upgradeCta( SITE_SUFFIX ) );
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_backup_plugin_upgrade_click', {
+			site: SITE_SUFFIX,
+		} );
+		expect( mockRecordEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'still lets the click reach checkout', async () => {
+		// The CTA is an anchor, so a handler that cancelled the event would
+		// record the intent and then strand the reader on this screen.
+		const cta = await upgradeCta( SITE_SUFFIX );
+
+		await userEvent.click( cta );
+
+		expect( defaultPrevented ).toBe( false );
+		expect( cta ).toHaveAttribute( 'href', expect.stringContaining( 'jetpack.com/redirect' ) );
+	} );
+
+	it( 'omits the site rather than reporting the word "undefined"', async () => {
+		await userEvent.click( await upgradeCta( undefined ) );
+
+		const [ , payload ] = mockRecordEvent.mock.calls[ 0 ];
+		expect( payload ).toBeUndefined();
+	} );
+
+	it( 'records nothing until the reader actually clicks', async () => {
+		await expect( upgradeCta( SITE_SUFFIX ) ).resolves.toBeInTheDocument();
+
+		expect( mockRecordEvent ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-2500

## Proposed changes

* The modernized Backup dashboard's no-plan gate is the only purchase path out of that screen, and its "Get VaultPress Backup" button recorded nothing. The legacy dashboard records `jetpack_backup_plugin_upgrade_click` on the equivalent button (`src/js/components/Admin/no-backup-capabilities.jsx`), so the modernized page dropped the event silently.
* `UpgradeButton` now records the same event name and payload on click. The rollout of the modernized dashboard is all-at-once, so there is no cohort to compare against afterwards — a gap starting on flip day would read in Tracks as "conversions stopped", not "telemetry stopped".
* Recorded on the click rather than at checkout: this page never sees the purchase, matching legacy and the `jetpack_backup_upgrade_storage_prompt_cta` handler next door. The `site` key is omitted rather than sent as `undefined` when the connection global carries no site suffix.
* The button is an anchor, so the handler records and lets the click through — one of the new tests asserts `defaultPrevented` is still false after React's handler has run.

I diffed every `jetpack_backup_*` event across `src/js/` and `src/dashboard/` before writing this: this was the only genuine gap. The other legacy-only events are deliberate (JETPACK-2371's un-ported CTA, three Calypso CTAs removed by JETPACK-2329) or a false positive from a product slug in a fixture — so no other events are added here.

## Related product discussion/links

* JETPACK-2500

## Does this pull request change what data or activity we track or use?

No new data. `jetpack_backup_plugin_upgrade_click` is an existing event with an existing payload (`{ site }`), already recorded by the legacy Backup dashboard; this restores it on the modernized dashboard so the two surfaces report the same thing. Nothing fires unless the reader presses the button.

## Testing instructions

The modernized dashboard is behind the `rsm_jetpack_ui_modernization_backup` filter, default off — with the filter off this change is a no-op.

Automated:

* `pnpm run test` in `projects/packages/backup` — see the new "Upgrade from the no-plan gate" block in `tests/tracks-events.test.tsx`.

Manual, on a site **without** a Backup plan:

* Enable the modernized dashboard (`add_filter( 'rsm_jetpack_ui_modernization_backup', '__return_true' );`) and go to **Jetpack → VaultPress Backup**. You should get the no-plan gate.
* Open the browser console and watch `window._tkq` (or the network tab for the Tracks pixel).
* Press **Get VaultPress Backup**. A `jetpack_backup_plugin_upgrade_click` event should be pushed carrying `site` set to the site suffix, and the browser should then follow the `jetpack.com/redirect` link to checkout in the same tab — the recording must not swallow the navigation.
* Compare against the legacy dashboard (filter off) on the same site: same event name, same payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1YJKRY7dY68t2PkvowQrp
