### PR TITLE
Premium Analytics: localize detail-page published dates

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2076-detail-page-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show detail-page published dates in the site's language and date format.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2076-detail-page-dates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show detail-page published dates in the site's language and date format.
+Show published dates in the site's language and date format.

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -14,7 +14,7 @@
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "PA_TEST_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card || exit 1; done",
+		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card routes/detail-header || exit 1; done",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -14,7 +14,7 @@
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "PA_TEST_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card routes/detail-header || exit 1; done",
+		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card routes/detail-header routes/post-detail/components/post-header-slots routes/video-detail/components/video-header-slots || exit 1; done",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
@@ -24,3 +24,10 @@ export const siteSettingsIn = ( timeZone: string ): DateSettings => ( {
 	...DEFAULTS,
 	timezone: { ...DEFAULTS.timezone, string: timeZone },
 } );
+
+// The locale fixtures live with the formatter that owns `date_format` handling;
+// re-exported here so suites in this package keep one fixture entry point.
+export {
+	EN_US_SETTINGS,
+	ES_ES_SETTINGS,
+} from '../../../formatters/src/date/__fixtures__/wp-date-settings';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/__tests__/post-highlight-card.test.tsx
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
+import { EN_US_SETTINGS, ES_ES_SETTINGS } from '../../../__fixtures__/wp-date-settings';
 import { PostHighlightCard } from '../post-highlight-card';
 import type { PostHighlightCardProps } from '../post-highlight-card';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
@@ -57,7 +59,14 @@ const props: PostHighlightCardProps = {
 	],
 };
 
+// Captured before any suite installs its own, since `setSettings` is global and
+// this suite shares a module registry with the rest of its group.
+const BASE_SETTINGS = getSettings();
+
 describe( 'PostHighlightCard', () => {
+	beforeEach( () => setSettings( EN_US_SETTINGS ) );
+	afterEach( () => setSettings( BASE_SETTINGS ) );
+
 	it( 'links the title to the detail route and carries the report window', () => {
 		render(
 			<PostHighlightCard
@@ -114,6 +123,14 @@ describe( 'PostHighlightCard', () => {
 		expect( screen.getByText( 'Post published on Jun 5, 2026' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Views' ) ).toBeInTheDocument();
 		expect( screen.getByText( '42' ) ).toBeInTheDocument();
+	} );
+
+	it( "writes the publish date in the site's locale and date format", () => {
+		setSettings( ES_ES_SETTINGS );
+
+		render( <PostHighlightCard { ...props } /> );
+
+		expect( screen.getByText( 'Post published on 5 de jun de 2026' ) ).toBeInTheDocument();
 	} );
 
 	it( 'omits the publish line when the post has no date', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-highlight-card/post-highlight-card.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import { reportingTimeZone, toLocalTZ } from '@jetpack-premium-analytics/datetime';
+import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
+import { formatDate } from '@jetpack-premium-analytics/formatters';
 import { __, sprintf } from '@wordpress/i18n';
-import { format } from 'date-fns';
 /**
  * Internal dependencies
  */
@@ -104,10 +104,8 @@ function formatPublishDate( date: string ): string {
 		return '';
 	}
 
-	// Read the instant in the site's zone: a plain `Date` would format in the
-	// visitor's, showing a late-evening post on the next day east of the site.
-	const parsed = toLocalTZ( date, reportingTimeZone() );
-	const formatted = Number.isNaN( parsed.getTime() ) ? date : format( parsed, 'PP' );
+	const parsed = parseSiteDateTime( date );
+	const formatted = parsed ? formatDate( parsed, 'compact' ) : date;
 
 	return sprintf(
 		/* translators: %s: the post's publish date, e.g. "Jun 5, 2026". */

--- a/projects/packages/premium-analytics/routes/detail-header.test.ts
+++ b/projects/packages/premium-analytics/routes/detail-header.test.ts
@@ -1,8 +1,28 @@
+/**
+ * External dependencies
+ */
+import { setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import {
+	EN_US_SETTINGS,
+	ES_ES_SETTINGS,
+	utcDate,
+} from '../packages/formatters/src/date/__fixtures__/wp-date-settings';
 import { formatPublishedDate, performanceSentence } from './detail-header';
 
 describe( 'formatPublishedDate', () => {
+	beforeEach( () => setSettings( EN_US_SETTINGS ) );
+
 	it( 'reads an offset-less value as site wall time', () => {
 		expect( formatPublishedDate( '2026-01-10T08:00:00' ) ).toBe( 'Jan 10, 2026' );
+	} );
+
+	it( "follows the site's locale and date format", () => {
+		setSettings( ES_ES_SETTINGS );
+
+		expect( formatPublishedDate( '2026-01-10T08:00:00' ) ).toBe( '10 de ene de 2026' );
 	} );
 
 	it.each( [ undefined, '', 'not a date', '0000-00-00 00:00:00' ] )(
@@ -14,18 +34,29 @@ describe( 'formatPublishedDate', () => {
 } );
 
 describe( 'performanceSentence', () => {
+	beforeEach( () => setSettings( EN_US_SETTINGS ) );
+
 	it( 'names both bounds of the committed range', () => {
 		expect(
-			performanceSentence( { from: new Date( 2026, 6, 9 ), to: new Date( 2026, 6, 15 ) } )
+			performanceSentence( { from: utcDate( 2026, 7, 9 ), to: utcDate( 2026, 7, 15 ) } )
 		).toBe( 'Performance from Jul 9, 2026 to Jul 15, 2026' );
 	} );
 
-	// An unparseable bound would otherwise reach `format`, which throws on it.
+	it( "follows the site's locale and date format", () => {
+		setSettings( ES_ES_SETTINGS );
+
+		expect(
+			performanceSentence( { from: utcDate( 2026, 7, 9 ), to: utcDate( 2026, 7, 15 ) } )
+		).toBe( 'Performance from 9 de jul de 2026 to 15 de jul de 2026' );
+	} );
+
+	// An unparseable bound would otherwise reach `formatDate`, which renders it
+	// as "Invalid date".
 	it.each( [
 		[ 'no range', undefined ],
-		[ 'an open start', { from: undefined, to: new Date( 2026, 6, 15 ) } ],
-		[ 'an open end', { from: new Date( 2026, 6, 9 ), to: undefined } ],
-		[ 'an unparseable bound', { from: new Date( 'nope' ), to: new Date( 2026, 6, 15 ) } ],
+		[ 'an open start', { from: undefined, to: utcDate( 2026, 7, 15 ) } ],
+		[ 'an open end', { from: utcDate( 2026, 7, 9 ), to: undefined } ],
+		[ 'an unparseable bound', { from: new Date( 'nope' ), to: utcDate( 2026, 7, 15 ) } ],
 	] )( 'states nothing for %s', ( _label, range ) => {
 		expect( performanceSentence( range ) ).toBeUndefined();
 	} );

--- a/projects/packages/premium-analytics/routes/detail-header.test.ts
+++ b/projects/packages/premium-analytics/routes/detail-header.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { setSettings } from '@wordpress/date';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
@@ -12,11 +12,17 @@ import {
 } from '../packages/formatters/src/date/__fixtures__/wp-date-settings';
 import { formatPublishedDate, performanceSentence } from './detail-header';
 
-describe( 'formatPublishedDate', () => {
-	beforeEach( () => setSettings( EN_US_SETTINGS ) );
+// Captured before any suite installs its own, since `setSettings` is global and
+// these suites share a module registry with the rest of their group.
+const BASE_SETTINGS = getSettings();
 
+beforeEach( () => setSettings( EN_US_SETTINGS ) );
+afterEach( () => setSettings( BASE_SETTINGS ) );
+
+describe( 'formatPublishedDate', () => {
 	it( 'reads an offset-less value as site wall time', () => {
-		expect( formatPublishedDate( '2026-01-10T08:00:00' ) ).toBe( 'Jan 10, 2026' );
+		// Late enough that a browser-local read would name the 11th east of the site.
+		expect( formatPublishedDate( '2026-01-10T23:30:00' ) ).toBe( 'Jan 10, 2026' );
 	} );
 
 	it( "follows the site's locale and date format", () => {
@@ -34,8 +40,6 @@ describe( 'formatPublishedDate', () => {
 } );
 
 describe( 'performanceSentence', () => {
-	beforeEach( () => setSettings( EN_US_SETTINGS ) );
-
 	it( 'names both bounds of the committed range', () => {
 		expect(
 			performanceSentence( { from: utcDate( 2026, 7, 9 ), to: utcDate( 2026, 7, 15 ) } )
@@ -50,8 +54,6 @@ describe( 'performanceSentence', () => {
 		).toBe( 'Performance from 9 de jul de 2026 to 15 de jul de 2026' );
 	} );
 
-	// An unparseable bound would otherwise reach `formatDate`, which renders it
-	// as "Invalid date".
 	it.each( [
 		[ 'no range', undefined ],
 		[ 'an open start', { from: undefined, to: utcDate( 2026, 7, 15 ) } ],

--- a/projects/packages/premium-analytics/routes/detail-header.ts
+++ b/projects/packages/premium-analytics/routes/detail-header.ts
@@ -22,7 +22,9 @@ export function formatPublishedDate( publishedDate: string | undefined ): string
 /**
  * States the window every widget below the header reflects.
  *
- * @param range - The committed report date range.
+ * @param range - The committed report date range. Both bounds render in the
+ *              reporting timezone, so a browser-local `Date` names the previous
+ *              day west of the site.
  * @return The sentence, or undefined when either bound is missing or unparseable.
  */
 export function performanceSentence( range: DateRange | undefined ): string | undefined {

--- a/projects/packages/premium-analytics/routes/detail-header.ts
+++ b/projects/packages/premium-analytics/routes/detail-header.ts
@@ -2,15 +2,8 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { format, isValid } from 'date-fns';
-import {
-	parseSiteDateTime,
-	reportingTimeZone,
-	toLocalTZ,
-	type DateRange,
-} from '@jetpack-premium-analytics/datetime';
-
-const DATE_FORMAT = 'MMM d, yyyy';
+import { parseSiteDateTime, type DateRange } from '@jetpack-premium-analytics/datetime';
+import { formatDate } from '@jetpack-premium-analytics/formatters';
 
 /**
  * Formats a resource's publish date for the header, in the site timezone —
@@ -23,7 +16,7 @@ const DATE_FORMAT = 'MMM d, yyyy';
 export function formatPublishedDate( publishedDate: string | undefined ): string | undefined {
 	const parsed = parseSiteDateTime( publishedDate );
 
-	return parsed ? format( toLocalTZ( parsed, reportingTimeZone() ), DATE_FORMAT ) : undefined;
+	return parsed ? formatDate( parsed, 'compact' ) : undefined;
 }
 
 /**
@@ -33,16 +26,19 @@ export function formatPublishedDate( publishedDate: string | undefined ): string
  * @return The sentence, or undefined when either bound is missing or unparseable.
  */
 export function performanceSentence( range: DateRange | undefined ): string | undefined {
-	const { from, to } = range ?? {};
+	// Doubles as the validity check: an unparseable bound would otherwise reach
+	// `formatDate` and render as "Invalid date".
+	const from = parseSiteDateTime( range?.from );
+	const to = parseSiteDateTime( range?.to );
 
-	if ( ! from || ! to || ! isValid( from ) || ! isValid( to ) ) {
+	if ( ! from || ! to ) {
 		return undefined;
 	}
 
 	return sprintf(
 		/* translators: %1$s and %2$s: the report range bounds, e.g. "Jul 9, 2026". */
 		__( 'Performance from %1$s to %2$s', 'jetpack-premium-analytics-pkg' ),
-		format( from, DATE_FORMAT ),
-		format( to, DATE_FORMAT )
+		formatDate( from, 'compact' ),
+		formatDate( to, 'compact' )
 	);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-header-slots/post-header-slots.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-header-slots/post-header-slots.test.tsx
@@ -13,6 +13,13 @@ const SUMMARY: PostSummary = {
 	isError: false,
 };
 
+// UTC-anchored: the sentence renders in the site zone, so a browser-local
+// `Date` would name the previous day in zones west of it.
+const PERFORMANCE_RANGE = {
+	from: new Date( Date.UTC( 2026, 6, 9 ) ),
+	to: new Date( Date.UTC( 2026, 6, 15 ) ),
+};
+
 /**
  * Renders the slots where they are consumed, since only the header places them.
  *
@@ -36,7 +43,7 @@ describe( 'postHeaderSlots', () => {
 	it( 'states the window the widgets below report over', () => {
 		renderHeader( {
 			summary: SUMMARY,
-			performanceRange: { from: new Date( 2026, 6, 9 ), to: new Date( 2026, 6, 15 ) },
+			performanceRange: PERFORMANCE_RANGE,
 		} );
 
 		expect(

--- a/projects/packages/premium-analytics/routes/video-detail/components/video-header-slots/video-header-slots.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/components/video-header-slots/video-header-slots.test.tsx
@@ -13,6 +13,13 @@ const SUMMARY: VideoSummary = {
 	refetch: () => {},
 };
 
+// UTC-anchored: the sentence renders in the site zone, so a browser-local
+// `Date` would name the previous day in zones west of it.
+const PERFORMANCE_RANGE = {
+	from: new Date( Date.UTC( 2026, 6, 9 ) ),
+	to: new Date( Date.UTC( 2026, 6, 15 ) ),
+};
+
 /**
  * Renders the slots where they are consumed, since only the header places them.
  *
@@ -27,7 +34,7 @@ describe( 'videoHeaderSlots', () => {
 	it( 'states the upload date and the window the widgets below report over', () => {
 		renderHeader( {
 			summary: SUMMARY,
-			performanceRange: { from: new Date( 2026, 6, 9 ), to: new Date( 2026, 6, 15 ) },
+			performanceRange: PERFORMANCE_RANGE,
 		} );
 
 		expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent( 'Launch recap' );
@@ -56,7 +63,7 @@ describe( 'videoHeaderSlots', () => {
 	] )( 'names the page from %s and states no window', ( flag, heading ) => {
 		renderHeader( {
 			summary: { ...SUMMARY, [ flag ]: true },
-			performanceRange: { from: new Date( 2026, 6, 9 ), to: new Date( 2026, 6, 15 ) },
+			performanceRange: PERFORMANCE_RANGE,
 		} );
 
 		expect( screen.getByRole( 'heading', { level: 1 } ) ).toHaveTextContent( heading );

--- a/projects/plugins/jetpack/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/jetpack/changelog/wooa7s-2076-detail-page-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: Show detail-page published dates in the site's language and date format.

--- a/projects/plugins/jetpack/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/jetpack/changelog/wooa7s-2076-detail-page-dates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Premium Analytics: Show detail-page published dates in the site's language and date format.
+Premium Analytics: Show published dates in the site's language and date format.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2076-detail-page-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show detail-page published dates in the site's language and date format.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2076-detail-page-dates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show detail-page published dates in the site's language and date format.
+Show published dates in the site's language and date format.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2076-detail-page-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: Show detail-page published dates in the site's language and date format.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2076-detail-page-dates
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2076-detail-page-dates
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Premium Analytics: Show detail-page published dates in the site's language and date format.
+Premium Analytics: Show published dates in the site's language and date format.


### PR DESCRIPTION
Fixes WOOA7S-2076

## Proposed changes

* Route the detail-page header dates through `formatDate()` instead of date-fns with a hardcoded pattern, so they follow the site's language and `date_format`.
* Covers the post/page/email header (`Post published on …`), the video header (`Video uploaded on …`), the `Performance from X to Y` sentence, and `PostHighlightCard`'s publish line.
* Picks the `compact` named format, which keeps today's `Jan 10, 2026` shape on English sites — this is a localization fix, not a restyle.
* `parseSiteDateTime()` now doubles as the validity guard on the range bounds, which is what lets the date-fns import go.
* Pins an English and a Spanish site in `detail-header.test.ts`, and adds that suite to `test-tz`.

date-fns was handed no locale, so its output was always English in US order whatever the site said. The chart axes on those same pages *are* localized, because the charts provider gets `intlLocale()` — so a non-English site rendered a localized chart beside an English header date.

## Before / after

Post detail page on a local site set to Español with `date_format` `j \d\e F \d\e Y`.

| | Before | After |
|---|---|---|
| Header | ![before](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2076-detail-dates/before-header.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2076-detail-dates/after-header.png) |
| Page | ![before](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2076-detail-dates/before-full.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2076-detail-dates/after-full.png) |

The full-page shots show the mismatch this fixes: the chart axis below the header was already localized (`6 ago`, `1 sept`) while the header date read `Jul 16, 2026`.

## Related product discussion/links

* WOOA7S-2076

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set a site to a non-English locale under Settings → General, with a matching date format — e.g. Español and `j \d\e F \d\e Y`.
* Open a post detail page in Premium Analytics. The published date in the header should read day-first with a Spanish month (`16 de Jul de 2026`), not `Jul 16, 2026`, and should match how dates read elsewhere on the dashboard.
* Check the `Performance from … to …` bounds on the same line, and a video detail page (`Video uploaded on …`).
* Switch the site back to English and confirm the header dates are unchanged from trunk.

