### PR TITLE
Help Center: add article-rating proxy endpoint

### DIFF
--- a/projects/packages/help-center/AGENTS.md
+++ b/projects/packages/help-center/AGENTS.md
@@ -47,6 +47,7 @@ All routes are registered under the `help-center` namespace (`/wp-json/help-cent
 | `/support-availability/email`                         | GET    | `Email_Support_Enabled`     | `GET /help/eligibility/email/mine`            | Check email support eligibility       |
 | `/fetch-post`                                         | GET    | `Fetch_Post`                | `GET /help/article/{blog_id}/{post_id}`       | Fetch a single support article        |
 | `/articles`                                           | GET    | `Fetch_Post`                | `GET /help/articles?blog_id=...&post_ids=...` | Fetch multiple support articles       |
+| `/article-rating`                                     | POST   | `Article_Rating`            | `POST /help/article/rating`                   | Save the user's rating of an article  |
 | `/forum/new`                                          | POST   | `Forum`                     | `POST /help/forum/new`                        | Create a forum topic                  |
 | `/jetpack-connection-health`                          | GET    | `Jetpack_Connection_Health` | `GET /sites/{site}/jetpack-connection-health` | Site connection health (reachability) |
 | `/jetpack-search/ai/search`                           | GET    | `Jetpack_Search_AI`         | `GET /sites/{site}/jetpack-search/ai/search`  | AI-powered article search             |

--- a/projects/packages/help-center/changelog/add-help-center-article-rating
+++ b/projects/packages/help-center/changelog/add-help-center-article-rating
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `/help-center/article-rating` endpoint so the Help Center can save a user's "Was this helpful?" answer for a support article.

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -557,6 +557,10 @@ class Help_Center {
 		$controller = new WP_REST_Help_Center_Fetch_Post( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
+		require_once __DIR__ . '/class-wp-rest-help-center-article-rating.php';
+		$controller = new WP_REST_Help_Center_Article_Rating( $this->wpcom_request_client );
+		$controller->register_rest_route();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-ticket.php';
 		$controller = new WP_REST_Help_Center_Ticket( $this->wpcom_request_client );
 		$controller->register_rest_route();

--- a/projects/packages/help-center/src/class-wp-rest-help-center-article-rating.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-article-rating.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WP_REST_Help_Center_Article_Rating file.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+namespace Automattic\Jetpack\Help_Center;
+
+/**
+ * Class WP_REST_Help_Center_Article_Rating.
+ *
+ * Proxies the "Was this helpful?" rating of a support article to WordPress.com,
+ * so wp-admin users get the same per-user rating memory as Calypso users.
+ */
+class WP_REST_Help_Center_Article_Rating extends WP_REST_Help_Center_Controller {
+	/**
+	 * WP_REST_Help_Center_Article_Rating constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 */
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
+		$this->namespace = 'help-center';
+		$this->rest_base = '/article-rating';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'save_rating' ),
+				'permission_callback' => '__return_true',
+				'args'                => array(
+					'blog_id' => array(
+						'required' => true,
+						'type'     => 'integer',
+					),
+					'post_id' => array(
+						'required' => true,
+						'type'     => 'integer',
+					),
+					'rating'  => array(
+						'required' => true,
+						'enum'     => array( 1, 2 ),
+						'type'     => 'integer',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Forward the rating to WordPress.com and return the rating on record.
+	 *
+	 * @param \WP_REST_Request $request The request sent to the API.
+	 */
+	public function save_rating( \WP_REST_Request $request ) {
+		$body = $this->wpcom_request_client->request(
+			'/help/article/rating',
+			'2',
+			array( 'method' => 'POST' ),
+			array(
+				'blog_id' => $request['blog_id'],
+				'post_id' => $request['post_id'],
+				'rating'  => $request['rating'],
+			)
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		return rest_ensure_response( json_decode( wp_remote_retrieve_body( $body ) ) );
+	}
+}

--- a/projects/packages/help-center/src/class-wp-rest-help-center-article-rating.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-article-rating.php
@@ -76,6 +76,14 @@ class WP_REST_Help_Center_Article_Rating extends WP_REST_Help_Center_Controller 
 			return $body;
 		}
 
-		return rest_ensure_response( json_decode( wp_remote_retrieve_body( $body ) ) );
+		$response = rest_ensure_response( json_decode( wp_remote_retrieve_body( $body ) ) );
+
+		// Pass the WordPress.com status through so clients see upstream failures as failures.
+		$status = (int) wp_remote_retrieve_response_code( $body );
+		if ( $status > 0 ) {
+			$response->set_status( $status );
+		}
+
+		return $response;
 	}
 }

--- a/projects/packages/help-center/tests/php/Article_Rating_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Article_Rating_Request_Test.php
@@ -15,9 +15,10 @@ class Article_Rating_Request_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Create a request client that captures the proxied request and returns the given response.
 	 *
+	 * The return type is left to inference so Phan knows about the anonymous class's `requests` property.
+	 *
 	 * @param int    $code Upstream HTTP status code.
 	 * @param string $body Upstream response body.
-	 * @return Wpcom_Request_Client
 	 */
 	private function create_request_client( $code, $body ) {
 		return new class( $code, $body ) implements Wpcom_Request_Client {

--- a/projects/packages/help-center/tests/php/Article_Rating_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Article_Rating_Request_Test.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Tests for the article rating proxy endpoint.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Article_Rating;
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+/**
+ * Class Article_Rating_Request_Test
+ */
+class Article_Rating_Request_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Create a request client that captures the proxied request and returns the given response.
+	 *
+	 * @param int    $code Upstream HTTP status code.
+	 * @param string $body Upstream response body.
+	 * @return Wpcom_Request_Client
+	 */
+	private function create_request_client( $code, $body ) {
+		return new class( $code, $body ) implements Wpcom_Request_Client {
+			/**
+			 * Captured requests.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			/**
+			 * Upstream HTTP status code.
+			 *
+			 * @var int
+			 */
+			private $code;
+
+			/**
+			 * Upstream response body.
+			 *
+			 * @var string
+			 */
+			private $body;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $code Upstream HTTP status code.
+			 * @param string $body Upstream response body.
+			 */
+			public function __construct( $code, $body ) {
+				$this->code = $code;
+				$this->body = $body;
+			}
+
+			public function is_user_connected() {
+				return true;
+			}
+
+			public function request(
+				$path,
+				$version = '2',
+				$args = array(),
+				$body = null,
+				$base_api_path = 'wpcom'
+			) {
+				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+				return array(
+					'headers'  => array(),
+					'body'     => $this->body,
+					'response' => array(
+						'code'    => $this->code,
+						'message' => '',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		};
+	}
+
+	/**
+	 * Build a rating request.
+	 *
+	 * @param int $rating Rating value.
+	 * @return \WP_REST_Request
+	 */
+	private function create_rating_request( $rating ) {
+		$request = new \WP_REST_Request( 'POST', '/help-center/article-rating' );
+		$request->set_param( 'blog_id', 9619154 );
+		$request->set_param( 'post_id', 185130 );
+		$request->set_param( 'rating', $rating );
+
+		return $request;
+	}
+
+	public function test_forwards_rating_to_wpcom_and_returns_the_rating_on_record() {
+		$wpcom_request_client = $this->create_request_client( 200, '{"user_rating":2}' );
+
+		$controller = new WP_REST_Help_Center_Article_Rating( $wpcom_request_client );
+		$response   = $controller->save_rating( $this->create_rating_request( 1 ) );
+
+		$this->assertSame(
+			array(
+				array(
+					'path'          => '/help/article/rating',
+					'version'       => '2',
+					'args'          => array( 'method' => 'POST' ),
+					'body'          => array(
+						'blog_id' => 9619154,
+						'post_id' => 185130,
+						'rating'  => 1,
+					),
+					'base_api_path' => 'wpcom',
+				),
+			),
+			$wpcom_request_client->requests
+		);
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 2, $response->get_data()->user_rating );
+	}
+
+	public function test_passes_upstream_failure_status_through() {
+		$wpcom_request_client = $this->create_request_client( 401, '{"code":"unauthorized"}' );
+
+		$controller = new WP_REST_Help_Center_Article_Rating( $wpcom_request_client );
+		$response   = $controller->save_rating( $this->create_rating_request( 1 ) );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'unauthorized', $response->get_data()->code );
+	}
+}


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-18102/help-center-articles-can-be-rated-multiple-times-by-the-same-user

## Proposed changes

* Add `WP_REST_Help_Center_Article_Rating`, registering `POST /help-center/article-rating` (`blog_id`, `post_id`, `rating` 1 = yes / 2 = no). It forwards the request to the WordPress.com `POST /wpcom/v2/help/article/rating` endpoint and returns its response, `{ "user_rating": 1|2 }`.
* Register the controller in `Help_Center` and document the route in the package `AGENTS.md`.

No change is needed for `fetch-post`: it already passes the WordPress.com article response through, so the new `user_rating` field on `GET /help/article` reaches wp-admin as is.

## Related product discussion/links

* wpcom: 239241-ghe-Automattic/wpcom (rating store) and 239246-ghe-Automattic/wpcom (the endpoint this proxies to)
* Calypso: https://github.com/Automattic/wp-calypso/pull/114081 (the Help Center UI that calls this route)

## Does this pull request change what data or activity we track or use?

The Help Center already records a Tracks event when an article is rated. This proxy additionally stores the rating itself against the WordPress.com user, so the Help Center can avoid asking again. No new data is stored on the site.

## Testing instructions

* On a sandboxed Atomic or Jetpack site with this branch, open wp-admin and the Help Center, then open a support article.
* Scroll to the bottom and click **Yes** or **No**. In the network panel, confirm `POST /wp-json/help-center/article-rating` returns `{ "user_rating": 1 }` or `2` (requires the wpcom branch on the sandbox).
* Close and reopen the Help Center. Confirm the article shows the answer instead of "Was this helpful?".
* `composer phpcs:lint` in `projects/packages/help-center`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
