### PR TITLE
Premium Analytics: try the design system Dialog for the feedback modal

### DIFF
--- a/projects/packages/premium-analytics/changelog/try-pa-feedback-modal-wp-ui-dialog
+++ b/projects/packages/premium-analytics/changelog/try-pa-feedback-modal-wp-ui-dialog
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Feedback modal: render with the design system Dialog and TextareaControl.

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -85,6 +85,7 @@ export {
 	Stack,
 	Tabs,
 	Text,
+	TextareaControl,
 	VisuallyHidden,
 } from '@wordpress/ui';
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
@@ -1,0 +1,6 @@
+// `Dialog.Content` has no bottom padding when a `Dialog.Footer` follows
+// and is the scroll container, so the last field's focus outline is
+// clipped. Give back the outline's reach: its offset plus its width.
+.body {
+	padding-block-end: calc(var(--wpds-border-width-focus) * 2);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
@@ -1,6 +1,6 @@
-// `Dialog.Content` has no bottom padding when a `Dialog.Footer` follows
-// and is the scroll container, so the last field's focus outline is
-// clipped. Give back the outline's reach: its offset plus its width.
+// TODO: drop when @wordpress/ui fixes this upstream. `Dialog.Content` loses its
+// bottom padding under a `Dialog.Footer` and also scrolls, clipping the last
+// field's focus outline; this gives back the outline's offset plus its width.
 .body {
 	padding-block-end: calc(var(--wpds-border-width-focus) * 2);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -90,6 +90,15 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 		[]
 	);
 
+	const handleOpenChange = useCallback(
+		( isOpen: boolean ) => {
+			if ( ! isOpen ) {
+				onClose();
+			}
+		},
+		[ onClose ]
+	);
+
 	const submit = useCallback( () => {
 		if ( rating === null ) {
 			return;
@@ -115,7 +124,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	}, [ comment, rating, trackEvent ] );
 
 	return (
-		<Dialog.Root open onOpenChange={ isOpen => ! isOpen && onClose() }>
+		<Dialog.Root open onOpenChange={ handleOpenChange }>
 			<Dialog.Popup size="medium">
 				<Dialog.Header>
 					<Dialog.Title>
@@ -162,7 +171,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 										label={ blockerQuestion }
 										value={ comment }
 										maxLength={ COMMENT_MAX_LENGTH }
-										onValueChange={ value => setComment( value ) }
+										onValueChange={ setComment }
 									/>
 								</Stack>
 							</Stack>

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -2,8 +2,15 @@
  * WordPress dependencies
  */
 import { submitStatsUserFeedback, type StatsFeedbackRating } from '@jetpack-premium-analytics/data';
-import { Button, Notice, Stack, Text } from '@jetpack-premium-analytics/externals';
-import { Modal, RadioControl, TextareaControl } from '@wordpress/components';
+import {
+	Button,
+	Dialog,
+	Notice,
+	Stack,
+	Text,
+	TextareaControl,
+} from '@jetpack-premium-analytics/externals';
+import { RadioControl } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
@@ -107,59 +114,75 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	}, [ comment, rating, trackEvent ] );
 
 	return (
-		<Modal
-			title={ __( 'Share your feedback', 'jetpack-premium-analytics-pkg' ) }
-			onRequestClose={ onClose }
-			size="medium"
-		>
-			{ hasSubmitted ? (
-				<Stack direction="column" gap="lg">
-					<Notice.Root intent="success">
-						<Notice.Description>
-							{ __( 'Thank you. This helps.', 'jetpack-premium-analytics-pkg' ) }
-						</Notice.Description>
-					</Notice.Root>
+		<Dialog.Root open onOpenChange={ isOpen => ! isOpen && onClose() }>
+			<Dialog.Popup size="medium">
+				<Dialog.Header>
+					<Dialog.Title>
+						{ __( 'Share your feedback', 'jetpack-premium-analytics-pkg' ) }
+					</Dialog.Title>
+					<Dialog.CloseIcon />
+				</Dialog.Header>
 
-					<Stack direction="row" gap="sm" justify="end">
-						<Button variant="solid" size="compact" onClick={ onClose }>
-							{ __( 'Done', 'jetpack-premium-analytics-pkg' ) }
-						</Button>
-					</Stack>
-				</Stack>
-			) : (
-				<Stack direction="column" gap="xl">
-					<Stack direction="column" gap="sm">
-						<Question>{ comparisonQuestion }</Question>
-						<RadioControl
-							hideLabelFromVision
-							label={ comparisonQuestion }
-							options={ ratingOptions() }
-							selected={ rating === null ? undefined : String( rating ) }
-							onChange={ selectRating }
-						/>
-					</Stack>
+				{ hasSubmitted ? (
+					<>
+						<Dialog.Content>
+							<Notice.Root intent="success">
+								<Notice.Description>
+									{ __( 'Thank you. This helps.', 'jetpack-premium-analytics-pkg' ) }
+								</Notice.Description>
+							</Notice.Root>
+						</Dialog.Content>
 
-					<Stack direction="column" gap="sm">
-						<Question>{ blockerQuestion }</Question>
-						<TextareaControl
-							hideLabelFromVision
-							label={ blockerQuestion }
-							value={ comment }
-							maxLength={ COMMENT_MAX_LENGTH }
-							onChange={ setComment }
-						/>
-					</Stack>
+						<Dialog.Footer>
+							<Dialog.Action variant="solid" size="compact">
+								{ __( 'Done', 'jetpack-premium-analytics-pkg' ) }
+							</Dialog.Action>
+						</Dialog.Footer>
+					</>
+				) : (
+					<>
+						<Dialog.Content>
+							<Stack direction="column" gap="xl">
+								<Stack direction="column" gap="sm">
+									<Question>{ comparisonQuestion }</Question>
+									<RadioControl
+										hideLabelFromVision
+										label={ comparisonQuestion }
+										options={ ratingOptions() }
+										selected={ rating === null ? undefined : String( rating ) }
+										onChange={ selectRating }
+									/>
+								</Stack>
 
-					<Stack direction="row" gap="sm" justify="end">
-						<Button variant="minimal" size="compact" onClick={ onClose }>
-							{ __( 'Cancel', 'jetpack-premium-analytics-pkg' ) }
-						</Button>
-						<Button variant="solid" size="compact" disabled={ rating === null } onClick={ submit }>
-							{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }
-						</Button>
-					</Stack>
-				</Stack>
-			) }
-		</Modal>
+								<Stack direction="column" gap="sm">
+									<Question>{ blockerQuestion }</Question>
+									<TextareaControl
+										hideLabelFromVision
+										label={ blockerQuestion }
+										value={ comment }
+										maxLength={ COMMENT_MAX_LENGTH }
+										onValueChange={ value => setComment( value ) }
+									/>
+								</Stack>
+							</Stack>
+						</Dialog.Content>
+
+						<Dialog.Footer>
+							<Dialog.Action variant="minimal" size="compact">
+								{ __( 'Cancel', 'jetpack-premium-analytics-pkg' ) }
+							</Dialog.Action>
+							<Button
+								variant="solid"
+								size="compact"
+								disabled={ rating === null }
+								onClick={ submit }
+							>
+								{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }
+							</Button>
+						</Dialog.Footer>
+					</>
+				) }
+			</Dialog.Popup>
+		</Dialog.Root>
 	);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
+import styles from './feedback-modal.module.scss';
 
 // Tracks drops an event whose properties are oversized, so a pasted essay would
 // cost us the rating too.
@@ -142,7 +143,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 				) : (
 					<>
 						<Dialog.Content>
-							<Stack direction="column" gap="xl">
+							<Stack className={ styles.body } direction="column" gap="xl">
 								<Stack direction="column" gap="sm">
 									<Question>{ comparisonQuestion }</Question>
 									<RadioControl


### PR DESCRIPTION


## Proposed changes

- Renders the Premium Analytics feedback modal with `Dialog` from `@wordpress/ui` instead of `Modal` from `@wordpress/components`.
- Swaps `TextareaControl` to the `@wordpress/ui` one, which Gutenberg's `use-recommended-components` rule points at.
- Exposes both through `packages/externals`, since that barrel owns every `@wordpress/ui` import in this package.

Exploratory, opened for the discussion in https://github.com/Automattic/jetpack/pull/51870#discussion_r3922683763. Draft on purpose: the trade-off below is the thing to decide, not the code.

**The cost.** `@wordpress/components` declares `wpScript`, so wp-build externalises it to the site's `wp-components` handle and `Modal` costs nothing. `@wordpress/ui` declares `wpScript: false`, so it is compiled into our `externals` module, which ships duplicated into `plugins/jetpack` and `jetpack-mu-wpcom`. Measured on this branch:

| `build/modules/externals/index.min.js` | minified     | gzip        |
| -------------------------------------- | ------------ | ----------- |
| trunk                                  | 1,924,931    | 477,199     |
| this branch                            | 1,996,429    | 487,332     |
| difference                             | **+69.8 KB** | **+9.9 KB** |

Most of that is `Dialog` pulling in `@base-ui/react/dialog`, which nothing else in the barrel uses.

**One visual difference, kept.** The `@wordpress/ui` field draws its focus ring as a separate blue outline outside the grey border, where the `@wordpress/components` one turns the border itself blue. That is the design system's own style and matches its Storybook, so it stays.

**One that needed a fix.** `Dialog.Content` drops its bottom padding when a `Dialog.Footer` follows it, and it is also the scroll container, so the outline on its last child was clipped along the bottom edge. The second commit gives the body back exactly the outline's reach, `calc(var(--wpds-border-width-focus) * 2)`. Worth raising upstream: any dialog whose content ends in a field hits this.

Also worth noting: Gutenberg's `use-recommended-components` rule treats `@wordpress/ui` as an allowlist, and `Dialog` is not on it yet.

## Related product discussion/links

- STATS-460

## Does this pull request change what data or activity we track or use?

No. The Tracks events and their properties are unchanged.

## Testing instructions

- Open **Stats v2** in wp-admin and click **Any feedback?** in the header.
- Check the dialog opens, the rating and comment work, **Send feedback** stays disabled until a rating is picked, and the thank-you state appears after sending.
- Check **Cancel**, the close icon, and <kbd>Esc</kbd> all close it, and that focus returns to the **Any feedback?** button.
- The existing test suite passes unchanged (`jetpack test js packages/premium-analytics`), including the `role="dialog"` and accessible-name assertions.

### Before / after

Captured in wp-admin at the same viewport.

| Before (`Modal`)                                                                                                     | After (`Dialog`)                                                                                                   |
| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/try/pa-feedback-modal-wp-ui-dialog/before-modal.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/try/pa-feedback-modal-wp-ui-dialog/after-modal.png) |

Focus ring on the comment field:

| Before (`@wordpress/components`)                                                                                     | After (`@wordpress/ui`)                                                                                            |
| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/try/pa-feedback-modal-wp-ui-dialog/before-focus.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/try/pa-feedback-modal-wp-ui-dialog/after-focus.png) |

