### PR TITLE
Premium Analytics: carry the reporting timezone on the normalized report

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2089-report-timezone
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2089-report-timezone
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor: the reporting timezone is carried on the normalized report instead of read from the environment mid-normalization.
+
+

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-report.test.tsx
@@ -86,6 +86,34 @@ describe( 'useReport', () => {
 		expect( calls[ 1 ].params ).not.toHaveProperty( 'compare_from' );
 	} );
 
+	it( 'records the reporting zone the params named', () => {
+		const queryFactory = (): UseQueryOptions< unknown > => ( {
+			queryKey: [ 'test-report' ],
+			queryFn: async () => ( { summary: {}, data: [] } ),
+			enabled: false,
+		} );
+
+		const { result } = renderHook(
+			() =>
+				useReport(
+					queryFactory,
+					{
+						from: '2026-06-01',
+						to: '2026-06-07',
+						compare_from: '2026-05-01',
+						compare_to: '2026-05-07',
+						comp: '1',
+						interval: 'day',
+						timezone: 'Asia/Kolkata',
+					},
+					{ enabled: false }
+				),
+			{ wrapper }
+		);
+
+		expect( result.current.timezone ).toBe( 'Asia/Kolkata' );
+	} );
+
 	it( 'awaits data when only the comparison window moves, leaving primary untouched', async () => {
 		// Deliberate: the whole widget skeletons even though the primary numbers
 		// never went stale, because the deltas on screen did — showing one

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
+import { resolveReportTimeZone, type ReportTimeZoneParams } from '../utils/report-timezone';
 import { hasComparisonEnabled, type ReportParams } from '../utils/search';
 import { isAwaitingData } from './awaiting-data';
 import { REFRESH_NOTICE_META } from './refresh-failure-scope';
@@ -25,11 +26,10 @@ type QueryFactory< TData > = (
  * query is driven by the comparison dates in `params`; when it is disabled the
  * query still mounts, parked on `options.disabledComparisonKey`.
  */
-export function useReport< TData, TParams extends ReportParams = ReportParams >(
-	queryFactory: QueryFactory< TData >,
-	params: TParams,
-	options?: UseReportOptions
-) {
+export function useReport<
+	TData,
+	TParams extends ReportParams & ReportTimeZoneParams = ReportParams,
+>( queryFactory: QueryFactory< TData >, params: TParams, options?: UseReportOptions ) {
 	const queryEnabled = options?.enabled ?? true;
 	const comparisonEnabled = hasComparisonEnabled( params );
 	const primaryParams = { ...params };
@@ -99,6 +99,9 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 		primary,
 		comparison,
 		hasComparison: comparisonEnabled,
+		// The zone both queries were built and normalized under, so a consumer
+		// reads the report it has rather than asking the environment again.
+		timezone: resolveReportTimeZone( params.timezone ),
 		isLoading,
 		isFetching,
 		hasData,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/streak.test.ts
@@ -1,41 +1,27 @@
-import { getSettings, setSettings } from '@wordpress/date';
 import { sanitizeStatsStreakResponse } from '..';
 import { streakFixture } from '../__fixtures__/streak';
+import type { StatsSanitizerParams } from '../../../utils/stats-params';
 
-const DEFAULTS = getSettings();
-
-const withTimezone = ( timezone: { offset: number; string: string } ) =>
-	setSettings( {
-		...DEFAULTS,
-		timezone: { ...timezone, offsetFormatted: String( timezone.offset ), abbr: '' },
-	} );
+const inZone = ( timezone: string ) => ( { timezone } ) as StatsSanitizerParams;
 
 describe( 'Stats streak normalizer', () => {
-	afterEach( () => setSettings( DEFAULTS ) );
-
 	it( 'normalizes timestamp counts into date buckets', () => {
-		withTimezone( { offset: 0, string: 'UTC' } );
-
-		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
+		expect( sanitizeStatsStreakResponse( streakFixture, inZone( 'UTC' ) ) ).toEqual( {
 			'2016-04-29': 2,
 			'2016-04-30': 1,
 		} );
 	} );
 
-	it( 'buckets by the site calendar day, not the UTC one', () => {
+	it( 'buckets by the report calendar day, not the UTC one', () => {
 		// The fixture's later timestamps are 23:30 UTC, so an India site has already
 		// turned the page on both of them.
-		withTimezone( { offset: 5.5, string: 'Asia/Kolkata' } );
-
-		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
+		expect( sanitizeStatsStreakResponse( streakFixture, inZone( 'Asia/Kolkata' ) ) ).toEqual( {
 			'2016-04-29': 1,
 			'2016-04-30': 1,
 			'2016-05-01': 1,
 		} );
 
-		withTimezone( { offset: -4, string: 'America/New_York' } );
-
-		expect( sanitizeStatsStreakResponse( streakFixture ) ).toEqual( {
+		expect( sanitizeStatsStreakResponse( streakFixture, inZone( 'America/New_York' ) ) ).toEqual( {
 			'2016-04-28': 1,
 			'2016-04-29': 1,
 			'2016-04-30': 1,
@@ -44,43 +30,37 @@ describe( 'Stats streak normalizer', () => {
 
 	it( 'buckets a half-hour zone by its own midnight', () => {
 		// 2016-04-29 18:45 UTC is 00:15 the next day in India.
-		withTimezone( { offset: 5.5, string: 'Asia/Kolkata' } );
-
-		expect( sanitizeStatsStreakResponse( { data: { 1461955500: 1 } } ) ).toEqual( {
-			'2016-04-30': 1,
-		} );
+		expect(
+			sanitizeStatsStreakResponse( { data: { 1461955500: 1 } }, inZone( 'Asia/Kolkata' ) )
+		).toEqual( { '2016-04-30': 1 } );
 	} );
 
-	it( 'falls back to the site offset when there is no named timezone', () => {
-		withTimezone( { offset: 5.5, string: '' } );
-
-		expect( sanitizeStatsStreakResponse( { data: { 1461955500: 1 } } ) ).toEqual( {
-			'2016-04-30': 1,
-		} );
+	it( 'accepts an offset zone as well as a named one', () => {
+		expect(
+			sanitizeStatsStreakResponse( { data: { 1461955500: 1 } }, inZone( '+05:30' ) )
+		).toEqual( { '2016-04-30': 1 } );
 	} );
 
 	it( 'follows the zone across a DST change', () => {
 		// New York is a day behind UTC on both, under EDT for the first and EST for
-		// the second: the reported -4 offset puts the second on 2016-01-01.
-		withTimezone( { offset: -4, string: 'America/New_York' } );
-
-		expect( sanitizeStatsStreakResponse( { data: { 1467343800: 1 } } ) ).toEqual( {
-			'2016-06-30': 1,
-		} );
-		expect( sanitizeStatsStreakResponse( { data: { 1451622600: 1 } } ) ).toEqual( {
-			'2015-12-31': 1,
-		} );
+		// the second: a pinned -4 offset would put the second on 2016-01-01.
+		expect(
+			sanitizeStatsStreakResponse( { data: { 1467343800: 1 } }, inZone( 'America/New_York' ) )
+		).toEqual( { '2016-06-30': 1 } );
+		expect(
+			sanitizeStatsStreakResponse( { data: { 1451622600: 1 } }, inZone( 'America/New_York' ) )
+		).toEqual( { '2015-12-31': 1 } );
 	} );
 
 	it( 'skips keys that are not timestamps', () => {
-		withTimezone( { offset: 0, string: 'UTC' } );
-
-		expect( sanitizeStatsStreakResponse( { data: { total: 5, 1461889800: 1 } } ) ).toEqual( {
-			'2016-04-29': 1,
-		} );
+		expect(
+			sanitizeStatsStreakResponse( { data: { total: 5, 1461889800: 1 } }, inZone( 'UTC' ) )
+		).toEqual( { '2016-04-29': 1 } );
 	} );
 
 	it( 'returns an empty response for malformed data', () => {
-		expect( sanitizeStatsStreakResponse( { data: [ 1461889800 ] } ) ).toEqual( {} );
+		expect( sanitizeStatsStreakResponse( { data: [ 1461889800 ] }, inZone( 'UTC' ) ) ).toEqual(
+			{}
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/streak.ts
@@ -1,8 +1,8 @@
 import { tz } from '@date-fns/tz';
-import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
 import { format, fromUnixTime } from 'date-fns';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsRecord } from './utils';
+import type { StatsSanitizerParams } from '../../utils/stats-params';
 
 export type StatsStreakResponse = Record< string, number >;
 
@@ -11,11 +11,14 @@ export type StatsStreakRawResponse = {
 	data?: Record< string, number >;
 };
 
-export function sanitizeStatsStreakResponse( response: unknown ): StatsStreakResponse {
+export function sanitizeStatsStreakResponse(
+	response: unknown,
+	query: StatsSanitizerParams
+): StatsStreakResponse {
 	const data = coerceStatsRecord( coerceStatsRecord( response ).data );
 	// Keyed by instant, not by day, so the calendar day is resolved here. By zone
 	// rather than by offset: a fixed offset is a day out either side of a DST change.
-	const zone = tz( reportingTimeZone() );
+	const zone = tz( query.timezone );
 	const streak: StatsStreakResponse = {};
 
 	for ( const [ timestamp, count ] of Object.entries( data ) ) {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -37,6 +37,7 @@ import { statsInsightsQuery } from '../stats-insights-query';
 import { statsLocationsQuery } from '../stats-locations-query';
 import { statsPostCommentsQuery } from '../stats-post-comments-query';
 import { statsPostQuery } from '../stats-post-query';
+import { statsProxyQuery } from '../stats-query';
 import { statsReferrersQuery } from '../stats-referrers-query';
 import { statsSearchTermsQuery } from '../stats-search-terms-query';
 import { statsSingleVideoQuery } from '../stats-single-video-query';
@@ -116,6 +117,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'referrers',
+			'UTC',
 		] );
 	} );
 
@@ -137,6 +139,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'post',
+			'UTC',
 		] );
 	} );
 
@@ -170,6 +173,7 @@ describe( 'Stats query factories', () => {
 			{ number: 10, type: 'comment', status: 'approved', order: 'DESC' },
 			undefined,
 			'postComments',
+			'UTC',
 		] );
 		expect( query.enabled ).toBe( true );
 	} );
@@ -193,6 +197,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'emailBreakdown',
+			'UTC',
 		] );
 	} );
 
@@ -208,6 +213,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'emailBreakdown',
+			'UTC',
 		] );
 	} );
 
@@ -234,6 +240,7 @@ describe( 'Stats query factories', () => {
 			undefined,
 			'emailTimeSeries',
 			{ window_start: '2026-06-01', window_end: '2026-06-07' },
+			'UTC',
 		] );
 	} );
 
@@ -352,6 +359,7 @@ describe( 'Stats query factories', () => {
 			expect.objectContaining( { filter_by_country: 'US' } ),
 			undefined,
 			'locations',
+			'UTC',
 		] );
 	} );
 
@@ -384,6 +392,7 @@ describe( 'Stats query factories', () => {
 			expect.objectContaining( { date: '2026-06-16' } ),
 			undefined,
 			'locations',
+			'UTC',
 		] );
 	} );
 
@@ -449,6 +458,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'fileDownloads',
+			'UTC',
 		] );
 		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
 	} );
@@ -497,6 +507,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'searchTerms',
+			'UTC',
 		] );
 		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
 	} );
@@ -525,6 +536,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'clicks',
+			'UTC',
 		] );
 		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
 	} );
@@ -562,6 +574,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'videoPlays',
+			'UTC',
 		] );
 	} );
 
@@ -628,6 +641,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'tags',
+			'UTC',
 		] );
 	} );
 
@@ -643,6 +657,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'tags',
+			'UTC',
 		] );
 	} );
 
@@ -659,6 +674,7 @@ describe( 'Stats query factories', () => {
 			{ max: 10 },
 			undefined,
 			'tags',
+			'UTC',
 		] );
 	} );
 
@@ -667,7 +683,17 @@ describe( 'Stats query factories', () => {
 	it( 'never sends a date on the tags query, whatever the selected period', () => {
 		const tagsQueryKey = ( period: Record< string, unknown > ) =>
 			statsTagsQuery( { max: 10, ...period } ).queryKey;
-		const maxOnly = [ 'stats', 'tags', '1.1', 'stats/tags', 'GET', { max: 10 }, undefined, 'tags' ];
+		const maxOnly = [
+			'stats',
+			'tags',
+			'1.1',
+			'stats/tags',
+			'GET',
+			{ max: 10 },
+			undefined,
+			'tags',
+			'UTC',
+		];
 
 		expect( tagsQueryKey( { to: '2026-01-31T23:59:59.999-08:00' } ) ).toEqual( maxOnly );
 		expect( tagsQueryKey( { date: '2026-06-30', period: 'year', days: 365 } ) ).toEqual( maxOnly );
@@ -690,6 +716,7 @@ describe( 'Stats query factories', () => {
 			expect.objectContaining( { date: '2026-06-16' } ),
 			undefined,
 			'devices',
+			'UTC',
 		] );
 	} );
 
@@ -724,6 +751,7 @@ describe( 'Stats query factories', () => {
 			} ),
 			undefined,
 			'commentFollowers',
+			'UTC',
 		] );
 		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'period' );
 	} );
@@ -791,6 +819,7 @@ describe( 'Stats query factories', () => {
 			{ type: 'all', filter_admin: false, max: 10 },
 			undefined,
 			'followers',
+			'UTC',
 		] );
 	} );
 
@@ -810,6 +839,7 @@ describe( 'Stats query factories', () => {
 			{ type: 'wpcom', filter_admin: true, max: 20 },
 			undefined,
 			'followers',
+			'UTC',
 		] );
 	} );
 
@@ -830,6 +860,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'emailSummary',
+			'UTC',
 		] );
 	} );
 
@@ -873,6 +904,7 @@ describe( 'Stats query factories', () => {
 			{ period: 'month' },
 			undefined,
 			'singleVideo',
+			'UTC',
 		] );
 	} );
 
@@ -1031,6 +1063,7 @@ describe( 'Stats query factories', () => {
 			{ source: 'stats-feedback' },
 			undefined,
 			'highlights',
+			'UTC',
 		] );
 		expect( query.staleTime ).toBe( STATS_HIGHLIGHTS_STALE_TIME );
 	} );
@@ -1047,6 +1080,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'comments',
+			'UTC',
 		] );
 	} );
 
@@ -1114,6 +1148,7 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'subscribers',
+			'UTC',
 		] );
 	} );
 
@@ -1146,6 +1181,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'subscribersCounts',
+			'UTC',
 		] );
 	} );
 
@@ -1227,6 +1263,7 @@ describe( 'Stats query factories', () => {
 				period: 'month',
 				date: '2026-06-30',
 			},
+			'UTC',
 		] );
 	} );
 
@@ -1448,6 +1485,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'wordAdsEarnings',
+			'UTC',
 		] );
 	} );
 
@@ -1515,6 +1553,7 @@ describe( 'Stats query factories', () => {
 			undefined,
 			'utm',
 			{ utm_param: 'utm_campaign,utm_source,utm_medium' },
+			'UTC',
 		] );
 		expect( query.enabled ).toBe( true );
 	} );
@@ -1599,6 +1638,7 @@ describe( 'Stats query factories', () => {
 			{},
 			undefined,
 			'insights',
+			'UTC',
 		] );
 	} );
 
@@ -1624,11 +1664,49 @@ describe( 'Stats query factories', () => {
 			},
 			undefined,
 			'streak',
+			'UTC',
 		] );
 	} );
 
 	it( 'disables streak queries until start and end dates are available', () => {
 		expect( statsStreakQuery( {} as StatsReportParams ).enabled ).toBe( false );
+	} );
+
+	it( 'normalizes a streak response in the reporting timezone, without requesting it', async () => {
+		// 2016-04-29 23:30 UTC has already turned the page in India.
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { string: 'Asia/Kolkata', offset: 5.5, offsetFormatted: '5.5', abbr: 'IST' },
+		} );
+		mockApiFetch.mockResolvedValueOnce( { data: { 1461972600: 1 } } );
+
+		try {
+			const query = statsStreakQuery( { from: '2026-06-01', to: '2026-06-30', interval: 'day' } );
+			const queryFn = query.queryFn as () => Promise< unknown >;
+
+			await expect( queryFn() ).resolves.toEqual( { '2016-04-30': 1 } );
+			expect( mockApiFetch.mock.calls[ 0 ][ 0 ].path ).not.toContain( 'timezone' );
+		} finally {
+			setSettings( settings );
+		}
+	} );
+
+	it( 'lets the query params name the reporting zone, overriding the environment', async () => {
+		// The file pins the environment to UTC, where the same instant is the 29th.
+		mockApiFetch.mockResolvedValueOnce( { data: { 1461972600: 1 } } );
+
+		const query = statsProxyQuery( {
+			name: 'streak',
+			version: '1.1',
+			endpoint: 'stats/streak',
+			params: { timezone: 'Asia/Kolkata' },
+			sanitizer: 'streak',
+		} );
+		const queryFn = query.queryFn as () => Promise< unknown >;
+
+		await expect( queryFn() ).resolves.toEqual( { '2016-04-30': 1 } );
+		expect( mockApiFetch.mock.calls[ 0 ][ 0 ].path ).not.toContain( 'timezone' );
 	} );
 
 	it( 'builds the published state query against the WPCOM proxy endpoint', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -41,11 +41,13 @@ import {
 	sanitizeStatsWordAdsEarningsResponse,
 	sanitizeStatsWordAdsStatsResponse,
 } from '../processing/stats';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import {
 	reportParamsToStatsQueryParams,
 	statsQueryParamsToApiParams,
 	type StatsQueryParams,
 	type StatsQueryParamFields,
+	type StatsSanitizerParams,
 } from '../utils/stats-params';
 import type { ReportParams } from '../utils/search';
 import type { UseQueryOptions } from '@tanstack/react-query';
@@ -53,7 +55,10 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 // `StatsProxyParams` is deliberately left out: its string index signature conflicts
 // with `ReportParams.filters`. Extras reach the proxy through `extraParams` instead.
 export type StatsReportParams = ReportParams & StatsQueryParamFields;
-type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQueryParams ) => TData;
+type StatsSanitizer< TData = unknown > = (
+	response: unknown,
+	params: StatsSanitizerParams
+) => TData;
 
 type StatsReportQuerySettings = {
 	/**
@@ -140,6 +145,7 @@ export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOpt
 	} = config;
 	const sanitizer = config.sanitizer ?? 'passthrough';
 	const apiParams = statsQueryParamsToApiParams( params );
+	const timezone = resolveReportTimeZone( params?.timezone );
 
 	return {
 		queryKey: [
@@ -152,6 +158,7 @@ export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOpt
 			body,
 			sanitizer,
 			...( sanitizerParams ? [ sanitizerParams ] : [] ),
+			timezone,
 		],
 		queryFn: async () => {
 			const response = await fetchStatsProxy( {
@@ -164,6 +171,7 @@ export function statsProxyQuery( config: StatsQueryConfig ): StatsReportQueryOpt
 			return statsSanitizers[ sanitizer ]( response, {
 				...apiParams,
 				...sanitizerParams,
+				timezone,
 			} );
 		},
 		enabled,

--- a/projects/packages/premium-analytics/packages/data/src/utils/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/index.ts
@@ -11,6 +11,7 @@ export { getDefaultIntervalForPeriod } from './interval';
 export { safeParseInt, safeParseFloat } from './parsing';
 export { computeDateRangeFromPreset } from './preset-date-range';
 export { hasProductFilters } from './product-filters';
+export { resolveReportTimeZone, type ReportTimeZoneParams } from './report-timezone';
 export { saveBlob } from './save-blob';
 export { toPostId } from './to-post-id';
 export { withoutComparison } from './without-comparison';

--- a/projects/packages/premium-analytics/packages/data/src/utils/report-timezone.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/report-timezone.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { reportingTimeZone } from '@jetpack-premium-analytics/datetime';
+
+/** Params naming the zone a report is built and read in. */
+export type ReportTimeZoneParams = { timezone?: string };
+
+/**
+ * The reporting timezone for one report, decided once where its query is built.
+ *
+ * The only place the data layer asks the environment: everything downstream
+ * takes the zone as a value, so a normalized report can be read back without
+ * replaying what the environment said when it was built.
+ *
+ * @param timezone - A zone the params already name, if any.
+ * @return An IANA zone name, or a `±HH:MM` offset.
+ */
+export function resolveReportTimeZone( timezone?: string ): string {
+	return timezone ?? reportingTimeZone();
+}

--- a/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/stats-params.ts
@@ -34,9 +34,15 @@ export type StatsQueryParamFields = {
 	// — deliberately absent from statsParamKeys so it can never reach a request.
 	window_start?: string;
 	window_end?: string;
+	// Sanitizer-only, and stripped alongside the trim window: the zone the
+	// report is normalized in, resolved once by `statsProxyQuery`.
+	timezone?: string;
 };
 
 export type StatsQueryParams = StatsProxyParams & StatsQueryParamFields;
+
+/** What a response sanitizer is handed: the request params, plus the report's zone. */
+export type StatsSanitizerParams = StatsQueryParams & { timezone: string };
 
 type StatsQueryParamInput = Partial< ReportParams > & {
 	[ key: string ]: unknown;
@@ -174,12 +180,13 @@ export function reportParamsToStatsQueryParams(
 }
 
 export function statsQueryParamsToApiParams( params: StatsQueryParams = {} ): StatsProxyParams {
-	// window_start/window_end are sanitizer-only (see StatsQueryParamFields);
-	// stripped here so a stray one can't leak into request URLs or query keys.
+	// window_start/window_end/timezone are sanitizer-only (see StatsQueryParamFields);
+	// stripped here so a stray one can't leak into a request URL.
 	const { end_date: endDate, ...apiParams } = params;
 
 	delete apiParams.window_start;
 	delete apiParams.window_end;
+	delete apiParams.timezone;
 
 	return {
 		...apiParams,


### PR DESCRIPTION
## Proposed changes

Stats sanitizers fold Unix timestamps into calendar days, and which day you get depends on the
timezone. `sanitizeStatsStreakResponse` read that zone from the environment while normalizing, so
the zone never reached the React Query key: a result cached under one zone could be served back
under another. This resolves the zone once where the query is built and passes it down as a value.
No behaviour change, it is the same value every call site already resolved to.

* `statsProxyQuery` resolves the reporting timezone once and hands it to the sanitizer.
* `sanitizeStatsStreakResponse` takes the zone as a parameter instead of reading the environment.
* `timezone` becomes a sanitizer-only field like `window_start`/`window_end`: stripped from the request URL, kept on the query key because it changes what the sanitizer emits.
* `useReport` records the zone on the report it returns (`report.timezone`), and `useStatsReport` passes it through.
* An IANA zone name is threaded, never an offset, so a range crossing a DST boundary still buckets correctly.
* Finishes WOOA7S-1978 steps 2 and 3, and unblocks WOOA7S-2077's `resolveBucketStamp( stamp, zone )`, which has nowhere to get a zone from until this lands.

Scope note: `parseBucketStart` and `siteChartFormatting` still read the environment; the first is deleted by WOOA7S-2077 step 2, the second runs at the app root, above any report.

## Related product discussion/links
* WOOA7S-2089

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `jetpack test js packages/premium-analytics` passes (156 suites, 3104 tests).
* `pnpm run test-tz` in `projects/packages/premium-analytics` runs the date-sensitive suites under `America/Los_Angeles` and `Asia/Tokyo`; both pass.
* `pnpm run typecheck` in the same directory passes.
* On a site whose timezone is not UTC, confirm the Posting activity widget still buckets by the site's calendar day, and that the `stats/streak` request carries no `timezone` param.
