### PR TITLE
Backup: isolate LTR data in the modernized dashboard for RTL

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
+++ b/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: isolate filenames, the file hash, the file preview source and the activity stats line wherever it is shown — in the list and in both detail panes — so RTL no longer moves their leading punctuation and digits to the visual end. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: isolate filenames, the file size and hash, the file preview source and the activity stats line wherever it is shown — in the list and in both detail panes — so RTL no longer moves their leading punctuation and digits to the visual end, and give the preview its own horizontal scroller so long lines stay reachable there. No-op when the filter is off.
 
 

--- a/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
+++ b/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: isolate filenames, the file hash and the activity stats line so RTL no longer moves their leading punctuation and digits to the visual end. No-op when the filter is off.
+
+

--- a/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
+++ b/projects/packages/backup/changelog/jetpack-2498-backup-rtl-bidi-isolation
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: isolate filenames, the file hash and the activity stats line so RTL no longer moves their leading punctuation and digits to the visual end. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: isolate filenames, the file hash, the file preview source and the activity stats line wherever it is shown — in the list and in both detail panes — so RTL no longer moves their leading punctuation and digits to the visual end. No-op when the filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
@@ -28,7 +28,8 @@ export default function ActivityDetail( { item }: Props ) {
 						{ ' · ' }
 						{ item.actor.name }
 					</Text>
-					{ item.summary && <Text>{ item.summary }</Text> }
+					{ /* `auto`, not `ltr`: WPCOM translates this line and may return it in RTL. */ }
+					{ item.summary && <Text dir="auto">{ item.summary }</Text> }
 				</Stack>
 			</Card.Content>
 		</Card.Root>

--- a/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
@@ -28,7 +28,6 @@ export default function ActivityDetail( { item }: Props ) {
 						{ ' · ' }
 						{ item.actor.name }
 					</Text>
-					{ /* `auto`, not `ltr`: WPCOM translates this line and may return it in RTL. */ }
 					{ item.summary && <Text dir="auto">{ item.summary }</Text> }
 				</Stack>
 			</Card.Content>

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -95,9 +95,8 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
 			</Text>
 			{ /*
-			 * `auto`, not `ltr`: an RTL page reorders this into "plugins, 23 themes … 47",
-			 * and WPCOM may legitimately translate the line into RTL. Same everywhere
-			 * `stats` and `summary` are rendered.
+			 * `auto`, not `ltr`: WPCOM may legitimately translate this line into RTL.
+			 * Same everywhere `stats` and `summary` are rendered.
 			 */ }
 			{ item.summary && (
 				<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__summary" dir="auto">

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -95,8 +95,9 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
 			</Text>
 			{ /*
-			 * `dir` isolates the stats line, which an RTL page otherwise reorders
-			 * into "plugins, 23 themes … 47"; `auto` because WPCOM may translate it.
+			 * `auto`, not `ltr`: an RTL page reorders this into "plugins, 23 themes … 47",
+			 * and WPCOM may legitimately translate the line into RTL. Same everywhere
+			 * `stats` and `summary` are rendered.
 			 */ }
 			{ item.summary && (
 				<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__summary" dir="auto">

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -94,8 +94,12 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 			<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__date">
 				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
 			</Text>
+			{ /*
+			 * `dir` isolates the stats line, which an RTL page otherwise reorders
+			 * into "plugins, 23 themes … 47"; `auto` because WPCOM may translate it.
+			 */ }
 			{ item.summary && (
-				<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__summary">
+				<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__summary" dir="auto">
 					{ item.summary }
 				</Text>
 			) }

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -139,7 +139,6 @@ export default function BackupDetail( { item }: Props ) {
 				</Stack>
 			</Card.Header>
 			<Card.Content className="jpb-backup-detail__body">
-				{ /* `auto`, not `ltr`: WPCOM translates this line and may return it in RTL. */ }
 				<Text className="jpb-backup-detail__stats" dir="auto">
 					{ item.stats }
 				</Text>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -139,7 +139,10 @@ export default function BackupDetail( { item }: Props ) {
 				</Stack>
 			</Card.Header>
 			<Card.Content className="jpb-backup-detail__body">
-				<Text className="jpb-backup-detail__stats">{ item.stats }</Text>
+				{ /* `auto`, not `ltr`: WPCOM translates this line and may return it in RTL. */ }
+				<Text className="jpb-backup-detail__stats" dir="auto">
+					{ item.stats }
+				</Text>
 				<Text variant="body-sm" className="jpb-text-muted jpb-backup-detail__by">
 					{ sprintf(
 						/* translators: %1$s formatted date+time, %2$s actor name */

--- a/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-browser/index.tsx
@@ -647,6 +647,10 @@ function NodeRow( {
 					) }
 					__nextHasNoMarginBottom
 				/>
+				{ /*
+				 * `dir` isolates the names below: an RTL page otherwise moves a
+				 * leading dot to the visual end, so `.htaccess` reads `htaccess.`.
+				 */ }
 				{ nodeIsFolder ? (
 					// The glyphs are `aria-hidden`, so the folder/file distinction they
 					// carry visually has to be spelled out for assistive tech.
@@ -668,7 +672,7 @@ function NodeRow( {
 					>
 						<Icon icon={ open ? chevronDown : chevronRight } size={ 16 } />
 						<Icon icon={ folderIcon } size={ 18 } />
-						<span>{ node.name }</span>
+						<span dir="ltr">{ node.name }</span>
 					</button>
 				) : (
 					<button
@@ -682,7 +686,7 @@ function NodeRow( {
 						onClick={ handleOpenFile }
 					>
 						<Icon icon={ fileIcon } size={ 18 } />
-						<span>{ node.name }</span>
+						<span dir="ltr">{ node.name }</span>
 					</button>
 				) }
 			</div>

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -222,7 +222,8 @@ function PreviewBody( {
 					) }
 				</Text>
 			) }
-			<pre>{ content }</pre>
+			{ /* `ltr`, not `auto`: source stays LTR even when it opens with an RTL string literal. */ }
+			<pre dir="ltr">{ content }</pre>
 		</>
 	);
 }

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -322,6 +322,11 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 					<Button.Icon icon={ closeSmall } />
 				</Button>
 			</Stack>
+			{ /*
+			 * `dir` on a span, not the `<dd>`: isolating the value there would flip
+			 * the row's `text-align: start` inside an RTL panel. `auto` for the
+			 * translated size unit, `ltr` for the hash.
+			 */ }
 			<dl className="jpb-file-info-card__meta">
 				{ modified && (
 					<div>
@@ -332,7 +337,9 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				{ size !== null && (
 					<div>
 						<dt>{ __( 'Size:', 'jetpack-backup-pkg' ) }</dt>
-						<dd>{ formatFileSize( size ) }</dd>
+						<dd>
+							<span dir="auto">{ formatFileSize( size ) }</span>
+						</dd>
 					</div>
 				) }
 				{ mimeType && (
@@ -344,8 +351,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				{ hash && (
 					<div>
 						<dt>{ __( 'Hash:', 'jetpack-backup-pkg' ) }</dt>
-						<dd className="jpb-file-info-card__hash" dir="ltr">
-							{ hash }
+						<dd className="jpb-file-info-card__hash">
+							<span dir="ltr">{ hash }</span>
 						</dd>
 					</div>
 				) }

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -308,7 +308,8 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				className="jpb-file-info-card__header"
 			>
 				<Text variant="heading-sm" render={ <h3 /> }>
-					{ file.name }
+					{ /* Isolated: an RTL page otherwise renders `.htaccess` as `htaccess.`. */ }
+					<span dir="ltr">{ file.name }</span>
 				</Text>
 				<Button
 					variant="minimal"
@@ -342,7 +343,9 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				{ hash && (
 					<div>
 						<dt>{ __( 'Hash:', 'jetpack-backup-pkg' ) }</dt>
-						<dd className="jpb-file-info-card__hash">{ hash }</dd>
+						<dd className="jpb-file-info-card__hash" dir="ltr">
+							{ hash }
+						</dd>
 					</div>
 				) }
 			</dl>

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -309,7 +309,7 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				className="jpb-file-info-card__header"
 			>
 				<Text variant="heading-sm" render={ <h3 /> }>
-					{ /* Isolated: an RTL page otherwise renders `.htaccess` as `htaccess.`. */ }
+					{ /* A filename is LTR data even on an RTL page. */ }
 					<span dir="ltr">{ file.name }</span>
 				</Text>
 				<Button
@@ -324,8 +324,7 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 			</Stack>
 			{ /*
 			 * `dir` on a span, not the `<dd>`: isolating the value there would flip
-			 * the row's `text-align: start` inside an RTL panel. `auto` for the
-			 * translated size unit, `ltr` for the hash.
+			 * the row's `text-align: start` inside an RTL panel.
 			 */ }
 			<dl className="jpb-file-info-card__meta">
 				{ modified && (

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -60,7 +60,6 @@
 			white-space: pre;
 			// The `<pre>` is `dir="ltr"`, so inside an RTL panel it overflows past
 			// the panel's inline-start edge, which Chrome never makes scrollable.
-			// Scrolling it here keeps long lines reachable in both directions.
 			overflow-x: auto;
 			color: var(--wp-components-color-foreground, #1e1e1e);
 		}

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -46,7 +46,8 @@
 
 	&__preview {
 		max-height: 320px;
-		overflow: auto;
+		overflow-y: auto;
+		overflow-x: hidden;
 		background-color: var(--wp-components-color-background-secondary, #f7f7f7);
 		border-radius: 4px;
 		padding: 12px;
@@ -57,6 +58,10 @@
 			font-size: 12px;
 			line-height: 1.5;
 			white-space: pre;
+			// The `<pre>` is `dir="ltr"`, so inside an RTL panel it overflows past
+			// the panel's inline-start edge, which Chrome never makes scrollable.
+			// Scrolling it here keeps long lines reachable in both directions.
+			overflow-x: auto;
 			color: var(--wp-components-color-foreground, #1e1e1e);
 		}
 	}

--- a/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
+++ b/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
@@ -1,0 +1,138 @@
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { render, screen } from '@testing-library/react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
+import FileInfoCard from '../src/dashboard/components/file-info-card';
+import { queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
+import type { FileNodeFile } from '../src/dashboard/types/file-tree';
+
+/** Neither closing nor selection is relevant here; everything renders regardless. */
+const noop = () => {};
+
+const HASH = 'd41d8cd98f00b204e9800998ecf8427e';
+const STATS = '47 plugins, 23 themes, 2138 uploads, 104 posts, 18 pages';
+
+const FILE: FileNodeFile = {
+	name: '..htaccess.swp',
+	path: '/..htaccess.swp',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/..htaccess.swp',
+};
+
+/**
+ * Assert that the element directly owning `text` carries its own `dir`.
+ *
+ * Reading `dir` off the text's own node is what stops the assertion passing
+ * on one an ancestor happens to set, which isolates nothing on its own.
+ *
+ * @param text     - The exact rendered string.
+ * @param expected - The `dir` value the node must carry.
+ */
+function expectIsolated( text: string, expected: 'ltr' | 'auto' ): void {
+	expect( screen.getByText( text ) ).toHaveAttribute( 'dir', expected );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	mockApiFetch.mockReset();
+	window.JP_CONNECTION_INITIAL_STATE = {
+		connectionStatus: { isRegistered: true, hasConnectedOwner: true, isUserConnected: true },
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+describe( 'bidi isolation on LTR data', () => {
+	it( 'isolates folder and file names in the browser tree', async () => {
+		mockApiFetch.mockResolvedValue( {
+			contents: {
+				'.git': { type: 'dir', has_children: true },
+				'.htaccess': { type: 'file', period: '1786644531' },
+			},
+		} );
+
+		render(
+			<QueryClientProvider>
+				<FileBrowser
+					rewindId="1786644531.123"
+					selection={ EMPTY_FILE_SELECTION }
+					onSelectionChange={ noop }
+				/>
+			</QueryClientProvider>
+		);
+
+		await expect(
+			screen.findByRole( 'button', { name: 'Folder: .git' } )
+		).resolves.toBeInTheDocument();
+
+		expectIsolated( '.git', 'ltr' );
+		expectIsolated( '.htaccess', 'ltr' );
+	} );
+
+	it( 'isolates the file name and hash on the info card', async () => {
+		mockApiFetch.mockImplementation( ( options: { path: string } ) =>
+			Promise.resolve(
+				options.path.includes( '/file-content' )
+					? { content: 'swap file', is_text: true, truncated: false }
+					: { size: 42, hash: HASH }
+			)
+		);
+
+		render(
+			<QueryClientProvider>
+				<FileInfoCard file={ FILE } onClose={ noop } />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( HASH ) ).resolves.toBeInTheDocument();
+
+		expectIsolated( FILE.name, 'ltr' );
+		expectIsolated( HASH, 'ltr' );
+	} );
+
+	it( 'isolates the activity stats line', async () => {
+		mockApiFetch.mockResolvedValue( {
+			current: {
+				orderedItems: [
+					{
+						activity_id: 'a1',
+						name: 'rewind__backup_complete_full',
+						gridicon: 'cloud',
+						rewind_id: '1786600000',
+						published: '2026-08-20T10:00:00+00:00',
+						summary: 'Backup complete',
+						content: { text: STATS },
+						is_rewindable: true,
+					},
+				],
+			},
+			totalItems: 1,
+			totalPages: 1,
+		} );
+
+		render(
+			<QueryClientProvider>
+				<ActivityList
+					selectedId={ null }
+					onSelect={ noop }
+					view={ INITIAL_VIEW }
+					onChangeView={ noop }
+				/>
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( STATS ) ).resolves.toBeInTheDocument();
+
+		// `auto`, not `ltr`: WPCOM translates this string and may return it in RTL.
+		expectIsolated( STATS, 'auto' );
+	} );
+} );

--- a/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
+++ b/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
@@ -1,3 +1,5 @@
+/* eslint jest/expect-expect: [ "warn", { assertFunctionNames: [ "expect", "expectIsolated" ] } ] */
+
 const mockApiFetch = jest.fn();
 
 jest.mock( '@wordpress/api-fetch', () => ( {
@@ -5,14 +7,21 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
 } ) );
 
-// Imports must come after the jest.mock factory above.
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { children, ...rest }: { children: React.ReactNode } ) => <a { ...rest }>{ children }</a>,
+} ) );
+
+// Imports must come after the jest.mock factories above.
 import { render, screen } from '@testing-library/react';
+import ActivityDetail from '../src/dashboard/components/activity-detail';
 import ActivityList from '../src/dashboard/components/activity-list';
+import BackupDetail from '../src/dashboard/components/backup-detail';
 import FileBrowser, { EMPTY_FILE_SELECTION } from '../src/dashboard/components/file-browser';
 import FileInfoCard from '../src/dashboard/components/file-info-card';
 import { queryClient } from '../src/dashboard/data/query-client';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
 import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
+import type { BackupActivityItem, NonBackupActivityItem } from '../src/dashboard/types/activity';
 import type { FileNodeFile } from '../src/dashboard/types/file-tree';
 
 /** Neither closing nor selection is relevant here; everything renders regardless. */
@@ -27,6 +36,38 @@ const FILE: FileNodeFile = {
 	type: 'file',
 	period: '1786644531',
 	manifestPath: 'f5:/..htaccess.swp',
+};
+
+/** An extension in the card's previewable map, so the `<pre>` actually renders. */
+const PHP_FILE: FileNodeFile = {
+	name: 'functions.php',
+	path: '/functions.php',
+	type: 'file',
+	period: '1786644531',
+	manifestPath: 'f5:/functions.php',
+};
+
+const SOURCE = "<?php // Load early. return [ 'key' => 'value' ];";
+
+// `normalizeActivityLog` fills `stats` and `summary` from the same
+// `content.text`, so both fixtures below carry the one string.
+const BACKUP_ITEM: BackupActivityItem = {
+	id: 'act-cloud',
+	kind: 'backup',
+	title: 'Backup complete',
+	publishedAt: '2026-08-13T18:08:56+00:00',
+	actor: { type: 'Application', name: 'Jetpack' },
+	rewindId: '1786644531.123',
+	stats: STATS,
+};
+
+const ACTIVITY_ITEM: NonBackupActivityItem = {
+	id: 'act-plugin',
+	kind: 'plugin-update',
+	title: 'Plugin updated',
+	publishedAt: '2026-08-13T18:08:56+00:00',
+	actor: { type: 'Person', name: 'Bob Sacramento' },
+	summary: STATS,
 };
 
 /**
@@ -134,5 +175,47 @@ describe( 'bidi isolation on LTR data', () => {
 
 		// `auto`, not `ltr`: WPCOM translates this string and may return it in RTL.
 		expectIsolated( STATS, 'auto' );
+	} );
+
+	// The right-hand pane prints this same string larger and bolder, so
+	// isolating only the list leaves the louder copy reordered.
+	it( 'isolates the same stats line on the backup detail pane', () => {
+		// The pane mounts a file browser, which fetches its root listing on
+		// mount. Nothing here reads those rows.
+		mockApiFetch.mockResolvedValue( {} );
+
+		render(
+			<QueryClientProvider>
+				<BackupDetail item={ BACKUP_ITEM } />
+			</QueryClientProvider>
+		);
+
+		expectIsolated( STATS, 'auto' );
+	} );
+
+	it( 'isolates the summary on the non-backup detail pane', () => {
+		render( <ActivityDetail item={ ACTIVITY_ITEM } /> );
+
+		expectIsolated( STATS, 'auto' );
+	} );
+
+	it( 'isolates the file preview source', async () => {
+		mockApiFetch.mockImplementation( ( options: { path: string } ) =>
+			Promise.resolve(
+				options.path.includes( '/file-content' )
+					? { content: SOURCE, is_text: true, truncated: false }
+					: { size: 42 }
+			)
+		);
+
+		render(
+			<QueryClientProvider>
+				<FileInfoCard file={ PHP_FILE } onClose={ noop } />
+			</QueryClientProvider>
+		);
+
+		await expect( screen.findByText( SOURCE ) ).resolves.toBeInTheDocument();
+
+		expectIsolated( SOURCE, 'ltr' );
 	} );
 } );

--- a/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
+++ b/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
@@ -119,7 +119,7 @@ describe( 'bidi isolation on LTR data', () => {
 		expectIsolated( '.htaccess', 'ltr' );
 	} );
 
-	it( 'isolates the file name and hash on the info card', async () => {
+	it( 'isolates the file name, size and hash on the info card', async () => {
 		mockApiFetch.mockImplementation( ( options: { path: string } ) =>
 			Promise.resolve(
 				options.path.includes( '/file-content' )
@@ -137,6 +137,7 @@ describe( 'bidi isolation on LTR data', () => {
 		await expect( screen.findByText( HASH ) ).resolves.toBeInTheDocument();
 
 		expectIsolated( FILE.name, 'ltr' );
+		expectIsolated( '42 B', 'auto' );
 		expectIsolated( HASH, 'ltr' );
 	} );
 
@@ -173,7 +174,6 @@ describe( 'bidi isolation on LTR data', () => {
 
 		await expect( screen.findByText( STATS ) ).resolves.toBeInTheDocument();
 
-		// `auto`, not `ltr`: WPCOM translates this string and may return it in RTL.
 		expectIsolated( STATS, 'auto' );
 	} );
 


### PR DESCRIPTION
Fixes JETPACK-2498

## Proposed changes

In the modernized Backup dashboard, several strings are LTR *data* rendered inside RTL paragraphs with no bidi isolation, so the bidirectional algorithm moves leading punctuation and digits to the visual end. Reproduced with `text_direction = 'rtl'`:

| Stored value | Rendered in RTL |
| -- | -- |
| `.htaccess` | `htaccess.` |
| `.htaccess.bak` | `htaccess.bak.` |
| `..htaccess.swp` | `htaccess.swp..` |
| `42 B` | `B 42` |
| `47 plugins, 23 themes, 2138 uploads, 104 posts, 18 pages` | `plugins, 23 themes, 2138 uploads, 104 posts, 18 pages 47` |

Nothing is mis-stored — the DOM holds the right characters. It is purely layout. For the stats line and the file size that is a readability annoyance; for filenames it is a correctness problem, because these name the files a reader is choosing to restore or download, on filesystems where a leading dot is the difference between `.htaccess` and `htaccess`.

* `dir="ltr"` on the folder and file names in the file browser tree.
* `dir="ltr"` on the filename heading and the `Hash:` value in the file info card.
* `dir="auto"` on the card's `Size:` value. `auto` rather than `ltr` because `formatFileSize` translates the unit as a whole string, so an RTL locale can legitimately return the whole value in RTL.
* `dir="ltr"` on the file preview's `<pre>`. `ltr` rather than `auto` because source stays LTR even when it happens to open with an RTL string literal.
* `dir="auto"` on the activity stats line **everywhere it is shown** — the activity list, the backup detail pane, and the non-backup activity detail pane. It gets `auto` rather than `ltr` because WordPress.com translates that string (it is the activity log's `content.text`) and may legitimately return it in RTL; `auto` isolates it either way and picks the direction from the first strong character, which fixes the reported case identically.

Marked in markup rather than with a `unicode-bidi: isolate` CSS rule, so the isolation survives the string being re-composed. The stats line is wrapped in `DescriptionCell`'s render rather than in the `description` field's `getValue`, because that value is also DataViews' text value for sorting and cannot carry markup. In the info card's meta list the `dir` goes on a `<span>` rather than the `<dd>`, so isolating a value does not also flip that row's `text-align: start` to left inside an otherwise RTL panel.

The file info card's heading keeps its existing `<Text variant="heading-sm" render={ <h3 /> }>` untouched — the `dir` goes on a `<span>` around the name — so this does not collide with JETPACK-2503, which changes that variant.

### One `.scss` change: the preview's horizontal scroll

Making the `<pre>` LTR inside an RTL panel flips which physical edge its long lines overflow past, and Chrome does not put inline-start overflow into the scrollable overflow region at all. Measured on an RTL page with a 420px panel and one 824px line:

| variant | panel `scrollWidth` / `clientWidth` | long line reachable? | translated notes |
| -- | -- | -- | -- |
| before this PR (`<pre>`, no `dir`) | 836 / 444 | yes | rtl |
| `<pre dir="ltr">`, panel unchanged | **444 / 444** | **no — clipped, max scroll 0 both ways** | rtl |
| `dir="ltr"` on the panel instead | 836 / 444 | yes | **ltr** |
| `pre { overflow-x: auto }` (this PR) | 444 / 444, `<pre>` scrolls 0→404 | yes | rtl |

So `.jpb-file-info-card__preview` keeps `overflow-y` and the `<pre>` takes its own `overflow-x`. Moving `dir="ltr"` up to the panel would fix the scroll too, but that panel also holds six translated strings and the Show-preview button across `PreviewBody`'s branches, and an LTR paragraph puts their sentence-final punctuation on the wrong side. Trade-off: the horizontal scrollbar now sits under the code instead of at the panel edge, in LTR as well as RTL.

The `Size:` row does not render at all on `trunk` today — the endpoint returns `size` as a decimal string and `toFileDetails` only accepts a number. #51959 (JETPACK-2501) fixes that; the two do not overlap, and this isolates the row ahead of it becoming visible.

## Related product discussion/links

* JETPACK-2498

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is behind the `rsm_jetpack_ui_modernization_backup` filter, which is off by default, so it is a no-op unless the modernized dashboard is enabled.

* Enable the modernized Backup dashboard (`rsm_jetpack_ui_modernization_backup`).
* Switch the site or user to an RTL locale, or set `text_direction = 'rtl'`.
* On the **Overview**, confirm a backup row's stats line in the list reads `47 plugins, 23 themes, …` and not `plugins, 23 themes, … 47`.
* Select that row and confirm the **right-hand detail pane** reads the same way — it prints the same string larger and bolder. Select a non-backup activity (a plugin or theme update) and check its pane too.
* Open **Restore/Download** and expand the file browser. Confirm dotfiles read `.htaccess`, `.git`, `..htaccess.swp` — not `htaccess.`, `git.`, `htaccess.swp..`.
* Click a dotfile to open the info card. Confirm the heading reads the same way, and that the `Hash:` value is not reordered. (`Size:` is blank until #51959 lands.)
* Click a **wide** text file — one with a line longer than the panel, e.g. a minified `.js` or a long `.php` line. Confirm the source reads LTR, opens at the start of the line, and can be scrolled right to its end.
* Confirm the panel's own prose is unaffected: a file too large to show in full still reads its "Preview truncated…" note as RTL.
* Switch back to an LTR locale and confirm nothing changed there, including the wide-file preview.

Automated coverage lives in `projects/packages/backup/tests/rtl-bidi-isolation.test.tsx`; it asserts the `dir` is on the node that directly owns each string, so it cannot pass on one an ancestor happens to set. jsdom does no bidi layout and computes no scroll geometry, so neither the visual RTL result nor the preview scroll fix is covered by tests — the table above is the record of measuring those in Chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NvAhqmx5QDrs4EKggwpVzJ
