### PR TITLE
Survicate: close surveys while another modal dialog is open in wp-admin

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-survicate-modal-aware-suppression
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-survicate-modal-aware-suppression
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Survicate: close surveys while another modal dialog is open in wp-admin, generalizing the existing Help-Center-only suppression.

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -190,6 +190,56 @@ class Survicate {
 		}
 	}
 
+	// Requiring aria-modal excludes popovers/tooltips that only set role="dialog";
+	// the .components-modal__screen-overlay class covers older @wordpress/components
+	// Modal versions whose aria-modal attribute sat on an inner node.
+	var MODAL_SELECTOR = '[role="dialog"][aria-modal="true"], dialog[open], .components-modal__screen-overlay';
+	// The Survicate widget renders role="dialog"/aria-modal elements inside
+	// <div id="survicate-box" class="survicate-box-...">; without this exclusion
+	// every survey would suppress itself on display.
+	var SURVICATE_CONTAINER_SELECTOR = '#survicate-box, [class*="survicate-box"]';
+	function isElementRendered( el ) {
+		if ( typeof el.checkVisibility === 'function' ) {
+			return el.checkVisibility();
+		}
+		return el.getClientRects().length > 0;
+	}
+	function isModalOpen() {
+		try {
+			var candidates = document.querySelectorAll( MODAL_SELECTOR );
+			for ( var i = 0; i < candidates.length; i++ ) {
+				if ( candidates[ i ].closest( SURVICATE_CONTAINER_SELECTOR ) ) {
+					continue;
+				}
+				if ( ! isElementRendered( candidates[ i ] ) ) {
+					continue;
+				}
+				return true;
+			}
+		} catch ( e ) {
+			return false;
+		}
+		return false;
+	}
+	function nodeContainsModal( node ) {
+		if ( ! node || node.nodeType !== 1 ) {
+			return false;
+		}
+		if ( node.closest( SURVICATE_CONTAINER_SELECTOR ) ) {
+			return false;
+		}
+		if ( node.matches( MODAL_SELECTOR ) ) {
+			return true;
+		}
+		var inner = node.querySelectorAll( MODAL_SELECTOR );
+		for ( var i = 0; i < inner.length; i++ ) {
+			if ( ! inner[ i ].closest( SURVICATE_CONTAINER_SELECTOR ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	if ( window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function' ) {
 		var wasShown = isHelpCenterShown();
 		// Scope the subscription to the Help Center store so the callback does not
@@ -206,8 +256,8 @@ class Survicate {
 	window.addEventListener( 'SurvicateReady', function () {
 		window._sva.setVisitorTraits( traits );
 
-		// Covers the race where the Help Center opened before the SDK finished loading.
-		if ( isHelpCenterShown() ) {
+		// Covers the race where the Help Center or a modal opened before the SDK finished loading.
+		if ( isHelpCenterShown() || isModalOpen() ) {
 			closeAnySurvey();
 		}
 
@@ -216,10 +266,27 @@ class Survicate {
 			// post-display event. This causes a brief flash but is the best the
 			// public API allows.
 			window._sva.addEventListener( 'survey_displayed', function () {
-				if ( isHelpCenterShown() ) {
+				if ( isHelpCenterShown() || isModalOpen() ) {
 					closeAnySurvey();
 				}
 			} );
+		}
+
+		if ( typeof MutationObserver === 'function' && document.body ) {
+			// Close a survey already on screen when a modal opens on top of it.
+			// Only added nodes are inspected, so the observer is cheap on
+			// ordinary DOM churn; closeAnySurvey() is a no-op without a survey.
+			new MutationObserver( function ( mutations ) {
+				for ( var m = 0; m < mutations.length; m++ ) {
+					var added = mutations[ m ].addedNodes;
+					for ( var n = 0; n < added.length; n++ ) {
+						if ( nodeContainsModal( added[ n ] ) ) {
+							closeAnySurvey();
+							return;
+						}
+					}
+				}
+			} ).observe( document.body, { childList: true, subtree: true } );
 		}
 	} );
 } )();

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -245,7 +245,7 @@ class Survicate {
 	// producing an endless display/close loop. The disableTargeting flag is
 	// read live by the engine — while truthy, auto-campaigns are not scheduled
 	// at all (API-triggered surveys are unaffected); retarget() re-runs the
-	// evaluation once the last modal closes.
+	// evaluation once neither a modal nor the Help Center remains open.
 	function pauseTargeting() {
 		if ( window._sva && ! window._sva.disableTargeting ) {
 			window._sva.disableTargeting = true;
@@ -267,7 +267,10 @@ class Survicate {
 		window.wp.data.subscribe( function () {
 			var shown = isHelpCenterShown();
 			if ( shown && ! wasShown ) {
+				pauseTargeting();
 				closeAnySurvey();
+			} else if ( ! shown && wasShown && ! isModalOpen() ) {
+				resumeTargeting();
 			}
 			wasShown = shown;
 		}, 'automattic/help-center' );
@@ -277,25 +280,19 @@ class Survicate {
 		window._sva.setVisitorTraits( traits );
 
 		// Covers the race where the Help Center or a modal opened before the SDK
-		// finished loading. A modal already open pauses targeting up front, so
-		// the survey never displays at all while it stays open.
-		if ( isModalOpen() ) {
-			pauseTargeting();
-		}
+		// finished loading. Either one already open pauses targeting up front,
+		// so the survey never displays at all while it stays open.
 		if ( isHelpCenterShown() || isModalOpen() ) {
+			pauseTargeting();
 			closeAnySurvey();
 		}
 
 		if ( typeof window._sva.addEventListener === 'function' ) {
 			// The SDK does not expose a pre-display hook, so we close on the
-			// post-display event. The Help Center path deliberately doesn't
-			// pause targeting — it has no close hook here to resume from and
-			// keeps its long-standing close-on-display behavior.
+			// post-display event, pausing targeting so it isn't re-displayed.
 			window._sva.addEventListener( 'survey_displayed', function () {
-				if ( isModalOpen() ) {
+				if ( isHelpCenterShown() || isModalOpen() ) {
 					pauseTargeting();
-					closeAnySurvey();
-				} else if ( isHelpCenterShown() ) {
 					closeAnySurvey();
 				}
 			} );
@@ -327,7 +324,7 @@ class Survicate {
 						}
 					}
 				}
-				if ( sawRemovedModal && ! isModalOpen() ) {
+				if ( sawRemovedModal && ! isModalOpen() && ! isHelpCenterShown() ) {
 					resumeTargeting();
 				}
 			} ).observe( document.body, { childList: true, subtree: true } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/survicate/class-survicate.php
@@ -190,10 +190,11 @@ class Survicate {
 		}
 	}
 
-	// Requiring aria-modal excludes popovers/tooltips that only set role="dialog";
-	// the .components-modal__screen-overlay class covers older @wordpress/components
-	// Modal versions whose aria-modal attribute sat on an inner node.
-	var MODAL_SELECTOR = '[role="dialog"][aria-modal="true"], dialog[open], .components-modal__screen-overlay';
+	// Requiring aria-modal excludes generic role="dialog" widgets; the
+	// .components-modal__screen-overlay class covers older @wordpress/components
+	// Modal versions whose aria-modal attribute sat on an inner node; Popover
+	// counts, but Tooltip reuses its class and must not suppress on every hover.
+	var MODAL_SELECTOR = '[role="dialog"][aria-modal="true"], dialog[open], .components-modal__screen-overlay, .components-popover:not(.components-tooltip)';
 	// The Survicate widget renders role="dialog"/aria-modal elements inside
 	// <div id="survicate-box" class="survicate-box-...">; without this exclusion
 	// every survey would suppress itself on display.
@@ -239,6 +240,25 @@ class Survicate {
 		}
 		return false;
 	}
+	// Closing a suppressed auto-campaign survey is not enough: the SDK's
+	// targeting engine re-evaluates every few seconds and re-displays it,
+	// producing an endless display/close loop. The disableTargeting flag is
+	// read live by the engine — while truthy, auto-campaigns are not scheduled
+	// at all (API-triggered surveys are unaffected); retarget() re-runs the
+	// evaluation once the last modal closes.
+	function pauseTargeting() {
+		if ( window._sva && ! window._sva.disableTargeting ) {
+			window._sva.disableTargeting = true;
+		}
+	}
+	function resumeTargeting() {
+		if ( window._sva && window._sva.disableTargeting ) {
+			window._sva.disableTargeting = false;
+			if ( typeof window._sva.retarget === 'function' ) {
+				window._sva.retarget();
+			}
+		}
+	}
 
 	if ( window.wp && window.wp.data && typeof window.wp.data.subscribe === 'function' ) {
 		var wasShown = isHelpCenterShown();
@@ -256,35 +276,59 @@ class Survicate {
 	window.addEventListener( 'SurvicateReady', function () {
 		window._sva.setVisitorTraits( traits );
 
-		// Covers the race where the Help Center or a modal opened before the SDK finished loading.
+		// Covers the race where the Help Center or a modal opened before the SDK
+		// finished loading. A modal already open pauses targeting up front, so
+		// the survey never displays at all while it stays open.
+		if ( isModalOpen() ) {
+			pauseTargeting();
+		}
 		if ( isHelpCenterShown() || isModalOpen() ) {
 			closeAnySurvey();
 		}
 
 		if ( typeof window._sva.addEventListener === 'function' ) {
 			// The SDK does not expose a pre-display hook, so we close on the
-			// post-display event. This causes a brief flash but is the best the
-			// public API allows.
+			// post-display event. The Help Center path deliberately doesn't
+			// pause targeting — it has no close hook here to resume from and
+			// keeps its long-standing close-on-display behavior.
 			window._sva.addEventListener( 'survey_displayed', function () {
-				if ( isHelpCenterShown() || isModalOpen() ) {
+				if ( isModalOpen() ) {
+					pauseTargeting();
+					closeAnySurvey();
+				} else if ( isHelpCenterShown() ) {
 					closeAnySurvey();
 				}
 			} );
 		}
 
 		if ( typeof MutationObserver === 'function' && document.body ) {
-			// Close a survey already on screen when a modal opens on top of it.
-			// Only added nodes are inspected, so the observer is cheap on
-			// ordinary DOM churn; closeAnySurvey() is a no-op without a survey.
+			// Close a survey already on screen when a modal opens on top of it,
+			// pausing targeting so the SDK doesn't re-display it; resume once
+			// the last modal is removed. Only added/removed nodes are
+			// inspected, so the observer is cheap on ordinary DOM churn.
 			new MutationObserver( function ( mutations ) {
+				var sawRemovedModal = false;
 				for ( var m = 0; m < mutations.length; m++ ) {
 					var added = mutations[ m ].addedNodes;
 					for ( var n = 0; n < added.length; n++ ) {
 						if ( nodeContainsModal( added[ n ] ) ) {
+							pauseTargeting();
 							closeAnySurvey();
 							return;
 						}
 					}
+					if ( ! sawRemovedModal ) {
+						var removed = mutations[ m ].removedNodes;
+						for ( var r = 0; r < removed.length; r++ ) {
+							if ( nodeContainsModal( removed[ r ] ) ) {
+								sawRemovedModal = true;
+								break;
+							}
+						}
+					}
+				}
+				if ( sawRemovedModal && ! isModalOpen() ) {
+					resumeTargeting();
 				}
 			} ).observe( document.body, { childList: true, subtree: true } );
 		}


### PR DESCRIPTION
## Proposed changes

* Generalize the wp-admin Survicate suppression from "the Help Center is open" to "any modal dialog is open", in the inline script emitted by `jetpack-mu-wpcom`'s `class-survicate.php`:
  * `isModalOpen()` detects an open, rendered modal (`[role="dialog"][aria-modal="true"]`, native `dialog[open]`, or a `@wordpress/components` Modal screen overlay), excluding Survicate's own widget container (`#survicate-box, [class*="survicate-box"]` — verified against the production widget bundle `widget_core-28.33.0.js`, which renders surveys with `role="dialog"`/`aria-modal="true"` inside it).
  * The `survey_displayed` handler and the SDK-ready race check now close the survey when the Help Center **or** any modal is open.
  * A `MutationObserver` on added nodes closes a survey that is already on screen when a modal opens on top of it.
* All detection fails open: any error means "no modal" and surveys behave exactly as before.

This mirrors the same change to the shared `@automattic/survicate` package used by Calypso and the Multi-site Dashboard: Automattic/wp-calypso#114083.

## Related product discussion/links

* Automattic/wp-calypso#114083

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a sandboxed Simple site as a new user, open wp-admin → Site Setup so the "What's your main goal?" onboarding modal shows while a Survicate auto-campaign targets the page: the survey no longer stays open over the modal (it closes right after displaying).
* Open a modal (e.g. any wp-admin screen that uses a `@wordpress/components` Modal) while a survey is visible: the survey closes.
* With no modal open, surveys still display normally, and the existing Help Center suppression still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NABEHFLishQEAMTvzQmKDX
