### PR TITLE
Jetpack AI: fix VIP connection links and feature visibility

### DIFF
--- a/projects/packages/my-jetpack/changelog/forno-516-517-vip-ai-hub
+++ b/projects/packages/my-jetpack/changelog/forno-516-517-vip-ai-hub
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Clarify Jetpack AI feature control documentation.

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -518,7 +518,7 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
-	 * Whether My Jetpack should surface the AI feature controls.
+	 * Whether My Jetpack should show the AI module switch and link to the AI Hub.
 	 *
 	 * @return bool
 	 */
@@ -604,6 +604,9 @@ class Jetpack_Ai extends Module_Product {
 
 	/**
 	 * Whether the 'ai' module backs this product's UI state.
+	 *
+	 * Returns true while the controls are hidden so the module check cannot mark
+	 * the product disabled.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -73,6 +73,19 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.queryByRole( 'separator' ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'an unavailable AI Answers row and its empty Search section stay hidden', () => {
+		renderFeatures( {
+			features: {
+				writing_assistant: { enabled: true },
+				ai_search: { enabled: true, available: false },
+			},
+		} );
+
+		expect( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'checkbox', { name: /AI Answers/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'region', { name: 'Search' } ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'the connect notice survives the card disappearing', () => {
 		renderFeatures( { is_connected: false, features: {} } );
 

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -55,7 +55,7 @@ const LEGACY_VIEW_ALIASES = {
 };
 
 // Views that retain an internal-testing badge when a host enables them for a
-// test request. MCP and Connectors ships publicly, so it is not in here.
+// test request. The MCP and Connectors view ships publicly, so it is not in here.
 const GATED_VIEWS = [ 'overview', 'features' ];
 
 // Views the master switch governs. MCP and Scheduled tasks are not gated by
@@ -194,6 +194,7 @@ export default function App() {
 		upgradeUrl,
 		planName,
 		isUserConnected,
+		userConnectionUrl = 'admin.php?page=my-jetpack#/connection',
 		showFeaturesView = false,
 		showA12sBadge = false,
 	} = window?.jetpackAiSettings ?? {};
@@ -437,7 +438,7 @@ export default function App() {
 							</Notice.Root>
 						) }
 
-						{ showConnectNotice && <McpConnectCallout /> }
+						{ showConnectNotice && <McpConnectCallout userConnectionUrl={ userConnectionUrl } /> }
 
 						{ ! isLoading && ! error && !! blogId && ! userUnlinked && ! hasMcpAccess && (
 							<McpUpsell />
@@ -488,6 +489,7 @@ export default function App() {
 						upgradeUrl={ upgradeUrl }
 						planName={ planName }
 						isUserConnected={ isUserConnected }
+						userConnectionUrl={ userConnectionUrl }
 						hostAllowsAi={ aiSettings?.host_allows_ai }
 						// Same preconditions the MCP hub applies to its copy of the
 						// row: the copy promises AI-agent actions, which need MCP.

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
@@ -13,9 +13,11 @@ import './style.scss';
 /**
  * Connect-account callout card.
  *
+ * @param {object} props                   - Component props.
+ * @param {string} props.userConnectionUrl - URL for connecting the current user.
  * @return {object} Component markup.
  */
-export default function McpConnectCallout() {
+export default function McpConnectCallout( { userConnectionUrl } ) {
 	// Announce like the notice this replaces: the design system does it via speak().
 	useEffect( () => {
 		speak( __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) );
@@ -36,7 +38,7 @@ export default function McpConnectCallout() {
 				<p className="jetpack-ai-mcp__upsell-callout-description">
 					{ __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) }
 				</p>
-				<Button variant="primary" href="admin.php?page=my-jetpack#/connection">
+				<Button variant="primary" href={ userConnectionUrl }>
 					{ __( 'Connect your user account', 'jetpack' ) }
 				</Button>
 			</div>

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -346,6 +346,7 @@ function UsageCard( { upgradeUrl, planName } ) {
  *                                          usage is shown and no upgrade is ever offered.
  * @param {boolean} [props.isUserConnected] - Whether the current user's own WordPress.com
  *                                          account is linked; the usage fetch needs it.
+ * @param {string}  props.userConnectionUrl - URL for connecting the current user.
  * @return {object} Component markup.
  */
 export default function AiOverview( {
@@ -356,6 +357,7 @@ export default function AiOverview( {
 	showActivityLog,
 	hostAllowsAi,
 	isUserConnected,
+	userConnectionUrl,
 } ) {
 	const hostBlocked = hostAllowsAi === false;
 	const userUnlinked = isUserConnected === false;
@@ -388,7 +390,7 @@ export default function AiOverview( {
 							{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
 						</Notice.Title>
 						<Notice.Description>
-							<Link href="admin.php?page=my-jetpack#/connection">
+							<Link href={ userConnectionUrl }>
 								{ __( 'Connect your user account to see your AI usage.', 'jetpack' ) }
 							</Link>
 						</Notice.Description>

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -50,6 +50,7 @@ const PROPS = {
 	activityLogUrl: 'https://example.com/activity',
 	upgradeUrl: 'https://example.com/upgrade',
 	showActivityLog: true,
+	userConnectionUrl: 'admin.php?page=my-jetpack#/connection',
 };
 
 // The design-system Notice mirrors its text into a hidden wp.a11y.speak live
@@ -339,6 +340,20 @@ describe( 'AiOverview', () => {
 		).toHaveAttribute( 'href', 'admin.php?page=my-jetpack#/connection' );
 		expect( screen.queryByText( 'Available requests' ) ).not.toBeInTheDocument();
 		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'user account not linked: uses the supplied connection screen', () => {
+		render(
+			<AiOverview
+				{ ...PROPS }
+				isUserConnected={ false }
+				userConnectionUrl="admin.php?page=jetpack#/connect-user"
+			/>
+		);
+
+		expect(
+			screen.getByRole( 'link', { name: 'Connect your user account to see your AI usage.' } )
+		).toHaveAttribute( 'href', 'admin.php?page=jetpack#/connect-user' );
 	} );
 
 	test( 'activity log: absent without an activityLogUrl', async () => {

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -458,6 +458,26 @@ describe( 'AI admin page (main.jsx)', () => {
 			);
 		} );
 
+		test( 'the connect card uses the supplied connection screen', async () => {
+			window.jetpackAiSettings = {
+				showFeaturesView: true,
+				blogId: 1,
+				isUserConnected: false,
+				userConnectionUrl: 'admin.php?page=jetpack#/connect-user',
+			};
+			mockApiFetch( { mcpGet: { has_mcp_access: false, mcp_abilities: {} } } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( CONNECT_CARD_TEXT, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Connect your user account' } ) ).toHaveAttribute(
+				'href',
+				'admin.php?page=jetpack#/connect-user'
+			);
+		} );
+
 		test( 'site connected, has plan: shows the connect card and not the hub', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
 			mockApiFetch( { mcpGet: connectedMcpGet() } );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -276,11 +276,14 @@ class Jetpack_AI_Page {
 			'jetpack_ai_admin_config',
 			array(
 				// The Overview and Features views launch on self-hosted sites first.
-				// Keep this filterable so hosts can close them independently.
-				'showGatedViews'  => ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ),
-				'showA12sBadge'   => $host->is_woa_site() && $is_internal_test,
-				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
-				'mcpSettingsApi'  => array(
+				// Filtering showGatedViews changes view visibility only, not enforcement.
+				'showGatedViews'    => ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ),
+				'showA12sBadge'     => $host->is_woa_site() && $is_internal_test,
+				'isUserConnected'   => ( new Connection_Manager() )->is_user_connected(),
+				'userConnectionUrl' => $host->is_vip_site()
+					? 'admin.php?page=jetpack#/connect-user'
+					: 'admin.php?page=my-jetpack#/connection',
+				'mcpSettingsApi'    => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
 					'format' => 'jetpack',
 				),
@@ -292,39 +295,40 @@ class Jetpack_AI_Page {
 		$plan_info = $show_gated_views ? self::get_ai_plan_info() : array( 'name' => '' );
 
 		$settings = array(
-			'blogId'           => $blog_id ? (int) $blog_id : 0,
-			'activityLogUrl'   => $activity_log_url,
-			'seoSettingsUrl'   => $seo_settings_url,
-			'siteAdminUrl'     => admin_url(),
-			'apiRoot'          => esc_url_raw( rest_url() ),
-			'apiNonce'         => wp_create_nonce( 'wp_rest' ),
-			'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			'blogId'            => $blog_id ? (int) $blog_id : 0,
+			'activityLogUrl'    => $activity_log_url,
+			'seoSettingsUrl'    => $seo_settings_url,
+			'siteAdminUrl'      => admin_url(),
+			'userConnectionUrl' => esc_url_raw( $config['userConnectionUrl'] ),
+			'apiRoot'           => esc_url_raw( rest_url() ),
+			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
+			'pluginUrl'         => plugins_url( '', JETPACK__PLUGIN_FILE ),
 			// The redirect entry bakes in the jetpack_ai_yearly product and
 			// a post-checkout return to this page, so both can be
 			// retargeted without shipping a code change.
-			'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
+			'upgradeUrl'        => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
 			// The purchase granting AI — the usage card only uses it to pick
 			// the right loading-skeleton shape before the usage fetch lands.
 			// Only looked up when a gated view can render the card.
-			'planName'         => $plan_info['name'],
-			'showFeaturesView' => $show_gated_views,
-			'showA12sBadge'    => ! empty( $config['showA12sBadge'] ),
+			'planName'          => $plan_info['name'],
+			'showFeaturesView'  => $show_gated_views,
+			'showA12sBadge'     => ! empty( $config['showA12sBadge'] ),
 			// The tab and its Agents Manager sidebar ship disabled by default.
-			'featureFlags'     => array(
+			'featureFlags'      => array(
 				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
 			),
 			// The usage endpoint proxies as the current user, which needs
 			// their own WordPress.com account linked — not just the site.
-			'isUserConnected'  => ! empty( $config['isUserConnected'] ),
+			'isUserConnected'   => ! empty( $config['isUserConnected'] ),
 			// Tracks audience properties for the jetpack_mcp_* events, per the
 			// Tracks standards for AI product events (AIINT-586). The client
 			// sends them as the strings 'true'/'false' (AIINT-576).
-			'isA11n'           => self::is_current_user_automattician(),
-			'isTest'           => $is_internal_test,
+			'isA11n'            => self::is_current_user_automattician(),
+			'isTest'            => $is_internal_test,
 			// Identity for Tracks; the lookup can call WordPress.com on a
 			// cache miss, so it shares the sender's guard.
-			'tracksUserData'   => $can_send_tracks ? self::get_tracks_user_data() : null,
-			'mcpSettingsApi'   => $config['mcpSettingsApi'],
+			'tracksUserData'    => $can_send_tracks ? self::get_tracks_user_data() : null,
+			'mcpSettingsApi'    => $config['mcpSettingsApi'],
 		);
 
 		wp_add_inline_script(

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -274,6 +274,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 				),
 				'ai_search'         => array(
 					'enabled'          => $stored['ai_search'],
+					// VIP does not expose the Search settings page that owns this control.
+					'available'        => ! ( new Host() )->is_vip_site(),
 					'requires_upgrade' => $ai_search_requires_upgrade,
 				),
 			),

--- a/projects/plugins/jetpack/changelog/forno-516-517-vip-ai-hub
+++ b/projects/plugins/jetpack/changelog/forno-516-517-vip-ai-hub
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Fix user connection links and hide unavailable AI Answers settings on VIP sites.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -89,6 +89,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		}
 		remove_filter( 'wp_supports_ai', '__return_false' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
+		Constants::clear_single_constant( 'WPCOM_IS_VIP_ENV' );
 
 		delete_option( Search_Plan::JETPACK_SEARCH_PLAN_INFO_OPTION_KEY );
 
@@ -440,8 +441,21 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		// page only carries the AI SEO row.
 		$this->assertArrayNotHasKey( 'seo_enhancer', $features );
 		$this->assertFalse( $features['ai_search']['enabled'] );
+		$this->assertTrue( $features['ai_search']['available'] );
 		// No paid Search product in the test environment.
 		$this->assertTrue( $features['ai_search']['requires_upgrade'] );
+	}
+
+	/**
+	 * VIP sites cannot reach the Search settings page that owns AI Answers.
+	 */
+	public function test_ai_search_is_unavailable_on_vip_sites() {
+		wp_set_current_user( self::$admin_id );
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+
+		$data = $this->dispatch( 'GET' )->get_data();
+
+		$this->assertFalse( $data['features']['ai_search']['available'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -263,8 +263,20 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $settings['showFeaturesView'] );
 		$this->assertFalse( $settings['showA12sBadge'] );
 		$this->assertFalse( $settings['isTest'] );
+		$this->assertSame( 'admin.php?page=my-jetpack#/connection', $settings['userConnectionUrl'] );
 		$this->assertArrayHasKey( 'featureFlags', $settings );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
+	}
+
+	/**
+	 * VIP sites connect users through the legacy Jetpack connection screen.
+	 */
+	public function test_vip_site_uses_jetpack_user_connection_url() {
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( 'admin.php?page=jetpack#/connect-user', $settings['userConnectionUrl'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORNO-516 and FORNO-517

## Proposed changes

* Send VIP users from both Jetpack AI user-connection prompts to the Jetpack user connection screen. Keep the My Jetpack route for other hosts.
* Hide AI Answers and its empty Search section on VIP sites, where the Search settings page is unavailable. Keep the saved Search setting and server-side update behavior unchanged.
* Clarify the AI Hub visibility and My Jetpack module comments raised during the review of #51909.
* Add focused PHP and React regression coverage.

## Related product discussion/links

* [FORNO-516](https://linear.app/a8c/issue/FORNO-516/hide-ai-answers-for-vip-sites)
* [FORNO-517](https://linear.app/a8c/issue/FORNO-517/fix-connect-user-link-for-vip-sites)
* #51909

## Does this pull request change what data or activity we track or use?

No.

## Automated checks

* Jetpack PHP tests: 58 passed, 178 assertions.
* Jetpack AI React tests: 97 passed.
* Jetpack production build passed.
* Phan, changed-file ESLint, PHPCS, Prettier, and diff checks passed.
* Claude review completed with no blocking findings.

## Testing instructions

### WordPress VIP

1. Go to **Jetpack → Jetpack AI → Overview**.
2. Select **Connect your user account to see your AI usage.**
3. Confirm the Jetpack user connection screen opens.
4. Return to **Jetpack → Jetpack AI → MCP and Connectors**.
5. Select **Connect your user account** and confirm the same Jetpack user connection screen opens.
6. Open **AI Features**.
7. Confirm **AI Answers** and the empty **Search** section are absent. Confirm the other available AI features remain visible.

### Self-hosted

1. Use a JN test site with Jetpack connected at the site level and the current admin user's WordPress.com account disconnected.
2. Install and activate the Jetpack build from this PR.
3. Open the user-connection prompts on **Overview** and **MCP and Connectors**.
4. Confirm both links still open the My Jetpack connection screen.
5. Open **AI Features**.
6. Confirm **AI Answers** remains listed under **Search**.
