### PR TITLE
CI: raise job timeouts while pnpm/action-setup is slow

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -79,7 +79,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 		'script'  => 'test-php',
 		'php'     => $phpver,
 		'wp'      => $wp,
-		'timeout' => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
+		'timeout' => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~7 minutes.
 	);
 }
 
@@ -89,7 +89,7 @@ $matrix[] = array(
 	'script'           => 'test-php',
 	'php'              => '7.4',
 	'wp'               => 'latest',
-	'timeout'          => 15, // 2025-11-06: Successful runs seem to take ~3 minutes.
+	'timeout'          => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~3 minutes.
 	'with-woocommerce' => true,
 );
 
@@ -99,7 +99,7 @@ $matrix[] = array(
 	'script'       => 'test-php',
 	'php'          => '8.3',
 	'wp'           => 'latest',
-	'timeout'      => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
+	'timeout'      => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~7 minutes.
 	'with-wpcomsh' => true,
 );
 
@@ -107,7 +107,7 @@ $matrix[] = array(
 $matrix[] = array(
 	'name'    => 'JS tests',
 	'script'  => 'test-js',
-	'timeout' => 15, // 2025-11-06: Successful runs seem to take ~5 minutes.
+	'timeout' => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~5 minutes.
 );
 
 // Add Coverage tests. Split into PHP and JS groups so they run in parallel.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   prepare:
     name: Prepare build matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2026-04-07: Should take about a minute.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     permissions:
       # actions/checkout
       contents: read

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
   create-test-matrix:
     name: "Determine tests matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2025-11-20: The pnpm install may take a few minutes on cache miss.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     # Only run tests in the main repository
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     outputs:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -30,7 +30,7 @@ jobs:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    timeout-minutes: 5  # 2026-05-21: Successful runs take 1–2 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     # See above.
     concurrency:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 3  # 2025-11-06: Successful runs seem to take ~1 minute
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     strategy:
       fail-fast: false
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -325,7 +325,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -355,7 +355,7 @@ jobs:
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.php_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
@@ -393,7 +393,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all JS deps to ensure valid linting.
+    timeout-minutes: 20  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -418,7 +418,7 @@ jobs:
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.js_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
@@ -450,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.css == 'true' || needs.changed_files.outputs.misc_css == 'true'
-    timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -474,7 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -507,7 +507,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.excludelist == 'true'
-    timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -529,7 +529,7 @@ jobs:
     name: Changelogger use
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       # We don't need full git history, but tools/check-changelogger-use.php does need everything up to the merge-base.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -554,7 +554,7 @@ jobs:
   changelogger_valid:
     name: Changelogger validity
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -576,7 +576,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -610,7 +610,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools
@@ -624,7 +624,7 @@ jobs:
   project_structure:
     name: Project structure
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # 2025-11-06: Takes a minute or two.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -680,7 +680,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 10 # 2025-11-20: Takes around 3 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take ~2 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -324,7 +324,7 @@ jobs:
   publish-coverage-data:
     name: Publish coverage data
     runs-on: ubuntu-latest
-    timeout-minutes: 10 # 2025-11-20 Takes about 2 minutes.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     needs: run-tests
     if: always() && needs.run-tests.outputs.did-coverage == 'true' && github.repository == 'Automattic/jetpack' && ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name == 'push' && github.ref == 'refs/heads/trunk' )
     steps:
@@ -420,7 +420,7 @@ jobs:
   plugin-deps:
     name: Check plugin monorepo dep versions
     runs-on: ubuntu-latest
-    timeout-minutes: 5 # 2025-11-20: Takes less than a minute.
+    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools


### PR DESCRIPTION
## Proposed changes

- Give every job that runs `Setup tools` enough budget to absorb a slow `pnpm/action-setup`: small jobs go to 15 minutes, ESLint to 20, and the test matrix entries that were timing out get +10.
- Temporary, revert once `pnpm/action-setup` is back to normal.

The `Setup pnpm` step is taking up to 7 minutes today, against about 20 seconds yesterday. All of it sits inside that step's `npm ci`, which logged `added 1 package in 7m`, while pnpm's own download a second later took under a second, so it looks specific to npm rather than the runner's network. Nothing else changed: `pnpm install` and the lint steps match yesterday's timings, and every other sub-step of `Setup tools` is under 10 seconds. That alone took the ESLint timeout rate from 2% (2 of 124 runs) to 43% (20 of 47), and it is now cancelling required checks across linting, tests, build and gardening. The step is slow rather than stuck, so a bigger budget does let the jobs finish.

Sizing is the job's own runtime plus the 7.5 minutes of setup, with a little margin. Jobs already at 15 or more, and the matrix entries at 20 and 30, are left alone because their existing budgets already cover it.

## Related product discussion/links

- Reported in #jetpack-releases.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Verified on a branch carrying the same ESLint change plus a throwaway JS file: the job finished in 11m45s, of which `Setup pnpm` was 4m38s. The old 10 minute cap would have cancelled it.
- CI here should show the previously cancelled checks running to completion. ESLint only runs when JS files change, so it stays skipped on this PR.
- `Manage labels and assignees` runs on `pull_request_target`, which uses the workflow from `trunk`, so its new budget only takes effect once this is merged.
