### PR TITLE
IP: add Utils::url_is_public() to check server-side request destinations

### DIFF
--- a/projects/packages/ip/changelog/add-ip-url-is-public-helper
+++ b/projects/packages/ip/changelog/add-ip-url-is-public-helper
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add Utils::url_is_public() to check whether a URL is a safe destination for a server-side request.

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -310,6 +310,13 @@ class Utils {
 			$host = preg_replace( '/%.*$/', '', $host );
 		}
 
+		// Trimming and decoding can empty the host ("[]") or put control bytes in it
+		// ("%00"), and gethostbynamel() throws a ValueError on a NUL rather than just
+		// failing to resolve. Neither is a host, so stop before the lookups.
+		if ( '' === $host || preg_match( '/[\x00-\x20\x7f]/', $host ) ) {
+			return array();
+		}
+
 		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
 			return array( $host );
 		}

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -233,6 +233,9 @@ class Utils {
 	 * This does not defend against DNS rebinding -- the address checked here is not
 	 * pinned for the request that follows.
 	 *
+	 * Without ext-dns there is no AAAA lookup, so only a host's IPv4 addresses are
+	 * checked and an internal IPv6 address sitting behind a public IPv4 one is missed.
+	 *
 	 * Returns a plain boolean rather than a WP_Error, so it can be dropped in as a
 	 * REST validate_callback and so a rejection reveals nothing about the host.
 	 *

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -282,6 +282,9 @@ class Utils {
 	 * empty list means the host is unusable -- malformed, or it resolved to nothing
 	 * -- and callers must treat that as unsafe rather than letting the host through.
 	 *
+	 * Every entry is a valid, distinct IP address; anything else a resolver hands
+	 * back is dropped.
+	 *
 	 * @since $$next-version$$
 	 *
 	 * @param string $host Host name or IP literal (IPv6 literals may be bracketed).
@@ -345,7 +348,16 @@ class Utils {
 			}
 		}
 
-		return $ips;
+		// Hand back addresses and nothing else, so a caller using these directly gets
+		// what the return type promises without re-checking the resolvers' output.
+		$ips = array_filter(
+			$ips,
+			function ( $ip ) {
+				return is_string( $ip ) && false !== filter_var( $ip, FILTER_VALIDATE_IP );
+			}
+		);
+
+		return array_values( array_unique( $ips ) );
 	}
 
 	/**

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -298,8 +298,12 @@ class Utils {
 			return array();
 		}
 
-		// IPv6 literals arrive bracketed, e.g. "[::1]".
-		$host = trim( $host, '[]' );
+		// IPv6 literals arrive bracketed, e.g. "[::1]". Strip one wrapping pair only --
+		// trimming every bracket would turn malformed input such as "]8.8.8.8[" into a
+		// clean address. Any bracket left after this is caught below.
+		if ( preg_match( '/^\[(.*)\]$/', $host, $matches ) ) {
+			$host = $matches[1];
+		}
 
 		// URL-decode so a percent-encoded host (e.g. "169%2e254%2e169%2e254") cannot
 		// slip past the IP-literal and DNS checks below.
@@ -316,10 +320,10 @@ class Utils {
 			$host = preg_replace( '/%.*$/', '', $host );
 		}
 
-		// Trimming and decoding can empty the host ("[]") or put control bytes in it
-		// ("%00"), and gethostbynamel() throws a ValueError on a NUL rather than just
-		// failing to resolve. Neither is a host, so stop before the lookups.
-		if ( '' === $host || preg_match( '/[\x00-\x20\x7f]/', $host ) ) {
+		// Unwrapping and decoding can empty the host ("[]") or leave bytes no host name
+		// holds: control characters from "%00", or a stray bracket. gethostbynamel()
+		// throws a ValueError on a NUL rather than failing to resolve, so stop here.
+		if ( '' === $host || preg_match( '/[\x00-\x20\x7f\[\]]/', $host ) ) {
 			return array();
 		}
 

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -246,11 +246,13 @@ class Utils {
 			return false;
 		}
 
-		if ( ! wp_http_validate_url( $url ) ) {
+		// Parse what core accepted, not what we were handed: it returns a normalized URL.
+		$validated_url = wp_http_validate_url( $url );
+		if ( ! $validated_url ) {
 			return false;
 		}
 
-		$host = wp_parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $validated_url, PHP_URL_HOST );
 		if ( ! is_string( $host ) || '' === $host ) {
 			return false;
 		}
@@ -277,8 +279,8 @@ class Utils {
 	 *
 	 * IP literals are returned as-is. Host names are resolved to their IPv4 and
 	 * IPv6 addresses so every address a request could connect to is checked. An
-	 * empty list means resolution failed; callers must treat that as unsafe rather
-	 * than letting the host through.
+	 * empty list means the host is unusable -- malformed, or it resolved to nothing
+	 * -- and callers must treat that as unsafe rather than letting the host through.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -293,12 +295,18 @@ class Utils {
 		// IPv6 literals arrive bracketed, e.g. "[::1]".
 		$host = trim( $host, '[]' );
 
-		// URL-decode so a percent-encoded host (e.g. "169%2e254%2e169%2e254")
-		// cannot slip past the IP-literal and DNS checks, then strip any IPv6 zone
-		// identifier (e.g. "fe80::1%eth0") -- which only becomes visible once "%25"
-		// is decoded to "%".
+		// URL-decode so a percent-encoded host (e.g. "169%2e254%2e169%2e254") cannot
+		// slip past the IP-literal and DNS checks below.
 		$host = rawurldecode( $host );
+
+		// Strip an IPv6 zone identifier (e.g. "fe80::1%eth0"), only visible once "%25"
+		// is decoded. Zone ids are IPv6-only, so a '%' on anything else is malformed:
+		// reject it rather than normalizing it into a host that looks safe, which is
+		// how ip_is_public() treats the same input.
 		if ( false !== strpos( $host, '%' ) ) {
+			if ( false === strpos( $host, ':' ) ) {
+				return array();
+			}
 			$host = preg_replace( '/%.*$/', '', $host );
 		}
 

--- a/projects/packages/ip/src/class-utils.php
+++ b/projects/packages/ip/src/class-utils.php
@@ -219,6 +219,121 @@ class Utils {
 	}
 
 	/**
+	 * Checks whether a URL is a safe destination for a server-side request.
+	 *
+	 * Runs core's wp_http_validate_url(), then rejects hosts that resolve to a
+	 * reserved or non-public IP core leaves open (Azure's metadata address, IPv6
+	 * link-local / ULA, and similar -- see ip_is_public()). Every address the host
+	 * resolves to is checked, and a host that resolves to none is rejected, so a
+	 * partly-internal or unresolvable host is never assumed safe.
+	 *
+	 * Callers that follow redirects must re-check every hop: this validates one URL,
+	 * and the request layer's own per-hop check is only core's weaker one.
+	 *
+	 * This does not defend against DNS rebinding -- the address checked here is not
+	 * pinned for the request that follows.
+	 *
+	 * Returns a plain boolean rather than a WP_Error, so it can be dropped in as a
+	 * REST validate_callback and so a rejection reveals nothing about the host.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $url URL to check.
+	 * @return bool True when the URL is safe to request, false otherwise.
+	 */
+	public static function url_is_public( $url ) {
+		if ( ! is_string( $url ) || '' === $url ) {
+			return false;
+		}
+
+		if ( ! wp_http_validate_url( $url ) ) {
+			return false;
+		}
+
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return false;
+		}
+
+		$ips = self::resolve_host_ips( $host );
+
+		// A host we cannot resolve to any IP must not be assumed safe: fail closed
+		// rather than deferring to the weaker checks in the request layer.
+		if ( empty( $ips ) ) {
+			return false;
+		}
+
+		foreach ( $ips as $ip ) {
+			if ( ! self::ip_is_public( $ip ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolves a host to the list of IP addresses that should be validated.
+	 *
+	 * IP literals are returned as-is. Host names are resolved to their IPv4 and
+	 * IPv6 addresses so every address a request could connect to is checked. An
+	 * empty list means resolution failed; callers must treat that as unsafe rather
+	 * than letting the host through.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $host Host name or IP literal (IPv6 literals may be bracketed).
+	 * @return string[] List of IP addresses.
+	 */
+	public static function resolve_host_ips( $host ) {
+		if ( ! is_string( $host ) || '' === $host ) {
+			return array();
+		}
+
+		// IPv6 literals arrive bracketed, e.g. "[::1]".
+		$host = trim( $host, '[]' );
+
+		// URL-decode so a percent-encoded host (e.g. "169%2e254%2e169%2e254")
+		// cannot slip past the IP-literal and DNS checks, then strip any IPv6 zone
+		// identifier (e.g. "fe80::1%eth0") -- which only becomes visible once "%25"
+		// is decoded to "%".
+		$host = rawurldecode( $host );
+		if ( false !== strpos( $host, '%' ) ) {
+			$host = preg_replace( '/%.*$/', '', $host );
+		}
+
+		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
+			return array( $host );
+		}
+
+		$ips = array();
+
+		if ( function_exists( 'gethostbynamel' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- gethostbynamel() warns on an unresolvable host.
+			$ipv4 = @gethostbynamel( $host );
+			if ( is_array( $ipv4 ) ) {
+				$ips = $ipv4;
+			}
+		}
+
+		// gethostbynamel() only resolves IPv4; check AAAA records too. dns_get_record()
+		// can be disabled on some hosts and may warn on lookup failure.
+		if ( function_exists( 'dns_get_record' ) ) {
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- dns_get_record may fail on some systems.
+			$aaaa = @dns_get_record( $host, DNS_AAAA );
+			if ( is_array( $aaaa ) ) {
+				foreach ( $aaaa as $record ) {
+					if ( ! empty( $record['ipv6'] ) ) {
+						$ips[] = $record['ipv6'];
+					}
+				}
+			}
+		}
+
+		return $ips;
+	}
+
+	/**
 	 * Validate an IP address.
 	 *
 	 * @param string $ip IP address.

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -485,6 +485,23 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Whatever a resolver returns, the list holds valid, distinct IP addresses.
+	 *
+	 * The lookup needs DNS, so the assertions are on the shape of the result rather
+	 * than a fixed set of addresses; with no network the list is empty and they hold
+	 * trivially.
+	 */
+	public function test_resolve_host_ips_returns_only_valid_distinct_addresses() {
+		$ips = Utils::resolve_host_ips( 'dns.google' );
+
+		$this->assertSame( array_values( array_unique( $ips ) ), $ips );
+		foreach ( $ips as $ip ) {
+			$this->assertIsString( $ip );
+			$this->assertNotFalse( filter_var( $ip, FILTER_VALIDATE_IP ), "$ip should be an IP address" );
+		}
+	}
+
+	/**
 	 * An unresolvable or empty host yields no addresses, which callers treat as unsafe.
 	 */
 	public function test_resolve_host_ips_returns_empty_for_unresolvable_host() {

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -350,7 +350,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 
 		$public_urls = array(
 			'http://8.8.8.8/image.jpg',
-			'https://203.0.113.10/a/b?c=d#e',
+			'https://1.1.1.1/a/b?c=d#e',
 			'https://[2606:4700:4700::1111]/image.jpg',
 			'https://[::ffff:8.8.8.8]/image.jpg',
 		);
@@ -381,6 +381,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 			'http://[fd00::1]/internal',                 // IPv6 unique-local.
 			'http://[::ffff:169.254.169.254]/',          // IPv4-mapped metadata.
 			'http://169%2e254%2e169%2e254/',             // Percent-encoded metadata host.
+			'http://8.8.8.8%foo/',                       // Zone id on a non-IPv6 host.
 		);
 		foreach ( $rejected_urls as $url ) {
 			$this->assertFalse( Utils::url_is_public( $url ), "$url should not be public" );
@@ -419,6 +420,19 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * The host checked is the one core handed back, not the one we passed in.
+	 *
+	 * Core returns a normalized URL, so parsing the argument instead would check a
+	 * host it never approved.
+	 */
+	public function test_url_is_public_checks_the_url_core_returned() {
+		$this->stub_url_helpers();
+		Functions\when( 'wp_http_validate_url' )->justReturn( 'http://169.254.169.254/' );
+
+		$this->assertFalse( Utils::url_is_public( 'http://8.8.8.8/image.jpg' ) );
+	}
+
+	/**
 	 * `resolve_host_ips` returns IP literals as-is, after undoing the encodings a
 	 * caller could hide one behind.
 	 */
@@ -431,6 +445,20 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 		);
 		foreach ( $literals as $host => $expected ) {
 			$this->assertSame( array( $expected ), Utils::resolve_host_ips( (string) $host ) );
+		}
+	}
+
+	/**
+	 * A '%' outside an IPv6 address is malformed, so the host resolves to nothing.
+	 *
+	 * Trimming it back to the prefix instead would launder a bad host into a public
+	 * one, undoing the same guard ip_is_public() applies.
+	 */
+	public function test_resolve_host_ips_rejects_zone_id_on_non_ipv6_host() {
+		$malformed = array( '8.8.8.8%foo', '8.8.8.8%25foo', 'example.com%foo' );
+		foreach ( $malformed as $host ) {
+			$this->assertSame( array(), Utils::resolve_host_ips( $host ), "$host should resolve to nothing" );
+			$this->assertFalse( Utils::ip_is_public( $host ), "$host should not be public" );
 		}
 	}
 

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -573,6 +573,22 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * Only a single wrapping bracket pair is stripped; anything else is rejected.
+	 *
+	 * Trimming every bracket would turn input like "]8.8.8.8[" into a clean address,
+	 * the same laundering the '%' handling above exists to prevent.
+	 */
+	public function test_resolve_host_ips_only_unwraps_a_single_bracket_pair() {
+		$this->assertSame( array( '::1' ), Utils::resolve_host_ips( '[::1]' ) );
+		$this->assertSame( array( 'fe80::1' ), Utils::resolve_host_ips( '[fe80::1%25eth0]' ) );
+
+		$malformed = array( '[[8.8.8.8]]', '[8.8.8.8', '8.8.8.8]', ']8.8.8.8[', '[[[::1]]]', '%5B8.8.8.8%5D' );
+		foreach ( $malformed as $host ) {
+			$this->assertSame( array(), Utils::resolve_host_ips( $host ), "$host should resolve to nothing" );
+		}
+	}
+
+	/**
 	 * An unresolvable or empty host yields no addresses, which callers treat as unsafe.
 	 */
 	public function test_resolve_host_ips_returns_empty_for_unresolvable_host() {

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -510,6 +510,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	 */
 	public function test_url_is_public_requires_every_resolved_address_to_be_public() {
 		$this->stub_url_helpers();
+		$this->require_aaaa_lookups();
 
 		\Jetpack_IP_Test_Resolver::$answers = array(
 			'all-public.test'    => array( 'ipv4' => array( '8.8.8.8', '1.1.1.1' ) ),
@@ -537,6 +538,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	 * Both the A and the AAAA answers are returned, not just whichever came first.
 	 */
 	public function test_resolve_host_ips_returns_both_a_and_aaaa_records() {
+		$this->require_aaaa_lookups();
 		\Jetpack_IP_Test_Resolver::$answers = array(
 			'dual.test'   => array(
 				'ipv4' => array( '8.8.8.8', '8.8.4.4' ),
@@ -556,6 +558,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	 * Anything a resolver returns that is not an address is dropped, repeats included.
 	 */
 	public function test_resolve_host_ips_drops_junk_and_duplicates() {
+		$this->require_aaaa_lookups();
 		\Jetpack_IP_Test_Resolver::$answers = array(
 			'noisy.test' => array(
 				'ipv4' => array( '8.8.8.8', 'not-an-ip', '8.8.8.8', '' ),
@@ -575,6 +578,18 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	public function test_resolve_host_ips_returns_empty_for_unresolvable_host() {
 		$this->assertSame( array(), Utils::resolve_host_ips( '' ) );
 		$this->assertSame( array(), Utils::resolve_host_ips( 'jetpack-ip-test.invalid' ) );
+	}
+
+	/**
+	 * Skips a test whose expectations need AAAA records.
+	 *
+	 * They are only looked up when ext-dns supplies dns_get_record(), and the package
+	 * does not require the extension.
+	 */
+	private function require_aaaa_lookups() {
+		if ( ! function_exists( 'dns_get_record' ) ) {
+			$this->markTestSkipped( 'AAAA lookups need dns_get_record() from ext-dns.' );
+		}
 	}
 
 	/**

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -34,6 +34,7 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		Monkey\tearDown();
+		\Jetpack_IP_Test_Resolver::reset();
 	}
 
 	/**
@@ -499,6 +500,73 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 			$this->assertIsString( $ip );
 			$this->assertNotFalse( filter_var( $ip, FILTER_VALIDATE_IP ), "$ip should be an IP address" );
 		}
+	}
+
+	/**
+	 * A host is public only when every address it resolves to is public.
+	 *
+	 * This is the whole point of the helper, and the one behaviour real DNS cannot
+	 * pin down, so the answers are supplied rather than looked up.
+	 */
+	public function test_url_is_public_requires_every_resolved_address_to_be_public() {
+		$this->stub_url_helpers();
+
+		\Jetpack_IP_Test_Resolver::$answers = array(
+			'all-public.test'    => array( 'ipv4' => array( '8.8.8.8', '1.1.1.1' ) ),
+			'one-internal.test'  => array( 'ipv4' => array( '8.8.8.8', '169.254.169.254' ) ),
+			'public-dual.test'   => array(
+				'ipv4' => array( '8.8.8.8' ),
+				'ipv6' => array( '2606:4700:4700::1111' ),
+			),
+			'internal-v6.test'   => array(
+				'ipv4' => array( '8.8.8.8' ),
+				'ipv6' => array( '2606:4700:4700::1111', 'fd00::1' ),
+			),
+			'only-internal.test' => array( 'ipv4' => array( '10.0.0.1' ) ),
+		);
+
+		$this->assertTrue( Utils::url_is_public( 'http://all-public.test/x' ) );
+		$this->assertTrue( Utils::url_is_public( 'http://public-dual.test/x' ) );
+
+		$this->assertFalse( Utils::url_is_public( 'http://one-internal.test/x' ), 'one internal A record rejects the host' );
+		$this->assertFalse( Utils::url_is_public( 'http://internal-v6.test/x' ), 'one internal AAAA record rejects the host' );
+		$this->assertFalse( Utils::url_is_public( 'http://only-internal.test/x' ) );
+	}
+
+	/**
+	 * Both the A and the AAAA answers are returned, not just whichever came first.
+	 */
+	public function test_resolve_host_ips_returns_both_a_and_aaaa_records() {
+		\Jetpack_IP_Test_Resolver::$answers = array(
+			'dual.test'   => array(
+				'ipv4' => array( '8.8.8.8', '8.8.4.4' ),
+				'ipv6' => array( '2001:4860:4860::8888' ),
+			),
+			'v6only.test' => array( 'ipv6' => array( '2001:4860:4860::8888' ) ),
+		);
+
+		$this->assertSame(
+			array( '8.8.8.8', '8.8.4.4', '2001:4860:4860::8888' ),
+			Utils::resolve_host_ips( 'dual.test' )
+		);
+		$this->assertSame( array( '2001:4860:4860::8888' ), Utils::resolve_host_ips( 'v6only.test' ) );
+	}
+
+	/**
+	 * Anything a resolver returns that is not an address is dropped, repeats included.
+	 */
+	public function test_resolve_host_ips_drops_junk_and_duplicates() {
+		\Jetpack_IP_Test_Resolver::$answers = array(
+			'noisy.test' => array(
+				'ipv4' => array( '8.8.8.8', 'not-an-ip', '8.8.8.8', '' ),
+				'ipv6' => array( '2001:4860:4860::8888', 'nonsense', '2001:4860:4860::8888' ),
+			),
+		);
+
+		$this->assertSame(
+			array( '8.8.8.8', '2001:4860:4860::8888' ),
+			Utils::resolve_host_ips( 'noisy.test' )
+		);
 	}
 
 	/**

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -463,6 +463,28 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * A host that decodes to nothing, or to bytes no host name can hold, is rejected.
+	 *
+	 * Reaching the lookup at all would be a fatal rather than a failed resolution:
+	 * gethostbynamel() throws a ValueError on a NUL byte.
+	 */
+	public function test_resolve_host_ips_rejects_empty_and_control_character_hosts() {
+		$malformed = array( '[]', '%00', 'example%00.com', 'exa%09mple.com', 'exa%20mple.com' );
+		foreach ( $malformed as $host ) {
+			$this->assertSame( array(), Utils::resolve_host_ips( $host ), "$host should resolve to nothing" );
+		}
+	}
+
+	/**
+	 * A URL whose host decodes to a NUL byte is rejected, not fatal.
+	 */
+	public function test_url_is_public_rejects_control_character_host() {
+		$this->stub_url_helpers();
+
+		$this->assertFalse( Utils::url_is_public( 'http://example%00.com/image.jpg' ) );
+	}
+
+	/**
 	 * An unresolvable or empty host yields no addresses, which callers treat as unsafe.
 	 */
 	public function test_resolve_host_ips_returns_empty_for_unresolvable_host() {

--- a/projects/packages/ip/tests/php/UtilsTest.php
+++ b/projects/packages/ip/tests/php/UtilsTest.php
@@ -339,6 +339,125 @@ final class UtilsTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
+	 * `url_is_public` accepts URLs whose host is a public address.
+	 *
+	 * Core's gate is stubbed open throughout these tests so the assertions are
+	 * about this helper's own check and not wp_http_validate_url()'s blocklist.
+	 * IP-literal hosts keep the whole set off DNS.
+	 */
+	public function test_url_is_public_accepts_public_hosts() {
+		$this->stub_url_helpers();
+
+		$public_urls = array(
+			'http://8.8.8.8/image.jpg',
+			'https://203.0.113.10/a/b?c=d#e',
+			'https://[2606:4700:4700::1111]/image.jpg',
+			'https://[::ffff:8.8.8.8]/image.jpg',
+		);
+		foreach ( $public_urls as $url ) {
+			$this->assertTrue( Utils::url_is_public( $url ), "$url should be public" );
+		}
+	}
+
+	/**
+	 * `url_is_public` rejects URLs pointing at reserved or internal addresses.
+	 *
+	 * Several of these are also rejected by core's wp_http_validate_url(); stubbing
+	 * it open is what makes this a test of our own check rather than of core's.
+	 */
+	public function test_url_is_public_rejects_reserved_hosts() {
+		$this->stub_url_helpers();
+
+		$rejected_urls = array(
+			'http://169.254.169.254/latest/meta-data/',  // Cloud metadata.
+			'http://168.63.129.16/metadata',             // Azure "Wire Server".
+			'http://100.64.0.1/',                        // CGNAT.
+			'http://198.18.0.1/',                        // Benchmarking.
+			'http://192.0.0.1/',                         // IETF protocol assignments.
+			'http://127.0.0.1/internal',                 // Loopback.
+			'http://10.0.0.1/internal',                  // Private.
+			'http://[::1]/internal',                     // IPv6 loopback.
+			'http://[fe80::1]/internal',                 // IPv6 link-local.
+			'http://[fd00::1]/internal',                 // IPv6 unique-local.
+			'http://[::ffff:169.254.169.254]/',          // IPv4-mapped metadata.
+			'http://169%2e254%2e169%2e254/',             // Percent-encoded metadata host.
+		);
+		foreach ( $rejected_urls as $url ) {
+			$this->assertFalse( Utils::url_is_public( $url ), "$url should not be public" );
+		}
+	}
+
+	/**
+	 * A host that resolves to nothing is rejected rather than passed to the request layer.
+	 */
+	public function test_url_is_public_rejects_unresolvable_host() {
+		$this->stub_url_helpers();
+
+		// RFC 2606 reserves .invalid, so this can never resolve.
+		$this->assertFalse( Utils::url_is_public( 'http://jetpack-ip-test.invalid/x' ) );
+	}
+
+	/**
+	 * Input that is not a usable URL is rejected before any lookup.
+	 */
+	public function test_url_is_public_rejects_malformed_input() {
+		$this->stub_url_helpers();
+
+		$malformed = array( '', 'not a url', '/relative/path', 'http:///nohost' );
+		foreach ( $malformed as $url ) {
+			$this->assertFalse( Utils::url_is_public( $url ), 'malformed input should not be public' );
+		}
+	}
+
+	/**
+	 * A URL core rejects stays rejected, whatever its host resolves to.
+	 */
+	public function test_url_is_public_defers_to_core_validation() {
+		Functions\when( 'wp_http_validate_url' )->justReturn( false );
+
+		$this->assertFalse( Utils::url_is_public( 'http://8.8.8.8/image.jpg' ) );
+	}
+
+	/**
+	 * `resolve_host_ips` returns IP literals as-is, after undoing the encodings a
+	 * caller could hide one behind.
+	 */
+	public function test_resolve_host_ips_normalizes_literals() {
+		$literals = array(
+			'8.8.8.8'               => '8.8.8.8',
+			'[::1]'                 => '::1',
+			'169%2e254%2e169%2e254' => '169.254.169.254', // Percent-encoded dots.
+			'fe80::1%25eth0'        => 'fe80::1',         // Encoded IPv6 zone id.
+		);
+		foreach ( $literals as $host => $expected ) {
+			$this->assertSame( array( $expected ), Utils::resolve_host_ips( (string) $host ) );
+		}
+	}
+
+	/**
+	 * An unresolvable or empty host yields no addresses, which callers treat as unsafe.
+	 */
+	public function test_resolve_host_ips_returns_empty_for_unresolvable_host() {
+		$this->assertSame( array(), Utils::resolve_host_ips( '' ) );
+		$this->assertSame( array(), Utils::resolve_host_ips( 'jetpack-ip-test.invalid' ) );
+	}
+
+	/**
+	 * Stubs the WordPress functions `url_is_public` depends on.
+	 *
+	 * Core's wp_http_validate_url() is stubbed to accept everything, so each URL is
+	 * judged by this package's own check alone.
+	 */
+	private function stub_url_helpers() {
+		Functions\when( 'wp_http_validate_url' )->returnArg();
+		Functions\when( 'wp_parse_url' )->alias(
+			function ( $url, $component = -1 ) {
+				return parse_url( $url, $component ); // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url -- This stub is what wp_parse_url() wraps.
+			}
+		);
+	}
+
+	/**
 	 * Test `convert_ip_address`.
 	 */
 	public function test_convert_ip_address() {

--- a/projects/packages/ip/tests/php/bootstrap.php
+++ b/projects/packages/ip/tests/php/bootstrap.php
@@ -9,3 +9,9 @@
  * Include the composer autoloader.
  */
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+/**
+ * Shadow the DNS lookups, so tests can supply their own answers.
+ */
+require_once __DIR__ . '/class-jetpack-ip-test-resolver.php';
+require_once __DIR__ . '/resolver-stubs.php';

--- a/projects/packages/ip/tests/php/class-jetpack-ip-test-resolver.php
+++ b/projects/packages/ip/tests/php/class-jetpack-ip-test-resolver.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Canned DNS answers for the resolver shadows in resolver-stubs.php.
+ *
+ * @package automattic/jetpack-ip
+ */
+
+/**
+ * Holds the answers the shadowed resolver functions return.
+ */
+class Jetpack_IP_Test_Resolver {
+
+	/**
+	 * Answers keyed by host name, each with optional 'ipv4' and 'ipv6' address
+	 * lists. Null means fall through to real name resolution.
+	 *
+	 * @var array<string, array<string, string[]>>|null
+	 */
+	public static $answers = null;
+
+	/**
+	 * Restores real name resolution.
+	 */
+	public static function reset() {
+		self::$answers = null;
+	}
+
+	/**
+	 * Answers an A record lookup, in gethostbynamel()'s shape.
+	 *
+	 * @param string $hostname Host to look up.
+	 * @return string[]|false Addresses, or false when the host is unknown.
+	 */
+	public static function ipv4( $hostname ) {
+		$answers = self::$answers;
+		if ( null === $answers ) {
+			return \gethostbynamel( $hostname );
+		}
+
+		return $answers[ $hostname ]['ipv4'] ?? false;
+	}
+
+	/**
+	 * Answers an AAAA record lookup, in dns_get_record()'s shape.
+	 *
+	 * @param string $hostname Host to look up.
+	 * @param int    $type     Record type requested.
+	 * @return array[] Records, empty when the host is unknown.
+	 */
+	public static function ipv6( $hostname, $type ) {
+		$answers = self::$answers;
+		if ( null === $answers ) {
+			return \dns_get_record( $hostname, $type );
+		}
+
+		$records = array();
+		if ( isset( $answers[ $hostname ]['ipv6'] ) ) {
+			foreach ( $answers[ $hostname ]['ipv6'] as $address ) {
+				$records[] = array(
+					'type' => 'AAAA',
+					'ipv6' => $address,
+				);
+			}
+		}
+
+		return $records;
+	}
+}

--- a/projects/packages/ip/tests/php/class-jetpack-ip-test-resolver.php
+++ b/projects/packages/ip/tests/php/class-jetpack-ip-test-resolver.php
@@ -43,14 +43,14 @@ class Jetpack_IP_Test_Resolver {
 	/**
 	 * Answers an AAAA record lookup, in dns_get_record()'s shape.
 	 *
-	 * @param string $hostname Host to look up.
-	 * @param int    $type     Record type requested.
+	 * @param string   $hostname Host to look up.
+	 * @param int|null $type     Record type requested, null for the default.
 	 * @return array[] Records, empty when the host is unknown.
 	 */
 	public static function ipv6( $hostname, $type ) {
 		$answers = self::$answers;
 		if ( null === $answers ) {
-			return \dns_get_record( $hostname, $type );
+			return null === $type ? \dns_get_record( $hostname ) : \dns_get_record( $hostname, $type );
 		}
 
 		$records = array();

--- a/projects/packages/ip/tests/php/resolver-stubs.php
+++ b/projects/packages/ip/tests/php/resolver-stubs.php
@@ -26,10 +26,14 @@ function gethostbynamel( $hostname ) {
 /**
  * Shadows dns_get_record() for calls made from this namespace.
  *
- * @param string $hostname Host to look up.
- * @param int    $type     Record type requested.
+ * The default is null rather than DNS_ANY so this file names no constant from
+ * ext-dns, which the package treats as optional. A null type is handed to the real
+ * function's own default.
+ *
+ * @param string   $hostname Host to look up.
+ * @param int|null $type     Record type requested, null for the default.
  * @return array[]|false
  */
-function dns_get_record( $hostname, $type = DNS_ANY ) {
+function dns_get_record( $hostname, $type = null ) {
 	return \Jetpack_IP_Test_Resolver::ipv6( $hostname, $type );
 }

--- a/projects/packages/ip/tests/php/resolver-stubs.php
+++ b/projects/packages/ip/tests/php/resolver-stubs.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Shadows the DNS lookups Utils::resolve_host_ips() makes, so tests can hand it a
+ * known set of addresses instead of depending on real name resolution.
+ *
+ * PHP resolves an unqualified call to a global function against the current namespace
+ * first, so defining these inside Automattic\Jetpack\IP intercepts that one call site
+ * and nothing else. With no answers set they delegate to the real functions, leaving
+ * tests that want live DNS working.
+ *
+ * @package automattic/jetpack-ip
+ */
+
+namespace Automattic\Jetpack\IP;
+
+/**
+ * Shadows gethostbynamel() for calls made from this namespace.
+ *
+ * @param string $hostname Host to look up.
+ * @return string[]|false
+ */
+function gethostbynamel( $hostname ) {
+	return \Jetpack_IP_Test_Resolver::ipv4( $hostname );
+}
+
+/**
+ * Shadows dns_get_record() for calls made from this namespace.
+ *
+ * @param string $hostname Host to look up.
+ * @param int    $type     Record type requested.
+ * @return array[]|false
+ */
+function dns_get_record( $hostname, $type = DNS_ANY ) {
+	return \Jetpack_IP_Test_Resolver::ipv6( $hostname, $type );
+}


### PR DESCRIPTION
## Proposed changes

Two new static methods on `Automattic\Jetpack\IP\Utils`:

* `url_is_public( $url )` tells you whether a URL is a safe destination for a server-side request.
* `resolve_host_ips( $host )` returns the addresses a host resolves to, and hands back IP literals as-is.

Right now, code that fetches a request-supplied URL only has core's `wp_http_validate_url()` to lean on. That leaves a few addresses open that nothing should ever be pointed at: Azure's metadata "Wire Server" (`168.63.129.16`), IPv6 link-local and unique-local ranges, CGNAT, and the IETF protocol-assignment block. The package has known how to classify those since `ip_is_public()` landed, but every caller had to resolve the host itself and then remember to check each address it got back.

`url_is_public()` does that in one call. It runs core's check first, resolves the host to every IPv4 and IPv6 address a request could reach, then requires all of them to pass `ip_is_public()`. If a host resolves to nothing at all, it's rejected rather than passed along, so an unresolvable or partly-internal host never gets assumed safe.

No caller is converted here. I'd rather land the helper on its own, so anything adopting it later doesn't depend on it arriving in the same deploy.

It returns a plain `bool` rather than a `WP_Error`, for two reasons: it can go straight into a REST `validate_callback`, and a rejection tells the caller nothing about the host it just rejected.

It's not a complete answer, and the docblock says so. It validates one URL, so callers that follow redirects still have to check each hop; the request layer's own per-hop check is only core's weaker one. And the address it resolves isn't pinned for the request that follows, so this doesn't protect against DNS rebinding.

`resolve_host_ips()` is public alongside it for callers that want the addresses themselves. It undoes the encodings a host can hide behind (percent-encoding, IPv6 zone identifiers) before working out whether it's looking at a literal or a name to resolve.

Of note, `packages/forms` already carries its own copy of this host-normalization logic in `class-form-webhooks.php`. Folding it onto `resolve_host_ips()` would change that method's `WP_Error` contract, so I left it for a separate PR. The version here is the stronger of the two anyway; it uses `gethostbynamel()` and checks every A record, not just the first :)

## Related product discussion/links

* n/a

## Does this pull request change what data or activity we track or use?

No. The helper resolves a host that a caller was already about to request, and it stores nothing.

## Testing instructions

No callers yet, so the test is the package's own suite:

```
jp test php packages/ip
```

Expect 38 passing tests.

The seven new ones stub `wp_http_validate_url()` open on purpose. Core already rejects most internal ranges, so leaving its gate closed would mean testing core instead of this helper.

If you want to confirm the tests really reach the new code, stub the method out and run again:

```php
public static function url_is_public( $url ) {
	return true; // Temporary.
	...
```

Four of them should go red. Put it back and they're green again.
