### PR TITLE
Backup: close the flex gap around the storage add-on price

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2502-backup-upsell-price-spacing
+++ b/projects/packages/backup/changelog/jetpack-2502-backup-upsell-price-spacing
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: close the flex gap either side of the price in the storage add-on offer button. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
@@ -93,8 +93,8 @@ function statusText(
  * Never a written currency symbol: `formatCurrency` places the right one for
  * `currencyCode`, which WordPress.com chooses from where the site appears to be.
  *
- * Returned as one element: the button is a flex container with a gap, so an
- * interpolated price left bare becomes its own flex item with 8px either side.
+ * Returned as one element: the button is a flex container, so an interpolated
+ * price left bare becomes its own flex item, with the button's gap either side.
  *
  * @param sizeText     - The add-on's size as WordPress.com words it, e.g. `100GB`.
  * @param monthlyPrice - One month of the add-on.

--- a/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
+++ b/projects/packages/backup/src/dashboard/components/storage-space/addon-upsell.tsx
@@ -93,6 +93,9 @@ function statusText(
  * Never a written currency symbol: `formatCurrency` places the right one for
  * `currencyCode`, which WordPress.com chooses from where the site appears to be.
  *
+ * Returned as one element: the button is a flex container with a gap, so an
+ * interpolated price left bare becomes its own flex item with 8px either side.
+ *
  * @param sizeText     - The add-on's size as WordPress.com words it, e.g. `100GB`.
  * @param monthlyPrice - One month of the add-on.
  * @param currencyCode - The currency WordPress.com priced it in.
@@ -105,9 +108,13 @@ function offerLabel( sizeText: string, monthlyPrice: number, currencyCode: strin
 		'jetpack-backup-pkg'
 	);
 
-	return createInterpolateElement( sprintf( offer, sizeText ), {
-		Price: <span>{ formatCurrency( monthlyPrice, currencyCode ) }</span>,
-	} );
+	return (
+		<span>
+			{ createInterpolateElement( sprintf( offer, sizeText ), {
+				Price: <span>{ formatCurrency( monthlyPrice, currencyCode ) }</span>,
+			} ) }
+		</span>
+	);
 }
 
 type Props = {

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -281,7 +281,7 @@ describe( 'when the upsell appears', () => {
 	} );
 } );
 
-describe( 'what the offer says', () => {
+describe( 'how the offer is laid out', () => {
 	it( 'hands the button one child, so nothing is spaced out as a flex item', async () => {
 		renderWithClient( <StorageSpace /> );
 		const link = await offerLink();
@@ -291,7 +291,9 @@ describe( 'what the offer says', () => {
 			/^Add 100GB additional storage for \$9\.95\/month, billed monthly$/
 		);
 	} );
+} );
 
+describe( 'what the offer says', () => {
 	it( 'quotes a Brazilian site in reais, with no dollar sign anywhere', async () => {
 		// Why `price.jsx` was not ported: it reads `currencyCode` off a block keyed
 		// `currency_code` and `getCurrencyObject` falls back to `$`. This catalogue is

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -282,6 +282,18 @@ describe( 'when the upsell appears', () => {
 } );
 
 describe( 'what the offer says', () => {
+	it( 'hands the button one child, so nothing is spaced out as a flex item', async () => {
+		// The button is a flex container with a gap, so an interpolated price left bare
+		// is a second flex item with 8px either side — a gap no msgid asked for.
+		renderWithClient( <StorageSpace /> );
+		const link = await offerLink();
+
+		expect( link.childNodes ).toHaveLength( 1 );
+		expect( link ).toHaveTextContent(
+			/^Add 100GB additional storage for \$9\.95\/month, billed monthly$/
+		);
+	} );
+
 	it( 'quotes a Brazilian site in reais, with no dollar sign anywhere', async () => {
 		// Why `price.jsx` was not ported: it reads `currencyCode` off a block keyed
 		// `currency_code` and `getCurrencyObject` falls back to `$`. This catalogue is

--- a/projects/packages/backup/tests/storage-addon-upsell.test.tsx
+++ b/projects/packages/backup/tests/storage-addon-upsell.test.tsx
@@ -283,8 +283,6 @@ describe( 'when the upsell appears', () => {
 
 describe( 'what the offer says', () => {
 	it( 'hands the button one child, so nothing is spaced out as a flex item', async () => {
-		// The button is a flex container with a gap, so an interpolated price left bare
-		// is a second flex item with 8px either side — a gap no msgid asked for.
 		renderWithClient( <StorageSpace /> );
 		const link = await offerLink();
 


### PR DESCRIPTION
Fixes JETPACK-2502

## Proposed changes

The Backup storage add-on offer button rendered a visible gap either side of the price:

> Add 10GB additional storage for⎵⎵$6.00⎵⎵/month, billed monthly

so `$6.00` read as a detached token and `/month` looked as if it belonged to whatever followed. The source string asks for no spaces there at all.

The cause is not the string. `createInterpolateElement` gives the `<Price />` token a real element, and `@wordpress/ui`'s button is `display: inline-flex` with `gap: var(--wpds-dimension-gap-sm)`. Measured live on the storage-full state:

```json
{"tag":"A","display":"flex","columnGap":"8px",
 "childTypes":["text","SPAN","text"],"spanDisplay":"block"}
```

Three children became three flex items, and the button injected 8px of gap between each — spacing no msgid asked for, and that a translator can neither see nor remove.

* Wrap the offer label in one element, so the button has a single flex item and the sentence runs uninterrupted.

### Why not drop the interpolation

`formatCurrency()` returns a string and the `<span>` carries no styling, so `sprintf`-ing the price straight in would also work and would read more simply. It was rejected because it changes the **msgid**, not just the code: `'Add %1$s additional storage for <Price />/month, billed monthly'` is legacy's string character for character, it is already translated, and legacy still renders it on the flag-off dashboard. Swapping `<Price />` for `%2$s` would put a near-duplicate of the same sentence into the same POT and leave the modernized dashboard showing English to non-English sites until the next GlotPress cycle — a regression this issue never asked for. Keeping the interpolation costs one wrapper element and keeps the translations.

No visible copy changed.

### Other `createInterpolateElement` sites

The issue notes the cause is "an interpolated element inside a flex control", so the rest of the dashboard was checked. Nothing else has this shape, and **nothing else is changed here**:

| Call site | Container | Verdict |
| --- | --- | --- |
| `usage-details.tsx` (`usageText`, days-saved label) | `Text` | `Text` is not a flex container |
| `help-popover.tsx` (forecast, advice) | `Popover.Description`, `Text` | neither is a flex container |
| `backup-status/index.tsx` (`ContactSupportLine`) | `EmptyState.Description`, `Text` | `.description` sets `margin` only |
| `review-request/index.tsx` | `Link` | not a flex container; and the `<strong>` wraps the whole msgid, so it is a single child regardless |

The two icon-plus-label buttons — `screens/download.tsx` and `screens/restore.tsx` — are flex items on purpose; that gap is the intended icon spacing.

## Related product discussion/links

* JETPACK-2502

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is behind the `rsm_jetpack_ui_modernization_backup` filter, default off, so it is a no-op on a stock site.

1. Enable the modernized Backup dashboard (`rsm_jetpack_ui_modernization_backup` filtered to `true`).
2. Put the site above the `Normal` storage level so the add-on offer renders — the storage-full state is the easiest, e.g. via the dashboard state simulator (`?jpb_sim=`) or by making `/site/backup/size` report a size at or above the plan's `storage_limit_bytes`.
3. Look at the "Add … additional storage for …/month, billed monthly" button under the storage meter.
   * **Before:** a clear gap either side of the price, as though the string contained double spaces.
   * **After:** one continuous sentence, with the price sitting flush against "for" and "/month".
4. Confirm the wording itself is unchanged, and that the button still links to `wordpress.com/checkout/<site>/<addon-slug>`.

Automated coverage: `pnpm run test` in `projects/packages/backup` (741 tests). The new case in `tests/storage-addon-upsell.test.tsx` pins the cause rather than the symptom — it asserts the button has exactly one child node, which fails with `Received length: 3 … [Add 100GB additional storage for , <span>$9.95</span>, /month, billed monthly]` when the wrapper is removed. The gap itself is CSS, so jsdom cannot compute it; the visual result needs a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1YJKRY7dY68t2PkvowQrp
