### PR TITLE
Help Center: add the /help-center/cta REST proxy endpoint

### DIFF
--- a/projects/packages/help-center/AGENTS.md
+++ b/projects/packages/help-center/AGENTS.md
@@ -44,6 +44,7 @@ All routes are registered under the `help-center` namespace (`/wp-json/help-cent
 | Route                                                 | Method | Controller                  | Proxies to                                    | Description                           |
 | ----------------------------------------------------- | ------ | --------------------------- | --------------------------------------------- | ------------------------------------- |
 | `/authenticate/chat`                                  | POST   | `Authenticate`              | `POST /help/authenticate/chat`                | Zendesk/messaging chat auth           |
+| `/cta`                                                | GET    | `CTA`                       | `GET /help/cta`                               | Contextual CTA for the current user   |
 | `/support-availability/email`                         | GET    | `Email_Support_Enabled`     | `GET /help/eligibility/email/mine`            | Check email support eligibility       |
 | `/fetch-post`                                         | GET    | `Fetch_Post`                | `GET /help/article/{blog_id}/{post_id}`       | Fetch a single support article        |
 | `/articles`                                           | GET    | `Fetch_Post`                | `GET /help/articles?blog_id=...&post_ids=...` | Fetch multiple support articles       |

--- a/projects/packages/help-center/changelog/add-help-center-cta-endpoint
+++ b/projects/packages/help-center/changelog/add-help-center-cta-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the `/help-center/cta` endpoint so the Help Center can fetch the contextual CTA for the current user from wp-admin.

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -592,6 +592,10 @@ class Help_Center {
 		require_once __DIR__ . '/class-wp-rest-help-center-ticket-csat.php';
 		$controller = new WP_REST_Help_Center_Ticket_CSAT( $this->wpcom_request_client );
 		$controller->register_rest_route();
+
+		require_once __DIR__ . '/class-wp-rest-help-center-cta.php';
+		$controller = new WP_REST_Help_Center_CTA( $this->wpcom_request_client );
+		$controller->register_rest_route();
 	}
 
 	/**

--- a/projects/packages/help-center/src/class-wp-rest-help-center-cta.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-cta.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WP_REST_Help_Center_CTA file.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+namespace Automattic\Jetpack\Help_Center;
+
+/**
+ * Class WP_REST_Help_Center_CTA.
+ */
+class WP_REST_Help_Center_CTA extends WP_REST_Help_Center_Controller {
+	/**
+	 * WP_REST_Help_Center_CTA constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 */
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
+		$this->namespace = 'help-center';
+		$this->rest_base = '/cta';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_cta' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * Get the contextual CTA for the current user.
+	 */
+	public function get_cta() {
+		$body = $this->wpcom_request_client->request( '/help/cta' );
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = rest_ensure_response( json_decode( wp_remote_retrieve_body( $body ) ) );
+
+		// Pass the upstream status through: a 204 means there is no CTA for this user.
+		$status = wp_remote_retrieve_response_code( $body );
+		if ( $status > 0 ) {
+			$response->set_status( $status );
+		}
+
+		return $response;
+	}
+}

--- a/projects/packages/help-center/tests/php/Cta_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Cta_Request_Test.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Tests for the Help Center CTA endpoint.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_CTA;
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+/**
+ * Class Cta_Request_Test
+ */
+class Cta_Request_Test extends \WorDBless\BaseTestCase {
+	public function test_cta_proxy_forwards_the_upstream_cta() {
+		$wpcom_request_client = $this->create_request_client(
+			200,
+			'{"id":"cta-1","variant":"default","url":"https://wordpress.com/help"}'
+		);
+
+		$controller = new WP_REST_Help_Center_CTA( $wpcom_request_client );
+		$response   = $controller->get_cta();
+
+		$this->assertSame(
+			array(
+				array(
+					'path'          => '/help/cta',
+					'version'       => '2',
+					'args'          => array(),
+					'body'          => null,
+					'base_api_path' => 'wpcom',
+				),
+			),
+			$wpcom_request_client->requests
+		);
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'cta-1', $response->get_data()->id );
+	}
+
+	public function test_cta_proxy_passes_a_no_content_response_through() {
+		$wpcom_request_client = $this->create_request_client( 204, '' );
+
+		$controller = new WP_REST_Help_Center_CTA( $wpcom_request_client );
+		$response   = $controller->get_cta();
+
+		$this->assertSame( 204, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+	}
+
+	public function test_cta_proxy_passes_an_error_status_through() {
+		$wpcom_request_client = $this->create_request_client( 401, '{"code":"unauthorized"}' );
+
+		$controller = new WP_REST_Help_Center_CTA( $wpcom_request_client );
+		$response   = $controller->get_cta();
+
+		$this->assertSame( 401, $response->get_status() );
+		$this->assertSame( 'unauthorized', $response->get_data()->code );
+	}
+
+	/**
+	 * Build a request client capturing the proxied request and returning a canned response.
+	 *
+	 * @param int    $code The upstream status code.
+	 * @param string $body The upstream response body.
+	 */
+	private function create_request_client( int $code, string $body ): Wpcom_Request_Client {
+		return new class( $code, $body ) implements Wpcom_Request_Client {
+			/**
+			 * Captured requests.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			/**
+			 * The upstream status code.
+			 *
+			 * @var int
+			 */
+			private $code;
+
+			/**
+			 * The upstream response body.
+			 *
+			 * @var string
+			 */
+			private $response_body;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int    $code          The upstream status code.
+			 * @param string $response_body The upstream response body.
+			 */
+			public function __construct( int $code, string $response_body ) {
+				$this->code          = $code;
+				$this->response_body = $response_body;
+			}
+
+			public function is_user_connected() {
+				return true;
+			}
+
+			public function request(
+				$path,
+				$version = '2',
+				$args = array(),
+				$body = null,
+				$base_api_path = 'wpcom'
+			) {
+				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+				return array(
+					'headers'  => array(),
+					'body'     => $this->response_body,
+					'response' => array(
+						'code'    => $this->code,
+						'message' => '',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		};
+	}
+}

--- a/projects/packages/help-center/tests/php/Cta_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Cta_Request_Test.php
@@ -6,7 +6,8 @@
  */
 
 use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_CTA;
-use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+require_once __DIR__ . '/class-cta-capturing-request-client.php';
 
 /**
  * Class Cta_Request_Test
@@ -63,64 +64,7 @@ class Cta_Request_Test extends \WorDBless\BaseTestCase {
 	 * @param int    $code The upstream status code.
 	 * @param string $body The upstream response body.
 	 */
-	private function create_request_client( int $code, string $body ): Wpcom_Request_Client {
-		return new class( $code, $body ) implements Wpcom_Request_Client {
-			/**
-			 * Captured requests.
-			 *
-			 * @var array
-			 */
-			public $requests = array();
-
-			/**
-			 * The upstream status code.
-			 *
-			 * @var int
-			 */
-			private $code;
-
-			/**
-			 * The upstream response body.
-			 *
-			 * @var string
-			 */
-			private $response_body;
-
-			/**
-			 * Constructor.
-			 *
-			 * @param int    $code          The upstream status code.
-			 * @param string $response_body The upstream response body.
-			 */
-			public function __construct( int $code, string $response_body ) {
-				$this->code          = $code;
-				$this->response_body = $response_body;
-			}
-
-			public function is_user_connected() {
-				return true;
-			}
-
-			public function request(
-				$path,
-				$version = '2',
-				$args = array(),
-				$body = null,
-				$base_api_path = 'wpcom'
-			) {
-				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
-
-				return array(
-					'headers'  => array(),
-					'body'     => $this->response_body,
-					'response' => array(
-						'code'    => $this->code,
-						'message' => '',
-					),
-					'cookies'  => array(),
-					'filename' => null,
-				);
-			}
-		};
+	private function create_request_client( int $code, string $body ): Cta_Capturing_Request_Client {
+		return new Cta_Capturing_Request_Client( $code, $body );
 	}
 }

--- a/projects/packages/help-center/tests/php/class-cta-capturing-request-client.php
+++ b/projects/packages/help-center/tests/php/class-cta-capturing-request-client.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test request client that captures proxied requests and returns a canned response.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+/**
+ * Request client that captures proxied requests and returns a canned upstream response.
+ */
+class Cta_Capturing_Request_Client implements Wpcom_Request_Client {
+	/**
+	 * Captured requests.
+	 *
+	 * @var array
+	 */
+	public $requests = array();
+
+	/**
+	 * The upstream status code.
+	 *
+	 * @var int
+	 */
+	private $code;
+
+	/**
+	 * The upstream response body.
+	 *
+	 * @var string
+	 */
+	private $response_body;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int    $code          The upstream status code.
+	 * @param string $response_body The upstream response body.
+	 */
+	public function __construct( int $code, string $response_body ) {
+		$this->code          = $code;
+		$this->response_body = $response_body;
+	}
+
+	public function is_user_connected() {
+		return true;
+	}
+
+	public function request(
+		$path,
+		$version = '2',
+		$args = array(),
+		$body = null,
+		$base_api_path = 'wpcom'
+	) {
+		$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+		return array(
+			'headers'  => array(),
+			'body'     => $this->response_body,
+			'response' => array(
+				'code'    => $this->code,
+				'message' => '',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+}

--- a/projects/plugins/wpcomsh/changelog/add-help-center-cta-endpoint
+++ b/projects/plugins/wpcomsh/changelog/add-help-center-cta-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Help Center: Show the contextual CTA in wp-admin.


### PR DESCRIPTION
## Proposed Changes

**The Help Center now has a `/help-center/cta` endpoint, so the contextual CTA can load in wp-admin on Atomic sites.**

- New `WP_REST_Help_Center_CTA` controller proxying to `GET wpcom/v2/help/cta`.
- Passes the upstream status through, so a `204` ("no CTA for you") stays a 204 instead of becoming a 200 with an empty body.


## Why are these changes being made?

The Help Center CTA was 404ing on Atomic sites.

## Testing Instructions

1. On an Atomic test site, follow the "Testing Changes → On an Atomic site" steps in `projects/packages/help-center/AGENTS.md` to load this branch.
2. Open wp-admin and hit `/wp-json/help-center/cta?_locale=user`.
3. It returns the CTA object (`id`, `variant`, `url`) with a 200, or an empty 204 if the user isn't eligible — no more 404.
