### PR TITLE
My Jetpack: restrict recommendations evaluation to admins

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommendations-evaluation-permissions
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-recommendations-evaluation-permissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Recommendations: Require administrator permissions on the site evaluation endpoints, and validate their input.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -934,7 +934,7 @@ class Initializer {
 	public static function get_recommended_modules() {
 		$recommendations_evaluation = \Jetpack_Options::get_option( 'recommendations_evaluation', null );
 
-		if ( ! $recommendations_evaluation ) {
+		if ( empty( $recommendations_evaluation ) || ! is_array( $recommendations_evaluation ) ) {
 			return null;
 		}
 

--- a/projects/packages/my-jetpack/src/class-rest-recommendations-evaluation.php
+++ b/projects/packages/my-jetpack/src/class-rest-recommendations-evaluation.php
@@ -29,6 +29,16 @@ class REST_Recommendations_Evaluation {
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => __CLASS__ . '::evaluate_site_recommendations',
 					'permission_callback' => __CLASS__ . '::permissions_callback',
+					'args'                => array(
+						'goals' => array(
+							'description' => __( 'List of goals selected by the user.', 'jetpack-my-jetpack' ),
+							'type'        => 'array',
+							'required'    => true,
+							'items'       => array(
+								'type' => 'string',
+							),
+						),
+					),
 				),
 			)
 		);
@@ -41,6 +51,16 @@ class REST_Recommendations_Evaluation {
 					'methods'             => \WP_REST_Server::EDITABLE,
 					'callback'            => __CLASS__ . '::save_evaluation_recommendations',
 					'permission_callback' => __CLASS__ . '::permissions_callback',
+					'args'                => array(
+						'recommendations' => array(
+							'description'          => __( 'Recommended module slugs mapped to their evaluation score.', 'jetpack-my-jetpack' ),
+							'type'                 => 'object',
+							'required'             => true,
+							'additionalProperties' => array(
+								'type' => 'number',
+							),
+						),
+					),
 				),
 			)
 		);
@@ -53,6 +73,13 @@ class REST_Recommendations_Evaluation {
 					'methods'             => \WP_REST_Server::DELETABLE,
 					'callback'            => __CLASS__ . '::dismiss_evaluation_recommendations',
 					'permission_callback' => __CLASS__ . '::permissions_callback',
+					'args'                => array(
+						'showWelcomeBanner' => array(
+							'description' => __( 'Whether the welcome banner should be shown again.', 'jetpack-my-jetpack' ),
+							'type'        => 'string',
+							'enum'        => array( 'true', 'false' ),
+						),
+					),
 				),
 			)
 		);
@@ -80,7 +107,18 @@ class REST_Recommendations_Evaluation {
 			);
 		}
 
-		return true; // We require site to be connected.
+		// These endpoints read and write site-wide options, so they are limited to administrators.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'invalid_user_permission_manage_options',
+				__( 'You do not have the correct user permissions to perform this action.', 'jetpack-my-jetpack' ),
+				array(
+					'status' => rest_authorization_required_code(),
+				)
+			);
+		}
+
+		return true;
 	}
 
 	/**
@@ -98,7 +136,7 @@ class REST_Recommendations_Evaluation {
 		}
 
 		$site_id        = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint = sprintf( '/sites/%1$d/jetpack-recommendations/evaluation?goals=%2$s', $site_id, implode( ',', $goals ) );
+		$wpcom_endpoint = sprintf( '/sites/%1$d/jetpack-recommendations/evaluation?goals=%2$s', $site_id, implode( ',', array_map( 'rawurlencode', (array) $goals ) ) );
 		$response       = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, '2', array(), null, 'wpcom' );
 		$response_code  = wp_remote_retrieve_response_code( $response );
 		$body           = json_decode( wp_remote_retrieve_body( $response ) );

--- a/projects/packages/my-jetpack/tests/php/Recommendations_Evaluation_Rest_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Recommendations_Evaluation_Rest_Test.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Test the Evaluation Recommendations REST API endpoints.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Tokens;
+use Jetpack_Options;
+use WorDBless\BaseTestCase;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Tests for REST_Recommendations_Evaluation.
+ *
+ * @see \Automattic\Jetpack\My_Jetpack\REST_Recommendations_Evaluation
+ */
+class Recommendations_Evaluation_Rest_Test extends BaseTestCase {
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Admin user id.
+	 *
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Editor user id.
+	 *
+	 * @var int
+	 */
+	private $editor_id;
+
+	/**
+	 * A payload that passes the endpoint's input schema.
+	 *
+	 * @var array
+	 */
+	private $valid_payload = array(
+		'recommendations' => array(
+			'backup'    => 3,
+			'anti-spam' => 2,
+		),
+	);
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		// Mock site connection. The endpoints refuse to run on a disconnected site.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		Jetpack_Options::update_option( 'id', 123 );
+		( new Connection_Manager() )->reset_connection_status();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		add_action(
+			'rest_api_init',
+			function () {
+				new REST_Recommendations_Evaluation();
+			}
+		);
+		do_action( 'rest_api_init' );
+
+		$this->admin_id  = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		$this->editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => '123',
+				'role'       => 'editor',
+			)
+		);
+
+		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		( new Connection_Manager() )->reset_connection_status();
+	}
+
+	/**
+	 * Build a request for the result endpoint.
+	 *
+	 * @param string $method HTTP method.
+	 * @param array  $body   JSON body params.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function build_result_request( $method, $body = array() ) {
+		$request = new WP_REST_Request( $method, '/my-jetpack/v1/site/recommendations/evaluation/result' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $body, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) );
+
+		return $request;
+	}
+
+	/**
+	 * Saving recommendations is rejected for anonymous requests.
+	 */
+	public function test_save_recommendations_rejects_anonymous_request() {
+		$response = $this->server->dispatch( $this->build_result_request( 'POST', $this->valid_payload ) );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'invalid_user_permission_manage_options', $response->get_data()['code'] );
+		$this->assertNull( Jetpack_Options::get_option( 'recommendations_evaluation', null ) );
+	}
+
+	/**
+	 * Saving recommendations is rejected for logged-in users without manage_options.
+	 */
+	public function test_save_recommendations_rejects_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$response = $this->server->dispatch( $this->build_result_request( 'POST', $this->valid_payload ) );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertNull( Jetpack_Options::get_option( 'recommendations_evaluation', null ) );
+	}
+
+	/**
+	 * Dismissing recommendations is rejected for anonymous requests.
+	 */
+	public function test_dismiss_recommendations_rejects_anonymous_request() {
+		$response = $this->server->dispatch( $this->build_result_request( 'DELETE' ) );
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertFalse( Jetpack_Options::get_option( 'dismissed_recommendations', false ) );
+	}
+
+	/**
+	 * Evaluating recommendations is rejected for logged-in users without manage_options.
+	 */
+	public function test_evaluate_recommendations_rejects_editor() {
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/my-jetpack/v1/site/recommendations/evaluation' );
+		$request->set_query_params( array( 'goals' => array( 'audience' ) ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * An administrator can still save a well-formed payload.
+	 */
+	public function test_save_recommendations_accepts_admin() {
+		wp_set_current_user( $this->admin_id );
+
+		$response = $this->server->dispatch( $this->build_result_request( 'POST', $this->valid_payload ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		// Modules come back sorted by descending score.
+		$this->assertSame( array( 'backup', 'anti-spam' ), $response->get_data() );
+		// Scores are stored as numbers; the schema casts them to float.
+		$this->assertEquals( $this->valid_payload['recommendations'], Jetpack_Options::get_option( 'recommendations_evaluation' ) );
+	}
+
+	/**
+	 * A scalar `recommendations` value is rejected by the input schema rather than
+	 * being written to the option, where it would later fatal in arsort().
+	 */
+	public function test_save_recommendations_rejects_non_object_payload() {
+		wp_set_current_user( $this->admin_id );
+
+		$response = $this->server->dispatch( $this->build_result_request( 'POST', array( 'recommendations' => 'PWNED' ) ) );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertNull( Jetpack_Options::get_option( 'recommendations_evaluation', null ) );
+	}
+
+	/**
+	 * A poisoned option value degrades gracefully instead of fataling.
+	 */
+	public function test_get_recommended_modules_ignores_non_array_option() {
+		Jetpack_Options::update_option( 'recommendations_evaluation', 'PWNED' );
+
+		$this->assertNull( Initializer::get_recommended_modules() );
+	}
+}


### PR DESCRIPTION
Closes MYJP-334

## Proposed changes

Hardens the `my-jetpack/v1/site/recommendations/evaluation` REST routes.

* Restricts the routes to users with `manage_options`. This aligns the REST layer with the capability the frontend already uses: `my-jetpack-screen` renders the recommendations section behind `userIsAdmin`, which is the same `current_user_can( 'manage_options' )` check. No legitimate user loses access.
* Adds `args` schemas to the routes so parameters are validated against expected types before the callbacks run.
* Makes `Initializer::get_recommended_modules()` defensive about the shape of the stored `recommendations_evaluation` option.
* URL-encodes the `goals` values interpolated into the WordPress.com request URL.

Adds PHPUnit coverage for the authorization matrix (anonymous, editor, administrator), for schema validation, and for the option guard.

See MYJP-334 for background and full details.

## Related product discussion/links

* MYJP-334

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The recommendations UI is rendered only for administrators both before and after this change, so there is no visible UI difference to check. Detailed verification steps are in MYJP-334.

**Automated**

```
jp test php packages/my-jetpack
```

All tests should pass, including the new `Recommendations_Evaluation_Rest_Test`.

**Manual smoke test**

On a Jetpack-connected test site:

1. Log in as an administrator and load **Jetpack → My Jetpack**. Confirm the page loads normally and, if the recommendations section is showing for your site, that dismissing it still works and stays dismissed after a reload.
2. Log in as an editor and load **Jetpack → My Jetpack**. Confirm the page still loads and behaves as before (the recommendations section is not rendered for non-admins, as previously).
