### PR TITLE
Admin page layout: fix RTL by pinning the content column with logical properties

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -112,10 +112,9 @@ $jp-breakpoint-mobile: 782px;
 		inset-inline-end: 0;
 		bottom: 0;
 		// wp-admin core sets `width: 100%` on #wpbody-content (common.css).
-		// With `position: fixed`, that resolves to 100% of the viewport and
-		// overrides `inset-inline-end: 0`, making the column extend past the
-		// viewport by the sidebar width. `width: auto` lets the inline
-		// insets size it.
+		// Under `position: fixed` that resolves to the viewport width and
+		// overrides `inset-inline-end: 0`, pushing the column past it by the
+		// sidebar width; `width: auto` lets the inline insets size it instead.
 		width: auto;
 		padding-bottom: 0;          // wp-admin default is 65px (clears #wpfooter).
 		overflow: hidden;
@@ -359,7 +358,7 @@ $jp-breakpoint-mobile: 782px;
 		}
 
 		.jp-admin-page {
-			margin-inline-start: 0;  // override legacy -10px @ ≤782px too.
+			margin-inline-start: 0;  // override AdminPage's own -10px @ ≤782px.
 		}
 	}
 }

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -69,7 +69,7 @@ $jp-breakpoint-mobile: 782px;
 @mixin jetpack-admin-page-layout {
 	// ── wp-admin chrome resets ────────────────────────────────────────
 	#wpcontent {
-		padding-left: 0;
+		padding-inline-start: 0;
 	}
 
 	// wp-admin's footer floats at the very bottom via `position: absolute`;
@@ -108,13 +108,14 @@ $jp-breakpoint-mobile: 782px;
 		box-sizing: border-box;
 		position: fixed;
 		top: var(--wp-admin-bar-height, #{$jp-admin-bar-height-desktop});
-		left: $jp-sidebar-width-expanded;
-		right: 0;
+		inset-inline-start: $jp-sidebar-width-expanded;
+		inset-inline-end: 0;
 		bottom: 0;
 		// wp-admin core sets `width: 100%` on #wpbody-content (common.css).
 		// With `position: fixed`, that resolves to 100% of the viewport and
-		// overrides `right: 0`, making the column extend past the viewport
-		// by the sidebar width. `width: auto` lets left+right size it.
+		// overrides `inset-inline-end: 0`, making the column extend past the
+		// viewport by the sidebar width. `width: auto` lets the inline
+		// insets size it.
 		width: auto;
 		padding-bottom: 0;          // wp-admin default is 65px (clears #wpfooter).
 		overflow: hidden;
@@ -125,7 +126,7 @@ $jp-breakpoint-mobile: 782px;
 	// `.folded` is the user's persistent "Collapse menu" preference; WP
 	// keeps it set at every viewport width, so we match it unconditionally.
 	&.folded #wpbody-content {
-		left: $jp-sidebar-width-folded;
+		inset-inline-start: $jp-sidebar-width-folded;
 	}
 
 	// `.auto-fold` is WP JS state, gated to narrow-desktop widths. Scope
@@ -136,7 +137,7 @@ $jp-breakpoint-mobile: 782px;
 	@media (max-width: #{$jp-breakpoint-auto-fold}) {
 
 		&.auto-fold #wpbody-content {
-			left: $jp-sidebar-width-folded;
+			inset-inline-start: $jp-sidebar-width-folded;
 		}
 	}
 
@@ -151,7 +152,7 @@ $jp-breakpoint-mobile: 782px;
 	@media (min-width: #{$jp-breakpoint-auto-fold + 1px}) {
 
 		&.is-nav-unification:not(.folded) #wpbody-content {
-			left: $jp-sidebar-width-nav-unification;
+			inset-inline-start: $jp-sidebar-width-nav-unification;
 		}
 	}
 
@@ -200,7 +201,7 @@ $jp-breakpoint-mobile: 782px;
 	// hidden` boundary, so consumer-side horizontal clipping isn't needed
 	// at this level.
 	.jp-admin-page {
-		margin-left: 0;
+		margin-inline-start: 0;
 		display: flex;
 		flex-direction: column;
 		flex: 1 1 auto;
@@ -347,18 +348,18 @@ $jp-breakpoint-mobile: 782px;
 	// ── Mobile: admin bar grows to 46px; sidebar goes off-canvas ─────
 	// Match `.folded` and `.auto-fold` explicitly: both outrank the bare
 	// `#wpbody-content` selector on specificity, so the media query needs
-	// equal specificity for `left: 0` to win over the desktop fold rules.
+	// equal specificity for the reset to win over the desktop fold rules.
 	@media (max-width: #{$jp-breakpoint-mobile}) {
 
 		#wpbody-content,
 		&.folded #wpbody-content,
 		&.auto-fold #wpbody-content {
 			top: var(--wp-admin-bar-height, #{$jp-admin-bar-height-mobile});
-			left: 0;                 // sidebar slides out of flow at this width.
+			inset-inline-start: 0;   // sidebar slides out of flow at this width.
 		}
 
 		.jp-admin-page {
-			margin-left: 0;          // override legacy -10px @ ≤782px too.
+			margin-inline-start: 0;  // override legacy -10px @ ≤782px too.
 		}
 	}
 }

--- a/projects/js-packages/base-styles/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/js-packages/base-styles/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page layout: Fix admin screens overlapping the admin menu in right-to-left languages.

--- a/projects/js-packages/components/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/js-packages/components/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -104,7 +104,7 @@
 	// line-height: 1.6666;` — see https://github.com/WordPress/WordPress/blob/trunk/wp-content/plugins/hello.php
 	// We override only the bits that need to differ from those defaults.
 	float: none;
-	text-align: right;
+	text-align: end;
 	background: var(--wpds-color-background-surface-neutral-strong, #fff);
 	font-style: italic;
 	color: var(--wpds-color-foreground-content-neutral-weak, #87a6bc);

--- a/projects/js-packages/components/components/admin-page/style.module.scss
+++ b/projects/js-packages/components/components/admin-page/style.module.scss
@@ -1,8 +1,8 @@
 .admin-page {
-	margin-left: -20px; // to neutralize the padding of #wpcontent.
+	margin-inline-start: -20px; // to neutralize the padding of #wpcontent.
 
 	@media (max-width: 782px) {
-		margin-left: -10px; // to neutralize the padding of #wpcontent.
+		margin-inline-start: -10px; // to neutralize the padding of #wpcontent.
 	}
 
 	&.background {

--- a/projects/plugins/backup/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/backup/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin pages: Fix the dashboard and Activity Log overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/backup/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/backup/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Admin pages: Fix the dashboard and Activity Log overlapping the admin menu in right-to-left languages.
+Activity Log: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/boost/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/boost/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -4,9 +4,10 @@
 // but not guaranteed here. Define a local fallback.
 $spacing-base: var(--spacing-base, 8px);
 
-// AdminPage uses margin-left: -20px to neutralize #wpcontent's default 20px
-// padding. But Jetpack's own CSS zeros out that padding (admin-static.scss,
-// _main.scss), so the -20px just shifts everything into the sidebar. Reset it.
+// AdminPage uses margin-inline-start: -20px to neutralize #wpcontent's
+// default 20px padding. But Jetpack's own CSS zeros out that padding
+// (admin-static.scss, _main.scss), so the -20px just shifts everything
+// into the sidebar. Reset it.
 // Double class for specificity over the CSS module rule.
 .jp-settings-admin-page.jp-settings-admin-page {
 	margin-left: 0;

--- a/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/settings-nav-tabs/style.scss
@@ -4,11 +4,9 @@
 // but not guaranteed here. Define a local fallback.
 $spacing-base: var(--spacing-base, 8px);
 
-// AdminPage uses margin-inline-start: -20px to neutralize #wpcontent's
-// default 20px padding. But Jetpack's own CSS zeros out that padding
-// (admin-static.scss, _main.scss), so the -20px just shifts everything
-// into the sidebar. Reset it.
-// Double class for specificity over the CSS module rule.
+// AdminPage's -20px neutralizes #wpcontent's default padding, which Jetpack's
+// own CSS already zeroes (admin-static.scss, _main.scss) — so it only shifts
+// everything into the sidebar. Double class beats the CSS module rule.
 .jp-settings-admin-page.jp-settings-admin-page {
 	margin-left: 0;
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -218,11 +218,9 @@ class Akismet_Admin_Chrome {
 				markup (#wpbody-content > #akismet-plugin-container > header/.akismet-lower/footer).
 				Scoped to both menu locations: jetpack_page_… and settings_page_…
 
-				The mixin uses physical `left`/`right` because its SCSS is compiled
-				through rtlcss, which emits a flipped stylesheet. This inline `<style>`
-				has no such build step, so it uses CSS logical properties
-				(`inset-inline-*`, `padding-inline-*`, `margin-inline`) to flip with the
-				admin menu under RTL locales. */
+				Logical properties throughout (`inset-inline-*`, `padding-inline-*`,
+				`margin-inline`), like the mixin, so this block flips with the admin
+				menu under RTL locales. */
 			body[class*="_page_akismet-key-config"] #wpcontent {
 				padding-inline-start: 0;
 			}

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -218,9 +218,7 @@ class Akismet_Admin_Chrome {
 				markup (#wpbody-content > #akismet-plugin-container > header/.akismet-lower/footer).
 				Scoped to both menu locations: jetpack_page_… and settings_page_…
 
-				Logical properties throughout (`inset-inline-*`, `padding-inline-*`,
-				`margin-inline`), like the mixin, so this block flips with the admin
-				menu under RTL locales. */
+				Logical properties throughout, like the mixin, so it flips under RTL. */
 			body[class*="_page_akismet-key-config"] #wpcontent {
 				padding-inline-start: 0;
 			}

--- a/projects/plugins/jetpack/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/jetpack/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Admin pages: Fix Jetpack dashboards overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/protect/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/protect/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/search/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/search/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/social/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/social/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page: Fix the dashboard overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/videopress/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/videopress/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Activity Log: Fix the page overlapping the admin menu in right-to-left languages.

--- a/projects/plugins/wpcomsh/changelog/jetpack-2497-admin-page-layout-logical-properties
+++ b/projects/plugins/wpcomsh/changelog/jetpack-2497-admin-page-layout-logical-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: Fix the dashboard overlapping the admin menu in right-to-left languages.


### PR DESCRIPTION
Fixes JETPACK-2497

## Proposed changes

`js-packages/base-styles/admin-page-layout.scss` pinned the wp-admin content column to the viewport with **physical** direction properties — `left` / `right` on `#wpbody-content` (plus the `.folded`, `.auto-fold` and `.is-nav-unification` offsets), `padding-left` on `#wpcontent`, and `margin-left` on `.jp-admin-page`.

In RTL, wp-admin renders `#adminmenumain` on the *inline-end* side, so those offsets pushed the column away from the menu on the side the menu no longer occupies: the page header was clipped and content ran underneath the admin menu. Verified live on the modernized Backup dashboard.

This converts every physical direction property in the mixin to its logical equivalent — `inset-inline-start` / `inset-inline-end`, `padding-inline-start`, `margin-inline-start`. The `$jp-sidebar-width-*` variables and every other declaration are unchanged; only the properties they feed change. Two comments that named a physical direction no longer present were reworded.

### The `AdminPage` neutralizer had to move with it

`AdminPage` carries a second physical margin on the very same node. `js-packages/components/components/admin-page/style.module.scss` sets `margin-left: -20px` (`-10px` at ≤782px) to cancel `#wpcontent`'s padding, and the hashed `.admin-page` class lands on the same element as `.jp-admin-page` (`components/admin-page/index.tsx:50`). Until now the mixin's reset cancelled it because both were `margin-left`.

Converting only the mixin would have *introduced* a bug rather than fixed one. In RTL `margin-inline-start: 0` computes to `margin-right: 0`, which leaves `margin-left: -20px` with no competitor at all: the element grows 20px past the column's inline-end edge and `#wpbody-content { overflow: hidden }` clips it. Webpack consumers were unaffected either way — rtlcss flips the physical rule to `margin-right`, so the reset still meets it — but every wp-build dashboard rendering `<AdminPage>` (Activity Log, Newsletter, Podcast, Scan, SEO, Social) would have kept a 20px inline-end clip in RTL. So the neutralizer is logical now too, and `js-packages/components` joins the PR.

### Hello Dolly, same blind spot

`text-align: right` on `:global(.jetpack-admin-page #dolly)` was the last physical direction property left in `style.module.scss`, and it fails in exactly the pipelines this PR is about: rtlcss flips it for webpack consumers, but the wp-build routes — and the two pages that hardcode the LTR bundle — never run rtlcss, so Dolly pinned to the inline-start edge in RTL. It is `end` now, which matches the Akismet inline mirror (`class-akismet-admin-chrome.php:204`) and is a no-op everywhere else: rtlcss passes `end` through, and `end` in RTL resolves to the same `left` the flipped `right` produced. Cosmetic, and only visible with Hello Dolly active.

Two comments that named the physical properties this branch removes were corrected at the same time (`class-akismet-admin-chrome.php`, `settings-nav-tabs/style.scss`). The Akismet one gave the mixin's physical properties as the *reason* its inline block diverges, which would have invited a revert.

### What actually made a dashboard safe

Worth knowing for review, because it is what decides the changelog scope below.

The safety net is not the webpack config — it is `Assets::register_script()`. `@automattic/jetpack-webpack-config` does run `WebpackRtlPlugin` (rtlcss) by default and emit a flipped `<base>.rtl.css`, but emitting the file loads nothing. `Assets::register_script()` is what swaps to it, and only when the file is actually there:

```php
// projects/packages/assets/src/class-assets.php:437-442
if ( is_rtl() ) {
	$rtlcsspath = substr( $csspath, 0, -4 ) . '.rtl.css';
	if ( file_exists( "$dir/$rtlcsspath" ) ) {
		$csspath = $rtlcsspath;
	}
}
```

A page was safe exactly when it enqueued through that helper *and* the flipped file existed. Two kinds of page fall outside it, and both were broken:

* **wp-build routes** emit no RTL variant at all — each route inlines its own SCSS into `build/routes/<route>/content.js` (`find build/routes -iname '*rtl*'` → nothing), so the `file_exists()` guard never fires and the physical offsets shipped unflipped.
* **Bare `wp_enqueue_style()` calls** bypass the helper even though rtlcss did emit the flipped file. Two `plugins/jetpack` pages hardcode the LTR filename: the AI page (`_inc/lib/admin-pages/class-jetpack-ai-page.php:368` → `_inc/build/jetpack-ai-admin.css`) and network admin (`class.jetpack-network.php:549` → `_inc/build/network-admin.css`). **Network admin is fully fixed here** — `_inc/client/network-admin.scss` is nothing but the mixin include, so making the mixin logical makes the whole stylesheet direction-agnostic and the hardcoded filename stops mattering.

  **The AI page only gets its layout column back.** This PR changes no PHP, so `class-jetpack-ai-page.php:368` still hardcodes the LTR bundle — and that bundle inlines `@wordpress/dataviews/build-style/style.css` (`_inc/client/ai/style.scss:6`), which carries ~39 physical direction declarations that stay unflipped in RTL. The column is fixed; the page is not. Routing that enqueue through `Assets::register_script()` (or hand-rolling the swap the way `packages/videopress` does) is tracked as JETPACK-2519 — it is PHP, and out of scope for a CSS-only change.

`packages/videopress` ran into this same gap before and hand-rolled the swap itself (`src/class-admin-ui.php:386`), which is why its own dashboard was already correct.

Logical properties are safe for every pipeline — rtlcss passes them through untouched, verified by diffing the two compiled bundles (see Testing instructions).

### Changelog scope

The two js-packages get their own entries. For the plugins, the question is which ones ship a surface that *actually* reached the broken code path.

Tracing each consumer of the mixin to the bundle it lands in:

| Consumer | Pipeline | Affected? |
| --- | --- | --- |
| `packages/activity-log` (`src/js/style.scss` ← `routes/dashboard/stage.tsx`) | wp-build only, no webpack config | **yes** |
| `packages/backup` (`src/dashboard/admin-shell.scss`) | wp-build routes | **yes** |
| `packages/forms` (`src/dashboard/wp-build/style.scss`) | wp-build routes | **yes** |
| `packages/newsletter` (`src/settings/style.scss` ← `routes/dashboard/stage.tsx`) | wp-build routes | **yes** |
| `packages/podcast` (`src/dashboard/style.scss` ← `routes/dashboard/stage.tsx`) | wp-build routes | **yes** |
| `packages/publicize` (`_inc/components/social-page.scss` ← `routes/dashboard/stage.tsx`) | wp-build routes | **yes** |
| `packages/scan` (`_inc/components/scan-page.scss` ← `routes/index/stage.tsx`) | wp-build routes | **yes** |
| `packages/seo` (`_inc/admin-page-layout.scss` ← `routes/*/stage.tsx`) | wp-build routes | **yes** |
| `plugins/jetpack` AI page, network admin | webpack, but enqueued with a bare `wp_enqueue_style()` that hardcodes the LTR file | **yes** |
| `packages/my-jetpack` | webpack + `Assets::register_script()` RTL swap | no |
| `packages/search` (dashboard) | webpack + `Assets::register_script()` RTL swap | no |
| `packages/videopress` (`src/dashboard/admin-shell.scss`) | separate **webpack** entry; `class-admin-ui.php` hand-rolls the RTL swap | no |
| `plugins/boost`, `plugins/protect` | webpack + `Assets::register_script()` RTL swap | no |

Mapping the affected packages to the plugins that register those pages:

**Entries added (10):**

* `js-packages/base-styles` and `js-packages/components` — the projects themselves.
* `plugins/jetpack` — registers Forms, Newsletter, SEO, Scan, Podcast, Social, Backup and Activity Log, every one a wp-build dashboard, plus the two bare-enqueue pages above.
* `plugins/social` — ships the modernized Social dashboard (`packages/publicize` wp-build route).
* `plugins/backup`, `plugins/boost`, `plugins/protect`, `plugins/search`, `plugins/videopress` — each calls `Jetpack_Activity_Log::initialize()`, so a site with only that plugin gets the (wp-build) Jetpack → Activity Log screen. All five entries are scoped to Activity Log and nothing else.
* `plugins/wpcomsh` — `Podcast_Admin_Page::add_wp_admin_submenu()` is called from exactly one place, `jetpack-mu-wpcom`'s `wpcom-admin-menu.php:457`, and wpcomsh requires `jetpack-mu-wpcom`, which requires `jetpack-podcast`. So on WoA the Podcast dashboard reaches the site through wpcomsh, whose changelog is that site's product record.

**Deliberately skipped:**

* `plugins/backup`'s *own* dashboard — the modernized Backup dashboard is gated on `rsm_jetpack_ui_modernization_backup`, which defaults to `false` (`packages/backup/src/class-jetpack-backup.php:1210`), so Backup plugin users cannot reach it yet. The entry claims Activity Log only.
* `plugins/videopress`'s *own* dashboard — its shell stylesheet is a webpack entry that already hand-rolls the RTL swap. That entry is scoped to Activity Log too.
* `plugins/stats` — bundles `packages/my-jetpack` but nothing else on this list, and does not register Activity Log. My Jetpack is webpack-built and already loads a flipped `index.rtl.css`.
* `plugins/mu-wpcom-plugin` and `plugins/starter-plugin` — per AGENTS.md, neither changelog is a product record.

## Related product discussion/links

* JETPACK-2497

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is CSS-only and needs a **right-to-left** admin locale to see. Set Settings → General → Site Language to Hebrew or Arabic (or set the user's own language), so `<body>` gets `dir="rtl"`.

**Before/after, on a modernized (wp-build) dashboard:**

1. Go to Jetpack → Activity Log (or Forms / Newsletter / Podcast / SEO / Scan / Social).
2. On trunk, the page header is clipped and the page content runs underneath the admin menu.
3. With this branch built, the content column sits flush beside the menu on the correct side, with no 20px overhang clipped at the inline-end edge.
4. Collapse the admin menu ("Collapse menu"), and resize the window through 960px and 782px — the column should track the sidebar width in each state (272px on WordPress.com nav-unification, 160px expanded, 36px folded/auto-fold, 0 below 782px).
5. Switch the site language back to English and confirm LTR is unchanged.

**Also worth a look in RTL:** on multisite, the Network Admin Jetpack page — broken for the same reason and fully fixed here. Jetpack → AI gets its layout column back too, but that page stays partly unflipped until its enqueue is fixed (see above), so do not read it as a clean before/after.

**No regression on the webpack-built dashboards** (My Jetpack, Search, VideoPress, Boost, Protect): visit each in RTL and confirm the layout is the same as before.

**Build-level check — the wp-build side now carries logical properties end to end:**

```bash
jp build js-packages/components && jp build packages/seo
grep -c "admin-page{margin-left:-20px" projects/packages/seo/build/routes/overview/content.js   # 0
grep -o "\.[_a-z0-9]*__admin-page{margin-inline-start:-20px}" projects/packages/seo/build/routes/overview/content.js
grep -o "#wpbody-content{[^}]*}" projects/packages/seo/build/routes/overview/content.js | head -1
```

The `#wpbody-content` rule comes out as `inset-inline-start: 160px; inset-inline-end: 0`, and the `AdminPage` neutralizer as `margin-inline-start: -20px` — so it now meets the mixin's reset in RTL instead of going uncontested.

**Build-level check — rtlcss still passes logical properties through unchanged:**

```bash
jp build plugins/protect
diff <(grep -o '\(inset\|margin\|padding\)-inline-\(start\|end\): *[^;}]*' projects/plugins/protect/build/index.css | sort) \
     <(grep -o '\(inset\|margin\|padding\)-inline-\(start\|end\): *[^;}]*' projects/plugins/protect/build/index.rtl.css | sort)
```

Empty — all 16 logical declarations are identical in the LTR and RTL bundles, so no double-flip is introduced. `.admin-page` now reads `margin-inline-start: -20px` in both, exactly where the RTL bundle used to read the rtlcss-flipped `margin-right: -20px`.

**Lint / types:**

```bash
pnpm run lint-style projects/js-packages/base-styles/admin-page-layout.scss \
                    projects/js-packages/components/components/admin-page/style.module.scss   # clean
pnpm run typecheck                                                                            # passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1YJKRY7dY68t2PkvowQrp

