### PR TITLE
Premium Analytics: make the date test doubles match production

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2090-date-doubles
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2090-date-doubles
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Fix the Storybook and test doubles for Woo report dates; no user-facing change.
+
+

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/woo-bucket-stamp.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/woo-bucket-stamp.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { dateToISOStringWithTZ, toLocalTZ } from '@jetpack-premium-analytics/datetime';
+/**
+ * Internal dependencies
+ */
+import { FIXTURE_SITE_TIME_ZONE } from './wp-date-settings';
+
+/**
+ * A `Date` names a wall time here: the report generators build days with `Date.UTC`.
+ *
+ * @param value - Wall time, as a string or a UTC-built `Date`.
+ * @return The wall time as a naive ISO string.
+ */
+function wallTimeOf( value: string | Date ): string {
+	return value instanceof Date ? value.toISOString().slice( 0, 19 ) : value;
+}
+
+/**
+ * A Woo interval bound the way wpcom stamps it: ISO 8601 in the site's own zone.
+ *
+ * Deriving the offset from the zone is the point — a hardcoded one describes a
+ * payload the server cannot send, and would fail for the wrong reason.
+ *
+ * @param wallTime - Wall time in the site's zone, e.g. `2024-01-01` or `2024-01-01T23:59:59`.
+ * @param timeZone - The site's timezone.
+ * @return The stamp, e.g. `2024-01-01T00:00:00+09:00`.
+ */
+export function wooBucketStamp(
+	wallTime: string | Date,
+	timeZone: string = FIXTURE_SITE_TIME_ZONE
+): string {
+	// PHP's `format( 'c' )` carries no milliseconds.
+	const stamp = dateToISOStringWithTZ( toLocalTZ( wallTimeOf( wallTime ), timeZone ), timeZone );
+
+	return stamp.replace( /\.\d{3}(?=[+-]\d{2}:\d{2}$)/, '' );
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/__fixtures__/wp-date-settings.ts
@@ -6,6 +6,15 @@ import { getSettings, type DateSettings } from '@wordpress/date';
 const DEFAULTS = getSettings();
 
 /**
+ * The timezone every fixture site sits in.
+ *
+ * Non-UTC on purpose: on a UTC site a bucket stamp that honours its offset and
+ * one that discards it resolve to the same instant, so the fixture would prove
+ * nothing.
+ */
+export const FIXTURE_SITE_TIME_ZONE = 'Asia/Tokyo';
+
+/**
  * Settings for a site in a given timezone, on the US English defaults.
  *
  * @param timeZone - IANA zone name.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -10,7 +10,10 @@ import { useState } from 'react';
 /**
  * Internal dependencies
  */
+import { FIXTURE_SITE_TIME_ZONE } from '../../../__fixtures__/wp-date-settings';
+import { siteChartFormatting } from '../../../helpers';
 import { useChartTheme } from '../../../hooks';
+import { applyFixtureSiteSettings } from '../../../stories/fixture-site';
 import { ReportPageLayout } from '../report-page-layout';
 import { ReportPageShell } from '../report-page-shell';
 import { ReportPerformanceChart } from '../report-performance-chart';
@@ -20,6 +23,8 @@ import type { IntervalType, StatsTimeSeriesReport } from '@jetpack-premium-analy
 import type { ReportDateFilters } from '@jetpack-premium-analytics/routing';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { ComponentProps, ReactNode } from 'react';
+
+applyFixtureSiteSettings();
 
 /**
  * Build a deterministic 30-day visits report fixture. `offsetDays` shifts the
@@ -134,7 +139,11 @@ interface ReportPageStoryControls {
 function StoryChartProviders( { children }: { children: ReactNode } ) {
 	const chartTheme = useChartTheme();
 
-	return <GlobalChartsProvider theme={ chartTheme }>{ children }</GlobalChartsProvider>;
+	return (
+		<GlobalChartsProvider theme={ chartTheme } { ...siteChartFormatting() }>
+			{ children }
+		</GlobalChartsProvider>
+	);
 }
 
 const withChartProviders: Decorator = Story => (
@@ -157,7 +166,7 @@ function StoryBreadcrumbs() {
 	);
 }
 
-const STORY_TIMEZONE = 'America/New_York';
+const STORY_TIMEZONE = FIXTURE_SITE_TIME_ZONE;
 const STORY_RANGE = computePrimaryRange( 'last-30-days', STORY_TIMEZONE );
 
 // Stand-in for `useReportDateFilters`, which needs a mounted router. Inert:

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-time-series-chart-data.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-time-series-chart-data.test.ts
@@ -1,6 +1,13 @@
 /**
+ * External dependencies
+ */
+import { setSettings } from '@wordpress/date';
+import { format } from 'date-fns';
+/**
  * Internal dependencies
  */
+import { wooBucketStamp } from '../../__fixtures__/woo-bucket-stamp';
+import { FIXTURE_SITE_TIME_ZONE, siteSettingsIn } from '../../__fixtures__/wp-date-settings';
 import { buildTimeSeriesChartData } from '../build-time-series-chart-data';
 
 const primary = {
@@ -57,5 +64,39 @@ describe( 'buildTimeSeriesChartData', () => {
 
 		expect( series ).toHaveLength( 1 );
 		expect( series[ 0 ].label ).toBe( 'Views' );
+	} );
+} );
+
+describe( 'buildTimeSeriesChartData with Woo bucket stamps', () => {
+	beforeEach( () => {
+		setSettings( siteSettingsIn( FIXTURE_SITE_TIME_ZONE ) );
+	} );
+
+	const wooPrimary = {
+		summary: {
+			date_start: wooBucketStamp( '2026-05-01' ),
+			date_end: wooBucketStamp( '2026-05-02T23:59:59' ),
+		},
+		data: [
+			{ date_start: wooBucketStamp( '2026-05-01' ), views: 10 },
+			{ date_start: wooBucketStamp( '2026-05-02' ), views: 20 },
+		],
+	};
+
+	it( "stamps a bucket with the site's own offset", () => {
+		expect( wooPrimary.data[ 0 ].date_start ).toBe( '2026-05-01T00:00:00+09:00' );
+	} );
+
+	it( 'reads a bucket as midnight on the site, not on the runtime', () => {
+		const [ series ] = buildTimeSeriesChartData( {
+			primary: wooPrimary,
+			metricKey: 'views',
+			label: 'Views',
+		} );
+
+		expect( series.data.map( point => format( point.date, 'yyyy-MM-dd HH:mm' ) ) ).toEqual( [
+			'2026-05-01 00:00',
+			'2026-05-02 00:00',
+		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/fixture-site.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/fixture-site.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { FIXTURE_SITE_TIME_ZONE, siteSettingsIn } from '../__fixtures__/wp-date-settings';
+
+/**
+ * Give Storybook the site date settings a WordPress page would supply.
+ *
+ * Without them `siteChartFormatting()` reads an empty timezone and charts format
+ * their axes in UTC, so a reviewer never sees the site's own zone applied.
+ */
+export function applyFixtureSiteSettings(): void {
+	setSettings( siteSettingsIn( FIXTURE_SITE_TIME_ZONE ) );
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/bookings.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/bookings.ts
@@ -5,6 +5,7 @@
  *
  * This module provides dynamic fixture generation based on request parameters.
  */
+import { wooBucketStamp } from '../../../__fixtures__/woo-bucket-stamp';
 import { seededRandom } from './orders-by-product-type';
 import type { fetchReportBookings } from '../../../../../data/src/api/report-bookings-fetch/report-bookings-fetch';
 
@@ -85,10 +86,6 @@ function generateDateIntervals(
 	return intervals;
 }
 
-function formatISODate( date: Date ): string {
-	return date.toISOString().replace( /\.\d{3}Z$/, '+00:00' );
-}
-
 // `time_interval` is a date-only field.
 function formatDateOnly( date: Date ): string {
 	return date.toISOString().split( 'T' )[ 0 ];
@@ -106,8 +103,8 @@ function generateIntervalData(
 	if ( ! hasBookings ) {
 		return {
 			time_interval: formatDateOnly( start ),
-			date_start: formatISODate( start ),
-			date_end: formatISODate( end ),
+			date_start: wooBucketStamp( start ),
+			date_end: wooBucketStamp( end ),
 			status_unpaid: '0',
 			status_pending_confirmation: '0',
 			status_confirmed: '0',
@@ -144,8 +141,8 @@ function generateIntervalData(
 
 	return {
 		time_interval: formatDateOnly( start ),
-		date_start: formatISODate( start ),
-		date_end: formatISODate( end ),
+		date_start: wooBucketStamp( start ),
+		date_end: wooBucketStamp( end ),
 		status_unpaid: statusUnpaid.toString(),
 		status_pending_confirmation: statusPendingConfirmation.toString(),
 		status_confirmed: statusConfirmed.toString(),
@@ -202,8 +199,8 @@ function calculateSummary(
 		attendance_status_booked: totals.attendance_status_booked.toString(),
 		attendance_status_no_show: totals.attendance_status_no_show.toString(),
 		attendance_status_checked_in: totals.attendance_status_checked_in.toString(),
-		date_start: formatISODate( new Date( from ) ),
-		date_end: formatISODate( new Date( to ) ),
+		date_start: wooBucketStamp( new Date( from ) ),
+		date_end: wooBucketStamp( new Date( to ) ),
 	};
 }
 
@@ -261,8 +258,8 @@ export function recalculateBookingsSummary(
 			attendance_status_booked: '0',
 			attendance_status_no_show: '0',
 			attendance_status_checked_in: '0',
-			date_start: formatISODate( new Date( from ) ),
-			date_end: formatISODate( new Date( to ) ),
+			date_start: wooBucketStamp( new Date( from ) ),
+			date_end: wooBucketStamp( new Date( to ) ),
 		};
 	}
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/coupons.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/coupons.ts
@@ -8,6 +8,11 @@
  * - data: CouponsDataItem[]
  */
 
+/**
+ * Internal dependencies
+ */
+import { wooBucketStamp } from '../../../__fixtures__/woo-bucket-stamp';
+
 export type MockCouponsItem = {
 	coupon_code: string;
 	discount_amount: string;
@@ -58,8 +63,8 @@ export const mockCouponsData: MockCouponsResponse = {
 		total_sales: '45678.90',
 		total_discount_amount: '3456.78',
 		total_orders: '234',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [
 		{
@@ -97,8 +102,8 @@ export const mockCouponsComparisonData: MockCouponsResponse = {
 		total_sales: '38765.40',
 		total_discount_amount: '2890.12',
 		total_orders: '198',
-		date_start: '2023-12-01',
-		date_end: '2023-12-31',
+		date_start: wooBucketStamp( '2023-12-01' ),
+		date_end: wooBucketStamp( '2023-12-31T23:59:59' ),
 	},
 	data: [
 		{
@@ -142,14 +147,14 @@ export const mockCouponsByDateData: MockCouponsByDateResponse = {
 		total_discount_amount: '3456.78',
 		net_sales_after_discount: '42222.12',
 		coupon_usage_percentage: '40.60',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [
 		{
 			time_interval: '2024-01-01',
-			date_start: '2024-01-01',
-			date_end: '2024-01-10',
+			date_start: wooBucketStamp( '2024-01-01' ),
+			date_end: wooBucketStamp( '2024-01-10T23:59:59' ),
 			total_orders: '78',
 			orders_with_coupon: '31',
 			orders_without_coupon: '47',
@@ -162,8 +167,8 @@ export const mockCouponsByDateData: MockCouponsByDateResponse = {
 		},
 		{
 			time_interval: '2024-01-11',
-			date_start: '2024-01-11',
-			date_end: '2024-01-20',
+			date_start: wooBucketStamp( '2024-01-11' ),
+			date_end: wooBucketStamp( '2024-01-20T23:59:59' ),
 			total_orders: '81',
 			orders_with_coupon: '34',
 			orders_without_coupon: '47',
@@ -176,8 +181,8 @@ export const mockCouponsByDateData: MockCouponsByDateResponse = {
 		},
 		{
 			time_interval: '2024-01-21',
-			date_start: '2024-01-21',
-			date_end: '2024-01-31',
+			date_start: wooBucketStamp( '2024-01-21' ),
+			date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 			total_orders: '75',
 			orders_with_coupon: '30',
 			orders_without_coupon: '45',
@@ -205,14 +210,14 @@ export const mockCouponsByDateComparisonData: MockCouponsByDateResponse = {
 		total_discount_amount: '2890.12',
 		net_sales_after_discount: '35875.28',
 		coupon_usage_percentage: '38.38',
-		date_start: '2023-12-01',
-		date_end: '2023-12-31',
+		date_start: wooBucketStamp( '2023-12-01' ),
+		date_end: wooBucketStamp( '2023-12-31T23:59:59' ),
 	},
 	data: [
 		{
 			time_interval: '2023-12-01',
-			date_start: '2023-12-01',
-			date_end: '2023-12-10',
+			date_start: wooBucketStamp( '2023-12-01' ),
+			date_end: wooBucketStamp( '2023-12-10T23:59:59' ),
 			total_orders: '64',
 			orders_with_coupon: '25',
 			orders_without_coupon: '39',
@@ -225,8 +230,8 @@ export const mockCouponsByDateComparisonData: MockCouponsByDateResponse = {
 		},
 		{
 			time_interval: '2023-12-11',
-			date_start: '2023-12-11',
-			date_end: '2023-12-20',
+			date_start: wooBucketStamp( '2023-12-11' ),
+			date_end: wooBucketStamp( '2023-12-20T23:59:59' ),
 			total_orders: '68',
 			orders_with_coupon: '26',
 			orders_without_coupon: '42',
@@ -239,8 +244,8 @@ export const mockCouponsByDateComparisonData: MockCouponsByDateResponse = {
 		},
 		{
 			time_interval: '2023-12-21',
-			date_start: '2023-12-21',
-			date_end: '2023-12-31',
+			date_start: wooBucketStamp( '2023-12-21' ),
+			date_end: wooBucketStamp( '2023-12-31T23:59:59' ),
 			total_orders: '66',
 			orders_with_coupon: '25',
 			orders_without_coupon: '41',
@@ -262,8 +267,8 @@ export const mockCouponsEmptyData: MockCouponsResponse = {
 		total_sales: '0',
 		total_discount_amount: '0',
 		total_orders: '0',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [],
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/customers.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/customers.ts
@@ -8,6 +8,11 @@
  * - data: CustomersNewReturningItem[]
  */
 
+/**
+ * Internal dependencies
+ */
+import { wooBucketStamp } from '../../../__fixtures__/woo-bucket-stamp';
+
 export type MockCustomersItem = {
 	customer_type: 'new' | 'returning';
 	net_sales: string;
@@ -37,8 +42,8 @@ export const mockCustomersData: MockCustomersResponse = {
 		total_orders: '456',
 		new_customer_sales: '34567.89',
 		returning_customer_sales: '53086.43',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [
 		{
@@ -63,8 +68,8 @@ export const mockCustomersComparisonData: MockCustomersResponse = {
 		total_orders: '389',
 		new_customer_sales: '28901.23',
 		returning_customer_sales: '43444.44',
-		date_start: '2023-12-01',
-		date_end: '2023-12-31',
+		date_start: wooBucketStamp( '2023-12-01' ),
+		date_end: wooBucketStamp( '2023-12-31T23:59:59' ),
 	},
 	data: [
 		{
@@ -89,8 +94,8 @@ export const mockCustomersEmptyData: MockCustomersResponse = {
 		total_orders: '0',
 		new_customer_sales: '0',
 		returning_customer_sales: '0',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [],
 };
@@ -183,8 +188,8 @@ export const mockCustomersByDateData: MockCustomersByDateResponse = {
 		returning_customer_orders: '267',
 		returning_customer_avg_order_value: '198.83',
 		returning_customer_avg_items_per_order: '2.5',
-		date_start: '2024-01-01',
-		date_end: '2024-01-31',
+		date_start: wooBucketStamp( '2024-01-01' ),
+		date_end: wooBucketStamp( '2024-01-31T23:59:59' ),
 	},
 	data: [],
 };
@@ -218,8 +223,8 @@ export const mockCustomersByDateComparisonData: MockCustomersByDateResponse = {
 		returning_customer_orders: '221',
 		returning_customer_avg_order_value: '196.58',
 		returning_customer_avg_items_per_order: '2.4',
-		date_start: '2023-12-01',
-		date_end: '2023-12-31',
+		date_start: wooBucketStamp( '2023-12-01' ),
+		date_end: wooBucketStamp( '2023-12-31T23:59:59' ),
 	},
 	data: [],
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/orders-by-product-type.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/orders-by-product-type.ts
@@ -7,6 +7,7 @@
  *
  * This module provides dynamic fixture generation based on request parameters.
  */
+import { wooBucketStamp } from '../../../__fixtures__/woo-bucket-stamp';
 import type { fetchReportOrders } from '../../../../../data/src/api/report-orders-fetch/report-orders-fetch';
 
 /**
@@ -106,10 +107,6 @@ function generateDateIntervals(
 	return intervals;
 }
 
-function formatISODate( date: Date ): string {
-	return date.toISOString().replace( /\.\d{3}Z$/, '+00:00' );
-}
-
 // `time_interval` is a date-only field.
 function formatDateOnly( date: Date ): string {
 	return date.toISOString().split( 'T' )[ 0 ];
@@ -127,8 +124,8 @@ function generateIntervalData(
 	if ( ! hasOrders ) {
 		return {
 			time_interval: formatDateOnly( start ),
-			date_start: formatISODate( start ),
-			date_end: formatISODate( end ),
+			date_start: wooBucketStamp( start ),
+			date_end: wooBucketStamp( end ),
 			orders_no: '0',
 			orders_value_net: '0.0',
 			orders_value_gross: '0.0',
@@ -169,8 +166,8 @@ function generateIntervalData(
 
 	return {
 		time_interval: formatDateOnly( start ),
-		date_start: formatISODate( start ),
-		date_end: formatISODate( end ),
+		date_start: wooBucketStamp( start ),
+		date_end: wooBucketStamp( end ),
 		orders_no: ordersNo.toString(),
 		orders_value_net: ordersValueNet.toFixed( 2 ),
 		orders_value_gross: ordersValueGross.toFixed( 2 ),
@@ -250,8 +247,8 @@ function calculateSummary(
 		paid_net_sales: totals.paid_net_sales.toFixed( 2 ),
 		unpaid_orders_count: totals.unpaid_orders_count.toString(),
 		unpaid_net_sales: totals.unpaid_net_sales.toFixed( 2 ),
-		date_start: formatISODate( new Date( from ) ),
-		date_end: formatISODate( new Date( to ) ),
+		date_start: wooBucketStamp( new Date( from ) ),
+		date_end: wooBucketStamp( new Date( to ) ),
 	};
 }
 
@@ -331,8 +328,8 @@ export function recalculateSummary(
 			paid_net_sales: '0.0',
 			unpaid_orders_count: '0',
 			unpaid_net_sales: '0.0',
-			date_start: formatISODate( new Date( from ) ),
-			date_end: formatISODate( new Date( to ) ),
+			date_start: wooBucketStamp( new Date( from ) ),
+			date_end: wooBucketStamp( new Date( to ) ),
 		};
 	}
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -13,6 +13,7 @@ import { differenceInCalendarDays, isValid, parseISO } from 'date-fns';
 /**
  * Internal dependencies
  */
+import { wooBucketStamp } from '../../__fixtures__/woo-bucket-stamp';
 import {
 	mockOrderAttributionDeviceData,
 	mockOrderAttributionByProductDeviceData,
@@ -468,8 +469,8 @@ function buildVisitorsByDateResponse( query: URLSearchParams ) {
 		sessionsTotal += activeSessions;
 
 		return {
-			date_start: date.toISOString(),
-			date_end: toDayEnd( date ).toISOString(),
+			date_start: wooBucketStamp( date ),
+			date_end: wooBucketStamp( toDayEnd( date ) ),
 			time_interval: date.toISOString(),
 			active_sessions: String( activeSessions ),
 			visitors: String( visitors ),
@@ -480,8 +481,8 @@ function buildVisitorsByDateResponse( query: URLSearchParams ) {
 		summary: {
 			active_sessions: String( sessionsTotal ),
 			visitors: String( visitorsTotal ),
-			date_start: from.toISOString(),
-			date_end: toDayEnd( new Date( from.getTime() + ( days - 1 ) * DAY_MS ) ).toISOString(),
+			date_start: wooBucketStamp( from ),
+			date_end: wooBucketStamp( toDayEnd( new Date( from.getTime() + ( days - 1 ) * DAY_MS ) ) ),
 		},
 		data,
 	};
@@ -522,8 +523,8 @@ function buildCustomersByDateRows( query: URLSearchParams, isComparison: boolean
 
 		return {
 			time_interval: date.toISOString(),
-			date_start: date.toISOString(),
-			date_end: toDayEnd( date ).toISOString(),
+			date_start: wooBucketStamp( date ),
+			date_end: wooBucketStamp( toDayEnd( date ) ),
 			total_customers: String( totalCustomers ),
 			new_customers: String( newCustomers ),
 			returning_customers: String( totalCustomers - newCustomers ),
@@ -585,8 +586,8 @@ function buildConversionRateResponse( query: URLSearchParams ) {
 		totals.completed_checkout += completedCheckout;
 
 		return {
-			date_start: date.toISOString(),
-			date_end: toDayEnd( date ).toISOString(),
+			date_start: wooBucketStamp( date ),
+			date_end: wooBucketStamp( toDayEnd( date ) ),
 			time_interval: date.toISOString(),
 			active_sessions: String( activeSessions ),
 			visitors: String( visitors ),
@@ -603,8 +604,8 @@ function buildConversionRateResponse( query: URLSearchParams ) {
 			with_cart_addition: String( totals.with_cart_addition ),
 			reached_checkout: String( totals.reached_checkout ),
 			completed_checkout: String( totals.completed_checkout ),
-			date_start: from.toISOString(),
-			date_end: toDayEnd( new Date( from.getTime() + ( days - 1 ) * DAY_MS ) ).toISOString(),
+			date_start: wooBucketStamp( from ),
+			date_end: wooBucketStamp( toDayEnd( new Date( from.getTime() + ( days - 1 ) * DAY_MS ) ) ),
 		},
 		data,
 	};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-chart-theme.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-chart-theme.tsx
@@ -1,19 +1,26 @@
 import { GlobalChartsProvider } from '@jetpack-premium-analytics/externals';
+import { siteChartFormatting } from '../helpers';
 import { useChartTheme } from '../hooks';
+import { applyFixtureSiteSettings } from './fixture-site';
 import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';
 
+applyFixtureSiteSettings();
+
 /**
- * Wraps children in a `GlobalChartsProvider` seeded with the Woo chart theme.
- * Mirrors what `WidgetRoot` does in the app, where the provider lives at the
- * top of the widget tree.
+ * Wraps children in a `GlobalChartsProvider` seeded with the Woo chart theme and
+ * the site's chart formatting, as `WidgetRoot` does in the app.
  *
  * @return The themed chart provider wrapping `children`.
  */
 const ChartThemeProvider = ( { children }: { children: ReactNode } ) => {
 	const theme = useChartTheme();
 
-	return <GlobalChartsProvider theme={ theme }>{ children }</GlobalChartsProvider>;
+	return (
+		<GlobalChartsProvider theme={ theme } { ...siteChartFormatting() }>
+			{ children }
+		</GlobalChartsProvider>
+	);
 };
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-widget-root.tsx
@@ -1,13 +1,16 @@
 import { getDefaultQueryParams, normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { WidgetRoot } from '../components/widget-root/widget-root';
+import { applyFixtureSiteSettings } from './fixture-site';
 import { registerReportMocks } from './mocks/register-report-mocks';
 import type { Decorator } from '@storybook/react';
 
 /*
- * Register the report-data `apiFetch` mock middleware as soon as this module is
- * imported. Any story using `withWidgetRoot()` therefore gets mocked report data
- * automatically, with no per-story wiring. `registerReportMocks` is idempotent.
+ * Seed the site and register the report-data `apiFetch` mock middleware as soon
+ * as this module is imported. Any story using `withWidgetRoot()` therefore gets
+ * the site's timezone and mocked report data automatically, with no per-story
+ * wiring. `registerReportMocks` is idempotent.
  */
+applyFixtureSiteSettings();
 registerReportMocks();
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/stage.test.tsx
@@ -19,9 +19,23 @@ jest.mock( '@jetpack-premium-analytics/externals', () => ( {
 	Stack: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
 } ) );
 
+const mockChartFormatting = { locale: 'en-US', timeZone: 'Asia/Tokyo' };
+
 jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
-	GlobalChartsProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
-	siteChartFormatting: () => ( {} ),
+	GlobalChartsProvider: ( {
+		children,
+		locale,
+		timeZone,
+	}: {
+		children: ReactNode;
+		locale?: string;
+		timeZone?: string;
+	} ) => (
+		<div data-testid="charts-provider" data-locale={ locale } data-time-zone={ timeZone }>
+			{ children }
+		</div>
+	),
+	siteChartFormatting: () => mockChartFormatting,
 	useChartTheme: () => ( {} ),
 } ) );
 
@@ -55,5 +69,14 @@ describe( 'Report stage report scope', () => {
 		render( <ReportStage /> );
 
 		await expect( screen.findByText( 'no comparison' ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( "formats charts with the site's locale and timezone", async () => {
+		render( <ReportStage /> );
+
+		const provider = await screen.findByTestId( 'charts-provider' );
+
+		expect( provider ).toHaveAttribute( 'data-locale', mockChartFormatting.locale );
+		expect( provider ).toHaveAttribute( 'data-time-zone', mockChartFormatting.timeZone );
 	} );
 } );


### PR DESCRIPTION

## Proposed changes
* Woo report fixtures stamped their interval bounds three different wrong ways: a bare `2024-01-01` (coupons, customers), a UTC `Z` from `toISOString()` (the visitors / customers-by-date / conversion-rate generators), and a literal `+00:00` (bookings, orders-by-product-type). wpcom stamps `analytics/reports/*` rows with PHP's `format( 'c' )`, so they arrive as `2026-05-01T00:00:00+09:00`, in the site's own timezone.
* Adds `wooBucketStamp()`, which derives the offset from the fixture site's zone instead of hardcoding it, and routes every Woo fixture through it. A hardcoded offset would describe a payload the server cannot send.
* Storybook mounted `GlobalChartsProvider` with the theme only, so axis labels were formatted in the reviewer's runtime zone rather than the site's. Both story decorators and the report-page stories now pass `siteChartFormatting()` and seed the site date settings a WordPress page would supply.
* `stage.test.tsx` mocked `siteChartFormatting` to `{}`, which asserted nothing and would not have noticed the spread being dropped. It now asserts the locale and timezone reach the provider.
* Adds coverage for the offset-bearing path in `build-time-series-chart-data`, which had none: its own test fed bare dates.

This is groundwork for WOOA7S-2077, which changes how bucket stamps are read and will be judged by these tests passing.

## Related product discussion/links
* WOOA7S-2090

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `cd projects/packages/premium-analytics && pnpm run test` — everything passes; the new cases live in `packages/widgets-toolkit/src/helpers/__tests__/build-time-series-chart-data.test.ts` and `routes/reports/stage.test.tsx`.
* Run Storybook (`pnpm run storybook` from the package) and open a Woo chart widget, e.g. **Packages/Premium Analytics/Widgets Toolkit/SalesByCoupon**. Axis labels and tooltips now read in the fixture site's timezone (`Asia/Tokyo`) rather than your machine's.
* Set your machine to a zone far from UTC before and after to see the difference: on trunk the axis follows your machine, on this branch it does not.
