### PR TITLE
Premium Analytics: scope the preview dashboard to the Traffic tab

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -138,6 +138,11 @@ and reaches `public-api.wordpress.com` directly. `jetpack-mu-wpcom` boots the pa
 opt-in or the `jetpack-premium-analytics` blog sticker, whichever says yes. Both answer the
 shared `jetpack_premium_analytics_enabled` filter, as they do on the other platforms.
 
+Which one says yes also decides how many tabs the dashboard offers: the site's own opt-in is the
+customer preview and exposes only the sections in `PREVIEW_SECTIONS`, while a sticker or filter
+override exposes every section the site qualifies for. `jetpack_premium_analytics_dashboard_preview_scope`
+overrides that per section — `__return_true` gives a development or test site the whole dashboard.
+
 ### Route guards must use the shared site-readiness helpers
 
 Every route's `beforeLoad` that checks connection state, and every sync check, must call

--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2093-preview-tab-scope
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2093-preview-tab-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: show only the Traffic tab while the site is running the customer preview.

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -170,9 +170,10 @@ final class Dashboard_Section {
 	 * @return bool
 	 */
 	public function is_available() {
-		// The preview scope is the one gate that is about the rollout rather than the site,
-		// so it sits here, ahead of the section's own check, for both readers of this method.
-		if ( ! is_dashboard_section_in_preview_scope( $this->id ) ) {
+		// The preview scope is about the rollout rather than the site, so it sits ahead of the
+		// section's own check. The default-layout route answers the same question separately,
+		// because it runs before the registry is populated.
+		if ( ! is_dashboard_section_in_preview_scope( $this->dashboard_name, $this->slug ) ) {
 			return false;
 		}
 

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -170,6 +170,12 @@ final class Dashboard_Section {
 	 * @return bool
 	 */
 	public function is_available() {
+		// The preview scope is the one gate that is about the rollout rather than the site,
+		// so it sits here, ahead of the section's own check, for both readers of this method.
+		if ( ! is_dashboard_section_in_preview_scope( $this->id ) ) {
+			return false;
+		}
+
 		if ( is_callable( $this->is_available ) ) {
 			return (bool) call_user_func( $this->is_available, $this );
 		}

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -101,7 +101,10 @@ function get_dashboard_default_layout_response( $request ) {
 	$gates          = get_dashboard_default_layout_gates();
 	$section_id     = get_dashboard_default_section_id_for( $dashboard_name );
 
-	if ( isset( $gates[ $section_id ] ) && ! call_user_func( $gates[ $section_id ] ) ) {
+	$out_of_preview = null !== $section_id
+		&& ! is_dashboard_section_in_preview_scope( DASHBOARD_NAME, $section_id );
+
+	if ( $out_of_preview || ( isset( $gates[ $section_id ] ) && ! call_user_func( $gates[ $section_id ] ) ) ) {
 		return new \WP_Error(
 			'dashboard_section_unavailable',
 			__( 'Dashboard section is not available.', 'jetpack-premium-analytics-pkg' ),

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -104,7 +104,11 @@ function get_dashboard_default_layout_response( $request ) {
 	$out_of_preview = null !== $section_id
 		&& ! is_dashboard_section_in_preview_scope( DASHBOARD_NAME, $section_id );
 
-	if ( $out_of_preview || ( isset( $gates[ $section_id ] ) && ! call_user_func( $gates[ $section_id ] ) ) ) {
+	$gate_fails = null !== $section_id
+		&& isset( $gates[ $section_id ] )
+		&& ! call_user_func( $gates[ $section_id ] );
+
+	if ( $out_of_preview || $gate_fails ) {
 		return new \WP_Error(
 			'dashboard_section_unavailable',
 			__( 'Dashboard section is not available.', 'jetpack-premium-analytics-pkg' ),

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -37,10 +37,11 @@ const ADS_DASHBOARD_SECTION_AVAILABLE_FILTER = 'jetpack_premium_analytics_ads_da
 const DASHBOARD_PREVIEW_SCOPE_FILTER = 'jetpack_premium_analytics_dashboard_preview_scope';
 
 /**
- * Sections the customer preview exposes. The single answer to what the preview shows;
- * a section still rolling out to some sites is opened through the filter instead.
+ * Section slugs the customer preview exposes as tabs. A section still rolling out to some
+ * sites is opened through the filter instead. Widget types are registered independently of
+ * this, as they are of the per-section availability checks.
  */
-const PREVIEW_SECTIONS = array( 'analytics/traffic' );
+const PREVIEW_SECTIONS = array( DASHBOARD_TRAFFIC_SECTION_ID );
 
 /**
  * Registers a dashboard section.
@@ -94,11 +95,14 @@ function is_dashboard_preview_scoped() {
  *
  * @since $$next-version$$
  *
- * @param string $id Namespaced section identifier.
+ * @param string $dashboard_name Dashboard identifier. Only this package's own dashboard is scoped.
+ * @param string $slug           URL-facing section slug.
  * @return bool
  */
-function is_dashboard_section_in_preview_scope( $id ) {
-	$in_scope = ! is_dashboard_preview_scoped() || in_array( $id, PREVIEW_SECTIONS, true );
+function is_dashboard_section_in_preview_scope( $dashboard_name, $slug ) {
+	$in_scope = DASHBOARD_NAME !== $dashboard_name
+		|| ! is_dashboard_preview_scoped()
+		|| in_array( $slug, PREVIEW_SECTIONS, true );
 
 	/**
 	 * Filters whether the preview exposes a dashboard section.
@@ -108,10 +112,11 @@ function is_dashboard_section_in_preview_scope( $id ) {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param bool   $in_scope Whether the preview exposes the section.
-	 * @param string $id       Namespaced section identifier.
+	 * @param bool   $in_scope       Whether the preview exposes the section.
+	 * @param string $slug           URL-facing section slug.
+	 * @param string $dashboard_name Dashboard the section belongs to.
 	 */
-	return (bool) apply_filters( DASHBOARD_PREVIEW_SCOPE_FILTER, $in_scope, $id );
+	return (bool) apply_filters( DASHBOARD_PREVIEW_SCOPE_FILTER, $in_scope, $slug, $dashboard_name );
 }
 
 /**

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -14,6 +14,7 @@ require_once __DIR__ . '/dashboard-layout.php';
 require_once __DIR__ . '/dashboard-grammar.php';
 require_once __DIR__ . '/class-dashboard-section.php';
 require_once __DIR__ . '/class-dashboard-section-registry.php';
+require_once __DIR__ . '/class-enablement-setting.php';
 
 /**
  * Filter through which WooCommerce section availability is resolved.
@@ -29,6 +30,17 @@ const SUBSCRIBERS_DASHBOARD_SECTION_AVAILABLE_FILTER = 'jetpack_premium_analytic
  * Filter for Ads section availability.
  */
 const ADS_DASHBOARD_SECTION_AVAILABLE_FILTER = 'jetpack_premium_analytics_ads_dashboard_section_available';
+
+/**
+ * Filter through which the preview's section scope is resolved.
+ */
+const DASHBOARD_PREVIEW_SCOPE_FILTER = 'jetpack_premium_analytics_dashboard_preview_scope';
+
+/**
+ * Sections the customer preview exposes. The single answer to what the preview shows;
+ * a section still rolling out to some sites is opened through the filter instead.
+ */
+const PREVIEW_SECTIONS = array( 'analytics/traffic' );
 
 /**
  * Registers a dashboard section.
@@ -61,6 +73,45 @@ function get_registered_dashboard_section( $dashboard_name, $id ) {
  */
 function get_available_dashboard_sections( $dashboard_name ) {
 	return Dashboard_Section_Registry::get_instance()->get_available_sections( $dashboard_name );
+}
+
+/**
+ * Whether the dashboard is running as the customer-facing preview.
+ *
+ * The site's own opt-in means the preview. Anything else that switches the dashboard on, the
+ * WordPress.com blog sticker or the `jetpack_premium_analytics_enabled` filter, means us.
+ *
+ * @since $$next-version$$
+ *
+ * @return bool
+ */
+function is_dashboard_preview_scoped() {
+	return (bool) get_option( Enablement_Setting::ENABLED_OPTION );
+}
+
+/**
+ * Whether the preview exposes a dashboard section.
+ *
+ * @since $$next-version$$
+ *
+ * @param string $id Namespaced section identifier.
+ * @return bool
+ */
+function is_dashboard_section_in_preview_scope( $id ) {
+	$in_scope = ! is_dashboard_preview_scoped() || in_array( $id, PREVIEW_SECTIONS, true );
+
+	/**
+	 * Filters whether the preview exposes a dashboard section.
+	 *
+	 * `__return_true` restores the whole dashboard, which is how a development or test site
+	 * sees every tab.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool   $in_scope Whether the preview exposes the section.
+	 * @param string $id       Namespaced section identifier.
+	 */
+	return (bool) apply_filters( DASHBOARD_PREVIEW_SCOPE_FILTER, $in_scope, $id );
 }
 
 /**

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -36,6 +36,8 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$this->reset_analytics_capabilities();
 		wp_set_current_user( 0 );
 		remove_all_filters( SUBSCRIBERS_DASHBOARD_SECTION_AVAILABLE_FILTER );
+		remove_all_filters( DASHBOARD_PREVIEW_SCOPE_FILTER );
+		delete_option( Enablement_Setting::ENABLED_OPTION );
 		Constants::clear_constants();
 		// The default layout now reaches Host::is_wpcom_platform(), which memoizes
 		// `is_woa_site` past Constants::clear_constants().
@@ -111,6 +113,33 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			array( Capabilities::class, 'current_user_can_view_analytics' ),
 			$routes[ self::ROUTE ][0]['permission_callback']
 		);
+	}
+
+	/**
+	 * This route keeps its own availability table, so the preview scope has to be applied
+	 * here too or a hidden tab still hands out its layout.
+	 */
+	public function test_default_layout_route_refuses_a_tab_the_preview_hides() {
+		$this->register_route_with_capabilities();
+		$this->login_as( 'administrator' );
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		list( $status ) = $this->request_default_layout( DASHBOARD_INSIGHTS_SECTION_ID );
+
+		$this->assertSame( 404, $status );
+	}
+
+	/**
+	 * The tab the preview does expose keeps serving its layout.
+	 */
+	public function test_default_layout_route_serves_the_traffic_tab_while_the_preview_is_scoped() {
+		$this->register_route_with_capabilities();
+		$this->login_as( 'administrator' );
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		list( $status ) = $this->request_default_layout( DASHBOARD_TRAFFIC_SECTION_ID );
+
+		$this->assertSame( 200, $status );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -1271,7 +1271,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The scope filter restores the whole dashboard, which is how our own sites see every tab.
+	 * The scope filter restores the whole dashboard for a development or test site.
 	 */
 	public function test_preview_scope_filter_restores_every_section() {
 		$this->enable_every_section();
@@ -1291,8 +1291,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
 		add_filter(
 			DASHBOARD_PREVIEW_SCOPE_FILTER,
-			static function ( $in_scope, $id ) {
-				return 'analytics/insights' === $id ? true : $in_scope;
+			static function ( $in_scope, $slug ) {
+				return 'insights' === $slug ? true : $in_scope;
 			},
 			10,
 			2
@@ -1304,6 +1304,82 @@ class Dashboard_Section_Test extends BaseTestCase {
 			array( 'analytics/traffic', 'analytics/insights' ),
 			$this->available_section_ids()
 		);
+	}
+
+	/**
+	 * The scope decides which sections the preview offers, never whether the site has them.
+	 */
+	public function test_preview_scope_does_not_bypass_a_section_own_availability() {
+		$this->set_admin_user();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_false' );
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+		add_filter( DASHBOARD_PREVIEW_SCOPE_FILTER, '__return_true' );
+
+		register_default_dashboard_sections();
+
+		$this->assertNotContains( 'woocommerce/store', $this->available_section_ids() );
+	}
+
+	/**
+	 * Switching the preview off stores a falsy option, which is not the same as running it.
+	 *
+	 * @param mixed $stored Value the opt-out leaves in the option.
+	 * @dataProvider provide_opted_out_option_values
+	 */
+	#[DataProvider( 'provide_opted_out_option_values' )]
+	public function test_an_explicit_opt_out_is_not_preview_scoped( $stored ) {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, $stored );
+
+		register_default_dashboard_sections();
+
+		$this->assertCount( 5, $this->available_section_ids() );
+	}
+
+	/**
+	 * Data provider for the opt-out values core can leave behind.
+	 *
+	 * @return array<string, array{mixed}>
+	 */
+	public static function provide_opted_out_option_values() {
+		return array(
+			'sanitized zero' => array( 0 ),
+			'empty string'   => array( '' ),
+		);
+	}
+
+	/**
+	 * The preview leaves nothing that waits on the analytics sync, so the sync stays idle
+	 * until the Store tab is exposed.
+	 */
+	public function test_preview_scope_leaves_no_section_awaiting_sync() {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		register_default_dashboard_sections();
+
+		$requires_sync = array_column(
+			array_map(
+				static function ( Dashboard_Section $section ) {
+					return $section->to_array();
+				},
+				get_available_dashboard_sections( DASHBOARD_NAME )
+			),
+			'requires_sync'
+		);
+
+		$this->assertSame( array( false ), $requires_sync );
+	}
+
+	/**
+	 * The scope governs this package's dashboard, not every dashboard using the registry.
+	 */
+	public function test_preview_scope_leaves_other_dashboards_alone() {
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		register_dashboard_section( 'other_dashboard', 'other/insights', array( 'label' => 'Insights' ) );
+
+		$this->assertCount( 1, get_available_dashboard_sections( 'other_dashboard' ) );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -81,6 +81,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
 		remove_all_filters( SUBSCRIBERS_DASHBOARD_SECTION_AVAILABLE_FILTER );
 		remove_all_filters( ADS_DASHBOARD_SECTION_AVAILABLE_FILTER );
+		remove_all_filters( DASHBOARD_PREVIEW_SCOPE_FILTER );
+		delete_option( Enablement_Setting::ENABLED_OPTION );
 
 		if ( null !== $this->available_modules_filter ) {
 			remove_filter( 'jetpack_get_available_standalone_modules', $this->available_modules_filter );
@@ -117,6 +119,17 @@ class Dashboard_Section_Test extends BaseTestCase {
 		};
 
 		add_filter( 'jetpack_get_available_standalone_modules', $this->available_modules_filter );
+	}
+
+	/**
+	 * Satisfy every built-in section's own availability check.
+	 *
+	 * @return void
+	 */
+	private function enable_every_section() {
+		$this->set_admin_user();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+		add_filter( ADS_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
 	}
 
 	/**
@@ -1223,6 +1236,89 @@ class Dashboard_Section_Test extends BaseTestCase {
 
 		$this->assertFalse( $ads->is_available() );
 		$this->assertNotContains( 'analytics/ads', $this->available_section_ids() );
+	}
+
+	/**
+	 * The customer preview exposes the Traffic tab and nothing else.
+	 */
+	public function test_preview_scope_leaves_only_the_traffic_section() {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		register_default_dashboard_sections();
+
+		$this->assertSame( array( 'analytics/traffic' ), $this->available_section_ids() );
+	}
+
+	/**
+	 * A dashboard switched on by anything but the site's own opt-in keeps every tab.
+	 */
+	public function test_an_overridden_dashboard_is_not_preview_scoped() {
+		$this->enable_every_section();
+
+		register_default_dashboard_sections();
+
+		$this->assertSame(
+			array(
+				'analytics/traffic',
+				'analytics/insights',
+				'analytics/subscribers',
+				'woocommerce/store',
+				'analytics/ads',
+			),
+			$this->available_section_ids()
+		);
+	}
+
+	/**
+	 * The scope filter restores the whole dashboard, which is how our own sites see every tab.
+	 */
+	public function test_preview_scope_filter_restores_every_section() {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+		add_filter( DASHBOARD_PREVIEW_SCOPE_FILTER, '__return_true' );
+
+		register_default_dashboard_sections();
+
+		$this->assertCount( 5, $this->available_section_ids() );
+	}
+
+	/**
+	 * The scope filter carries the section id, so one tab can open without the rest.
+	 */
+	public function test_preview_scope_filter_can_open_a_single_section() {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+		add_filter(
+			DASHBOARD_PREVIEW_SCOPE_FILTER,
+			static function ( $in_scope, $id ) {
+				return 'analytics/insights' === $id ? true : $in_scope;
+			},
+			10,
+			2
+		);
+
+		register_default_dashboard_sections();
+
+		$this->assertSame(
+			array( 'analytics/traffic', 'analytics/insights' ),
+			$this->available_section_ids()
+		);
+	}
+
+	/**
+	 * A section the preview hides is a 404 for anyone who addresses it directly.
+	 */
+	public function test_preview_scope_hides_a_section_from_the_route() {
+		$this->enable_every_section();
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		register_default_dashboard_sections();
+
+		$section = get_available_dashboard_section_for_route( DASHBOARD_NAME, 'analytics/insights' );
+
+		$this->assertInstanceOf( \WP_Error::class, $section );
+		$this->assertSame( 'dashboard_section_unavailable', $section->get_error_code() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/change-wooa7s-2093-preview-tab-scope
+++ b/projects/plugins/jetpack/changelog/change-wooa7s-2093-preview-tab-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: show only the Traffic tab while the site is running the Stats preview.

--- a/projects/plugins/wpcomsh/changelog/change-wooa7s-2093-preview-tab-scope
+++ b/projects/plugins/wpcomsh/changelog/change-wooa7s-2093-preview-tab-scope
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: show only the Traffic tab while the site is running the Stats preview.


### PR DESCRIPTION
Fixes WOOA7S-2093

## Proposed changes

- Limit customer-enabled Premium Analytics preview dashboards to the **Traffic** tab.
- Keep internally enabled dashboards unchanged, showing every section the site qualifies for.
- Make direct links to unavailable sections fall back to Traffic.
- Add a section-aware preview-scope filter so individual sections can be progressively rolled out.

This keeps the customer preview aligned with the intended Traffic-only launch while preserving the existing internal rollout path.

**Reports and detail pages (`/reports/…`, post detail, video detail) are out of scope here.** In the preview they are reachable only by typing a URL, because no Traffic widget links to an out-of-scope report. **A follow-up PR will gate them.**

<img width="1449" height="741" alt="Screenshot 2026-09-04 at 6 04 50 PM" src="https://github.com/user-attachments/assets/7a206322-a839-436b-bfdb-02d947fd6e36" />

 
## Related product discussion/links

- WOOA7S-2093; UNI-716 and STATS-461.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Use a site that can display the Premium Analytics dashboard.

1. Enable the customer preview: `wp option update jetpack_premium_analytics_enabled 1`.
2. Open Stats v2 in wp-admin. Confirm that only the **Traffic** tab is available.
3. Add `&p=%2F%3Fsection%3Dinsights` to the dashboard URL. Confirm it falls back to Traffic instead of displaying Insights.
4. Add this to an mu-plugin, then reload the dashboard:
   ```php
   add_filter( 'jetpack_premium_analytics_dashboard_preview_scope', '__return_true' );
   ```
   Confirm that every tab the site qualifies for is available again.
5. Remove the option and the scope filter. Enable the dashboard with this filter instead:
   ```php
   add_filter( 'jetpack_premium_analytics_enabled', '__return_true' );
   ```
   Confirm that every tab the site qualifies for is available; this is the internal rollout behavior.

### Screenshots

| Customer preview | Scope overridden |
| --- | --- |
| ![Only the Traffic tab](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2093-preview-tab-scope/scoped-traffic-only.jpg) | ![All five tabs](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2093-preview-tab-scope/override-all-tabs.jpg) |

Directly opening a hidden section falls back to Traffic:

![section=insights rewritten to traffic](https://github.com/Automattic/jetpack/raw/screenshots/change/wooa7s-2093-preview-tab-scope/scoped-direct-section-url.jpg)



