### PR TITLE
Premium Analytics: revise the onboarding copy and reorder the tour

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/packages/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.

--- a/projects/packages/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/packages/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.
+Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the page options menu.

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/__tests__/onboarding-welcome-modal.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/__tests__/onboarding-welcome-modal.test.tsx
@@ -15,10 +15,12 @@ describe( 'OnboardingWelcomeModal', () => {
 	it( 'introduces the new experience with the tour as the primary action', () => {
 		renderModal();
 
-		const dialog = screen.getByRole( 'dialog', { name: 'Introducing an updated experience' } );
+		const dialog = screen.getByRole( 'dialog', { name: 'Welcome to the new Traffic page' } );
 		expect( dialog ).toBeInTheDocument();
-		expect( dialog ).toHaveTextContent( 'Now you are able to decide how to display your data.' );
-		expect( screen.getByRole( 'button', { name: 'Get started' } ) ).toBeInTheDocument();
+		expect( dialog ).toHaveTextContent(
+			"we'll keep adding new tabs and features in regular updates."
+		);
+		expect( screen.getByRole( 'button', { name: 'Take a quick tour' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Close' } ) ).toBeInTheDocument();
 	} );
 
@@ -28,10 +30,10 @@ describe( 'OnboardingWelcomeModal', () => {
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'reports Get started without counting it as a dismissal', async () => {
+	it( 'reports the tour button without counting it as a dismissal', async () => {
 		const { onStart, onDismiss } = renderModal();
 
-		await userEvent.click( screen.getByRole( 'button', { name: 'Get started' } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: 'Take a quick tour' } ) );
 
 		expect( onStart ).toHaveBeenCalledTimes( 1 );
 		expect( onDismiss ).not.toHaveBeenCalled();

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.module.scss
@@ -21,9 +21,9 @@
 	z-index: 1;
 }
 
-// Below this height the stage would push Get started out of the popup, so the
-// copy and the button take the room instead, and the close icon goes back to
-// its neutral colors over the white popup.
+// Below this height the stage would push the tour button out of the popup,
+// so the copy and the button take the room instead, and the close icon goes
+// back to its neutral colors over the white popup.
 @media (max-height: 600px) {
 
 	.close {

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.tsx
@@ -38,8 +38,8 @@ export function OnboardingWelcomeModal( {
 	onStart,
 	onDismiss,
 }: OnboardingWelcomeModalProps ) {
-	// Get started closes through its own handler, so any close reaching here
-	// came from the chrome.
+	// The tour button closes through its own handler, so any close reaching
+	// here came from the chrome.
 	const handleOpenChange = useCallback(
 		( nextOpen: boolean, details?: OpenChangeDetails ) => {
 			if ( ! nextOpen ) {
@@ -53,7 +53,7 @@ export function OnboardingWelcomeModal( {
 		<Dialog.Root open={ open } onOpenChange={ handleOpenChange }>
 			<Dialog.Popup size="small">
 				<Dialog.CloseIcon className={ styles.close } />
-				{ /* The stage lives in the scroll region so the copy and Get started
+				{ /* The stage lives in the scroll region so the copy and the button
 				     stay reachable on short viewports; the footer stays pinned. */ }
 				<Dialog.Content>
 					<div className={ styles.stage }>
@@ -61,11 +61,11 @@ export function OnboardingWelcomeModal( {
 					</div>
 					<Stack direction="column" gap="md">
 						<Dialog.Title>
-							{ __( 'Introducing an updated experience', 'jetpack-premium-analytics-pkg' ) }
+							{ __( 'Welcome to the new Traffic page', 'jetpack-premium-analytics-pkg' ) }
 						</Dialog.Title>
 						<Dialog.Description>
 							{ __(
-								'We are excited to introduce a new experience for your Jetpack Stats. More consistent and more versatile. Now you are able to decide how to display your data.',
+								"It's built from widgets you can move and resize, so the page can match how you read your site. This is an early version and we'll keep adding new tabs and features in regular updates.",
 								'jetpack-premium-analytics-pkg'
 							) }
 						</Dialog.Description>
@@ -73,7 +73,7 @@ export function OnboardingWelcomeModal( {
 				</Dialog.Content>
 				<Dialog.Footer>
 					<Button variant="solid" onClick={ onStart }>
-						{ __( 'Get started', 'jetpack-premium-analytics-pkg' ) }
+						{ __( 'Take a quick tour', 'jetpack-premium-analytics-pkg' ) }
 					</Button>
 				</Dialog.Footer>
 			</Dialog.Popup>

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/stories/onboarding-welcome-modal.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/stories/onboarding-welcome-modal.stories.tsx
@@ -16,10 +16,10 @@ const meta: Meta< typeof OnboardingWelcomeModal > = {
 					'the new experience over the widget grid animation and hands off to ' +
 					'the tour.\n\n' +
 					'The consumer owns the open state. `onStart` fires when the reader ' +
-					'presses Get started; `onDismiss` when they close the dialog any other ' +
+					'presses Take a quick tour; `onDismiss` when they close the dialog any other ' +
 					'way, naming which (the close button, Escape, a click outside). The ' +
 					'onboarding hook decides what each one means for the journey.\n\n' +
-					'On viewports too short for the animation, the copy and Get started ' +
+					'On viewports too short for the animation, the copy and the tour button ' +
 					'take the room instead; on the ones in between, the content scrolls ' +
 					'while the footer stays pinned.',
 			},
@@ -55,7 +55,7 @@ function WelcomeModalDemo() {
 }
 
 /**
- * Opens on load, as it would on a reader's first visit. Get started and the
+ * Opens on load, as it would on a reader's first visit. Take a quick tour and the
  * close button both close it here and report which one the reader chose;
  * the button below reopens it.
  */

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
@@ -31,19 +31,24 @@ type Story = StoryObj< typeof SpotlightStep >;
 
 const STEPS = [
 	{
-		title: 'Customize your experience',
+		title: 'Everything is a widget',
 		description:
-			'Access customization from this menu. Move and resize widgets to prioritize what you need.',
+			'Each block of data is a widget you can move and resize to suit how you read your site.',
 	},
 	{
-		title: 'Improved date selection',
+		title: 'A better date picker',
 		description:
-			'Simplified and more powerful. You can now compare your data with past periods and adjust your chart intervals.',
+			"Compare any period with the one before it, and change the chart interval to suit the range you're looking at.",
 	},
 	{
-		title: 'Introducing widgets',
+		title: 'Rearrange it your way',
 		description:
-			'All data is delivered using powerful and versatile widgets for better visualization.',
+			'Access the settings here and select Customize to move and resize widgets. Your layout is saved to your profile.',
+	},
+	{
+		title: 'One last thing',
+		description:
+			"This same menu is where you'll be able to share feedback and deactivate this tab if you want. It's an early version, so do tell us what's working and what isn't.",
 	},
 ];
 
@@ -52,7 +57,7 @@ function TourDemo() {
 	const [ menu, setMenu ] = useState< HTMLElement | null >( null );
 	const [ dates, setDates ] = useState< HTMLElement | null >( null );
 	const [ widget, setWidget ] = useState< HTMLElement | null >( null );
-	const anchors = [ menu, dates, widget ];
+	const anchors = [ widget, dates, menu, menu ];
 
 	const next = () =>
 		setStep( current => ( current && current < STEPS.length ? current + 1 : null ) );
@@ -106,7 +111,7 @@ function TourDemo() {
 					totalSteps={ STEPS.length }
 					onNext={ next }
 					onDismiss={ () => setStep( null ) }
-					side={ step === 3 ? 'top' : 'bottom' }
+					side={ step === 1 ? 'top' : 'bottom' }
 				/>
 			) }
 		</div>
@@ -114,8 +119,8 @@ function TourDemo() {
 }
 
 /**
- * The three onboarding steps on a mock of the dashboard header: the options
- * menu, the date controls and the first widget. Continue walks them, Finish
+ * The onboarding steps on a mock of the dashboard header: the first widget,
+ * the date controls and the options menu twice. Continue walks them, Finish
  * ends, Escape leaves at any point; the button that appears afterwards
  * restarts the tour.
  */

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
@@ -43,12 +43,12 @@ const STEPS = [
 	{
 		title: 'Rearrange it your way',
 		description:
-			'Access the settings here and select Customize to move and resize widgets. Your layout is saved to your profile.',
+			'Select Customize to move and resize widgets. Your layout is saved to your profile.',
 	},
 	{
 		title: 'One last thing',
 		description:
-			"This same menu is where you'll be able to share feedback and deactivate this tab if you want. It's an early version, so do tell us what's working and what isn't.",
+			"This menu is where you can share feedback and switch the preview off if you want. It's an early version, so do tell us what's working and what isn't.",
 	},
 ];
 
@@ -120,7 +120,7 @@ function TourDemo() {
 
 /**
  * The onboarding steps on a mock of the dashboard header: the first widget,
- * the date controls and the options menu twice. Continue walks them, Finish
+ * the date controls, Customize and the options menu. Continue walks them, Finish
  * ends, Escape leaves at any point; the button that appears afterwards
  * restarts the tour.
  */

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
@@ -57,7 +57,8 @@ function TourDemo() {
 	const [ menu, setMenu ] = useState< HTMLElement | null >( null );
 	const [ dates, setDates ] = useState< HTMLElement | null >( null );
 	const [ widget, setWidget ] = useState< HTMLElement | null >( null );
-	const anchors = [ widget, dates, menu, menu ];
+	const [ customize, setCustomize ] = useState< HTMLElement | null >( null );
+	const anchors = [ widget, dates, customize, menu ];
 
 	const next = () =>
 		setStep( current => ( current && current < STEPS.length ? current + 1 : null ) );
@@ -72,6 +73,9 @@ function TourDemo() {
 							Last 30 days
 						</Button>
 					</div>
+					<Button ref={ setCustomize } variant="outline" tone="neutral">
+						Customize
+					</Button>
 					<IconButton
 						ref={ setMenu }
 						icon={ moreVertical }

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/onboarding-tour.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/onboarding-tour.test.tsx
@@ -12,20 +12,18 @@ type HarnessProps = {
 	current: number;
 	onNext: () => void;
 	onDismiss: () => void;
-	withDateControls?: boolean;
 };
 
 /**
  * Mounts anchors in the same tree as the tour, the way the stage does.
  *
- * @param props                  - Harness props.
- * @param props.current          - Zero-based index of the current step.
- * @param props.onNext           - Advances the tour.
- * @param props.onDismiss        - Leaves the tour.
- * @param props.withDateControls - Whether the second step's anchor is mounted.
+ * @param props           - Harness props.
+ * @param props.current   - Zero-based index of the current step.
+ * @param props.onNext    - Advances the tour.
+ * @param props.onDismiss - Leaves the tour.
  * @return The anchors and the tour.
  */
-function Harness( { current, onNext, onDismiss, withDateControls = true }: HarnessProps ) {
+function Harness( { current, onNext, onDismiss }: HarnessProps ) {
 	const [ actions, setActions ] = useState< HTMLElement | null >( null );
 	const [ dates, setDates ] = useState< HTMLElement | null >( null );
 
@@ -37,7 +35,7 @@ function Harness( { current, onNext, onDismiss, withDateControls = true }: Harne
 	return (
 		<>
 			<button ref={ setActions }>Customize</button>
-			{ withDateControls && <button ref={ setDates }>Last 30 days</button> }
+			<button ref={ setDates }>Last 30 days</button>
 			<OnboardingTour
 				steps={ steps }
 				current={ current }
@@ -58,16 +56,6 @@ describe( 'OnboardingTour', () => {
 		).toBeInTheDocument();
 		expect( screen.getByText( '2 of 2' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Finish' } ) ).toBeInTheDocument();
-	} );
-
-	it( 'skips a step whose anchor is not on the surface', () => {
-		const onNext = jest.fn();
-		render(
-			<Harness current={ 1 } onNext={ onNext } onDismiss={ jest.fn() } withDateControls={ false } />
-		);
-
-		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
-		expect( onNext ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'renders nothing past the last step', () => {

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/onboarding-tour.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/onboarding-tour.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { SpotlightStep, type SpotlightStepProps } from '@jetpack-premium-analytics/ui';
-import { useEffect, useRef } from 'react';
 
 export type OnboardingTourStep = Pick<
 	SpotlightStepProps,
@@ -22,38 +21,26 @@ type OnboardingTourProps = {
 };
 
 /**
- * Renders the current step of the onboarding tour over its anchor. A step
- * whose anchor is not on this surface is skipped rather than left invisible,
- * so the tour never stalls on a control the section does not show.
+ * Renders the current step of the onboarding tour over its anchor. The stage
+ * hands in only the steps whose anchors are on the page.
  *
  * @param props           - Component props.
  * @param props.steps     - The tour steps in order.
  * @param props.current   - Zero-based index of the current step.
  * @param props.onNext    - Advances the tour, or finishes it on the last step.
  * @param props.onDismiss - Leaves the tour, and how.
- * @return The current step, or nothing while it has no anchor.
+ * @return The current step, or nothing past the last one.
  */
 export function OnboardingTour( { steps, current, onNext, onDismiss }: OnboardingTourProps ) {
 	const step = steps[ current ];
-	const anchor = step?.anchor ?? null;
 
-	// Skip a step at most once: the parent re-renders before it moves on, and a
-	// second call would advance past the next step too.
-	const skippedRef = useRef< number | null >( null );
-	useEffect( () => {
-		if ( step && ! anchor && skippedRef.current !== current ) {
-			skippedRef.current = current;
-			onNext();
-		}
-	}, [ step, anchor, current, onNext ] );
-
-	if ( ! step || ! anchor ) {
+	if ( ! step?.anchor ) {
 		return null;
 	}
 
 	return (
 		<SpotlightStep
-			anchor={ anchor }
+			anchor={ step.anchor }
 			title={ step.title }
 			description={ step.description }
 			side={ step.side }

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.test.ts
@@ -1,25 +1,35 @@
 import { onboardingTourSteps } from './steps';
 
 describe( 'onboardingTourSteps', () => {
-	it( 'walks the actions, the date controls and the first widget in that order', () => {
-		const actions = document.createElement( 'div' );
-		const dateControls = document.createElement( 'div' );
+	it( 'walks the first widget, the date controls and the options menu twice', () => {
 		const firstWidget = document.createElement( 'section' );
+		const dateControls = document.createElement( 'div' );
+		const optionsMenu = document.createElement( 'button' );
 
-		const steps = onboardingTourSteps( { actions, dateControls, firstWidget } );
+		const steps = onboardingTourSteps( { firstWidget, dateControls, optionsMenu } );
 
-		expect( steps.map( step => step.anchor ) ).toEqual( [ actions, dateControls, firstWidget ] );
-		expect( steps.map( step => step.side ) ).toEqual( [ 'bottom', 'bottom', 'top' ] );
+		expect( steps.map( step => step.anchor ) ).toEqual( [
+			firstWidget,
+			dateControls,
+			optionsMenu,
+			optionsMenu,
+		] );
+		expect( steps.map( step => step.side ) ).toEqual( [ 'top', 'bottom', 'bottom', 'bottom' ] );
 		expect( steps.map( step => step.title ) ).toEqual( [
-			'Customize your experience',
-			'Improved date selection',
-			'Introducing widgets',
+			'Everything is a widget',
+			'A better date picker',
+			'Rearrange it your way',
+			'One last thing',
 		] );
 	} );
 
 	it( 'keeps the steps whose anchors are not mounted yet', () => {
-		const steps = onboardingTourSteps( { actions: null, dateControls: null, firstWidget: null } );
+		const steps = onboardingTourSteps( {
+			firstWidget: null,
+			dateControls: null,
+			optionsMenu: null,
+		} );
 
-		expect( steps.map( step => step.anchor ) ).toEqual( [ null, null, null ] );
+		expect( steps.map( step => step.anchor ) ).toEqual( [ null, null, null, null ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.test.ts
@@ -1,17 +1,18 @@
 import { onboardingTourSteps } from './steps';
 
 describe( 'onboardingTourSteps', () => {
-	it( 'walks the first widget, the date controls and the options menu twice', () => {
+	it( 'walks the first widget, the date controls, Customize and the options menu', () => {
 		const firstWidget = document.createElement( 'section' );
 		const dateControls = document.createElement( 'div' );
+		const customize = document.createElement( 'button' );
 		const optionsMenu = document.createElement( 'button' );
 
-		const steps = onboardingTourSteps( { firstWidget, dateControls, optionsMenu } );
+		const steps = onboardingTourSteps( { firstWidget, dateControls, customize, optionsMenu } );
 
 		expect( steps.map( step => step.anchor ) ).toEqual( [
 			firstWidget,
 			dateControls,
-			optionsMenu,
+			customize,
 			optionsMenu,
 		] );
 		expect( steps.map( step => step.side ) ).toEqual( [ 'top', 'bottom', 'bottom', 'bottom' ] );
@@ -27,6 +28,7 @@ describe( 'onboardingTourSteps', () => {
 		const steps = onboardingTourSteps( {
 			firstWidget: null,
 			dateControls: null,
+			customize: null,
 			optionsMenu: null,
 		} );
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.ts
@@ -11,13 +11,16 @@ export type OnboardingTourAnchors = {
 	/** The section header's date controls. */
 	dateControls: Element | null;
 
-	/** The configurations menu trigger among the dashboard actions (WOOA7S-2055). */
+	/** The Customize button among the dashboard actions. */
+	customize: Element | null;
+
+	/** The page options menu trigger beside it: feedback and the way back to classic Stats. */
 	optionsMenu: Element | null;
 };
 
 /**
  * The four steps of the tour, in order, over the elements the dashboard
- * stage hands in. The last two share the configurations menu.
+ * stage hands in. The last two sit side by side in the page header.
  *
  * @param anchors - The elements each step highlights, or null while unmounted.
  * @return The tour steps.
@@ -43,10 +46,10 @@ export function onboardingTourSteps( anchors: OnboardingTourAnchors ): Onboardin
 			side: 'bottom',
 		},
 		{
-			anchor: anchors.optionsMenu,
+			anchor: anchors.customize,
 			title: __( 'Rearrange it your way', 'jetpack-premium-analytics-pkg' ),
 			description: __(
-				'Access the settings here and select Customize to move and resize widgets. Your layout is saved to your profile.',
+				'Select Customize to move and resize widgets. Your layout is saved to your profile.',
 				'jetpack-premium-analytics-pkg'
 			),
 			side: 'bottom',
@@ -55,7 +58,7 @@ export function onboardingTourSteps( anchors: OnboardingTourAnchors ): Onboardin
 			anchor: anchors.optionsMenu,
 			title: __( 'One last thing', 'jetpack-premium-analytics-pkg' ),
 			description: __(
-				"This same menu is where you'll be able to share feedback and deactivate this tab if you want. It's an early version, so do tell us what's working and what isn't.",
+				"This menu is where you can share feedback and switch the preview off if you want. It's an early version, so do tell us what's working and what isn't.",
 				'jetpack-premium-analytics-pkg'
 			),
 			side: 'bottom',

--- a/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/components/onboarding-tour/steps.ts
@@ -5,19 +5,19 @@ import { __ } from '@wordpress/i18n';
 import type { OnboardingTourStep } from './onboarding-tour';
 
 export type OnboardingTourAnchors = {
-	/** The dashboard actions: Customize today, the configurations menu once it lands. */
-	actions: Element | null;
+	/** The first widget of the section, the traffic summary. */
+	firstWidget: Element | null;
 
 	/** The section header's date controls. */
 	dateControls: Element | null;
 
-	/** The first widget of the section. */
-	firstWidget: Element | null;
+	/** The configurations menu trigger among the dashboard actions (WOOA7S-2055). */
+	optionsMenu: Element | null;
 };
 
 /**
- * The three steps of the tour, in order, over the elements the dashboard
- * stage hands in. Copy is the design's proposal.
+ * The four steps of the tour, in order, over the elements the dashboard
+ * stage hands in. The last two share the configurations menu.
  *
  * @param anchors - The elements each step highlights, or null while unmounted.
  * @return The tour steps.
@@ -25,31 +25,40 @@ export type OnboardingTourAnchors = {
 export function onboardingTourSteps( anchors: OnboardingTourAnchors ): OnboardingTourStep[] {
 	return [
 		{
-			anchor: anchors.actions,
-			title: __( 'Customize your experience', 'jetpack-premium-analytics-pkg' ),
-			description: __(
-				'Access customization from this menu. Move and resize widgets to prioritize what you need.',
-				'jetpack-premium-analytics-pkg'
-			),
-			side: 'bottom',
-		},
-		{
-			anchor: anchors.dateControls,
-			title: __( 'Improved date selection', 'jetpack-premium-analytics-pkg' ),
-			description: __(
-				'Simplified and more powerful. You can now compare your data with past periods and adjust your chart intervals.',
-				'jetpack-premium-analytics-pkg'
-			),
-			side: 'bottom',
-		},
-		{
 			anchor: anchors.firstWidget,
-			title: __( 'Introducing widgets', 'jetpack-premium-analytics-pkg' ),
+			title: __( 'Everything is a widget', 'jetpack-premium-analytics-pkg' ),
 			description: __(
-				'All data is delivered using powerful and versatile widgets for better visualization.',
+				'Each block of data is a widget you can move and resize to suit how you read your site.',
 				'jetpack-premium-analytics-pkg'
 			),
 			side: 'top',
+		},
+		{
+			anchor: anchors.dateControls,
+			title: __( 'A better date picker', 'jetpack-premium-analytics-pkg' ),
+			description: __(
+				"Compare any period with the one before it, and change the chart interval to suit the range you're looking at.",
+				'jetpack-premium-analytics-pkg'
+			),
+			side: 'bottom',
+		},
+		{
+			anchor: anchors.optionsMenu,
+			title: __( 'Rearrange it your way', 'jetpack-premium-analytics-pkg' ),
+			description: __(
+				'Access the settings here and select Customize to move and resize widgets. Your layout is saved to your profile.',
+				'jetpack-premium-analytics-pkg'
+			),
+			side: 'bottom',
+		},
+		{
+			anchor: anchors.optionsMenu,
+			title: __( 'One last thing', 'jetpack-premium-analytics-pkg' ),
+			description: __(
+				"This same menu is where you'll be able to share feedback and deactivate this tab if you want. It's an early version, so do tell us what's working and what isn't.",
+				'jetpack-premium-analytics-pkg'
+			),
+			side: 'bottom',
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -343,8 +343,11 @@ describe( 'Dashboard options menu', () => {
 
 		const actions = screen.getByTestId( 'widget-dashboard-actions' );
 
+		// Each sits in its own frame, the tour's anchors; the menu's frame follows the actions'.
 		// eslint-disable-next-line testing-library/no-node-access -- order within the actions slot is what this test is for.
-		expect( actions.nextElementSibling ).toBe( screen.getByTestId( 'dashboard-options-menu' ) );
+		expect( actions.parentElement?.nextElementSibling ).toContainElement(
+			screen.getByTestId( 'dashboard-options-menu' )
+		);
 	} );
 } );
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -117,15 +117,18 @@ function Dashboard(): JSX.Element {
 
 	// The tour's anchors, handed in by the elements below once they mount.
 	const [ actionsFrame, setActionsFrame ] = useState< HTMLDivElement | null >( null );
+	const [ optionsMenuFrame, setOptionsMenuFrame ] = useState< HTMLDivElement | null >( null );
 	const [ controlsAnchor, setControlsAnchor ] = useState< HTMLDivElement | null >( null );
 	const [ widgetsFrame, setWidgetsFrame ] = useState< HTMLDivElement | null >( null );
-	// A step without its anchor is left out so the counter counts what is on the
-	// page: the configurations menu only arrives with WOOA7S-2055.
+	// A step without its anchor is left out, so the counter counts what is on the page.
 	const tourSteps = onboardingTourSteps( {
 		// Every tile is a section; the grid draws them in layout order.
 		firstWidget: widgetsFrame?.querySelector( 'section' ) ?? null,
 		dateControls: controlsAnchor,
-		optionsMenu: actionsFrame?.querySelector( '[aria-haspopup="menu"]' ) ?? null,
+		// At rest the dashboard's first button is Customize; its own menu, when the
+		// policy allows one, comes after it.
+		customize: actionsFrame?.querySelector( 'button' ) ?? null,
+		optionsMenu: optionsMenuFrame?.querySelector( 'button' ) ?? null,
 	} ).filter( step => step.anchor );
 
 	// The journey introduces the default section at rest: not another tab, and
@@ -260,9 +263,13 @@ function Dashboard(): JSX.Element {
 							visual={ <StatsPageIcon /> }
 							breadcrumbs={ <StatsBreadcrumbs isRoot /> }
 							actions={
-								<Stack ref={ setActionsFrame } direction="row" gap="sm">
-									<WidgetDashboard.Actions />
-									<DashboardOptionsMenu />
+								<Stack direction="row" gap="sm">
+									<Stack ref={ setActionsFrame } direction="row">
+										<WidgetDashboard.Actions />
+									</Stack>
+									<Stack ref={ setOptionsMenuFrame } direction="row">
+										<DashboardOptionsMenu />
+									</Stack>
 								</Stack>
 							}
 							className={ styles.dashboard }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -116,15 +116,17 @@ function Dashboard(): JSX.Element {
 	const [ editMode, setEditMode ] = useState( false );
 
 	// The tour's anchors, handed in by the elements below once they mount.
-	const [ actionsAnchor, setActionsAnchor ] = useState< HTMLDivElement | null >( null );
+	const [ actionsFrame, setActionsFrame ] = useState< HTMLDivElement | null >( null );
 	const [ controlsAnchor, setControlsAnchor ] = useState< HTMLDivElement | null >( null );
 	const [ widgetsFrame, setWidgetsFrame ] = useState< HTMLDivElement | null >( null );
+	// A step without its anchor is left out so the counter counts what is on the
+	// page: the configurations menu only arrives with WOOA7S-2055.
 	const tourSteps = onboardingTourSteps( {
-		actions: actionsAnchor,
-		dateControls: controlsAnchor,
 		// Every tile is a section; the grid draws them in layout order.
 		firstWidget: widgetsFrame?.querySelector( 'section' ) ?? null,
-	} );
+		dateControls: controlsAnchor,
+		optionsMenu: actionsFrame?.querySelector( '[aria-haspopup="menu"]' ) ?? null,
+	} ).filter( step => step.anchor );
 
 	// The journey introduces the default section at rest: not another tab, and
 	// not while the reader is already customizing.
@@ -258,7 +260,7 @@ function Dashboard(): JSX.Element {
 							visual={ <StatsPageIcon /> }
 							breadcrumbs={ <StatsBreadcrumbs isRoot /> }
 							actions={
-								<Stack ref={ setActionsAnchor } direction="row" gap="sm">
+								<Stack ref={ setActionsFrame } direction="row" gap="sm">
 									<WidgetDashboard.Actions />
 									<DashboardOptionsMenu />
 								</Stack>

--- a/projects/plugins/jetpack/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/plugins/jetpack/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: revise the onboarding welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.

--- a/projects/plugins/jetpack/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/plugins/jetpack/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Premium Analytics: revise the onboarding welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.
+Premium Analytics: revise the onboarding welcome modal copy and reorder the tour to start from the widgets and end on the page options menu.

--- a/projects/plugins/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/plugins/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.

--- a/projects/plugins/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
+++ b/projects/plugins/premium-analytics/changelog/update-pa-onboarding-copy-and-tour-order
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the configurations menu.
+Onboarding: revise the welcome modal copy and reorder the tour to start from the widgets and end on the page options menu.


### PR DESCRIPTION
## Proposed changes

Follow-up to #51938 and #51949 after the copy review on WOOA7S-2044. Stacked on #52025, which sits on #52023; it merges once those two are in.

### What

* Welcome modal: new title, description and button. It now reads "Welcome to the new Traffic page" and hands off with "Take a quick tour".
* Tour: four steps in a new order with new copy. The first widget ("Everything is a widget"), the date controls ("A better date picker"), the Customize button ("Rearrange it your way") and the page options menu ("One last thing").
* Customize stays a button for the soft launch, so step 3 anchors it (the dashboard's first button at rest, inside its own frame) and step 4 anchors the page options menu from #52023, which holds feedback and the switch-off from #52025. The stage still leaves out any step whose anchor is not on the page, and the Tracks `step` numbers follow the same list.
* Steps 3 and 4 are reworded for that split: "Select Customize to move and resize widgets. Your layout is saved to your profile." and "This menu is where you can share feedback and switch the preview off if you want. It's an early version, so do tell us what's working and what isn't." Both are on WOOA7S-2095 for Gary to confirm.
* Tests and stories updated; the spotlight story mirrors the new order.

## Related product discussion/links

* Linear: WOOA7S-2095 (this change), WOOA7S-2044 (the copy review), WOOA7S-2097 and #52023 (the page options menu), WOOA7S-2094 and #52025 (the switch-off the last step mentions).

## Does this pull request change what data or activity we track or use?

No. The same onboarding events fire; `step` counts the steps the reader can see, in the new order.

## Testing instructions

* Build the package, clear the preference from the console and reload:

  ```js
  wp.data
    .dispatch( 'core/preferences' )
    .set( 'jetpack-premium-analytics/dashboard', 'onboardingCompletedAt', null );
  ```
* The modal reads "Welcome to the new Traffic page" with a "Take a quick tour" button.
* The tour highlights the first widget ("Everything is a widget", 1 of 4), the date controls ("A better date picker", 2 of 4), the Customize button ("Rearrange it your way", 3 of 4) and the page options menu trigger ("One last thing", 4 of 4, Finish).
* Storybook, after `pnpm run build` in `projects/packages/premium-analytics`: Packages › Premium Analytics › UI › OnboardingWelcomeModal and SpotlightStep show the new copy.
* Unit tests, from the package: `pnpm run test -- packages/ui/src/onboarding-welcome-modal routes/dashboard/components/onboarding-tour routes/dashboard/stage.test`.



https://github.com/user-attachments/assets/a2bf83e0-7101-4a4b-8663-f8f6e4b157aa

