### PR TITLE
Sitemaps: flat master sitemap index, behind a filter [JETPACK-2067]

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: other
 
-Sitemaps: Link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects. Sites with too many sitemap files to list in one index keep the nested layout.
+Sitemaps: Add a jetpack_sitemap_flat_master_index filter that makes sitemap.xml list individual sitemap files instead of nesting sitemap index files, which Google Search Console rejects. Off by default while it is rolled out.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sitemaps: link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Sitemaps: link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects. Sites with too many sitemap files to list in one index keep the nested layout.
+Sitemaps: Link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects. Sites with too many sitemap files to list in one index keep the nested layout.

--- a/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-2067-flatten-sitemap-index
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Sitemaps: link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects.
+Sitemaps: link individual sitemap files directly from sitemap.xml instead of nesting sitemap index files, which Google Search Console rejects. Sites with too many sitemap files to list in one index keep the nested layout.

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -499,6 +499,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * buffer. They no longer fit somewhere north of a million URLs, and only then
 	 * does it fall back to linking the per-type `*-sitemap-index-N.xml` files.
 	 *
+	 * Either way the buffer is only stored once it covers every sitemap this
+	 * generation cycle produced; a master that reaches fewer URLs than the last
+	 * one is worse than leaving the last one in place.
+	 *
 	 * @link https://www.sitemaps.org/protocol.html#index
 	 *
 	 * @param array $max Array of sitemap types with max index and datetime.
@@ -516,13 +520,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			JP_VIDEO_SITEMAP_TYPE,
 		);
 
-		/*
-		 * Both the item limit and the byte limit can stop the flat listing, and
-		 * how soon the byte limit bites depends on how long this site's URLs are,
-		 * so the flat build reports whether everything fit instead of quietly
-		 * storing a master that omits sitemaps.
-		 */
-		$buffer = $this->build_flat_master_buffer( $sitemap_types );
+		$buffer = $this->build_flat_master_buffer( $sitemap_types, $max );
 
 		if ( ! $buffer ) {
 			/*
@@ -549,17 +547,23 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	/**
 	 * Build a master sitemap buffer listing every individual sitemap file.
 	 *
-	 * Returns false if the buffer filled up before every file was listed, in
-	 * which case the partial buffer is discarded rather than stored.
+	 * Returns false, discarding the partial buffer, unless every file this cycle
+	 * generated was listed. The buffer's item and byte limits can both stop it
+	 * short, and how soon the byte limit bites depends on how long this site's
+	 * URLs are, so the count is checked rather than assumed. Rows are also
+	 * matched against the filenames this cycle should have produced, so a short
+	 * read or a row left behind by an interrupted cleanup fails the build instead
+	 * of quietly changing what the master points at.
 	 *
 	 * @access private
 	 * @since 16.2
 	 *
 	 * @param array $sitemap_types The sitemap types to list, in order.
+	 * @param array $max           Array of sitemap types with max index and datetime.
 	 *
-	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if they did not all fit.
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if it does not list every file.
 	 */
-	private function build_flat_master_buffer( $sitemap_types ) {
+	private function build_flat_master_buffer( $sitemap_types, $max ) {
 		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
 			'master',
 			JP_SITEMAP_MAX_ITEMS,
@@ -571,21 +575,38 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		}
 
 		foreach ( $sitemap_types as $sitemap_type ) {
+			$expected        = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
+			$listed          = 0;
 			$last_sitemap_id = 0;
 
-			while ( true ) {
+			while ( $listed < $expected ) {
 				$rows = $this->librarian->query_sitemaps_after_id(
 					$sitemap_type,
 					$last_sitemap_id,
-					JP_SITEMAP_BATCH_SIZE
+					min( JP_SITEMAP_BATCH_SIZE, $expected - $listed )
 				);
 
 				if ( empty( $rows ) ) {
-					break;
+					if ( $this->logger ) {
+						$this->logger->report( "-- Only found $listed of $expected $sitemap_type rows; not flattening." );
+					}
+
+					return false;
 				}
 
 				foreach ( $rows as $row ) {
-					$current_item = $this->sitemap_row_to_index_item( (array) $row );
+					$row = (array) $row;
+					++$listed;
+
+					if ( jp_sitemap_filename( $sitemap_type, $listed ) !== $row['post_title'] ) {
+						if ( $this->logger ) {
+							$this->logger->report( "-- Unexpected row {$row['post_title']} for $sitemap_type; not flattening." );
+						}
+
+						return false;
+					}
+
+					$current_item = $this->sitemap_row_to_index_item( $row );
 
 					if ( true !== $buffer->append( $current_item['xml'] ) ) {
 						if ( $this->logger ) {
@@ -618,7 +639,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * @param array $sitemap_types The sitemap types to list, in order.
 	 * @param array $max           Array of sitemap types with max index and datetime.
 	 *
-	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if the state is incomplete.
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if it does not list every type.
 	 */
 	private function build_nested_master_buffer( $sitemap_types, $max ) {
 		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
@@ -652,7 +673,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 				return false;
 			}
 
-			$buffer->append(
+			$appended = $buffer->append(
 				array(
 					'sitemap' => array(
 						'loc'     => $this->finder->construct_sitemap_url( $filename ),
@@ -660,6 +681,14 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 					),
 				)
 			);
+
+			if ( true !== $appended ) {
+				if ( $this->logger ) {
+					$this->logger->report( "-- No room for $filename; keeping the previous Master Sitemap." );
+				}
+
+				return false;
+			}
 		}
 
 		return $buffer;

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -494,14 +494,17 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	/**
 	 * Builds the master sitemap index.
 	 *
+	 * Per the sitemap protocol a sitemap index may not list other sitemap
+	 * indexes, so the master lists every individual sitemap file directly and
+	 * never links the per-type `*-sitemap-index-N.xml` files.
+	 *
+	 * @link https://www.sitemaps.org/protocol.html#index
+	 *
 	 * @param array $max Array of sitemap types with max index and datetime.
 	 *
 	 * @since 4.8.0
 	 */
 	private function build_master_sitemap( $max ) {
-		$page  = array();
-		$image = array();
-		$video = array();
 		if ( $this->logger ) {
 			$this->logger->report( '-- Building Master Sitemap.' );
 		}
@@ -516,67 +519,55 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			return;
 		}
 
-		if ( isset( $max[ JP_PAGE_SITEMAP_TYPE ] ) && 0 < $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
-			if ( 1 === $max[ JP_PAGE_SITEMAP_TYPE ]['number'] ) {
-				$page['filename']      = jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, 1 );
-				$page['last_modified'] = jp_sitemap_datetime( $max[ JP_PAGE_SITEMAP_TYPE ]['lastmod'] );
-			} else {
-				$page['filename']      = jp_sitemap_filename(
-					JP_PAGE_SITEMAP_INDEX_TYPE,
-					$max[ JP_PAGE_SITEMAP_INDEX_TYPE ]['number']
-				);
-				$page['last_modified'] = jp_sitemap_datetime( $max[ JP_PAGE_SITEMAP_INDEX_TYPE ]['lastmod'] );
-			}
+		$sitemap_types = array(
+			JP_PAGE_SITEMAP_TYPE,
+			JP_IMAGE_SITEMAP_TYPE,
+			JP_VIDEO_SITEMAP_TYPE,
+		);
 
-			$buffer->append(
-				array(
-					'sitemap' => array(
-						'loc'     => $this->finder->construct_sitemap_url( $page['filename'] ),
-						'lastmod' => $page['last_modified'],
-					),
-				)
-			);
+		// Total number of individual sitemap files to list.
+		$total = 0;
+		foreach ( $sitemap_types as $sitemap_type ) {
+			if ( isset( $max[ $sitemap_type ]['number'] ) ) {
+				$total += (int) $max[ $sitemap_type ]['number'];
+			}
 		}
 
-		if ( isset( $max[ JP_IMAGE_SITEMAP_TYPE ] ) && 0 < $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
-			if ( 1 === $max[ JP_IMAGE_SITEMAP_TYPE ]['number'] ) {
-				$image['filename']      = jp_sitemap_filename( JP_IMAGE_SITEMAP_TYPE, 1 );
-				$image['last_modified'] = jp_sitemap_datetime( $max[ JP_IMAGE_SITEMAP_TYPE ]['lastmod'] );
+		/*
+		 * Listing every file directly needs room for all of them. Above the
+		 * buffer's item capacity (a million-plus URLs) fall back to the nested
+		 * indexes: Google flags the nesting, but that beats dropping URLs.
+		 *
+		 * ponytail: raising this ceiling means paginating the master itself,
+		 * which the protocol can't express without nesting anyway.
+		 */
+		$flatten = ( $total <= JP_SITEMAP_MAX_ITEMS );
+
+		foreach ( $sitemap_types as $sitemap_type ) {
+			if ( ! isset( $max[ $sitemap_type ]['number'] ) || 0 >= $max[ $sitemap_type ]['number'] ) {
+				continue;
+			}
+
+			if ( $flatten ) {
+				$this->append_sitemaps_to_master( $buffer, $sitemap_type );
+				continue;
+			}
+
+			$index_type = jp_sitemap_index_type_of( $sitemap_type );
+
+			if ( 1 === $max[ $sitemap_type ]['number'] || ! isset( $max[ $index_type ]['number'] ) ) {
+				$filename = jp_sitemap_filename( $sitemap_type, 1 );
+				$lastmod  = $max[ $sitemap_type ]['lastmod'];
 			} else {
-				$image['filename']      = jp_sitemap_filename(
-					JP_IMAGE_SITEMAP_INDEX_TYPE,
-					$max[ JP_IMAGE_SITEMAP_INDEX_TYPE ]['number']
-				);
-				$image['last_modified'] = jp_sitemap_datetime( $max[ JP_IMAGE_SITEMAP_INDEX_TYPE ]['lastmod'] );
+				$filename = jp_sitemap_filename( $index_type, $max[ $index_type ]['number'] );
+				$lastmod  = $max[ $index_type ]['lastmod'];
 			}
 
 			$buffer->append(
 				array(
 					'sitemap' => array(
-						'loc'     => $this->finder->construct_sitemap_url( $image['filename'] ),
-						'lastmod' => $image['last_modified'],
-					),
-				)
-			);
-		}
-
-		if ( isset( $max[ JP_VIDEO_SITEMAP_TYPE ] ) && 0 < $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
-			if ( 1 === $max[ JP_VIDEO_SITEMAP_TYPE ]['number'] ) {
-				$video['filename']      = jp_sitemap_filename( JP_VIDEO_SITEMAP_TYPE, 1 );
-				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_TYPE ]['lastmod'] );
-			} else {
-				$video['filename']      = jp_sitemap_filename(
-					JP_VIDEO_SITEMAP_INDEX_TYPE,
-					$max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['number']
-				);
-				$video['last_modified'] = jp_sitemap_datetime( $max[ JP_VIDEO_SITEMAP_INDEX_TYPE ]['lastmod'] );
-			}
-
-			$buffer->append(
-				array(
-					'sitemap' => array(
-						'loc'     => $this->finder->construct_sitemap_url( $video['filename'] ),
-						'lastmod' => $video['last_modified'],
+						'loc'     => $this->finder->construct_sitemap_url( $filename ),
+						'lastmod' => jp_sitemap_datetime( $lastmod ),
 					),
 				)
 			);
@@ -588,6 +579,44 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			$buffer->contents(),
 			''
 		);
+	}
+
+	/**
+	 * Append every stored sitemap file of the given type to the master sitemap.
+	 *
+	 * Stops early if the buffer fills up; see build_master_sitemap() for how
+	 * that case is avoided.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param Jetpack_Sitemap_Buffer $buffer       The master sitemap buffer.
+	 * @param string                 $sitemap_type The type of sitemap to list.
+	 */
+	private function append_sitemaps_to_master( $buffer, $sitemap_type ) {
+		$last_sitemap_id = 0;
+
+		while ( false === $buffer->is_full() ) {
+			$rows = $this->librarian->query_sitemaps_after_id(
+				$sitemap_type,
+				$last_sitemap_id,
+				JP_SITEMAP_BATCH_SIZE
+			);
+
+			if ( empty( $rows ) ) {
+				return;
+			}
+
+			foreach ( $rows as $row ) {
+				$current_item = $this->sitemap_row_to_index_item( (array) $row );
+
+				if ( true !== $buffer->append( $current_item['xml'] ) ) {
+					return;
+				}
+
+				$last_sitemap_id = $row['ID'];
+			}
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -510,10 +510,12 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	/**
 	 * Builds the master sitemap index.
 	 *
-	 * A sitemap index file may not list other sitemap index files, so the master
-	 * lists every individual sitemap file directly whenever they all fit in one
-	 * buffer. They no longer fit somewhere north of a million URLs, and only then
-	 * does it fall back to linking the per-type `*-sitemap-index-N.xml` files.
+	 * A sitemap index file may not list other sitemap index files, so with the
+	 * `jetpack_sitemap_flat_master_index` filter on, the master lists every
+	 * individual sitemap file directly whenever they all fit in one buffer. They
+	 * no longer fit somewhere north of a million URLs, and only then does it fall
+	 * back to linking the per-type `*-sitemap-index-N.xml` files. With the filter
+	 * off, which is still the default, it always links them.
 	 *
 	 * Either way the buffer is only stored once every sitemap this generation
 	 * cycle recorded is accounted for. If one is missing, the master the previous
@@ -537,13 +539,35 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			JP_VIDEO_SITEMAP_TYPE,
 		);
 
-		$buffer = $this->build_flat_master_buffer( $sitemap_types, $max );
+		$buffer = null;
 
-		if ( self::MASTER_OVERFLOW === $buffer ) {
+		/**
+		 * Whether the master sitemap lists each individual sitemap file directly.
+		 *
+		 * A sitemap index file may not list other sitemap index files, and Google
+		 * Search Console reports the nested layout as "Nested indexing". Listing
+		 * the files directly is what fixes that.
+		 *
+		 * Off by default so the flat layout can be rolled out a site at a time.
+		 * The default is expected to flip once it has been verified in production,
+		 * at which point this filter goes away.
+		 *
+		 * @module sitemaps
+		 *
+		 * @since 16.2
+		 *
+		 * @param bool $flat_master_index Whether to list sitemap files directly. Default false.
+		 */
+		if ( apply_filters( 'jetpack_sitemap_flat_master_index', false ) ) {
+			$buffer = $this->build_flat_master_buffer( $sitemap_types, $max );
+		}
+
+		if ( null === $buffer || self::MASTER_OVERFLOW === $buffer ) {
 			/*
-			 * Nesting is invalid and Google flags it, but a complete invalid
-			 * tree beats a valid one that drops URLs, and a sitemap index
-			 * cannot be paginated to make the flat layout scale further.
+			 * Either the flat layout is off, or the files did not fit in one
+			 * buffer. Nesting is invalid and Google flags it, but a complete
+			 * invalid tree beats a valid one that drops URLs, and a sitemap
+			 * index cannot be paginated to make the flat layout scale further.
 			 */
 			$buffer = $this->build_nested_master_buffer( $sitemap_types, $max );
 		}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -561,6 +561,25 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	}
 
 	/**
+	 * Create the buffer a master sitemap is assembled in.
+	 *
+	 * Extracted as a protected seam so a test can hand back a buffer small
+	 * enough to overflow without generating a million URLs.
+	 *
+	 * @access protected
+	 * @since 16.2
+	 *
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if one cannot be created.
+	 */
+	protected function create_master_buffer() {
+		return Jetpack_Sitemap_Buffer_Factory::create(
+			'master',
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES
+		);
+	}
+
+	/**
 	 * Build a master sitemap buffer listing every individual sitemap file.
 	 *
 	 * The buffer's item and byte limits can both stop this short, and how soon
@@ -580,11 +599,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|string The buffer, or MASTER_OVERFLOW / MASTER_INCOMPLETE.
 	 */
 	private function build_flat_master_buffer( $sitemap_types, $max ) {
-		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
-			'master',
-			JP_SITEMAP_MAX_ITEMS,
-			JP_SITEMAP_MAX_BYTES
-		);
+		$buffer = $this->create_master_buffer();
 
 		if ( ! $buffer ) {
 			return self::MASTER_INCOMPLETE;
@@ -644,11 +659,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|string The buffer, or MASTER_INCOMPLETE.
 	 */
 	private function build_nested_master_buffer( $sitemap_types, $max ) {
-		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
-			'master',
-			JP_SITEMAP_MAX_ITEMS,
-			JP_SITEMAP_MAX_BYTES
-		);
+		$buffer = $this->create_master_buffer();
 
 		if ( ! $buffer ) {
 			return self::MASTER_INCOMPLETE;

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -541,10 +541,9 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 
 		if ( self::MASTER_OVERFLOW === $buffer ) {
 			/*
-			 * ponytail: nested indexes are invalid per the protocol and Google
-			 * flags them, but a complete invalid tree beats a valid tree that
-			 * drops URLs. Lifting this ceiling means paginating the master
-			 * itself, which the protocol cannot express without nesting anyway.
+			 * Nesting is invalid and Google flags it, but a complete invalid
+			 * tree beats a valid one that drops URLs, and a sitemap index
+			 * cannot be paginated to make the flat layout scale further.
 			 */
 			$buffer = $this->build_nested_master_buffer( $sitemap_types, $max );
 		}

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -515,10 +515,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * buffer. They no longer fit somewhere north of a million URLs, and only then
 	 * does it fall back to linking the per-type `*-sitemap-index-N.xml` files.
 	 *
-	 * Either way the buffer is only stored once it covers every sitemap this
-	 * generation cycle recorded. If a file it should link is missing, the master
-	 * the previous cycle stored is left in place: it reaches more URLs than
-	 * anything that could be built right now.
+	 * Either way the buffer is only stored once every sitemap this generation
+	 * cycle recorded is accounted for. If one is missing, the master the previous
+	 * cycle stored is left in place: it reaches more URLs than anything that
+	 * could be built right now.
 	 *
 	 * @link https://www.sitemaps.org/protocol.html#index
 	 *
@@ -567,7 +567,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * The buffer's item and byte limits can both stop this short, and how soon
 	 * the byte limit bites depends on how long this site's URLs are, so the
 	 * partial buffer is discarded and MASTER_OVERFLOW returned rather than
-	 * storing a master that omits sitemaps.
+	 * storing a master that omits sitemaps. Every type is still checked over
+	 * once the buffer overflows, so a missing file is reported as
+	 * MASTER_INCOMPLETE instead of sending the caller off to build a nested
+	 * master out of the same broken state.
 	 *
 	 * @access private
 	 * @since 16.2
@@ -588,46 +591,50 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			return self::MASTER_INCOMPLETE;
 		}
 
+		$overflowed = false;
+
 		foreach ( $sitemap_types as $sitemap_type ) {
-			$expected = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
+			$expected = $this->sitemap_count_of( $max, $sitemap_type );
 
 			if ( $expected < 1 ) {
 				continue;
 			}
 
-			$timestamps = $this->librarian->query_sitemap_timestamps( $sitemap_type );
+			$timestamps = $this->stored_sitemap_timestamps( $sitemap_type, $expected );
+
+			if ( false === $timestamps ) {
+				return self::MASTER_INCOMPLETE;
+			}
+
+			if ( $overflowed ) {
+				continue;
+			}
 
 			for ( $number = 1; $number <= $expected; $number++ ) {
 				$filename = jp_sitemap_filename( $sitemap_type, $number );
-
-				if ( ! isset( $timestamps[ $filename ] ) ) {
-					if ( $this->logger ) {
-						$this->logger->report( "-- $filename is missing; keeping the previous Master Sitemap." );
-					}
-
-					return self::MASTER_INCOMPLETE;
-				}
 
 				if ( ! $this->append_sitemap_to_master( $buffer, $filename, $timestamps[ $filename ] ) ) {
 					if ( $this->logger ) {
 						$this->logger->report( '-- Master Sitemap is full; falling back to nested indexes.' );
 					}
 
-					return self::MASTER_OVERFLOW;
+					$overflowed = true;
+					break;
 				}
 			}
 		}
 
-		return $buffer;
+		return $overflowed ? self::MASTER_OVERFLOW : $buffer;
 	}
 
 	/**
 	 * Build a master sitemap buffer linking one file per sitemap type: the single
 	 * sitemap when there is only one, otherwise that type's newest index file.
 	 *
-	 * Only used when the individual files do not all fit. Returns
-	 * MASTER_INCOMPLETE if the file a type would be reached through is missing,
-	 * or if even these few entries do not fit.
+	 * Only used when the individual files do not all fit. The whole index chain
+	 * has to be intact, because the newest index reaches the older ones only by
+	 * linking back through them, so every index of a type is checked and not just
+	 * the one the master names.
 	 *
 	 * @access private
 	 * @since 16.2
@@ -649,34 +656,38 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		}
 
 		foreach ( $sitemap_types as $sitemap_type ) {
-			$number = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
+			$expected = $this->sitemap_count_of( $max, $sitemap_type );
 
-			if ( $number < 1 ) {
+			if ( $expected < 1 ) {
 				continue;
 			}
 
-			if ( 1 === $number ) {
-				// A type with a single sitemap has no index; link the sitemap.
-				$linked_type = $sitemap_type;
-				$linked_name = jp_sitemap_filename( $sitemap_type, 1 );
-			} else {
-				// Every other file of this type hangs off its newest index.
-				$linked_type = jp_sitemap_index_type_of( $sitemap_type );
-				$linked_name = jp_sitemap_filename(
-					$linked_type,
-					isset( $max[ $linked_type ]['number'] ) ? (int) $max[ $linked_type ]['number'] : 0
-				);
-			}
+			// The files reached through the index still have to be there.
+			$timestamps = $this->stored_sitemap_timestamps( $sitemap_type, $expected );
 
-			$timestamps = $this->librarian->query_sitemap_timestamps( $linked_type );
-
-			if ( ! isset( $timestamps[ $linked_name ] ) ) {
-				if ( $this->logger ) {
-					$this->logger->report( "-- $linked_name is missing; keeping the previous Master Sitemap." );
-				}
-
+			if ( false === $timestamps ) {
 				return self::MASTER_INCOMPLETE;
 			}
+
+			$linked_type  = $sitemap_type;
+			$linked_count = $expected;
+
+			if ( 1 !== $expected ) {
+				// Only a type with a single sitemap has no index to link.
+				$linked_type  = jp_sitemap_index_type_of( $sitemap_type );
+				$linked_count = $this->sitemap_count_of( $max, $linked_type );
+				$timestamps   = $this->stored_sitemap_timestamps( $linked_type, $linked_count );
+
+				if ( $linked_count < 1 || false === $timestamps ) {
+					if ( $this->logger ) {
+						$this->logger->report( "-- No usable index for $sitemap_type; keeping the previous Master Sitemap." );
+					}
+
+					return self::MASTER_INCOMPLETE;
+				}
+			}
+
+			$linked_name = jp_sitemap_filename( $linked_type, $linked_count );
 
 			if ( ! $this->append_sitemap_to_master( $buffer, $linked_name, $timestamps[ $linked_name ] ) ) {
 				if ( $this->logger ) {
@@ -688,6 +699,57 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		}
 
 		return $buffer;
+	}
+
+	/**
+	 * The number of sitemap files of a type the current generation cycle recorded.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param array  $max  Array of sitemap types with max index and datetime.
+	 * @param string $type A sitemap or sitemap index type.
+	 *
+	 * @return int The count, or 0 if the type produced nothing.
+	 */
+	private function sitemap_count_of( $max, $type ) {
+		return isset( $max[ $type ]['number'] ) ? (int) $max[ $type ]['number'] : 0;
+	}
+
+	/**
+	 * Look up the timestamps of files 1..$count of a sitemap type, by filename.
+	 *
+	 * Filenames rather than row order, because a row rewritten by an interrupted
+	 * cleanup no longer sorts where its number says it should.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param string $type  A sitemap or sitemap index type.
+	 * @param int    $count How many files of that type to expect.
+	 *
+	 * @return array|false Map of filename to timestamp, or false if any is missing.
+	 */
+	private function stored_sitemap_timestamps( $type, $count ) {
+		$names = array();
+
+		for ( $number = 1; $number <= $count; $number++ ) {
+			$names[] = jp_sitemap_filename( $type, $number );
+		}
+
+		$timestamps = $this->librarian->query_sitemap_timestamps( $type, $names );
+
+		foreach ( $names as $name ) {
+			if ( ! isset( $timestamps[ $name ] ) ) {
+				if ( $this->logger ) {
+					$this->logger->report( "-- $name is missing; keeping the previous Master Sitemap." );
+				}
+
+				return false;
+			}
+		}
+
+		return $timestamps;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -494,9 +494,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	/**
 	 * Builds the master sitemap index.
 	 *
-	 * Per the sitemap protocol a sitemap index may not list other sitemap
-	 * indexes, so the master lists every individual sitemap file directly and
-	 * never links the per-type `*-sitemap-index-N.xml` files.
+	 * A sitemap index file may not list other sitemap index files, so the master
+	 * lists every individual sitemap file directly whenever they all fit in one
+	 * buffer. They no longer fit somewhere north of a million URLs, and only then
+	 * does it fall back to linking the per-type `*-sitemap-index-N.xml` files.
 	 *
 	 * @link https://www.sitemaps.org/protocol.html#index
 	 *
@@ -509,6 +510,56 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			$this->logger->report( '-- Building Master Sitemap.' );
 		}
 
+		$sitemap_types = array(
+			JP_PAGE_SITEMAP_TYPE,
+			JP_IMAGE_SITEMAP_TYPE,
+			JP_VIDEO_SITEMAP_TYPE,
+		);
+
+		/*
+		 * Both the item limit and the byte limit can stop the flat listing, and
+		 * how soon the byte limit bites depends on how long this site's URLs are,
+		 * so the flat build reports whether everything fit instead of quietly
+		 * storing a master that omits sitemaps.
+		 */
+		$buffer = $this->build_flat_master_buffer( $sitemap_types );
+
+		if ( ! $buffer ) {
+			/*
+			 * ponytail: nested indexes are invalid per the protocol and Google
+			 * flags them, but a complete invalid tree beats a valid tree that
+			 * drops URLs. Lifting this ceiling means paginating the master
+			 * itself, which the protocol cannot express without nesting anyway.
+			 */
+			$buffer = $this->build_nested_master_buffer( $sitemap_types, $max );
+		}
+
+		if ( ! $buffer ) {
+			return;
+		}
+
+		$this->librarian->store_sitemap_data(
+			0,
+			JP_MASTER_SITEMAP_TYPE,
+			$buffer->contents(),
+			''
+		);
+	}
+
+	/**
+	 * Build a master sitemap buffer listing every individual sitemap file.
+	 *
+	 * Returns false if the buffer filled up before every file was listed, in
+	 * which case the partial buffer is discarded rather than stored.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param array $sitemap_types The sitemap types to list, in order.
+	 *
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if they did not all fit.
+	 */
+	private function build_flat_master_buffer( $sitemap_types ) {
 		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
 			'master',
 			JP_SITEMAP_MAX_ITEMS,
@@ -516,51 +567,89 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		);
 
 		if ( ! $buffer ) {
-			return;
+			return false;
 		}
 
-		$sitemap_types = array(
-			JP_PAGE_SITEMAP_TYPE,
-			JP_IMAGE_SITEMAP_TYPE,
-			JP_VIDEO_SITEMAP_TYPE,
+		foreach ( $sitemap_types as $sitemap_type ) {
+			$last_sitemap_id = 0;
+
+			while ( true ) {
+				$rows = $this->librarian->query_sitemaps_after_id(
+					$sitemap_type,
+					$last_sitemap_id,
+					JP_SITEMAP_BATCH_SIZE
+				);
+
+				if ( empty( $rows ) ) {
+					break;
+				}
+
+				foreach ( $rows as $row ) {
+					$current_item = $this->sitemap_row_to_index_item( (array) $row );
+
+					if ( true !== $buffer->append( $current_item['xml'] ) ) {
+						if ( $this->logger ) {
+							$this->logger->report( '-- Master Sitemap is full; falling back to nested indexes.' );
+						}
+
+						return false;
+					}
+
+					$last_sitemap_id = $row['ID'];
+				}
+			}
+		}
+
+		return $buffer;
+	}
+
+	/**
+	 * Build a master sitemap buffer linking one file per sitemap type: the single
+	 * sitemap when there is only one, otherwise that type's newest index file.
+	 *
+	 * Returns false if a type reports several sitemap files but no index to reach
+	 * them through, which means this generation cycle is incomplete. Publishing
+	 * then would drop every file after the first, so the caller keeps the master
+	 * built by the previous cycle instead.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param array $sitemap_types The sitemap types to list, in order.
+	 * @param array $max           Array of sitemap types with max index and datetime.
+	 *
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if the state is incomplete.
+	 */
+	private function build_nested_master_buffer( $sitemap_types, $max ) {
+		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
+			'master',
+			JP_SITEMAP_MAX_ITEMS,
+			JP_SITEMAP_MAX_BYTES
 		);
 
-		// Total number of individual sitemap files to list.
-		$total = 0;
-		foreach ( $sitemap_types as $sitemap_type ) {
-			if ( isset( $max[ $sitemap_type ]['number'] ) ) {
-				$total += (int) $max[ $sitemap_type ]['number'];
-			}
+		if ( ! $buffer ) {
+			return false;
 		}
 
-		/*
-		 * Listing every file directly needs room for all of them. Above the
-		 * buffer's item capacity (a million-plus URLs) fall back to the nested
-		 * indexes: Google flags the nesting, but that beats dropping URLs.
-		 *
-		 * ponytail: raising this ceiling means paginating the master itself,
-		 * which the protocol can't express without nesting anyway.
-		 */
-		$flatten = ( $total <= JP_SITEMAP_MAX_ITEMS );
-
 		foreach ( $sitemap_types as $sitemap_type ) {
-			if ( ! isset( $max[ $sitemap_type ]['number'] ) || 0 >= $max[ $sitemap_type ]['number'] ) {
-				continue;
-			}
-
-			if ( $flatten ) {
-				$this->append_sitemaps_to_master( $buffer, $sitemap_type );
+			if ( empty( $max[ $sitemap_type ]['number'] ) ) {
 				continue;
 			}
 
 			$index_type = jp_sitemap_index_type_of( $sitemap_type );
 
-			if ( 1 === $max[ $sitemap_type ]['number'] || ! isset( $max[ $index_type ]['number'] ) ) {
+			if ( 1 === $max[ $sitemap_type ]['number'] ) {
 				$filename = jp_sitemap_filename( $sitemap_type, 1 );
 				$lastmod  = $max[ $sitemap_type ]['lastmod'];
-			} else {
+			} elseif ( ! empty( $max[ $index_type ]['number'] ) ) {
 				$filename = jp_sitemap_filename( $index_type, $max[ $index_type ]['number'] );
 				$lastmod  = $max[ $index_type ]['lastmod'];
+			} else {
+				if ( $this->logger ) {
+					$this->logger->report( "-- No index for $sitemap_type; keeping the previous Master Sitemap." );
+				}
+
+				return false;
 			}
 
 			$buffer->append(
@@ -573,50 +662,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			);
 		}
 
-		$this->librarian->store_sitemap_data(
-			0,
-			JP_MASTER_SITEMAP_TYPE,
-			$buffer->contents(),
-			''
-		);
-	}
-
-	/**
-	 * Append every stored sitemap file of the given type to the master sitemap.
-	 *
-	 * Stops early if the buffer fills up; see build_master_sitemap() for how
-	 * that case is avoided.
-	 *
-	 * @access private
-	 * @since 16.2
-	 *
-	 * @param Jetpack_Sitemap_Buffer $buffer       The master sitemap buffer.
-	 * @param string                 $sitemap_type The type of sitemap to list.
-	 */
-	private function append_sitemaps_to_master( $buffer, $sitemap_type ) {
-		$last_sitemap_id = 0;
-
-		while ( false === $buffer->is_full() ) {
-			$rows = $this->librarian->query_sitemaps_after_id(
-				$sitemap_type,
-				$last_sitemap_id,
-				JP_SITEMAP_BATCH_SIZE
-			);
-
-			if ( empty( $rows ) ) {
-				return;
-			}
-
-			foreach ( $rows as $row ) {
-				$current_item = $this->sitemap_row_to_index_item( (array) $row );
-
-				if ( true !== $buffer->append( $current_item['xml'] ) ) {
-					return;
-				}
-
-				$last_sitemap_id = $row['ID'];
-			}
-		}
+		return $buffer;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-builder.php
@@ -90,6 +90,22 @@ class Jetpack_Sitemap_Buffer_Empty extends Jetpack_Sitemap_Buffer {
 class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound,Generic.Classes.OpeningBraceSameLine.ContentAfterBrace
 
 	/**
+	 * Returned by the master sitemap builders when the entries do not fit in one
+	 * buffer, so the flat listing has to give way to the nested indexes.
+	 *
+	 * @since 16.2
+	 */
+	const MASTER_OVERFLOW = 'overflow';
+
+	/**
+	 * Returned by the master sitemap builders when a sitemap file they would link
+	 * is missing, so any master built now would reach fewer URLs than the last one.
+	 *
+	 * @since 16.2
+	 */
+	const MASTER_INCOMPLETE = 'incomplete';
+
+	/**
 	 * Librarian object for storing and retrieving sitemap data.
 	 *
 	 * @access private
@@ -500,8 +516,9 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * does it fall back to linking the per-type `*-sitemap-index-N.xml` files.
 	 *
 	 * Either way the buffer is only stored once it covers every sitemap this
-	 * generation cycle produced; a master that reaches fewer URLs than the last
-	 * one is worse than leaving the last one in place.
+	 * generation cycle recorded. If a file it should link is missing, the master
+	 * the previous cycle stored is left in place: it reaches more URLs than
+	 * anything that could be built right now.
 	 *
 	 * @link https://www.sitemaps.org/protocol.html#index
 	 *
@@ -522,7 +539,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 
 		$buffer = $this->build_flat_master_buffer( $sitemap_types, $max );
 
-		if ( ! $buffer ) {
+		if ( self::MASTER_OVERFLOW === $buffer ) {
 			/*
 			 * ponytail: nested indexes are invalid per the protocol and Google
 			 * flags them, but a complete invalid tree beats a valid tree that
@@ -532,7 +549,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 			$buffer = $this->build_nested_master_buffer( $sitemap_types, $max );
 		}
 
-		if ( ! $buffer ) {
+		if ( ! is_object( $buffer ) ) {
 			return;
 		}
 
@@ -547,13 +564,10 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	/**
 	 * Build a master sitemap buffer listing every individual sitemap file.
 	 *
-	 * Returns false, discarding the partial buffer, unless every file this cycle
-	 * generated was listed. The buffer's item and byte limits can both stop it
-	 * short, and how soon the byte limit bites depends on how long this site's
-	 * URLs are, so the count is checked rather than assumed. Rows are also
-	 * matched against the filenames this cycle should have produced, so a short
-	 * read or a row left behind by an interrupted cleanup fails the build instead
-	 * of quietly changing what the master points at.
+	 * The buffer's item and byte limits can both stop this short, and how soon
+	 * the byte limit bites depends on how long this site's URLs are, so the
+	 * partial buffer is discarded and MASTER_OVERFLOW returned rather than
+	 * storing a master that omits sitemaps.
 	 *
 	 * @access private
 	 * @since 16.2
@@ -561,7 +575,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * @param array $sitemap_types The sitemap types to list, in order.
 	 * @param array $max           Array of sitemap types with max index and datetime.
 	 *
-	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if it does not list every file.
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|string The buffer, or MASTER_OVERFLOW / MASTER_INCOMPLETE.
 	 */
 	private function build_flat_master_buffer( $sitemap_types, $max ) {
 		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
@@ -571,52 +585,35 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		);
 
 		if ( ! $buffer ) {
-			return false;
+			return self::MASTER_INCOMPLETE;
 		}
 
 		foreach ( $sitemap_types as $sitemap_type ) {
-			$expected        = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
-			$listed          = 0;
-			$last_sitemap_id = 0;
+			$expected = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
 
-			while ( $listed < $expected ) {
-				$rows = $this->librarian->query_sitemaps_after_id(
-					$sitemap_type,
-					$last_sitemap_id,
-					min( JP_SITEMAP_BATCH_SIZE, $expected - $listed )
-				);
+			if ( $expected < 1 ) {
+				continue;
+			}
 
-				if ( empty( $rows ) ) {
+			$timestamps = $this->librarian->query_sitemap_timestamps( $sitemap_type );
+
+			for ( $number = 1; $number <= $expected; $number++ ) {
+				$filename = jp_sitemap_filename( $sitemap_type, $number );
+
+				if ( ! isset( $timestamps[ $filename ] ) ) {
 					if ( $this->logger ) {
-						$this->logger->report( "-- Only found $listed of $expected $sitemap_type rows; not flattening." );
+						$this->logger->report( "-- $filename is missing; keeping the previous Master Sitemap." );
 					}
 
-					return false;
+					return self::MASTER_INCOMPLETE;
 				}
 
-				foreach ( $rows as $row ) {
-					$row = (array) $row;
-					++$listed;
-
-					if ( jp_sitemap_filename( $sitemap_type, $listed ) !== $row['post_title'] ) {
-						if ( $this->logger ) {
-							$this->logger->report( "-- Unexpected row {$row['post_title']} for $sitemap_type; not flattening." );
-						}
-
-						return false;
+				if ( ! $this->append_sitemap_to_master( $buffer, $filename, $timestamps[ $filename ] ) ) {
+					if ( $this->logger ) {
+						$this->logger->report( '-- Master Sitemap is full; falling back to nested indexes.' );
 					}
 
-					$current_item = $this->sitemap_row_to_index_item( $row );
-
-					if ( true !== $buffer->append( $current_item['xml'] ) ) {
-						if ( $this->logger ) {
-							$this->logger->report( '-- Master Sitemap is full; falling back to nested indexes.' );
-						}
-
-						return false;
-					}
-
-					$last_sitemap_id = $row['ID'];
+					return self::MASTER_OVERFLOW;
 				}
 			}
 		}
@@ -628,10 +625,9 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * Build a master sitemap buffer linking one file per sitemap type: the single
 	 * sitemap when there is only one, otherwise that type's newest index file.
 	 *
-	 * Returns false if a type reports several sitemap files but no index to reach
-	 * them through, which means this generation cycle is incomplete. Publishing
-	 * then would drop every file after the first, so the caller keeps the master
-	 * built by the previous cycle instead.
+	 * Only used when the individual files do not all fit. Returns
+	 * MASTER_INCOMPLETE if the file a type would be reached through is missing,
+	 * or if even these few entries do not fit.
 	 *
 	 * @access private
 	 * @since 16.2
@@ -639,7 +635,7 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 	 * @param array $sitemap_types The sitemap types to list, in order.
 	 * @param array $max           Array of sitemap types with max index and datetime.
 	 *
-	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if it does not list every type.
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|string The buffer, or MASTER_INCOMPLETE.
 	 */
 	private function build_nested_master_buffer( $sitemap_types, $max ) {
 		$buffer = Jetpack_Sitemap_Buffer_Factory::create(
@@ -649,49 +645,72 @@ class Jetpack_Sitemap_Builder { // phpcs:ignore Generic.Files.OneObjectStructure
 		);
 
 		if ( ! $buffer ) {
-			return false;
+			return self::MASTER_INCOMPLETE;
 		}
 
 		foreach ( $sitemap_types as $sitemap_type ) {
-			if ( empty( $max[ $sitemap_type ]['number'] ) ) {
+			$number = isset( $max[ $sitemap_type ]['number'] ) ? (int) $max[ $sitemap_type ]['number'] : 0;
+
+			if ( $number < 1 ) {
 				continue;
 			}
 
-			$index_type = jp_sitemap_index_type_of( $sitemap_type );
-
-			if ( 1 === $max[ $sitemap_type ]['number'] ) {
-				$filename = jp_sitemap_filename( $sitemap_type, 1 );
-				$lastmod  = $max[ $sitemap_type ]['lastmod'];
-			} elseif ( ! empty( $max[ $index_type ]['number'] ) ) {
-				$filename = jp_sitemap_filename( $index_type, $max[ $index_type ]['number'] );
-				$lastmod  = $max[ $index_type ]['lastmod'];
+			if ( 1 === $number ) {
+				// A type with a single sitemap has no index; link the sitemap.
+				$linked_type = $sitemap_type;
+				$linked_name = jp_sitemap_filename( $sitemap_type, 1 );
 			} else {
-				if ( $this->logger ) {
-					$this->logger->report( "-- No index for $sitemap_type; keeping the previous Master Sitemap." );
-				}
-
-				return false;
+				// Every other file of this type hangs off its newest index.
+				$linked_type = jp_sitemap_index_type_of( $sitemap_type );
+				$linked_name = jp_sitemap_filename(
+					$linked_type,
+					isset( $max[ $linked_type ]['number'] ) ? (int) $max[ $linked_type ]['number'] : 0
+				);
 			}
 
-			$appended = $buffer->append(
-				array(
-					'sitemap' => array(
-						'loc'     => $this->finder->construct_sitemap_url( $filename ),
-						'lastmod' => jp_sitemap_datetime( $lastmod ),
-					),
-				)
-			);
+			$timestamps = $this->librarian->query_sitemap_timestamps( $linked_type );
 
-			if ( true !== $appended ) {
+			if ( ! isset( $timestamps[ $linked_name ] ) ) {
 				if ( $this->logger ) {
-					$this->logger->report( "-- No room for $filename; keeping the previous Master Sitemap." );
+					$this->logger->report( "-- $linked_name is missing; keeping the previous Master Sitemap." );
 				}
 
-				return false;
+				return self::MASTER_INCOMPLETE;
+			}
+
+			if ( ! $this->append_sitemap_to_master( $buffer, $linked_name, $timestamps[ $linked_name ] ) ) {
+				if ( $this->logger ) {
+					$this->logger->report( "-- No room for $linked_name; keeping the previous Master Sitemap." );
+				}
+
+				return self::MASTER_INCOMPLETE;
 			}
 		}
 
 		return $buffer;
+	}
+
+	/**
+	 * Append one <sitemap> entry to a master sitemap buffer.
+	 *
+	 * @access private
+	 * @since 16.2
+	 *
+	 * @param Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter $buffer   The master sitemap buffer.
+	 * @param string                                                  $filename The sitemap filename to link.
+	 * @param string                                                  $lastmod  Its timestamp, in 'YYYY-MM-DD hh:mm:ss' format.
+	 *
+	 * @return bool Whether the entry fit.
+	 */
+	private function append_sitemap_to_master( $buffer, $filename, $lastmod ) {
+		return true === $buffer->append(
+			array(
+				'sitemap' => array(
+					'loc'     => $this->finder->construct_sitemap_url( $filename ),
+					'lastmod' => jp_sitemap_datetime( $lastmod ),
+				),
+			)
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -253,39 +253,48 @@ class Jetpack_Sitemap_Librarian {
 	}
 
 	/**
-	 * Retrieve the timestamp of every stored sitemap of a given type, keyed by filename.
+	 * Retrieve the timestamps of named sitemaps of a given type, keyed by filename.
 	 *
-	 * Deliberately skips post_content: a caller listing sitemaps in an index needs
-	 * only the filename and its timestamp, and the bodies are large enough that
-	 * loading a site's worth of them is a real memory cost. Keying by filename
-	 * also means the caller does not have to assume anything about row order.
+	 * Only the named rows are read, and only their titles and dates: a caller
+	 * listing sitemaps in an index needs nothing else, and the base64 bodies are
+	 * large enough that reading a site's worth of them is a real memory cost.
+	 * Names missing from the result are not stored.
 	 *
 	 * @access public
 	 * @since 16.2
 	 *
-	 * @param string $type Type of the sitemap rows to retrieve.
+	 * @param string $type  Type of the sitemap rows to retrieve.
+	 * @param array  $names Sitemap filenames to look for.
 	 *
 	 * @return array Map of sitemap filename to its 'YYYY-MM-DD hh:mm:ss' timestamp.
 	 */
-	public function query_sitemap_timestamps( $type ) {
+	public function query_sitemap_timestamps( $type, $names ) {
 		global $wpdb;
-
-		$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->prepare(
-				"SELECT post_title, post_date
-					FROM $wpdb->posts
-					WHERE post_type=%s
-						AND post_status=%s;",
-				$type,
-				'draft'
-			),
-			ARRAY_A
-		);
 
 		$timestamps = array();
 
-		foreach ( (array) $rows as $row ) {
-			$timestamps[ $row['post_title'] ] = $row['post_date'];
+		foreach ( array_chunk( (array) $names, JP_SITEMAP_BATCH_SIZE ) as $chunk ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $chunk ), '%s' ) );
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated list of %s.
+			$sql = "SELECT post_title, post_date
+					FROM $wpdb->posts
+					WHERE post_type=%s
+						AND post_status=%s
+						AND post_title IN ( $placeholders );";
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+			$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+				$wpdb->prepare(
+					$sql, // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Prepared right here.
+					array_merge( array( $type, 'draft' ), array_values( $chunk ) )
+				),
+				ARRAY_A
+			);
+
+			foreach ( (array) $rows as $row ) {
+				$timestamps[ $row['post_title'] ] = $row['post_date'];
+			}
 		}
 
 		return $timestamps;

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -253,6 +253,45 @@ class Jetpack_Sitemap_Librarian {
 	}
 
 	/**
+	 * Retrieve the timestamp of every stored sitemap of a given type, keyed by filename.
+	 *
+	 * Deliberately skips post_content: a caller listing sitemaps in an index needs
+	 * only the filename and its timestamp, and the bodies are large enough that
+	 * loading a site's worth of them is a real memory cost. Keying by filename
+	 * also means the caller does not have to assume anything about row order.
+	 *
+	 * @access public
+	 * @since 16.2
+	 *
+	 * @param string $type Type of the sitemap rows to retrieve.
+	 *
+	 * @return array Map of sitemap filename to its 'YYYY-MM-DD hh:mm:ss' timestamp.
+	 */
+	public function query_sitemap_timestamps( $type ) {
+		global $wpdb;
+
+		$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT post_title, post_date
+					FROM $wpdb->posts
+					WHERE post_type=%s
+						AND post_status=%s;",
+				$type,
+				'draft'
+			),
+			ARRAY_A
+		);
+
+		$timestamps = array();
+
+		foreach ( (array) $rows as $row ) {
+			$timestamps[ $row['post_title'] ] = $row['post_date'];
+		}
+
+		return $timestamps;
+	}
+
+	/**
 	 * Retrieve an array of sitemap rows (of a given type) sorted by ID.
 	 *
 	 * Returns the smallest $num_posts sitemap rows (measured by ID)

--- a/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
+++ b/projects/plugins/jetpack/modules/sitemaps/sitemap-librarian.php
@@ -255,10 +255,11 @@ class Jetpack_Sitemap_Librarian {
 	/**
 	 * Retrieve the timestamps of named sitemaps of a given type, keyed by filename.
 	 *
-	 * Only the named rows are read, and only their titles and dates: a caller
-	 * listing sitemaps in an index needs nothing else, and the base64 bodies are
-	 * large enough that reading a site's worth of them is a real memory cost.
-	 * Names missing from the result are not stored.
+	 * Looking rows up by name is what lets a caller avoid assuming the Nth row of
+	 * a type is file N, which an interrupted cleanup can make false by rewriting a
+	 * row and moving it in ID order. Only the named rows are read, in batches, so
+	 * the result is bounded by what was asked for rather than by how many sitemap
+	 * rows the site has. Names with no stored row are absent from the result.
 	 *
 	 * @access public
 	 * @since 16.2

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -412,6 +412,59 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A master sitemap is not replaced by one that cannot reach every file.
+	 *
+	 * This guard is not behind the flat-layout filter, so it applies to every
+	 * site. Losing a sitemap file the state still expects has to leave the
+	 * previously stored master alone rather than publish one that no longer
+	 * reaches those URLs.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_master_sitemap_is_kept_when_a_sitemap_file_is_missing() {
+		$callback = $this->add_split_page_sitemap_fixture();
+		$this->enable_flat_master_index();
+
+		$this->builder->update_sitemap();
+
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$before    = $librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE );
+
+		$this->assertStringContainsString( 'sitemap-2.xml', $before );
+
+		// Lose a file the state still expects, then run the master step again.
+		$librarian->delete_sitemap_data( 'sitemap-2.xml', JP_PAGE_SITEMAP_TYPE );
+		update_option(
+			'jetpack-sitemap-state',
+			array(
+				'sitemap-type'  => JP_MASTER_SITEMAP_TYPE,
+				'last-added'    => 0,
+				'number'        => 0,
+				'last-modified' => '1970-01-01 00:00:00',
+				'max'           => array(
+					JP_PAGE_SITEMAP_TYPE => array(
+						'number'  => 2,
+						'lastmod' => '1970-01-01 00:00:00',
+					),
+				),
+			)
+		);
+
+		$this->builder->update_sitemap();
+
+		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+		remove_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );
+
+		$this->assertSame(
+			$before,
+			$librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE ),
+			'The master sitemap should be left alone when a file it lists is gone.'
+		);
+	}
+
+	/**
 	 * The flat layout is opt-in: without the filter the master still nests.
 	 *
 	 * The default is expected to flip once the flat layout has been verified in

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -327,10 +327,12 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 		add_filter( 'jetpack_page_sitemap_other_urls', $callback );
 
-		// Run to completion: page sitemaps, indexes, then the master.
-		for ( $i = 0; $i < 10; $i++ ) {
-			$this->builder->update_sitemap();
-		}
+		/*
+		 * One pass covers this fixture: update_sitemap() builds up to
+		 * JP_SITEMAP_UPDATE_SIZE files per call and this needs four. Calling it
+		 * again would start a fresh cycle rather than continue this one.
+		 */
+		$this->builder->update_sitemap();
 
 		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
 

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -305,6 +305,51 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The master sitemap links leaf sitemaps directly, never a nested sitemap index.
+	 *
+	 * A sitemap index file may not list other sitemap index files.
+	 *
+	 * @link https://www.sitemaps.org/protocol.html#index
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_master_sitemap_is_not_nested() {
+		// Enough URLs to spill over JP_SITEMAP_MAX_ITEMS into a second page sitemap.
+		$callback = function () {
+			$urls = array();
+			for ( $i = 0; $i <= JP_SITEMAP_MAX_ITEMS; $i++ ) {
+				$urls[] = 'https://example.com/' . $i;
+			}
+			return $urls;
+		};
+
+		add_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		// Run to completion: page sitemaps, indexes, then the master.
+		for ( $i = 0; $i < 10; $i++ ) {
+			$this->builder->update_sitemap();
+		}
+
+		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		$librarian = new Jetpack_Sitemap_Librarian();
+
+		// Sanity check: the content really did split across two sitemaps.
+		$this->assertNotEmpty(
+			$librarian->get_sitemap_text( 'sitemap-2.xml', JP_PAGE_SITEMAP_TYPE ),
+			'Expected the URLs to split across more than one page sitemap.'
+		);
+
+		$master = $librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE );
+
+		$this->assertStringContainsString( 'sitemap-1.xml', $master );
+		$this->assertStringContainsString( 'sitemap-2.xml', $master );
+		$this->assertStringNotContainsString( 'sitemap-index-', $master );
+	}
+
+	/**
 	 * Test that cache suspension state is restored after sitemap update
 	 *
 	 * @group jetpack-sitemap

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -301,6 +301,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		$result  = $builder->build_one_page_sitemap( 1, 1 );
 
 		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+		remove_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );
 
 		$this->assertSame( '2024-03-08T01:02:03Z', $result['last_modified'], 'Last modified date is not the one from the other_urls filter.' );
 	}
@@ -325,6 +326,13 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Turn on the flat master sitemap layout, which ships off by default.
+	 */
+	private function enable_flat_master_index() {
+		add_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );
+	}
+
+	/**
 	 * The master sitemap links leaf sitemaps directly when they fit in its buffer.
 	 *
 	 * A sitemap index file may not list other sitemap index files. When the leaf
@@ -339,6 +347,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	#[Group( 'jetpack-sitemap' )]
 	public function test_master_sitemap_lists_leaf_sitemaps_when_they_fit() {
 		$callback = $this->add_split_page_sitemap_fixture();
+		$this->enable_flat_master_index();
 
 		/*
 		 * One pass covers this fixture: update_sitemap() builds up to
@@ -348,6 +357,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		$this->builder->update_sitemap();
 
 		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+		remove_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );
 
 		$librarian = new Jetpack_Sitemap_Librarian();
 
@@ -378,12 +388,14 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	#[Group( 'jetpack-sitemap' )]
 	public function test_master_sitemap_falls_back_to_nested_index_when_leaves_do_not_fit() {
 		$callback = $this->add_split_page_sitemap_fixture();
+		$this->enable_flat_master_index();
 
 		Jetpack_Sitemap_Builder_Test_Stub::$master_item_limit = 1;
 		$builder = new Jetpack_Sitemap_Builder_Test_Stub();
 		$builder->update_sitemap();
 
 		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+		remove_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );
 		Jetpack_Sitemap_Builder_Test_Stub::reset();
 
 		$librarian = new Jetpack_Sitemap_Librarian();
@@ -397,6 +409,30 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'sitemap-1.xml', $index );
 		$this->assertStringContainsString( 'sitemap-2.xml', $index );
+	}
+
+	/**
+	 * The flat layout is opt-in: without the filter the master still nests.
+	 *
+	 * The default is expected to flip once the flat layout has been verified in
+	 * production, at which point this test goes with it.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_master_sitemap_nests_by_default() {
+		$callback = $this->add_split_page_sitemap_fixture();
+
+		$this->builder->update_sitemap();
+
+		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$master    = $librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE );
+
+		$this->assertStringContainsString( 'sitemap-index-1.xml', $master );
+		$this->assertStringNotContainsString( 'sitemap-1.xml', $master );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
 require_once JETPACK__PLUGIN_DIR . 'modules/sitemaps/sitemap-builder.php';
+require_once __DIR__ . '/class-jetpack-sitemap-builder-test-stub.php';
 
 /**
  * Test class for Jetpack_Sitemap_Builder.
@@ -305,18 +306,11 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The master sitemap links leaf sitemaps directly, never a nested sitemap index.
+	 * Enough URLs to spill over JP_SITEMAP_MAX_ITEMS into a second page sitemap.
 	 *
-	 * A sitemap index file may not list other sitemap index files.
-	 *
-	 * @link https://www.sitemaps.org/protocol.html#index
-	 *
-	 * @group jetpack-sitemap
-	 * @since 16.2
+	 * @return callable The filter callback, so the caller can remove it again.
 	 */
-	#[Group( 'jetpack-sitemap' )]
-	public function test_master_sitemap_is_not_nested() {
-		// Enough URLs to spill over JP_SITEMAP_MAX_ITEMS into a second page sitemap.
+	private function add_split_page_sitemap_fixture() {
 		$callback = function () {
 			$urls = array();
 			for ( $i = 0; $i < JP_SITEMAP_MAX_ITEMS * 2; $i++ ) {
@@ -326,6 +320,25 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		};
 
 		add_filter( 'jetpack_page_sitemap_other_urls', $callback );
+
+		return $callback;
+	}
+
+	/**
+	 * The master sitemap links leaf sitemaps directly when they fit in its buffer.
+	 *
+	 * A sitemap index file may not list other sitemap index files. When the leaf
+	 * files do not fit, the master deliberately keeps the nested layout instead
+	 * of dropping URLs — see the overflow test below.
+	 *
+	 * @link https://www.sitemaps.org/protocol.html#index
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_master_sitemap_lists_leaf_sitemaps_when_they_fit() {
+		$callback = $this->add_split_page_sitemap_fixture();
 
 		/*
 		 * One pass covers this fixture: update_sitemap() builds up to
@@ -349,6 +362,41 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'sitemap-1.xml', $master );
 		$this->assertStringContainsString( 'sitemap-2.xml', $master );
 		$this->assertStringNotContainsString( 'sitemap-index-', $master );
+	}
+
+	/**
+	 * Too many leaf sitemaps to list falls back to the nested index, intact.
+	 *
+	 * Filling the real buffer would take a million-plus URLs, so this shrinks it
+	 * to one entry through the builder's buffer seam. The master must then link
+	 * the per-type index rather than list some leaves and drop the rest, and the
+	 * index it links must still reach every leaf.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_master_sitemap_falls_back_to_nested_index_when_leaves_do_not_fit() {
+		$callback = $this->add_split_page_sitemap_fixture();
+
+		Jetpack_Sitemap_Builder_Test_Stub::$master_item_limit = 1;
+		$builder = new Jetpack_Sitemap_Builder_Test_Stub();
+		$builder->update_sitemap();
+
+		remove_filter( 'jetpack_page_sitemap_other_urls', $callback );
+		Jetpack_Sitemap_Builder_Test_Stub::reset();
+
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$master    = $librarian->get_sitemap_text( 'sitemap.xml', JP_MASTER_SITEMAP_TYPE );
+
+		$this->assertStringContainsString( 'sitemap-index-1.xml', $master );
+		$this->assertStringNotContainsString( 'sitemap-1.xml', $master );
+
+		// The fallback is only acceptable because the index still reaches everything.
+		$index = $librarian->get_sitemap_text( 'sitemap-index-1.xml', JP_PAGE_SITEMAP_INDEX_TYPE );
+
+		$this->assertStringContainsString( 'sitemap-1.xml', $index );
+		$this->assertStringContainsString( 'sitemap-2.xml', $index );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Builder_Test.php
@@ -319,7 +319,7 @@ class Jetpack_Sitemap_Builder_Test extends WP_UnitTestCase {
 		// Enough URLs to spill over JP_SITEMAP_MAX_ITEMS into a second page sitemap.
 		$callback = function () {
 			$urls = array();
-			for ( $i = 0; $i <= JP_SITEMAP_MAX_ITEMS; $i++ ) {
+			for ( $i = 0; $i < JP_SITEMAP_MAX_ITEMS * 2; $i++ ) {
 				$urls[] = 'https://example.com/' . $i;
 			}
 			return $urls;

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/Jetpack_Sitemap_Librarian_Test.php
@@ -202,6 +202,90 @@ class Jetpack_Sitemap_Librarian_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Timestamps come back keyed by filename, for the names that were asked for.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_query_sitemap_timestamps_is_keyed_by_filename() {
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$librarian->store_sitemap_data( 1, JP_PAGE_SITEMAP_TYPE, '<urlset></urlset>', '1998-07-17 00:00:00' );
+		$librarian->store_sitemap_data( 2, JP_PAGE_SITEMAP_TYPE, '<urlset></urlset>', '2005-03-01 00:00:00' );
+
+		$timestamps = $librarian->query_sitemap_timestamps(
+			JP_PAGE_SITEMAP_TYPE,
+			array( 'sitemap-1.xml', 'sitemap-2.xml' )
+		);
+
+		$this->assertSame(
+			array(
+				'sitemap-1.xml' => '1998-07-17 00:00:00',
+				'sitemap-2.xml' => '2005-03-01 00:00:00',
+			),
+			$timestamps
+		);
+	}
+
+	/**
+	 * A name with no stored row is absent, which is how the builder spots a gap.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_query_sitemap_timestamps_omits_missing_names() {
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$librarian->store_sitemap_data( 1, JP_PAGE_SITEMAP_TYPE, '<urlset></urlset>', '1970-01-01 00:00:00' );
+
+		$timestamps = $librarian->query_sitemap_timestamps(
+			JP_PAGE_SITEMAP_TYPE,
+			array( 'sitemap-1.xml', 'sitemap-2.xml' )
+		);
+
+		$this->assertArrayHasKey( 'sitemap-1.xml', $timestamps );
+		$this->assertArrayNotHasKey( 'sitemap-2.xml', $timestamps );
+	}
+
+	/**
+	 * A name list longer than one batch is queried in chunks, not truncated.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_query_sitemap_timestamps_asks_in_batches() {
+		$librarian = new Jetpack_Sitemap_Librarian();
+		$librarian->store_sitemap_data( 1, JP_PAGE_SITEMAP_TYPE, '<urlset></urlset>', '1970-01-01 00:00:00' );
+
+		// Only the first and last names exist, and they land in different chunks.
+		$names = array();
+		for ( $number = 1; $number <= JP_SITEMAP_BATCH_SIZE + 1; $number++ ) {
+			$names[] = jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, $number );
+		}
+		$librarian->store_sitemap_data( JP_SITEMAP_BATCH_SIZE + 1, JP_PAGE_SITEMAP_TYPE, '<urlset></urlset>', '1970-01-01 00:00:00' );
+
+		$timestamps = $librarian->query_sitemap_timestamps( JP_PAGE_SITEMAP_TYPE, $names );
+
+		$this->assertArrayHasKey( 'sitemap-1.xml', $timestamps );
+		$this->assertArrayHasKey( jp_sitemap_filename( JP_PAGE_SITEMAP_TYPE, JP_SITEMAP_BATCH_SIZE + 1 ), $timestamps );
+		$this->assertCount( 2, $timestamps );
+	}
+
+	/**
+	 * An empty name list makes no query and returns nothing.
+	 *
+	 * @group jetpack-sitemap
+	 * @since 16.2
+	 */
+	#[Group( 'jetpack-sitemap' )]
+	public function test_query_sitemap_timestamps_with_no_names() {
+		$librarian = new Jetpack_Sitemap_Librarian();
+
+		$this->assertSame( array(), $librarian->query_sitemap_timestamps( JP_PAGE_SITEMAP_TYPE, array() ) );
+	}
+
+	/**
 	 * Index queries select only the columns the index builder needs.
 	 *
 	 * Sitemap rows store the sitemap XML in post_content, which can run to

--- a/projects/plugins/jetpack/tests/php/modules/sitemaps/class-jetpack-sitemap-builder-test-stub.php
+++ b/projects/plugins/jetpack/tests/php/modules/sitemaps/class-jetpack-sitemap-builder-test-stub.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Test-only subclass of Jetpack_Sitemap_Builder that overrides the master
+ * buffer seam, so the overflow fallback can be exercised without generating
+ * the million-plus URLs it would otherwise take to fill the real buffer.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Test-only subclass overriding Jetpack_Sitemap_Builder's buffer seam.
+ */
+class Jetpack_Sitemap_Builder_Test_Stub extends Jetpack_Sitemap_Builder {
+
+	/**
+	 * Item capacity to give the master sitemap buffer.
+	 *
+	 * @var int
+	 */
+	public static $master_item_limit = JP_SITEMAP_MAX_ITEMS;
+
+	/**
+	 * Restore the real item capacity.
+	 */
+	public static function reset() {
+		self::$master_item_limit = JP_SITEMAP_MAX_ITEMS;
+	}
+
+	/**
+	 * Create the master sitemap buffer with the seeded item capacity.
+	 *
+	 * @return Jetpack_Sitemap_Buffer|Jetpack_Sitemap_Buffer_XMLWriter|false The buffer, or false if one cannot be created.
+	 */
+	protected function create_master_buffer() {
+		return Jetpack_Sitemap_Buffer_Factory::create(
+			'master',
+			self::$master_item_limit,
+			JP_SITEMAP_MAX_BYTES
+		);
+	}
+}


### PR DESCRIPTION
Fixes #7828

## Proposed changes

A sitemap index file can't list other sitemap index files. Ours does: once a content type needs more than one sitemap file, `sitemap.xml` links that type's `*-sitemap-index-N.xml` rather than the sitemap files themselves. Search Console calls this "Nested indexing". `JP_SITEMAP_MAX_ITEMS` is 1,000, so it starts at ~1,000 URLs of a type — jetpack.com hits it today.

Before:

```
/sitemap.xml                sitemapindex
└── /sitemap-index-1.xml    sitemapindex   <- invalid
    ├── /sitemap-1.xml      urlset
    ├── /sitemap-2.xml      urlset
    └── /sitemap-3.xml      urlset
```

After:

```
/sitemap.xml                sitemapindex
├── /sitemap-1.xml          urlset
├── /sitemap-2.xml          urlset
└── /sitemap-3.xml          urlset
```

* `build_master_sitemap()` lists the sitemap files directly, behind a new `jetpack_sitemap_flat_master_index` filter that defaults to **false**. Nothing changes for any site until it opts in — the plan is to enable it for jetpack.com first, watch Search Console, then flip the default and drop the filter. A type with one sitemap is linked exactly as before either way.
* The `*-sitemap-index-N.xml` files are still generated and served, so URLs already submitted to Search Console don't start 404ing.
* The master buffer holds 1,000 items or 700KB, whichever runs out first. If the files don't all fit we keep today's nested layout instead of storing a flat list that quietly drops sitemaps. A sitemap index can't be paginated, so there's no flat layout that scales past that.
* Either layout is stored only when every sitemap file the cycle recorded is actually there. If one is missing we leave the previous `sitemap.xml` alone and let the next cycle rebuild.
* New `Jetpack_Sitemap_Librarian::query_sitemap_timestamps()` looks rows up by filename. Walking them in ID order would mean assuming the Nth row is file N, which stops holding once an interrupted cleanup rewrites a row.

One thing is **not** behind the filter: both layouts now refuse to publish a master that can't reach every sitemap file the cycle recorded, keeping the previous one instead. That only does anything in a state where today's code would publish a master linking a file that no longer exists.

Two behaviour changes the diff doesn't show:

* The Sitemaps abilities `get-status` payload parses `sitemap.xml`, so on a site with the filter on it reports N sitemap files where it reported one index. `packages/seo` only builds the URL, so it's unaffected.
* If a sitemap file the cycle recorded has gone missing we don't publish a master at all. An established site keeps its last good one; a first-time site serves the empty-sitemapindex response until the next cron run. Trunk publishes a master pointing at the missing file, which 404s.

### Tests

Three tests, each running `update_sitemap()` to completion with enough URLs to split the page sitemap:

* `test_master_sitemap_nests_by_default` — without the filter, the master still links `sitemap-index-1.xml`.
* `test_master_sitemap_lists_leaf_sitemaps_when_they_fit` — with the filter on, it lists `sitemap-1.xml` and `sitemap-2.xml` and no `sitemap-index-`.
* `test_master_sitemap_falls_back_to_nested_index_when_leaves_do_not_fit` — with the filter on and the master buffer shrunk to one entry through a protected seam, the master links the index rather than listing one leaf and dropping the rest, and that index still reaches both leaves. Checked against a mutant that stores the truncated buffer.

Still uncovered: the incomplete-state bail-out, image/video types, and the DOM buffer variant. There are manual steps below for the bail-out.

## Related product discussion/links

* JETPACK-2067

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

To see the bug with no setup at all, jetpack.com is running trunk and is over the threshold:

```
curl -s https://jetpack.com/sitemap.xml       # one <loc>, to /sitemap-index-1.xml
curl -s https://jetpack.com/sitemap-index-1.xml   # ...which is another <sitemapindex>
```

To test the patch you need a site with more than 1,000 URLs, or the split path never runs.

* With the Sitemaps module active: `wp post generate --count=2100`
* Confirm the default first: generate, load `/sitemap.xml`, and you should still get the nested `/sitemap-index-1.xml` — this PR changes nothing until the filter is on.
* Then turn it on: `add_filter( 'jetpack_sitemap_flat_master_index', '__return_true' );`
* `wp cron event run jp_sitemap_cron_hook` — run it again if it doesn't finish in one pass, generation is resumable
* Load `/sitemap.xml`. Every `<loc>` should be a `sitemap-N.xml` that opens as a `<urlset>`, not the nested index above.
* `/sitemap-index-1.xml` should still return 200.
* Delete posts to drop back under 1,000 URLs and regenerate: `/sitemap.xml` lists `sitemap-1.xml` alone, same as trunk.
* Overflow fallback, without building a million URLs: pass `1` instead of `JP_SITEMAP_MAX_ITEMS` in `create_master_buffer()`, then regenerate. The master should fall back to `/sitemap-index-1.xml`.
* Bail-out: delete the `jp_sitemap` post titled `sitemap-2.xml` and re-run the master step. The stored `sitemap.xml` should be untouched.

Automated coverage: `jetpack docker phpunit jetpack -- --group jetpack-sitemap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeBhByzYrWr7M9Fr8omKGU
