### PR TITLE
Subscriptions: don't email subscribers for posts published long ago

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-stale-post-age-veto
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-stale-post-age-veto
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Stop sending subscriber emails for posts published more than 30 days ago.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-stale-post-age-veto
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-stale-post-age-veto
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Stop sending subscriber emails for posts published more than 30 days ago.
+Subscriptions: Stop emailing subscribers when an old post is republished or a trashed post is restored.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -83,6 +83,13 @@ class Jetpack_Subscriptions {
 	public static $hash;
 
 	/**
+	 * Status each post was published from this request, keyed by post ID.
+	 *
+	 * @var array
+	 */
+	private $published_from_status = array();
+
+	/**
 	 * Singleton
 	 *
 	 * @static
@@ -129,6 +136,8 @@ class Jetpack_Subscriptions {
 		add_action( 'post_submitbox_misc_actions', array( $this, 'subscription_post_page_metabox' ) );
 
 		add_action( 'transition_post_status', array( $this, 'maybe_send_subscription_email' ), 10, 3 );
+
+		add_action( 'transition_post_status', array( $this, 'record_published_from_status' ), 10, 3 );
 
 		add_filter( 'jetpack_published_post_flags', array( $this, 'set_post_flags' ), 10, 2 );
 
@@ -289,7 +298,17 @@ class Jetpack_Subscriptions {
 		}
 
 		/*
-		 * Restoring or re-publishing an old post must not email the back catalog.
+		 * Restoring a trashed post re-publishes it, which must not email subscribers.
+		 * WordPress.com already drops this transition for Simple sites, but
+		 * jetpack_published_post carries no previous status, so on Jetpack sites only
+		 * the plugin can tell a restore from a first publish.
+		 */
+		if ( $this->was_published_from_trash( $post ) ) {
+			return false;
+		}
+
+		/*
+		 * Re-publishing an old post must not email the back catalog either.
 		 * WordPress.com vetoes the same sends for every Jetpack version in
 		 * jetpack_newsletter_allow_send_for_post_age(); keep the thresholds in step.
 		 */
@@ -334,6 +353,38 @@ class Jetpack_Subscriptions {
 		}
 
 		return $should_email;
+	}
+
+	/**
+	 * Record the status a post was published from, for was_published_from_trash().
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string  $new_status The new post status.
+	 * @param string  $old_status The old post status.
+	 * @param WP_Post $post       The post.
+	 * @return void
+	 */
+	public function record_published_from_status( $new_status, $old_status, $post ) {
+		if ( 'publish' === $new_status && $post instanceof WP_Post ) {
+			$this->published_from_status[ $post->ID ] = $old_status;
+		}
+	}
+
+	/**
+	 * Whether this request published the post by restoring it from the trash.
+	 *
+	 * False when the post did not change status this request, so a stale record can
+	 * never suppress a later genuine publish.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $post The post.
+	 * @return bool
+	 */
+	public function was_published_from_trash( $post ) {
+		return isset( $this->published_from_status[ $post->ID ] )
+			&& 'trash' === $this->published_from_status[ $post->ID ];
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -288,6 +288,15 @@ class Jetpack_Subscriptions {
 			return false;
 		}
 
+		/*
+		 * Restoring or re-publishing an old post must not email the back catalog.
+		 * WordPress.com vetoes the same sends for every Jetpack version in
+		 * jetpack_newsletter_allow_send_for_post_age(); keep the thresholds in step.
+		 */
+		if ( $this->is_post_too_old_to_email( $post ) ) {
+			return false;
+		}
+
 		/**
 		 * Array of categories that will never trigger subscription emails.
 		 *
@@ -325,6 +334,54 @@ class Jetpack_Subscriptions {
 		}
 
 		return $should_email;
+	}
+
+	/**
+	 * Whether a post was published too long ago to email subscribers.
+	 *
+	 * An unknown or unparseable publish date returns false: a missed newsletter is
+	 * worse than an extra one, so bad dates fall through to the other checks.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param object $post The post.
+	 * @return bool
+	 */
+	public function is_post_too_old_to_email( $post ) {
+		/**
+		 * Maximum age a post can have and still email subscribers when published.
+		 *
+		 * Set to 0 to disable the age check entirely.
+		 *
+		 * @module subscriptions
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param int $max_age Maximum post age in seconds. Default 30 days.
+		 */
+		$max_age = (int) apply_filters( 'jetpack_subscriptions_max_post_age', 30 * DAY_IN_SECONDS );
+
+		if ( $max_age <= 0 ) {
+			return false;
+		}
+
+		$post_date_gmt = isset( $post->post_date_gmt ) ? trim( (string) $post->post_date_gmt ) : '';
+
+		/*
+		 * wp_publish_post() leaves a draft's post_date_gmt at the zero date, and
+		 * strtotime() reads that as year 0 rather than failing, which would suppress
+		 * every such publish. Treat it as unknown instead.
+		 */
+		if ( '' === $post_date_gmt || '0000-00-00 00:00:00' === $post_date_gmt ) {
+			return false;
+		}
+
+		$published = strtotime( $post_date_gmt . ' UTC' );
+		if ( false === $published || $published <= 0 ) {
+			return false;
+		}
+
+		return ( time() - $published ) > $max_age;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -195,6 +195,60 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression tests for NL-895: restoring or re-publishing a years-old post
+	 * emailed it to every subscriber. WordPress.com cannot catch this on its own --
+	 * its `email_notification` dedup meta is only written by a WordPress.com send, so
+	 * a back catalog predating the connection has no record of ever being emailed.
+	 */
+	public function test_recent_post_is_emailed_to_subscribers() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post          = self::factory()->post->create_and_get(
+			array( 'post_date_gmt' => gmdate( 'Y-m-d H:i:s', time() - 2 * DAY_IN_SECONDS ) )
+		);
+
+		$this->assertFalse( $subscriptions->is_post_too_old_to_email( $post ) );
+		$this->assertTrue( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
+	public function test_old_post_is_not_emailed_to_subscribers() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post          = self::factory()->post->create_and_get(
+			array( 'post_date_gmt' => '2010-03-06 23:21:00' )
+		);
+
+		$this->assertTrue( $subscriptions->is_post_too_old_to_email( $post ) );
+		$this->assertFalse( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
+	/**
+	 * Drafts published by wp_publish_post() keep the zero post_date_gmt, which
+	 * strtotime() reads as year 0. Suppressing on that would kill the newsletter for
+	 * every draft published that way.
+	 */
+	public function test_zero_publish_date_is_still_emailed_to_subscribers() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post          = self::factory()->post->create_and_get();
+
+		$post->post_date_gmt = '0000-00-00 00:00:00';
+
+		$this->assertFalse( $subscriptions->is_post_too_old_to_email( $post ) );
+		$this->assertTrue( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
+	public function test_post_age_check_is_filterable() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post          = self::factory()->post->create_and_get(
+			array( 'post_date_gmt' => '2010-03-06 23:21:00' )
+		);
+
+		add_filter( 'jetpack_subscriptions_max_post_age', '__return_zero' );
+		$this->assertFalse( $subscriptions->is_post_too_old_to_email( $post ) );
+		remove_filter( 'jetpack_subscriptions_max_post_age', '__return_zero' );
+
+		$this->assertTrue( $subscriptions->is_post_too_old_to_email( $post ) );
+	}
+
+	/**
 	 * Contributors can submit a post for review without the "was ever published" meta
 	 * blocking the save. Regression test for NL-706 / CM-232: the meta is included in
 	 * the editor save payload, and its auth_callback previously required publish_posts,

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -235,6 +235,47 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		$this->assertTrue( $subscriptions->should_email_post_to_subscribers( $post ) );
 	}
 
+	/**
+	 * Restoring a trashed post republishes it at its original date. WordPress.com drops
+	 * that transition for Simple sites, but jetpack_published_post carries no previous
+	 * status, so on Jetpack sites only the plugin can tell a restore from a publish.
+	 */
+	public function test_post_restored_from_trash_is_not_emailed_to_subscribers() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post_id       = self::factory()->post->create();
+
+		wp_trash_post( $post_id );
+		wp_publish_post( $post_id );
+
+		$post = get_post( $post_id );
+		$this->assertSame( 'publish', $post->post_status );
+		$this->assertTrue( $subscriptions->was_published_from_trash( $post ) );
+		$this->assertFalse( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
+	public function test_post_published_from_draft_is_emailed_to_subscribers() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post_id       = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		wp_publish_post( $post_id );
+
+		$post = get_post( $post_id );
+		$this->assertFalse( $subscriptions->was_published_from_trash( $post ) );
+		$this->assertTrue( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
+	/**
+	 * A post that did not change status this request has no record, so an unrelated
+	 * publish elsewhere can never be mistaken for a restore.
+	 */
+	public function test_untouched_post_is_not_treated_as_restored_from_trash() {
+		$subscriptions = Jetpack_Subscriptions::init();
+		$post          = self::factory()->post->create_and_get();
+
+		$this->assertFalse( $subscriptions->was_published_from_trash( $post ) );
+		$this->assertTrue( $subscriptions->should_email_post_to_subscribers( $post ) );
+	}
+
 	public function test_post_age_check_is_filterable() {
 		$subscriptions = Jetpack_Subscriptions::init();
 		$post          = self::factory()->post->create_and_get(


### PR DESCRIPTION
Fixes NL-895

## Proposed changes

Two guards in `Jetpack_Subscriptions::should_email_post_to_subscribers()`, so a post that was already published years ago stops emailing subscribers when it gets republished.

* **Restoring a trashed post no longer emails.** Restoring republishes the post at its original date, which emits `jetpack_published_post`. WordPress.com already drops this transition for Simple sites in `async-jobs/jobs.php`, but `jetpack_published_post` carries no previous status, so on a Jetpack site only the plugin can tell a restore from a first publish. The module now records the status each post was published from during the request. Only `trash` needs excluding: sync emits the publish action solely on a non-publish to publish transition, so publish to publish never gets this far.
* **Posts published long ago no longer email.** Filterable via `jetpack_subscriptions_max_post_age`, default 30 days, 0 to disable. This threshold is a starting point rather than a researched number, and is easy to change.

An unknown or unparseable publish date still sends. A missed newsletter is worse than an extra one, and this matters concretely: `wp_publish_post()` leaves a draft's `post_date_gmt` at the zero date, which `strtotime()` reads as year 0 rather than failing. Vetoing on that would have suppressed the newsletter for every draft published that way.

Why this is needed even though WordPress.com dedups sends: its `email_notification` meta is only ever written by a WordPress.com send, so a site's back catalog from before the Jetpack connection has no record of having been emailed and the dedup guard passes. In the reported case a post from 2010 reached 882 subscribers in 2026 while the owner was bulk-editing ~2500 old posts.

`update_published_message()` calls the same method, so the editor also stops showing "Post published and sending emails to subscribers." for a post that won't be.

A matching age veto is going out on the WordPress.com side (wpcom PR 239370), which covers Simple, Atomic, and every already-released Jetpack version without waiting for a plugin release. The two carry cross-references to each other so the thresholds don't drift.

## Related product discussion/links

* NL-895
* NL-193 shipped a sync-lag limiter. It caps how *many* stale posts email (3, then suppress for 24h); it doesn't stop a single stale post, so this send would still have gone out with it live.
* Prior report of the same class, closed without a fix: `Automattic/wp-calypso` issue 94833.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a Jetpack-connected site with the Subscriptions module active and at least one subscriber:

* Trash a recently published post, then restore it. It should not email, and the publish notice should read "Post published." rather than "Post published and sending emails to subscribers."
* Take a post published more than 30 days ago, move it to draft, then publish it. Same result.
* Publish a brand-new post. It should still email, with the subscriber notice shown and the `send_subscription` sync flag `true`.
* Save a draft, then publish it without ever setting a date (so `post_date_gmt` stays at the zero date). It must still email: unknown dates always send.

`jetpack docker phpunit jetpack -- --filter '(Jetpack_Subscriptions_Test|Jetpack_Sync_Post_Test)'`

Ran locally against WordPress 7.1 / PHP 8.4: 146 tests, 377 assertions, 2 skipped, no failures. That covers the existing `send_subscription` flag tests in `Jetpack_Sync_Post_Test`.

Both new guards were also checked against a neutered call site to confirm the tests fail without the fix rather than passing vacuously.
