### PR TITLE
VideoPress: add a site-wide setting to turn off player preloading

### DIFF
--- a/projects/packages/sync/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
+++ b/projects/packages/sync/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Sync the videopress_player_preload_disabled option to WordPress.com.

--- a/projects/packages/sync/src/class-defaults.php
+++ b/projects/packages/sync/src/class-defaults.php
@@ -169,6 +169,7 @@ class Defaults {
 		'users_can_register',
 		'verification_services_codes',
 		'videopress_auto_subtitles_disabled',
+		'videopress_player_preload_disabled',
 		'videopress_private_enabled_for_site',
 		'wordads_ccpa_enabled',
 		'wordads_ccpa_privacy_policy_url',

--- a/projects/packages/videopress/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
+++ b/projects/packages/videopress/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a site-wide setting to turn off player preloading for every embed.

--- a/projects/packages/videopress/routes/settings/package.json
+++ b/projects/packages/videopress/routes/settings/package.json
@@ -13,7 +13,8 @@
 		"@wordpress/ui": "0.21.0"
 	},
 	"devDependencies": {
-		"@testing-library/react": "16.3.2"
+		"@testing-library/react": "16.3.2",
+		"@testing-library/user-event": "^14.5.2"
 	},
 	"route": {
 		"path": "/settings",

--- a/projects/packages/videopress/routes/settings/stage.tsx
+++ b/projects/packages/videopress/routes/settings/stage.tsx
@@ -23,6 +23,7 @@ const SettingsForm = () => {
 	const { createErrorNotice } = useGlobalNotices();
 	const privateForSite = settings.data?.videoPressVideosPrivateForSite ?? false;
 	const autoSubtitlesDisabled = settings.data?.videoPressAutoSubtitlesDisabled ?? false;
+	const playerPreloadDisabled = settings.data?.videoPressPlayerPreloadDisabled ?? false;
 	const disabled = settings.isLoading || update.isPending;
 
 	// The mutation rolls the optimistic value back on failure; without a notice
@@ -87,6 +88,17 @@ const SettingsForm = () => {
 						checked={ ! autoSubtitlesDisabled }
 						disabled={ disabled }
 						onChange={ next => save( { videoPressAutoSubtitlesDisabled: ! next } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Preload video data when pages load', 'jetpack-videopress-pkg' ) }
+						help={ __(
+							'When enabled, embedded videos fetch their metadata and seek-bar preview thumbnails as the page loads. Turn it off to reduce page weight on pages with many videos; each video then loads its data when playback starts.',
+							'jetpack-videopress-pkg'
+						) }
+						checked={ ! playerPreloadDisabled }
+						disabled={ disabled }
+						onChange={ next => save( { videoPressPlayerPreloadDisabled: ! next } ) }
 					/>
 				</Stack>
 			</Card.Content>

--- a/projects/packages/videopress/routes/settings/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/settings/test/stage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useFreeTier } from '../../../src/dashboard/hooks/use-free-tier';
 import { stage as Stage } from '../stage';
 import type { FreeTierState } from '../../../src/dashboard/hooks/use-free-tier';
@@ -57,13 +58,18 @@ jest.mock( '../../../src/dashboard/components/query-client-wrapper', () => {
 
 // The settings form's data layer is covered by use-settings.test.ts; here it
 // only needs to render, so pin it to a settled, server-uncontrolled state.
+const mockMutate = jest.fn();
 jest.mock( '../../../src/dashboard/hooks/use-settings', () => ( {
 	isPrivateForSiteServerControlled: () => false,
 	useSettings: () => ( {
-		data: { videoPressVideosPrivateForSite: false, videoPressAutoSubtitlesDisabled: false },
+		data: {
+			videoPressVideosPrivateForSite: false,
+			videoPressAutoSubtitlesDisabled: false,
+			videoPressPlayerPreloadDisabled: false,
+		},
 		isLoading: false,
 	} ),
-	useUpdateSettings: () => ( { mutate: jest.fn(), isPending: false } ),
+	useUpdateSettings: () => ( { mutate: mockMutate, isPending: false } ),
 } ) );
 
 // Free-tier state is what the tests steer; the notice's checkout wiring is
@@ -116,5 +122,21 @@ describe( 'Settings stage', () => {
 			screen.queryByText( 'You’ve reached the free plan’s 1-video limit. Upgrade to upload more.' )
 		).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'saves the preload opt-out when the preload toggle is switched off', async () => {
+		mockedUseFreeTier.mockReturnValue( freeTierState() );
+
+		render( <Stage /> );
+
+		const toggle = screen.getByLabelText( 'Preload video data when pages load' );
+		expect( toggle ).toBeChecked();
+
+		await userEvent.click( toggle );
+
+		expect( mockMutate ).toHaveBeenCalledWith(
+			{ videoPressPlayerPreloadDisabled: true },
+			expect.objectContaining( { onError: expect.any( Function ) } )
+		);
 	} );
 } );

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -94,6 +94,11 @@ class Block_Editor_Content {
 			unset( $atts['preloadcontent'] );
 		}
 
+		// The site-wide opt-out wins over the shortcode's own preload attribute.
+		if ( Data::get_videopress_player_preload_disabled() ) {
+			$atts['preloadcontent'] = 'none';
+		}
+
 		$atts = shortcode_atts( $defaults, $atts, 'videopress' );
 
 		$base_url     = 'https://videopress.com/embed/' . $guid;

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -62,6 +62,17 @@ class Data {
 	}
 
 	/**
+	 * Gets whether player preloading is turned off for every embed on the site.
+	 *
+	 * Preloading is on by default, so this opt-out option defaults to false.
+	 *
+	 * @return boolean If embeds should wait for playback before fetching video data and player assets.
+	 */
+	public static function get_videopress_player_preload_disabled() {
+		return boolval( get_option( 'videopress_player_preload_disabled', false ) );
+	}
+
+	/**
 	 * Gets the VideoPress Settings.
 	 *
 	 * @return array The settings as an associative array.
@@ -81,6 +92,7 @@ class Data {
 		return array(
 			'videopress_videos_private_for_site' => self::get_videopress_videos_private_for_site(),
 			'videopress_auto_subtitles_disabled' => self::get_videopress_auto_subtitles_disabled(),
+			'videopress_player_preload_disabled' => self::get_videopress_player_preload_disabled(),
 			'site_is_private'                    => $site_is_private,
 			'site_type'                          => $site_type,
 		);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -664,7 +664,7 @@ class Initializer {
 	private static function playlist_embed_url( $guid, $autoplay, $muted = false ) {
 		$args = array(
 			'cover'          => 1,
-			'preloadContent' => 'metadata',
+			'preloadContent' => Data::get_videopress_player_preload_disabled() ? 'none' : 'metadata',
 			'autoPlay'       => $autoplay ? 1 : 0,
 		);
 		if ( $muted ) {

--- a/projects/packages/videopress/src/class-utils.php
+++ b/projects/packages/videopress/src/class-utils.php
@@ -41,6 +41,11 @@ class Utils {
 			)
 		);
 
+		// The site-wide opt-out wins over the block's own preload attribute.
+		if ( Data::get_videopress_player_preload_disabled() ) {
+			$video_press_url_options['preload'] = 'none';
+		}
+
 		$query_args = array(
 			'resizeToParent'  => 1,
 			'cover'           => 1,

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
@@ -57,6 +57,10 @@ class VideoPress_Rest_Api_V1_Settings {
 							'description' => __( 'If auto-generated subtitles should be skipped for new videos', 'jetpack-videopress-pkg' ),
 							'type'        => 'boolean',
 						),
+						'videopress_player_preload_disabled' => array(
+							'description' => __( 'If embedded players should wait for playback before preloading video data', 'jetpack-videopress-pkg' ),
+							'type'        => 'boolean',
+						),
 					),
 				),
 			)
@@ -129,6 +133,7 @@ class VideoPress_Rest_Api_V1_Settings {
 
 		$private_for_site        = $request->get_param( 'videopress_videos_private_for_site' );
 		$auto_subtitles_disabled = $request->get_param( 'videopress_auto_subtitles_disabled' );
+		$player_preload_disabled = $request->get_param( 'videopress_player_preload_disabled' );
 
 		if ( null !== $private_for_site ) {
 			update_option( 'videopress_private_enabled_for_site', $private_for_site );
@@ -136,6 +141,10 @@ class VideoPress_Rest_Api_V1_Settings {
 
 		if ( null !== $auto_subtitles_disabled ) {
 			update_option( 'videopress_auto_subtitles_disabled', $auto_subtitles_disabled );
+		}
+
+		if ( null !== $player_preload_disabled ) {
+			update_option( 'videopress_player_preload_disabled', $player_preload_disabled );
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -272,6 +272,10 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 							'description' => __( 'If auto-generated subtitles should be skipped for new videos', 'jetpack-videopress-pkg' ),
 							'type'        => 'boolean',
 						),
+						'videopress_player_preload_disabled' => array(
+							'description' => __( 'If embedded players should wait for playback before preloading video data', 'jetpack-videopress-pkg' ),
+							'type'        => 'boolean',
+						),
 					),
 				),
 			)
@@ -330,7 +334,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	 * Updates the VideoPress site settings.
 	 *
 	 * Mirrors `VideoPress_Rest_Api_V1_Settings::update_settings()`, except
-	 * on WPCOM only `videopress_auto_subtitles_disabled` is honored:
+	 * on WPCOM `videopress_videos_private_for_site` is not honored:
 	 * `videopress_private_enabled_for_site` is a dead option on Simple,
 	 * where the site-default privacy derives from the site's own privacy
 	 * setting. When a caller supplies that param on WPCOM it is not
@@ -343,6 +347,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	public function videopress_update_settings( $request ) {
 		$private_for_site        = $request->get_param( 'videopress_videos_private_for_site' );
 		$auto_subtitles_disabled = $request->get_param( 'videopress_auto_subtitles_disabled' );
+		$player_preload_disabled = $request->get_param( 'videopress_player_preload_disabled' );
 
 		$ignored = array();
 
@@ -363,6 +368,10 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 
 		if ( null !== $auto_subtitles_disabled ) {
 			update_option( 'videopress_auto_subtitles_disabled', $auto_subtitles_disabled );
+		}
+
+		if ( null !== $player_preload_disabled ) {
+			update_option( 'videopress_player_preload_disabled', $player_preload_disabled );
 		}
 
 		$response = array(

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
@@ -41,6 +41,7 @@ describe( 'useSettings', () => {
 				return {
 					videopress_videos_private_for_site: true,
 					videopress_auto_subtitles_disabled: true,
+					videopress_player_preload_disabled: false,
 					site_is_private: false,
 					site_type: 'jetpack',
 				};
@@ -52,6 +53,7 @@ describe( 'useSettings', () => {
 		await waitFor( () => expect( result.current.data ).toBeDefined() );
 		expect( result.current.data?.videoPressVideosPrivateForSite ).toBe( true );
 		expect( result.current.data?.videoPressAutoSubtitlesDisabled ).toBe( true );
+		expect( result.current.data?.videoPressPlayerPreloadDisabled ).toBe( false );
 		expect( result.current.data?.siteIsPrivate ).toBe( false );
 	} );
 } );
@@ -71,6 +73,7 @@ describe( 'useUpdateSettings', () => {
 			return {
 				videopress_videos_private_for_site: serverValue,
 				videopress_auto_subtitles_disabled: false,
+				videopress_player_preload_disabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -107,6 +110,7 @@ describe( 'useUpdateSettings', () => {
 			return {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: serverValue,
+				videopress_player_preload_disabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -131,6 +135,45 @@ describe( 'useUpdateSettings', () => {
 		);
 	} );
 
+	it( 'POSTs videopress_player_preload_disabled and optimistically updates the cache', async () => {
+		const calls: { path?: string; method?: string; data?: unknown }[] = [];
+		// Track server state so the refetch after onSettled returns the updated value.
+		let serverValue = false;
+		mockApiFetch( async ( { path, method, data } ) => {
+			calls.push( { path, method, data } );
+			if ( method === 'POST' ) {
+				serverValue = ( data as Record< string, unknown > )
+					?.videopress_player_preload_disabled as boolean;
+				return { code: 'success', message: 'ok', data: 200 };
+			}
+			return {
+				videopress_videos_private_for_site: false,
+				videopress_auto_subtitles_disabled: false,
+				videopress_player_preload_disabled: serverValue,
+				site_is_private: false,
+				site_type: 'jetpack',
+			};
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result: settingsResult } = renderHook( () => useSettings(), { wrapper } );
+		await waitFor( () => expect( settingsResult.current.data ).toBeDefined() );
+
+		const { result: mutationResult } = renderHook( () => useUpdateSettings(), { wrapper } );
+		await act( async () => {
+			await mutationResult.current.mutateAsync( {
+				videoPressPlayerPreloadDisabled: true,
+			} );
+		} );
+
+		const postCall = calls.find( c => c.method === 'POST' );
+		expect( postCall?.data ).toEqual( { videopress_player_preload_disabled: true } );
+		await waitFor( () =>
+			expect( settingsResult.current.data?.videoPressPlayerPreloadDisabled ).toBe( true )
+		);
+	} );
+
 	it( 'sends no request for an empty patch', async () => {
 		const calls: { method?: string }[] = [];
 		mockApiFetch( async ( { method } ) => {
@@ -138,6 +181,7 @@ describe( 'useUpdateSettings', () => {
 			return {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: false,
+				videopress_player_preload_disabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -160,6 +204,7 @@ describe( 'useUpdateSettings', () => {
 			return {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: false,
+				videopress_player_preload_disabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -195,6 +240,7 @@ describe( 'on WordPress.com Simple', () => {
 				return {
 					videopress_videos_private_for_site: false,
 					videopress_auto_subtitles_disabled: true,
+					videopress_player_preload_disabled: false,
 					site_is_private: true,
 					site_type: 'simple',
 				};
@@ -219,6 +265,7 @@ describe( 'on WordPress.com Simple', () => {
 			return {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: true,
+				videopress_player_preload_disabled: false,
 				site_is_private: true,
 				site_type: 'simple',
 			};

--- a/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
@@ -4,6 +4,7 @@ import apiFetch from '@wordpress/api-fetch';
 type ApiSettings = {
 	videopress_videos_private_for_site: boolean;
 	videopress_auto_subtitles_disabled: boolean;
+	videopress_player_preload_disabled: boolean;
 	site_is_private: boolean;
 	site_type: string;
 };
@@ -11,12 +12,18 @@ type ApiSettings = {
 export type Settings = {
 	videoPressVideosPrivateForSite: boolean;
 	videoPressAutoSubtitlesDisabled: boolean;
+	videoPressPlayerPreloadDisabled: boolean;
 	siteIsPrivate: boolean;
 	siteType: string;
 };
 
 export type SettingsPatch = Partial<
-	Pick< Settings, 'videoPressVideosPrivateForSite' | 'videoPressAutoSubtitlesDisabled' >
+	Pick<
+		Settings,
+		| 'videoPressVideosPrivateForSite'
+		| 'videoPressAutoSubtitlesDisabled'
+		| 'videoPressPlayerPreloadDisabled'
+	>
 >;
 
 /**
@@ -64,6 +71,7 @@ function fromApi( raw: ApiSettings ): Settings {
 	return {
 		videoPressVideosPrivateForSite: raw.videopress_videos_private_for_site,
 		videoPressAutoSubtitlesDisabled: raw.videopress_auto_subtitles_disabled,
+		videoPressPlayerPreloadDisabled: raw.videopress_player_preload_disabled,
 		siteIsPrivate: raw.site_is_private,
 		siteType: raw.site_type,
 	};
@@ -98,7 +106,9 @@ export function useUpdateSettings() {
 			const data: Partial<
 				Pick<
 					ApiSettings,
-					'videopress_videos_private_for_site' | 'videopress_auto_subtitles_disabled'
+					| 'videopress_videos_private_for_site'
+					| 'videopress_auto_subtitles_disabled'
+					| 'videopress_player_preload_disabled'
 				>
 			> = {};
 			if ( patch.videoPressVideosPrivateForSite !== undefined ) {
@@ -106,6 +116,9 @@ export function useUpdateSettings() {
 			}
 			if ( patch.videoPressAutoSubtitlesDisabled !== undefined ) {
 				data.videopress_auto_subtitles_disabled = patch.videoPressAutoSubtitlesDisabled;
+			}
+			if ( patch.videoPressPlayerPreloadDisabled !== undefined ) {
+				data.videopress_player_preload_disabled = patch.videoPressPlayerPreloadDisabled;
 			}
 			if ( Object.keys( data ).length === 0 ) {
 				return;

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -7,12 +7,33 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use WorDBless\BaseTestCase;
 
 /**
  * Class Block_Editor_Content_Test
+ *
+ * Runs in separate processes because the shortcode loads Jwt_Token_Bridge, which
+ * Uploader_Test replaces with a Mockery alias mock that requires the real class
+ * to not be loaded yet.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
 class Block_Editor_Content_Test extends BaseTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		// Each isolated process starts without the package's utility functions.
+		require_once __DIR__ . '/../../src/utility-functions.php';
+	}
 
 	/**
 	 * Tear down after each test.

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -53,7 +53,7 @@ class Block_Editor_Content_Test extends BaseTestCase {
 
 		$html = Block_Editor_Content::videopress_embed_shortcode(
 			array(
-				'abcDEF12',
+				0         => 'abcDEF12',
 				'preload' => 'none',
 			)
 		);
@@ -68,7 +68,7 @@ class Block_Editor_Content_Test extends BaseTestCase {
 
 		$html = Block_Editor_Content::videopress_embed_shortcode(
 			array(
-				'abcDEF12',
+				0                => 'abcDEF12',
 				'preloadcontent' => 'metadata',
 			)
 		);

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\VideoPress\Block_Editor_Content methods
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Block_Editor_Content_Test
+ */
+class Block_Editor_Content_Test extends BaseTestCase {
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		delete_option( 'videopress_player_preload_disabled' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the shortcode preloads metadata by default and honors an explicit preload attribute.
+	 */
+	public function test_shortcode_preload_attribute() {
+		$html = Block_Editor_Content::videopress_embed_shortcode( array( 'abcDEF12' ) );
+		$this->assertStringContainsString( 'videopress.com/embed/abcDEF12', $html );
+		$this->assertStringContainsString( 'preloadContent=metadata', $html );
+
+		$html = Block_Editor_Content::videopress_embed_shortcode(
+			array(
+				'abcDEF12',
+				'preload' => 'none',
+			)
+		);
+		$this->assertStringContainsString( 'preloadContent=none', $html );
+	}
+
+	/**
+	 * Test that the site-wide preload opt-out overrides the shortcode's preload attribute.
+	 */
+	public function test_shortcode_honors_site_preload_opt_out() {
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$html = Block_Editor_Content::videopress_embed_shortcode(
+			array(
+				'abcDEF12',
+				'preloadcontent' => 'metadata',
+			)
+		);
+
+		$this->assertStringContainsString( 'preloadContent=none', $html );
+		$this->assertStringNotContainsString( 'preloadContent=metadata', $html );
+	}
+}

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -544,4 +544,38 @@ class Data_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'videopress_auto_subtitles_disabled', $settings );
 		$this->assertTrue( $settings['videopress_auto_subtitles_disabled'] );
 	}
+
+	/**
+	 * Test that player preloading is not disabled by default (preload on).
+	 */
+	public function test_player_preload_disabled_defaults_to_false() {
+		delete_option( 'videopress_player_preload_disabled' );
+
+		$this->assertFalse( Data::get_videopress_player_preload_disabled() );
+	}
+
+	/**
+	 * Test that the stored player preload opt-out option is honored.
+	 */
+	public function test_player_preload_disabled_reflects_stored_option() {
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$this->assertTrue( Data::get_videopress_player_preload_disabled() );
+
+		delete_option( 'videopress_player_preload_disabled' );
+	}
+
+	/**
+	 * Test that get_videopress_settings exposes the player preload opt-out value.
+	 */
+	public function test_get_videopress_settings_includes_player_preload() {
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$settings = Data::get_videopress_settings();
+
+		$this->assertArrayHasKey( 'videopress_player_preload_disabled', $settings );
+		$this->assertTrue( $settings['videopress_player_preload_disabled'] );
+
+		delete_option( 'videopress_player_preload_disabled' );
+	}
 }

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -36,6 +36,7 @@ class Initializer_Test extends BaseTestCase {
 	public function tear_down() {
 		parent::tear_down();
 		unset( $GLOBALS['post'] );
+		delete_option( 'videopress_player_preload_disabled' );
 	}
 
 	/**
@@ -112,6 +113,17 @@ class Initializer_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'allow="clipboard-write; presentation"', $html );
 		$this->assertStringContainsString( 'width="640"', $html );
 		$this->assertStringContainsString( 'height="360"', $html );
+	}
+
+	/** Tests that the site-wide preload opt-out reaches the block's embed URL. */
+	public function test_block_embed_honors_site_preload_opt_out() {
+		$this->assertStringContainsString( 'preloadContent=metadata', $this->render() );
+
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$html = $this->render( array( 'preload' => 'metadata' ) );
+		$this->assertStringContainsString( 'preloadContent=none', $html );
+		$this->assertStringNotContainsString( 'preloadContent=metadata', $html );
 	}
 
 	/** Tests that the fallback filter is cleaned up after rendering. */

--- a/projects/packages/videopress/tests/php/Playlist_Block_Test.php
+++ b/projects/packages/videopress/tests/php/Playlist_Block_Test.php
@@ -49,6 +49,7 @@ class Playlist_Block_Test extends BaseTestCase {
 	 */
 	protected function tear_down() {
 		\WP_Block_Supports::$block_to_render = null;
+		delete_option( 'videopress_player_preload_disabled' );
 
 		$registry = \WP_Block_Type_Registry::get_instance();
 		if ( $registry->is_registered( 'videopress/playlist' ) ) {
@@ -313,6 +314,21 @@ class Playlist_Block_Test extends BaseTestCase {
 		);
 		$this->assertStringContainsString( 'data-autoplay-next="1"', $loop_only );
 		$this->assertStringContainsString( 'data-loop="1"', $loop_only );
+	}
+
+	/**
+	 * The site-wide preload opt-out rides on every embed URL: the player and the entries.
+	 */
+	public function test_render_honors_site_preload_opt_out() {
+		$markup = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertSame( 3, substr_count( $markup, 'preloadContent=metadata' ) );
+		$this->assertStringNotContainsString( 'preloadContent=none', $markup );
+
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$markup = VideoPress_Initializer::render_videopress_playlist_block( $this->attributes() );
+		$this->assertSame( 3, substr_count( $markup, 'preloadContent=none' ) );
+		$this->assertStringNotContainsString( 'preloadContent=metadata', $markup );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/UtilsTest.php
+++ b/projects/packages/videopress/tests/php/UtilsTest.php
@@ -15,6 +15,30 @@ use WorDBless\BaseTestCase;
  */
 class UtilsTest extends BaseTestCase {
 	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		delete_option( 'videopress_player_preload_disabled' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the site-wide preload opt-out overrides the block's preload attribute.
+	 */
+	public function test_get_video_press_url_honors_site_preload_opt_out() {
+		$guid = '123abc';
+
+		$url = Utils::get_video_press_url( $guid, array( 'preload' => 'metadata' ) );
+		$this->assertStringContainsString( 'preloadContent=metadata', $url );
+
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$url = Utils::get_video_press_url( $guid, array( 'preload' => 'metadata' ) );
+		$this->assertStringContainsString( 'preloadContent=none', $url );
+		$this->assertStringNotContainsString( 'preloadContent=metadata', $url );
+	}
+
+	/**
 	 * Test the get_video_press_url method.
 	 */
 	public function test_get_video_press_url() {

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Settings_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Settings_Test.php
@@ -161,4 +161,34 @@ class VideoPress_Rest_Api_V1_Settings_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'videopress_auto_subtitles_disabled', $data );
 		$this->assertTrue( $data['videopress_auto_subtitles_disabled'] );
 	}
+
+	/**
+	 * Test that posting videopress_player_preload_disabled persists the option
+	 * without touching the others.
+	 */
+	public function test_update_persists_player_preload_disabled() {
+		delete_option( 'videopress_player_preload_disabled' );
+		update_option( 'videopress_auto_subtitles_disabled', true );
+
+		$response = $this->update_settings( array( 'videopress_player_preload_disabled' => true ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( boolval( get_option( 'videopress_player_preload_disabled' ) ) );
+		$this->assertTrue( boolval( get_option( 'videopress_auto_subtitles_disabled' ) ) );
+	}
+
+	/**
+	 * Test that the GET endpoint exposes the player preload setting.
+	 */
+	public function test_get_settings_returns_player_preload_disabled() {
+		update_option( 'videopress_player_preload_disabled', true );
+
+		$request  = new WP_REST_Request( 'GET', '/videopress/v1/settings' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'videopress_player_preload_disabled', $data );
+		$this->assertTrue( $data['videopress_player_preload_disabled'] );
+	}
 }

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -121,6 +121,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'videopress_videos_private_for_site', $data );
 		$this->assertArrayHasKey( 'videopress_auto_subtitles_disabled', $data );
+		$this->assertArrayHasKey( 'videopress_player_preload_disabled', $data );
 		$this->assertArrayHasKey( 'site_is_private', $data );
 		$this->assertArrayHasKey( 'site_type', $data );
 	}
@@ -133,10 +134,12 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	public function test_update_settings_persists_options() {
 		delete_option( 'videopress_private_enabled_for_site' );
 		delete_option( 'videopress_auto_subtitles_disabled' );
+		delete_option( 'videopress_player_preload_disabled' );
 
 		$request = new \WP_REST_Request( 'POST', self::ROUTE_SETTINGS );
 		$request->set_param( 'videopress_videos_private_for_site', true );
 		$request->set_param( 'videopress_auto_subtitles_disabled', true );
+		$request->set_param( 'videopress_player_preload_disabled', true );
 
 		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
 		$response = $endpoint->videopress_update_settings( $request );
@@ -146,6 +149,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( 'ignored', $response->get_data() );
 		$this->assertTrue( (bool) get_option( 'videopress_private_enabled_for_site' ) );
 		$this->assertTrue( (bool) get_option( 'videopress_auto_subtitles_disabled' ) );
+		$this->assertTrue( (bool) get_option( 'videopress_player_preload_disabled' ) );
 	}
 
 	/**
@@ -154,6 +158,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	public function test_update_settings_ignores_absent_params() {
 		update_option( 'videopress_private_enabled_for_site', true );
 		update_option( 'videopress_auto_subtitles_disabled', false );
+		update_option( 'videopress_player_preload_disabled', true );
 
 		$request = new \WP_REST_Request( 'POST', self::ROUTE_SETTINGS );
 		$request->set_param( 'videopress_auto_subtitles_disabled', true );
@@ -163,6 +168,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 
 		$this->assertTrue( (bool) get_option( 'videopress_private_enabled_for_site' ) );
 		$this->assertTrue( (bool) get_option( 'videopress_auto_subtitles_disabled' ) );
+		$this->assertTrue( (bool) get_option( 'videopress_player_preload_disabled' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
+++ b/projects/plugins/jetpack/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: Add a site-wide setting to turn off player preloading for every embed.

--- a/projects/plugins/jetpack/modules/videopress/shortcode.php
+++ b/projects/plugins/jetpack/modules/videopress/shortcode.php
@@ -4,6 +4,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
+use Automattic\Jetpack\VideoPress\Data as VideoPress_Data;
+
 /**
  * VideoPress Shortcode Handler
  *
@@ -106,6 +108,11 @@ class VideoPress_Shortcode {
 
 		if ( isset( $attr['preload'] ) ) {
 			$attr['preloadcontent'] = $attr['preload'];
+		}
+
+		// The site-wide opt-out wins over the shortcode's own preload attribute.
+		if ( VideoPress_Data::get_videopress_player_preload_disabled() ) {
+			$attr['preloadcontent'] = 'none';
 		}
 
 		$attr = shortcode_atts( $defaults, $attr, 'videopress' );

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -255,6 +255,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'wpcom_is_fse_activated'                       => '1',
 			'videopress_private_enabled_for_site'          => false,
 			'videopress_auto_subtitles_disabled'           => true,
+			'videopress_player_preload_disabled'           => true,
 			'wpcom_featured_image_in_email'                => false,
 			'jetpack_gravatar_in_email'                    => false,
 			'jetpack_author_in_email'                      => false,

--- a/projects/plugins/videopress/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
+++ b/projects/plugins/videopress/changelog/vidp-384-videopress-add-a-site-wide-setting-to-turn-off-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a site-wide setting to turn off player preloading for every embed.


### PR DESCRIPTION
Fixes N/A — Linear [VIDP-384](https://linear.app/a8c/issue/VIDP-384/videopress-add-a-site-wide-setting-to-turn-off-player)

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add a site-wide **"Preload video data when pages load"** toggle to the VideoPress Settings tab (on by default). It is stored as the `videopress_player_preload_disabled` option and exposed through `videopress/v1/settings` and `wpcom/v2/videopress/settings`, following the shape of the auto-subtitles opt-out (#50014).
* When the site turns preloading off, every embed Jetpack renders sends `preloadContent=none` to the player, overriding the block's own "Preload Metadata" attribute: the VideoPress video block (`Utils::get_video_press_url()`), the playlist block, the package's `[videopress]`/`[wpvideo]` shortcode handler and the Jetpack plugin's legacy one. The player already skips thumbgrid preloading and media-segment fetches under `preload=none`.
* Sync the option to WordPress.com (`packages/sync` whitelist). Embeds the site does not render itself — page-builder widgets, third-party oEmbeds — never see Jetpack's PHP, so the player has to learn the setting from the video-info response; the WordPress.com side (exposes it as `preload_disabled` on `/videos/{guid}`) and the player side (forces `preload( 'none' )` before setting a source) are companion changes tracked from the Linear issue.
* Tests: `Data_Test`, `VideoPress_Rest_Api_V1_Settings_Test`, `WPCOM_REST_API_V2_Endpoint_VideoPress_Test`, `UtilsTest`, `Initializer_Test`, `Playlist_Block_Test`, a new `Block_Editor_Content_Test` for the shortcode path, `use-settings.test.ts`, the settings stage test, and the sync options fixture.

Why a site-wide setting: preloading could only be turned off one block at a time, and not at all for embeds built outside the block editor. On a page with several videos the player fetches the first media segments plus every thumbgrid sprite sheet for each embed before anyone presses play — a network trace of one embed from the report shows ~1.35 MB of media segments and ~710 KB of thumbgrid per video under the default `preloadContent=metadata`, none of it under `none`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: [VIDP-384](https://linear.app/a8c/issue/VIDP-384/videopress-add-a-site-wide-setting-to-turn-off-player)
* Companion player change (consumes the synced flag, and fixes the v2 chrome fetching the first thumbgrid sheet even under `preloadContent=none`) and WordPress.com change (sync allowlist + `preload_disabled` on the video-info response): both linked from the Linear issue.
* Deploy order is free: this PR is fully useful on its own for Jetpack-rendered embeds; the other two only add coverage for embeds Jetpack does not render.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No new tracking. One new boolean site option (`videopress_player_preload_disabled`) is synced to WordPress.com, alongside the two existing VideoPress site options.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Setup: a Jetpack-connected site with VideoPress active (Jurassic Ninja or `jp docker`), `jp build packages/videopress plugins/jetpack`, and a page containing a VideoPress video block (leave its "Preload Metadata" toggle on), a `[videopress <guid>]` shortcode and a Video Playlist block.

* Go to **Jetpack → VideoPress → Settings**. A new "Preload video data when pages load" toggle appears under the subtitles one, switched on. Turn it off, reload the page: it stays off. `GET /wp-json/wpcom/v2/videopress/settings` (and `/wp-json/videopress/v1/settings`) now report `"videopress_player_preload_disabled": true`.
* View the test page's source: every embed URL — the block's `videopress.com/v/…` (and the `/embed/` iframe it turns into), the shortcode iframe, and all three playlist embed URLs — carries `preloadContent=none`. In DevTools → Network, filter on `thumbgrid` and `.mp4`: nothing loads until you press play.
* Turn the setting back on and reload: the URLs carry `preloadContent=metadata` again and the block's own "Preload Metadata" toggle is honored as before.
* With the standalone VideoPress plugin *inactive* (Jetpack plugin only), repeat the shortcode check — that path goes through `modules/videopress/shortcode.php`.
* Automated: `jp test php packages/videopress`, `jp test js packages/videopress`. The `Jetpack_Sync_Options_Test` fixture change needs `jp docker phpunit jetpack -- --filter Jetpack_Sync_Options_Test`; I could not run that one locally.

Known gaps on purpose: until the companion player change ships, the v2 player chrome still fetches the first thumbgrid sheet even under `preloadContent=none` (a pre-existing bug the trace above surfaced); until it and the WordPress.com change ship, embeds Jetpack does not render (e.g. a page builder's own VideoPress widget) keep preloading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L84aNxBedd6AWnbWFAVkq4

