### PR TITLE
VideoPress: add an inline player mode that loads the player once per page

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-inline-player
+++ b/projects/packages/videopress/changelog/add-videopress-inline-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add an inline player mode that loads the VideoPress player once per page instead of once per embedded frame.

--- a/projects/packages/videopress/routes/settings/stage.tsx
+++ b/projects/packages/videopress/routes/settings/stage.tsx
@@ -24,6 +24,7 @@ const SettingsForm = () => {
 	const privateForSite = settings.data?.videoPressVideosPrivateForSite ?? false;
 	const autoSubtitlesDisabled = settings.data?.videoPressAutoSubtitlesDisabled ?? false;
 	const playerPreloadDisabled = settings.data?.videoPressPlayerPreloadDisabled ?? false;
+	const inlinePlayerEnabled = settings.data?.videoPressInlinePlayerEnabled ?? false;
 	const disabled = settings.isLoading || update.isPending;
 
 	// The mutation rolls the optimistic value back on failure; without a notice
@@ -99,6 +100,20 @@ const SettingsForm = () => {
 						checked={ ! playerPreloadDisabled }
 						disabled={ disabled }
 						onChange={ next => save( { videoPressPlayerPreloadDisabled: ! next } ) }
+					/>
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __(
+							'Load the player once per page instead of once per video',
+							'jetpack-videopress-pkg'
+						) }
+						help={ __(
+							'Renders every video directly in your page from one shared player script instead of a separate embedded frame per video, so page-speed tools stop counting the player once for each video. Playlists and videos with hover previews keep using frames.',
+							'jetpack-videopress-pkg'
+						) }
+						checked={ inlinePlayerEnabled }
+						disabled={ disabled }
+						onChange={ next => save( { videoPressInlinePlayerEnabled: next } ) }
 					/>
 				</Stack>
 			</Card.Content>

--- a/projects/packages/videopress/routes/settings/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/settings/test/stage.test.tsx
@@ -66,6 +66,7 @@ jest.mock( '../../../src/dashboard/hooks/use-settings', () => ( {
 			videoPressVideosPrivateForSite: false,
 			videoPressAutoSubtitlesDisabled: false,
 			videoPressPlayerPreloadDisabled: false,
+			videoPressInlinePlayerEnabled: false,
 		},
 		isLoading: false,
 	} ),
@@ -136,6 +137,24 @@ describe( 'Settings stage', () => {
 
 		expect( mockMutate ).toHaveBeenCalledWith(
 			{ videoPressPlayerPreloadDisabled: true },
+			expect.objectContaining( { onError: expect.any( Function ) } )
+		);
+	} );
+
+	it( 'enables the inline player when its toggle is switched on', async () => {
+		mockedUseFreeTier.mockReturnValue( freeTierState() );
+
+		render( <Stage /> );
+
+		const toggle = screen.getByLabelText(
+			'Load the player once per page instead of once per video'
+		);
+		expect( toggle ).not.toBeChecked();
+
+		await userEvent.click( toggle );
+
+		expect( mockMutate ).toHaveBeenCalledWith(
+			{ videoPressInlinePlayerEnabled: true },
 			expect.objectContaining( { onError: expect.any( Function ) } )
 		);
 	} );

--- a/projects/packages/videopress/src/class-block-editor-content.php
+++ b/projects/packages/videopress/src/class-block-editor-content.php
@@ -120,6 +120,30 @@ class Block_Editor_Content {
 			$height = absint( $atts['h'] );
 		}
 
+		if ( Inline_Player::is_enabled() ) {
+			$player = Inline_Player::render(
+				$guid,
+				Inline_Player::get_player_options(
+					array(
+						'autoplay'        => $atts['autoplay'],
+						'loop'            => $atts['loop'],
+						'muted'           => $atts['muted'],
+						'controls'        => $atts['controls'],
+						'playsinline'     => $atts['playsinline'],
+						'useAverageColor' => $atts['useaveragecolor'],
+						'preload'         => $atts['preloadcontent'],
+						'cover'           => $atts['cover'],
+						'at'              => $atts['at'],
+					)
+				),
+				$width > 0 ? ( $height / $width ) * 100 : null
+			);
+
+			return '<figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player">' .
+				'<div class="jetpack-videopress-player__wrapper">' . $player . '</div>' .
+			'</figure>';
+		}
+
 		$cover = $atts['cover'] ? ' data-resize-to-parent="true"' : '';
 
 		$block_template =

--- a/projects/packages/videopress/src/class-data.php
+++ b/projects/packages/videopress/src/class-data.php
@@ -73,6 +73,17 @@ class Data {
 	}
 
 	/**
+	 * Gets whether embeds render an inline player instead of one iframe per video.
+	 *
+	 * Iframes are the default, so this opt-in option defaults to false.
+	 *
+	 * @return boolean If embeds should mount players in the page from one shared player script.
+	 */
+	public static function get_videopress_inline_player_enabled() {
+		return boolval( get_option( 'videopress_inline_player_enabled', false ) );
+	}
+
+	/**
 	 * Gets the VideoPress Settings.
 	 *
 	 * @return array The settings as an associative array.
@@ -93,6 +104,7 @@ class Data {
 			'videopress_videos_private_for_site' => self::get_videopress_videos_private_for_site(),
 			'videopress_auto_subtitles_disabled' => self::get_videopress_auto_subtitles_disabled(),
 			'videopress_player_preload_disabled' => self::get_videopress_player_preload_disabled(),
+			'videopress_inline_player_enabled'   => self::get_videopress_inline_player_enabled(),
 			'site_is_private'                    => $site_is_private,
 			'site_type'                          => $site_type,
 		);

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -217,6 +217,11 @@ class Initializer {
 		}
 		self::register_oembed_providers();
 
+		// In inline mode a VideoPress URL never needs the oEmbed round trip: skip
+		// the fetch, and swap iframes already cached in post meta for a placeholder.
+		add_filter( 'pre_oembed_result', array( __CLASS__, 'maybe_pre_oembed_inline_player' ), 10, 2 );
+		add_filter( 'embed_oembed_html', array( __CLASS__, 'maybe_render_oembed_inline_player' ), 5, 4 );
+
 		// Enqueuethe VideoPress Iframe API script in the front-end.
 		add_filter( 'embed_oembed_html', array( __CLASS__, 'enqueue_videopress_iframe_api_script' ), 10, 4 );
 
@@ -416,7 +421,18 @@ class Initializer {
 		$video_wrapper         = '';
 		$video_wrapper_classes = 'jetpack-videopress-player__wrapper';
 
-		if ( $videopress_url ) {
+		// Preview on hover drives the player through the iframe API, so it keeps the iframe.
+		if ( $guid && ! $is_poh_enabled && Inline_Player::is_enabled() ) {
+			$video_wrapper = sprintf(
+				'<div class="%s">%s</div>',
+				$video_wrapper_classes,
+				Inline_Player::render(
+					$guid,
+					Inline_Player::get_player_options( $block_attributes ),
+					$block_attributes['videoRatio'] ?? null
+				)
+			);
+		} elseif ( $videopress_url ) {
 			$videopress_url = wp_kses_post( $videopress_url );
 
 			/*
@@ -996,7 +1012,7 @@ class Initializer {
 	 * @return string|false
 	 */
 	public static function enqueue_videopress_iframe_api_script( $cache, $url, $attr, $post_ID ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		if ( Utils::is_videopress_url( $url ) ) {
+		if ( Utils::is_videopress_url( $url ) && ! Inline_Player::is_enabled() ) {
 			// Enqueue the VideoPress IFrame API in the front-end.
 			wp_enqueue_script(
 				self::JETPACK_VIDEOPRESS_IFRAME_API_HANDLER,
@@ -1008,5 +1024,59 @@ class Initializer {
 		}
 
 		return $cache;
+	}
+
+	/**
+	 * Short-circuit the oEmbed request for VideoPress URLs when the inline player is on.
+	 *
+	 * @param null|string $result The oEmbed result, null to let WordPress fetch it.
+	 * @param string      $url    The URL being embedded.
+	 * @return null|string Inline player markup, or the untouched result.
+	 */
+	public static function maybe_pre_oembed_inline_player( $result, $url ) {
+		$inline = self::render_inline_player_for_url( $url );
+
+		return null === $inline ? $result : $inline;
+	}
+
+	/**
+	 * Replace a VideoPress oEmbed iframe (fresh or cached) with an inline player when the inline player is on.
+	 *
+	 * @param string|false $cache   The oEmbed HTML.
+	 * @param string       $url     The URL being embedded.
+	 * @param array        $attr    Shortcode attributes.
+	 * @param int          $post_ID Post ID.
+	 * @return string|false Inline player markup, or the untouched HTML.
+	 */
+	public static function maybe_render_oembed_inline_player( $cache, $url, $attr, $post_ID = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! is_string( $cache ) || false === strpos( $cache, '<iframe' ) ) {
+			return $cache;
+		}
+
+		$inline = self::render_inline_player_for_url( $url );
+
+		return null === $inline ? $cache : $inline;
+	}
+
+	/**
+	 * Build inline player markup for a videopress.com URL, honoring the player parameters in its query string.
+	 *
+	 * @param string $url The URL being embedded.
+	 * @return string|null Markup, or null when the URL is not a VideoPress video or the inline player is off.
+	 */
+	private static function render_inline_player_for_url( $url ) {
+		if ( ! Inline_Player::is_enabled() ) {
+			return null;
+		}
+
+		$guid = Utils::extract_videopress_guid_from_url( $url );
+		if ( null === $guid ) {
+			return null;
+		}
+
+		return Inline_Player::render(
+			$guid,
+			Inline_Player::get_player_options( Inline_Player::get_attributes_from_embed_url( $url ) )
+		);
 	}
 }

--- a/projects/packages/videopress/src/class-inline-player.php
+++ b/projects/packages/videopress/src/class-inline-player.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * Inline (non-iframe) VideoPress player rendering.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * Renders VideoPress players in the page from one shared player script.
+ *
+ * Every `videopress.com/embed/` iframe downloads and runs its own copy of the
+ * player, so a page pays for it once per video. In inline mode the player
+ * bundle and stylesheet load once from v0.wordpress.com and a small boot
+ * script mounts a player on each placeholder.
+ */
+class Inline_Player {
+
+	const PLAYER_SCRIPT_URL = 'https://v0.wordpress.com/js/videojs/videopress.js';
+	const PLAYER_STYLE_URL  = 'https://v0.wordpress.com/js/videojs/videopress.css';
+
+	// The Jetpack plugin's legacy in-page embed used this handle; keep it so existing dequeue hooks still apply.
+	const PLAYER_HANDLE = 'videopress-videojs';
+	const BOOT_HANDLE   = 'videopress-inline-player';
+
+	const PLACEHOLDER_CLASS = 'jetpack-videopress-player__inline';
+
+	/**
+	 * Whether embeds rendered by this site should mount an inline player instead of an iframe.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		/**
+		 * Filter whether VideoPress videos are embedded with an iframe.
+		 *
+		 * Return false to render the player directly in the page from one shared
+		 * player script. Defaults to the inverse of the site's inline player setting.
+		 *
+		 * @module videopress
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param bool $use_iframe Whether to embed with an iframe.
+		 */
+		return ! apply_filters( 'jetpack_videopress_player_use_iframe', ! Data::get_videopress_inline_player_enabled() );
+	}
+
+	/**
+	 * Map block or shortcode attributes to player options.
+	 *
+	 * Accepts the video block's attribute names (`autoplay`, `preload`, ...);
+	 * anything missing falls back to the player's defaults.
+	 *
+	 * @param array $attributes Attributes to map.
+	 * @return array Player options, ready to pass to `videopress()`.
+	 */
+	public static function get_player_options( array $attributes = array() ) {
+		$attributes = wp_parse_args(
+			$attributes,
+			array(
+				'autoplay'            => false,
+				'controls'            => true,
+				'loop'                => false,
+				'muted'               => false,
+				'playsinline'         => false,
+				'poster'              => '',
+				'preload'             => 'metadata',
+				'seekbarColor'        => '',
+				'seekbarPlayedColor'  => '',
+				'seekbarLoadingColor' => '',
+				'useAverageColor'     => true,
+				'cover'               => true,
+				'hd'                  => false,
+				'at'                  => 0,
+				'defaultLangCode'     => '',
+			)
+		);
+
+		$preload = is_string( $attributes['preload'] ) ? strtolower( $attributes['preload'] ) : 'metadata';
+		if ( ! in_array( $preload, array( 'auto', 'metadata', 'none' ), true ) ) {
+			$preload = 'metadata';
+		}
+		// The site-wide opt-out wins over the embed's own preload attribute.
+		if ( Data::get_videopress_player_preload_disabled() ) {
+			$preload = 'none';
+		}
+
+		$options = array(
+			'autoPlay'        => self::to_bool( $attributes['autoplay'] ),
+			'controls'        => self::to_bool( $attributes['controls'] ),
+			'loop'            => self::to_bool( $attributes['loop'] ),
+			'muted'           => self::to_bool( $attributes['muted'] ),
+			'persistVolume'   => ! self::to_bool( $attributes['muted'] ),
+			'playsinline'     => self::to_bool( $attributes['playsinline'] ),
+			'cover'           => self::to_bool( $attributes['cover'] ),
+			'hd'              => self::to_bool( $attributes['hd'] ),
+			'useAverageColor' => self::to_bool( $attributes['useAverageColor'] ),
+			'preloadContent'  => $preload,
+			// Embed pages default to the current player skin; match them.
+			'chrome'          => 'v2',
+		);
+
+		if ( (int) $attributes['at'] > 0 ) {
+			$options['at'] = (int) $attributes['at'];
+		}
+
+		if ( ! empty( $attributes['poster'] ) && is_string( $attributes['poster'] ) ) {
+			$options['poster'] = esc_url_raw( $attributes['poster'] );
+		}
+
+		if ( ! empty( $attributes['defaultLangCode'] ) && is_string( $attributes['defaultLangCode'] ) ) {
+			$options['defaultLangCode'] = $attributes['defaultLangCode'];
+		}
+
+		$colors = array(
+			'seekbarColor'        => 'seekbarColor',
+			'seekbarPlayedColor'  => 'seekbarPlayedColor',
+			'seekbarLoadingColor' => 'seekbarLoadedColor',
+		);
+		foreach ( $colors as $attribute => $option ) {
+			if ( ! empty( $attributes[ $attribute ] ) && is_string( $attributes[ $attribute ] ) ) {
+				$options[ $option ] = $attributes[ $attribute ];
+			}
+		}
+
+		/**
+		 * Filter the options passed to an inline VideoPress player.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $options    Player options.
+		 * @param array $attributes The block or shortcode attributes they were built from.
+		 */
+		return apply_filters( 'jetpack_videopress_inline_player_options', $options, $attributes );
+	}
+
+	/**
+	 * Read the player attributes an embed URL carries in its query string.
+	 *
+	 * Used to render inline players for videopress.com URLs that reach the
+	 * page through oEmbed. Only parameters present in the URL are returned.
+	 *
+	 * @param string $url A videopress.com/v or /embed URL.
+	 * @return array Attributes in the shape `get_player_options()` accepts.
+	 */
+	public static function get_attributes_from_embed_url( $url ) {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return array();
+		}
+
+		$params = array();
+		parse_str( html_entity_decode( $query ), $params );
+
+		$booleans = array(
+			'autoPlay'        => 'autoplay',
+			'autoplay'        => 'autoplay',
+			'controls'        => 'controls',
+			'loop'            => 'loop',
+			'muted'           => 'muted',
+			'playsinline'     => 'playsinline',
+			'useAverageColor' => 'useAverageColor',
+			'cover'           => 'cover',
+			'hd'              => 'hd',
+		);
+		$strings  = array(
+			'posterUrl'       => 'poster',
+			'preloadContent'  => 'preload',
+			'sbc'             => 'seekbarColor',
+			'sbpc'            => 'seekbarPlayedColor',
+			'sblc'            => 'seekbarLoadingColor',
+			'defaultLangCode' => 'defaultLangCode',
+		);
+
+		$attributes = array();
+		foreach ( $booleans as $param => $attribute ) {
+			if ( isset( $params[ $param ] ) && is_string( $params[ $param ] ) ) {
+				$attributes[ $attribute ] = self::to_bool( $params[ $param ] );
+			}
+		}
+		foreach ( $strings as $param => $attribute ) {
+			if ( ! empty( $params[ $param ] ) && is_string( $params[ $param ] ) ) {
+				$attributes[ $attribute ] = $params[ $param ];
+			}
+		}
+		if ( isset( $params['at'] ) && (int) $params['at'] > 0 ) {
+			$attributes['at'] = (int) $params['at'];
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Enqueue the shared player assets and the boot script, once per page.
+	 */
+	public static function enqueue_assets() {
+		wp_enqueue_style( self::PLAYER_HANDLE, self::PLAYER_STYLE_URL, array(), Package_Version::PACKAGE_VERSION );
+		wp_enqueue_script( self::PLAYER_HANDLE, self::PLAYER_SCRIPT_URL, array(), Package_Version::PACKAGE_VERSION, true );
+		wp_enqueue_script(
+			self::BOOT_HANDLE,
+			plugins_url( '../build/lib/inline-player.js', __FILE__ ),
+			array( self::PLAYER_HANDLE ),
+			Package_Version::PACKAGE_VERSION,
+			true
+		);
+
+		// Private videos ask the page for a playback token, same as iframes do.
+		Jwt_Token_Bridge::enqueue_jwt_token_bridge();
+	}
+
+	/**
+	 * Render the placeholder the boot script mounts a player on.
+	 *
+	 * @param string     $guid    Video GUID.
+	 * @param array      $options Player options, see `get_player_options()`.
+	 * @param float|null $ratio   Height as a percentage of width (the block's `videoRatio`); 16:9 when unknown.
+	 * @return string Placeholder markup, or an empty string for an invalid GUID.
+	 */
+	public static function render( $guid, array $options = array(), $ratio = null ) {
+		if ( ! is_string( $guid ) || ! ctype_alnum( $guid ) ) {
+			return '';
+		}
+
+		self::enqueue_assets();
+
+		$ratio = is_numeric( $ratio ) && (float) $ratio > 0 ? (float) $ratio : 56.25;
+		$style = sprintf(
+			'position:relative;width:100%%;aspect-ratio:100 / %s;',
+			rtrim( rtrim( number_format( $ratio, 4, '.', '' ), '0' ), '.' )
+		);
+
+		return sprintf(
+			'<div class="%1$s" data-videopress-guid="%2$s" data-videopress-options="%3$s" style="%4$s"></div>',
+			esc_attr( self::PLACEHOLDER_CLASS ),
+			esc_attr( $guid ),
+			esc_attr( wp_json_encode( (object) $options, JSON_UNESCAPED_SLASHES ) ),
+			esc_attr( $style )
+		);
+	}
+
+	/**
+	 * Interpret the boolean spellings that reach us from attributes and query strings.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return bool
+	 */
+	private static function to_bool( $value ) {
+		if ( is_string( $value ) ) {
+			return ! in_array( strtolower( $value ), array( '', '0', 'false', 'no', 'off' ), true );
+		}
+		return (bool) $value;
+	}
+}

--- a/projects/packages/videopress/src/class-inline-player.php
+++ b/projects/packages/videopress/src/class-inline-player.php
@@ -152,7 +152,7 @@ class Inline_Player {
 		}
 
 		$params = array();
-		parse_str( html_entity_decode( $query ), $params );
+		parse_str( html_entity_decode( $query, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ), $params );
 
 		$booleans = array(
 			'autoPlay'        => 'autoplay',

--- a/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
+++ b/projects/packages/videopress/src/class-videopress-rest-api-v1-settings.php
@@ -61,6 +61,10 @@ class VideoPress_Rest_Api_V1_Settings {
 							'description' => __( 'If embedded players should wait for playback before preloading video data', 'jetpack-videopress-pkg' ),
 							'type'        => 'boolean',
 						),
+						'videopress_inline_player_enabled' => array(
+							'description' => __( 'If videos should render an inline player from one shared script instead of one frame per video', 'jetpack-videopress-pkg' ),
+							'type'        => 'boolean',
+						),
 					),
 				),
 			)
@@ -134,6 +138,7 @@ class VideoPress_Rest_Api_V1_Settings {
 		$private_for_site        = $request->get_param( 'videopress_videos_private_for_site' );
 		$auto_subtitles_disabled = $request->get_param( 'videopress_auto_subtitles_disabled' );
 		$player_preload_disabled = $request->get_param( 'videopress_player_preload_disabled' );
+		$inline_player_enabled   = $request->get_param( 'videopress_inline_player_enabled' );
 
 		if ( null !== $private_for_site ) {
 			update_option( 'videopress_private_enabled_for_site', $private_for_site );
@@ -145,6 +150,10 @@ class VideoPress_Rest_Api_V1_Settings {
 
 		if ( null !== $player_preload_disabled ) {
 			update_option( 'videopress_player_preload_disabled', $player_preload_disabled );
+		}
+
+		if ( null !== $inline_player_enabled ) {
+			update_option( 'videopress_inline_player_enabled', $inline_player_enabled );
 		}
 
 		return rest_ensure_response(

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -276,6 +276,10 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 							'description' => __( 'If embedded players should wait for playback before preloading video data', 'jetpack-videopress-pkg' ),
 							'type'        => 'boolean',
 						),
+						'videopress_inline_player_enabled' => array(
+							'description' => __( 'If videos should render an inline player from one shared script instead of one frame per video', 'jetpack-videopress-pkg' ),
+							'type'        => 'boolean',
+						),
 					),
 				),
 			)
@@ -348,6 +352,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		$private_for_site        = $request->get_param( 'videopress_videos_private_for_site' );
 		$auto_subtitles_disabled = $request->get_param( 'videopress_auto_subtitles_disabled' );
 		$player_preload_disabled = $request->get_param( 'videopress_player_preload_disabled' );
+		$inline_player_enabled   = $request->get_param( 'videopress_inline_player_enabled' );
 
 		$ignored = array();
 
@@ -372,6 +377,10 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 
 		if ( null !== $player_preload_disabled ) {
 			update_option( 'videopress_player_preload_disabled', $player_preload_disabled );
+		}
+
+		if ( null !== $inline_player_enabled ) {
+			update_option( 'videopress_inline_player_enabled', $inline_player_enabled );
 		}
 
 		$response = array(

--- a/projects/packages/videopress/src/client/lib/inline-player/index.ts
+++ b/projects/packages/videopress/src/client/lib/inline-player/index.ts
@@ -1,0 +1,70 @@
+/**
+ * Mounts one VideoPress player per inline placeholder from the player bundle
+ * that Inline_Player::enqueue_assets() loads once per page (`window.videopress`).
+ */
+
+export const PLACEHOLDER_SELECTOR = '.jetpack-videopress-player__inline[data-videopress-guid]';
+
+type PlayerOptions = Record< string, unknown >;
+type PlayerFactory = ( guid: string, container: HTMLElement, options: PlayerOptions ) => unknown;
+
+declare global {
+	interface Window {
+		videopress?: PlayerFactory;
+	}
+}
+
+/**
+ * Parse the options a placeholder carries; malformed JSON yields no options.
+ *
+ * @param raw - The `data-videopress-options` attribute value.
+ * @return The parsed options object.
+ */
+export function parsePlaceholderOptions( raw: string | undefined ): PlayerOptions {
+	if ( ! raw ) {
+		return {};
+	}
+	try {
+		const parsed = JSON.parse( raw );
+		return parsed && typeof parsed === 'object' && ! Array.isArray( parsed ) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Mount a player on every placeholder under `root` that does not have one yet.
+ *
+ * @param root - Where to look for placeholders; the whole document by default.
+ * @return How many players were mounted by this call.
+ */
+export function mountInlinePlayers( root: ParentNode = document ): number {
+	const videopress = window.videopress;
+	if ( typeof videopress !== 'function' ) {
+		return 0;
+	}
+
+	let mounted = 0;
+	root.querySelectorAll< HTMLElement >( PLACEHOLDER_SELECTOR ).forEach( placeholder => {
+		if ( placeholder.dataset.videopressMounted ) {
+			return;
+		}
+		placeholder.dataset.videopressMounted = '1';
+
+		videopress( placeholder.dataset.videopressGuid as string, placeholder, {
+			width: placeholder.offsetWidth,
+			height: placeholder.offsetHeight,
+			fill: true,
+			...parsePlaceholderOptions( placeholder.dataset.videopressOptions ),
+		} );
+		mounted++;
+	} );
+
+	return mounted;
+}
+
+if ( document.readyState === 'loading' ) {
+	document.addEventListener( 'DOMContentLoaded', () => mountInlinePlayers() );
+} else {
+	mountInlinePlayers();
+}

--- a/projects/packages/videopress/src/client/lib/inline-player/index.ts
+++ b/projects/packages/videopress/src/client/lib/inline-player/index.ts
@@ -4,6 +4,7 @@
  */
 
 export const PLACEHOLDER_SELECTOR = '.jetpack-videopress-player__inline[data-videopress-guid]';
+const PLAYER_ID_PREFIX = 'videopress-player-';
 
 type PlayerOptions = Record< string, unknown >;
 type PlayerFactory = ( guid: string, container: HTMLElement, options: PlayerOptions ) => unknown;
@@ -33,6 +34,33 @@ export function parsePlaceholderOptions( raw: string | undefined ): PlayerOption
 }
 
 /**
+ * Hand an earlier instance of the same video a unique element id before this one mounts.
+ *
+ * The bundle names its element after the GUID and adopts any element already carrying that
+ * name, so a second embed of one video would otherwise pile onto the first.
+ *
+ * @param guid        - The video being mounted.
+ * @param placeholder - The placeholder about to receive it.
+ */
+function releasePlayerId( guid: string, placeholder: HTMLElement ): void {
+	const id = PLAYER_ID_PREFIX + guid;
+	const holder = document.getElementById( id );
+	if ( ! holder || placeholder.contains( holder ) ) {
+		return;
+	}
+	let unique = id;
+	for ( let n = 2; document.getElementById( unique ); n++ ) {
+		unique = `${ id }-${ n }`;
+	}
+	// video.js moves the id to its wrapper and suffixes the tag it wrapped.
+	const tag = document.getElementById( `${ id }_html5_api` );
+	holder.id = unique;
+	if ( tag && holder.contains( tag ) ) {
+		tag.id = `${ unique }_html5_api`;
+	}
+}
+
+/**
  * Mount a player on every placeholder under `root` that does not have one yet.
  *
  * @param root - Where to look for placeholders; the whole document by default.
@@ -51,7 +79,9 @@ export function mountInlinePlayers( root: ParentNode = document ): number {
 		}
 		placeholder.dataset.videopressMounted = '1';
 
-		videopress( placeholder.dataset.videopressGuid as string, placeholder, {
+		const guid = placeholder.dataset.videopressGuid as string;
+		releasePlayerId( guid, placeholder );
+		videopress( guid, placeholder, {
 			width: placeholder.offsetWidth,
 			height: placeholder.offsetHeight,
 			fill: true,

--- a/projects/packages/videopress/src/client/lib/inline-player/test/index.test.ts
+++ b/projects/packages/videopress/src/client/lib/inline-player/test/index.test.ts
@@ -1,0 +1,75 @@
+import { mountInlinePlayers, parsePlaceholderOptions } from '../index';
+
+const placeholder = ( guid: string, options?: string ) => {
+	const el = document.createElement( 'div' );
+	el.className = 'jetpack-videopress-player__inline';
+	el.dataset.videopressGuid = guid;
+	if ( options !== undefined ) {
+		el.dataset.videopressOptions = options;
+	}
+	document.body.appendChild( el );
+	return el;
+};
+
+describe( 'parsePlaceholderOptions', () => {
+	it( 'returns the parsed object', () => {
+		expect( parsePlaceholderOptions( '{"muted":true,"preloadContent":"none"}' ) ).toEqual( {
+			muted: true,
+			preloadContent: 'none',
+		} );
+	} );
+
+	it( 'tolerates missing, malformed, and non-object values', () => {
+		expect( parsePlaceholderOptions( undefined ) ).toEqual( {} );
+		expect( parsePlaceholderOptions( 'not json' ) ).toEqual( {} );
+		expect( parsePlaceholderOptions( '[1,2]' ) ).toEqual( {} );
+	} );
+} );
+
+describe( 'mountInlinePlayers', () => {
+	let factory: jest.Mock;
+
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		factory = jest.fn();
+		window.videopress = factory;
+	} );
+
+	afterEach( () => {
+		delete window.videopress;
+	} );
+
+	it( 'mounts one player per placeholder with its options', () => {
+		const first = placeholder( 'abcDEF12', '{"muted":true}' );
+		const second = placeholder( 'ghiJKL34' );
+
+		expect( mountInlinePlayers() ).toBe( 2 );
+
+		expect( factory ).toHaveBeenCalledTimes( 2 );
+		expect( factory ).toHaveBeenCalledWith(
+			'abcDEF12',
+			first,
+			expect.objectContaining( { fill: true, muted: true } )
+		);
+		expect( factory ).toHaveBeenCalledWith(
+			'ghiJKL34',
+			second,
+			expect.objectContaining( { fill: true } )
+		);
+	} );
+
+	it( 'never mounts the same placeholder twice', () => {
+		placeholder( 'abcDEF12' );
+
+		expect( mountInlinePlayers() ).toBe( 1 );
+		expect( mountInlinePlayers() ).toBe( 0 );
+		expect( factory ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does nothing without the player bundle', () => {
+		delete window.videopress;
+		placeholder( 'abcDEF12' );
+
+		expect( mountInlinePlayers() ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/videopress/src/client/lib/inline-player/test/index.test.ts
+++ b/projects/packages/videopress/src/client/lib/inline-player/test/index.test.ts
@@ -66,6 +66,42 @@ describe( 'mountInlinePlayers', () => {
 		expect( factory ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'gives every embed of one video its own element when the bundle reuses ids', () => {
+		// Behave like the bundle: adopt any element already named after the GUID, then wrap it the way video.js does.
+		factory.mockImplementation( ( guid: string, parent: HTMLElement ) => {
+			const id = `videopress-player-${ guid }`;
+			let video = document.getElementById( id );
+			if ( ! video ) {
+				video = document.createElement( 'video' );
+				video.id = id;
+				parent.appendChild( video );
+			}
+			const root = document.createElement( 'div' );
+			root.className = 'video-js';
+			root.id = id;
+			video.replaceWith( root );
+			video.id = `${ id }_html5_api`;
+			root.appendChild( video );
+		} );
+		const embeds = [
+			placeholder( 'abcDEF12' ),
+			placeholder( 'abcDEF12' ),
+			placeholder( 'abcDEF12' ),
+		];
+
+		expect( mountInlinePlayers() ).toBe( 3 );
+
+		embeds.forEach( el => {
+			const roots = el.querySelectorAll< HTMLElement >( 'div.video-js' );
+			expect( roots ).toHaveLength( 1 );
+			expect( el.querySelector( 'video' )?.id ).toBe( `${ roots[ 0 ].id }_html5_api` );
+		} );
+		const ids = Array.from( document.querySelectorAll( '[id^="videopress-player-"]' ) ).map(
+			el => el.id
+		);
+		expect( new Set( ids ).size ).toBe( ids.length );
+	} );
+
 	it( 'does nothing without the player bundle', () => {
 		delete window.videopress;
 		placeholder( 'abcDEF12' );

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -88,7 +88,9 @@ export async function tokenBridgeHandler(
 		return;
 	}
 
-	if ( ! isAllowedOrigin( event.origin ) ) {
+	// An inline player (Inline_Player) runs in this very window, so its request
+	// carries the page's own origin; iframes must come from VideoPress.
+	if ( event.source !== window && ! isAllowedOrigin( event.origin ) ) {
 		debug( '(%s) Invalid origin', context );
 		return;
 	}

--- a/projects/packages/videopress/src/client/lib/token-bridge/test/index.test.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/test/index.test.ts
@@ -98,6 +98,25 @@ describe( 'tokenBridgeHandler', () => {
 		expect( mockGetMediaToken ).not.toHaveBeenCalled();
 	} );
 
+	it( 'accepts a same-window request from an inline player on the page origin', async () => {
+		mockGetMediaToken.mockResolvedValue( { token: 'jwt-inline' } );
+		const postMessage = jest.spyOn( window, 'postMessage' ).mockImplementation( () => {} );
+		const event = createMessageEvent( {
+			data: validData,
+			origin: window.location.origin,
+			source: window as unknown as { postMessage: jest.Mock },
+		} );
+
+		await tokenBridgeHandler( event );
+
+		expect( mockGetMediaToken ).toHaveBeenCalled();
+		expect( postMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { event: 'videopress_token_received', jwt: 'jwt-inline' } ),
+			{ targetOrigin: window.location.origin }
+		);
+		postMessage.mockRestore();
+	} );
+
 	it( 'rejects messages missing guid', async () => {
 		const source = { postMessage: jest.fn() };
 		const event = createMessageEvent( {

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-settings.test.ts
@@ -42,6 +42,7 @@ describe( 'useSettings', () => {
 					videopress_videos_private_for_site: true,
 					videopress_auto_subtitles_disabled: true,
 					videopress_player_preload_disabled: false,
+					videopress_inline_player_enabled: false,
 					site_is_private: false,
 					site_type: 'jetpack',
 				};
@@ -54,6 +55,7 @@ describe( 'useSettings', () => {
 		expect( result.current.data?.videoPressVideosPrivateForSite ).toBe( true );
 		expect( result.current.data?.videoPressAutoSubtitlesDisabled ).toBe( true );
 		expect( result.current.data?.videoPressPlayerPreloadDisabled ).toBe( false );
+		expect( result.current.data?.videoPressInlinePlayerEnabled ).toBe( false );
 		expect( result.current.data?.siteIsPrivate ).toBe( false );
 	} );
 } );
@@ -74,6 +76,7 @@ describe( 'useUpdateSettings', () => {
 				videopress_videos_private_for_site: serverValue,
 				videopress_auto_subtitles_disabled: false,
 				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -111,6 +114,7 @@ describe( 'useUpdateSettings', () => {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: serverValue,
 				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -150,6 +154,7 @@ describe( 'useUpdateSettings', () => {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: false,
 				videopress_player_preload_disabled: serverValue,
+				videopress_inline_player_enabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -174,6 +179,44 @@ describe( 'useUpdateSettings', () => {
 		);
 	} );
 
+	it( 'POSTs videopress_inline_player_enabled and optimistically updates the cache', async () => {
+		const calls: { path?: string; method?: string; data?: unknown }[] = [];
+		// Track server state so the refetch after onSettled returns the updated value.
+		let serverValue = false;
+		mockApiFetch( async ( { path, method, data } ) => {
+			calls.push( { path, method, data } );
+			if ( method === 'POST' ) {
+				serverValue = ( data as Record< string, unknown > )
+					?.videopress_inline_player_enabled as boolean;
+				return { code: 'success', message: 'ok', data: 200 };
+			}
+			return {
+				videopress_videos_private_for_site: false,
+				videopress_auto_subtitles_disabled: false,
+				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: serverValue,
+				site_is_private: false,
+				site_type: 'jetpack',
+			};
+		} );
+
+		const client = createTestQueryClient();
+		const wrapper = createTestWrapper( client );
+		const { result: settingsResult } = renderHook( () => useSettings(), { wrapper } );
+		await waitFor( () => expect( settingsResult.current.data ).toBeDefined() );
+
+		const { result: mutationResult } = renderHook( () => useUpdateSettings(), { wrapper } );
+		await act( async () => {
+			await mutationResult.current.mutateAsync( { videoPressInlinePlayerEnabled: true } );
+		} );
+
+		const postCall = calls.find( c => c.method === 'POST' );
+		expect( postCall?.data ).toEqual( { videopress_inline_player_enabled: true } );
+		await waitFor( () =>
+			expect( settingsResult.current.data?.videoPressInlinePlayerEnabled ).toBe( true )
+		);
+	} );
+
 	it( 'sends no request for an empty patch', async () => {
 		const calls: { method?: string }[] = [];
 		mockApiFetch( async ( { method } ) => {
@@ -182,6 +225,7 @@ describe( 'useUpdateSettings', () => {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: false,
 				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -205,6 +249,7 @@ describe( 'useUpdateSettings', () => {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: false,
 				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: false,
 				site_is_private: false,
 				site_type: 'jetpack',
 			};
@@ -241,6 +286,7 @@ describe( 'on WordPress.com Simple', () => {
 					videopress_videos_private_for_site: false,
 					videopress_auto_subtitles_disabled: true,
 					videopress_player_preload_disabled: false,
+					videopress_inline_player_enabled: false,
 					site_is_private: true,
 					site_type: 'simple',
 				};
@@ -266,6 +312,7 @@ describe( 'on WordPress.com Simple', () => {
 				videopress_videos_private_for_site: false,
 				videopress_auto_subtitles_disabled: true,
 				videopress_player_preload_disabled: false,
+				videopress_inline_player_enabled: false,
 				site_is_private: true,
 				site_type: 'simple',
 			};

--- a/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-settings.ts
@@ -5,6 +5,7 @@ type ApiSettings = {
 	videopress_videos_private_for_site: boolean;
 	videopress_auto_subtitles_disabled: boolean;
 	videopress_player_preload_disabled: boolean;
+	videopress_inline_player_enabled: boolean;
 	site_is_private: boolean;
 	site_type: string;
 };
@@ -13,6 +14,7 @@ export type Settings = {
 	videoPressVideosPrivateForSite: boolean;
 	videoPressAutoSubtitlesDisabled: boolean;
 	videoPressPlayerPreloadDisabled: boolean;
+	videoPressInlinePlayerEnabled: boolean;
 	siteIsPrivate: boolean;
 	siteType: string;
 };
@@ -23,6 +25,7 @@ export type SettingsPatch = Partial<
 		| 'videoPressVideosPrivateForSite'
 		| 'videoPressAutoSubtitlesDisabled'
 		| 'videoPressPlayerPreloadDisabled'
+		| 'videoPressInlinePlayerEnabled'
 	>
 >;
 
@@ -72,6 +75,7 @@ function fromApi( raw: ApiSettings ): Settings {
 		videoPressVideosPrivateForSite: raw.videopress_videos_private_for_site,
 		videoPressAutoSubtitlesDisabled: raw.videopress_auto_subtitles_disabled,
 		videoPressPlayerPreloadDisabled: raw.videopress_player_preload_disabled,
+		videoPressInlinePlayerEnabled: raw.videopress_inline_player_enabled,
 		siteIsPrivate: raw.site_is_private,
 		siteType: raw.site_type,
 	};
@@ -109,6 +113,7 @@ export function useUpdateSettings() {
 					| 'videopress_videos_private_for_site'
 					| 'videopress_auto_subtitles_disabled'
 					| 'videopress_player_preload_disabled'
+					| 'videopress_inline_player_enabled'
 				>
 			> = {};
 			if ( patch.videoPressVideosPrivateForSite !== undefined ) {
@@ -119,6 +124,9 @@ export function useUpdateSettings() {
 			}
 			if ( patch.videoPressPlayerPreloadDisabled !== undefined ) {
 				data.videopress_player_preload_disabled = patch.videoPressPlayerPreloadDisabled;
+			}
+			if ( patch.videoPressInlinePlayerEnabled !== undefined ) {
+				data.videopress_inline_player_enabled = patch.videoPressInlinePlayerEnabled;
 			}
 			if ( Object.keys( data ).length === 0 ) {
 				return;

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -42,7 +42,33 @@ class Block_Editor_Content_Test extends BaseTestCase {
 		delete_option( 'videopress_player_preload_disabled' );
 		remove_filter( 'default_content', array( Block_Editor_Content::class, 'videopress_video_block_by_guid' ), 10 );
 		unset( $_GET['videopress_guid'], $_GET['_wpnonce'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		delete_option( 'videopress_inline_player_enabled' );
 		parent::tear_down();
+	}
+
+	/**
+	 * Test that the shortcode renders an inline player, with its own attributes, when the site turns it on.
+	 */
+	public function test_shortcode_renders_inline_player_when_enabled() {
+		update_option( 'videopress_inline_player_enabled', true );
+
+		$html = Block_Editor_Content::videopress_embed_shortcode(
+			array(
+				'abcDEF12',
+				'w'       => 400,
+				'h'       => 300,
+				'muted'   => 'true',
+				'preload' => 'none',
+			)
+		);
+
+		$this->assertStringNotContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'jetpack-videopress-player__wrapper', $html );
+		$this->assertStringContainsString( 'data-videopress-guid="abcDEF12"', $html );
+		$this->assertStringContainsString( '&quot;muted&quot;:true', $html );
+		$this->assertStringContainsString( '&quot;preloadContent&quot;:&quot;none&quot;', $html );
+		$this->assertStringContainsString( 'aspect-ratio:100 / 75', $html );
+		$this->assertFalse( wp_script_is( 'videopress-iframe', 'enqueued' ) );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
+++ b/projects/packages/videopress/tests/php/Block_Editor_Content_Test.php
@@ -54,7 +54,7 @@ class Block_Editor_Content_Test extends BaseTestCase {
 
 		$html = Block_Editor_Content::videopress_embed_shortcode(
 			array(
-				'abcDEF12',
+				0         => 'abcDEF12',
 				'w'       => 400,
 				'h'       => 300,
 				'muted'   => 'true',

--- a/projects/packages/videopress/tests/php/Data_Test.php
+++ b/projects/packages/videopress/tests/php/Data_Test.php
@@ -578,4 +578,19 @@ class Data_Test extends BaseTestCase {
 
 		delete_option( 'videopress_player_preload_disabled' );
 	}
+
+	/**
+	 * Test that the inline player is off by default, honors the stored option, and is exposed in the settings.
+	 */
+	public function test_inline_player_enabled_option() {
+		delete_option( 'videopress_inline_player_enabled' );
+		$this->assertFalse( Data::get_videopress_inline_player_enabled() );
+		$this->assertFalse( Data::get_videopress_settings()['videopress_inline_player_enabled'] );
+
+		update_option( 'videopress_inline_player_enabled', true );
+		$this->assertTrue( Data::get_videopress_inline_player_enabled() );
+		$this->assertTrue( Data::get_videopress_settings()['videopress_inline_player_enabled'] );
+
+		delete_option( 'videopress_inline_player_enabled' );
+	}
 }

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -37,6 +37,7 @@ class Initializer_Test extends BaseTestCase {
 		parent::tear_down();
 		unset( $GLOBALS['post'] );
 		delete_option( 'videopress_player_preload_disabled' );
+		delete_option( 'videopress_inline_player_enabled' );
 	}
 
 	/**
@@ -124,6 +125,84 @@ class Initializer_Test extends BaseTestCase {
 		$html = $this->render( array( 'preload' => 'metadata' ) );
 		$this->assertStringContainsString( 'preloadContent=none', $html );
 		$this->assertStringNotContainsString( 'preloadContent=metadata', $html );
+	}
+
+	/**
+	 * Tests that the inline player replaces the iframe when the site turns it on.
+	 *
+	 * Runs in a separate process: rendering the inline player loads Jwt_Token_Bridge,
+	 * which Uploader_Test replaces with an alias mock that needs the class unloaded.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_block_renders_inline_player_when_enabled() {
+		update_option( 'videopress_inline_player_enabled', true );
+
+		$html = $this->render(
+			array(
+				'muted'      => true,
+				'videoRatio' => 75,
+			)
+		);
+
+		$this->assertStringNotContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'jetpack-videopress-player__wrapper', $html );
+		$this->assertStringContainsString( 'data-videopress-guid="testGUID1"', $html );
+		$this->assertStringContainsString( '&quot;muted&quot;:true', $html );
+		$this->assertStringContainsString( 'aspect-ratio:100 / 75', $html );
+		$this->assertTrue( wp_script_is( 'videopress-inline-player', 'enqueued' ) );
+	}
+
+	/** Tests that preview on hover keeps the iframe, since it drives the player through the iframe API. */
+	public function test_block_keeps_iframe_for_preview_on_hover() {
+		update_option( 'videopress_inline_player_enabled', true );
+
+		$html = $this->render(
+			array(
+				'posterData' => array(
+					'previewOnHover'      => true,
+					'previewAtTime'       => 0,
+					'previewLoopDuration' => 3,
+				),
+			)
+		);
+
+		$this->assertStringContainsString( '<iframe', $html );
+		$this->assertStringNotContainsString( 'data-videopress-guid', $html );
+	}
+
+	/**
+	 * Tests that VideoPress oEmbeds become inline players and skip the remote fetch when enabled.
+	 *
+	 * Runs in a separate process for the same Jwt_Token_Bridge reason as the block test above.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_oembed_filters_render_inline_player_when_enabled() {
+		$url    = 'https://videopress.com/v/abcDEF12?preloadContent=none&amp;muted=1';
+		$iframe = '<iframe src="https://videopress.com/embed/abcDEF12"></iframe>';
+
+		$this->assertNull( VideoPress_Initializer::maybe_pre_oembed_inline_player( null, $url ) );
+		$this->assertSame( $iframe, VideoPress_Initializer::maybe_render_oembed_inline_player( $iframe, $url, array(), 0 ) );
+
+		update_option( 'videopress_inline_player_enabled', true );
+
+		$pre = VideoPress_Initializer::maybe_pre_oembed_inline_player( null, $url );
+		$this->assertStringContainsString( 'data-videopress-guid="abcDEF12"', $pre );
+		$this->assertStringContainsString( '&quot;preloadContent&quot;:&quot;none&quot;', $pre );
+		$this->assertStringContainsString( '&quot;muted&quot;:true', $pre );
+
+		$this->assertStringContainsString( 'data-videopress-guid="abcDEF12"', VideoPress_Initializer::maybe_render_oembed_inline_player( $iframe, $url, array(), 0 ) );
+
+		// Anything that is not a VideoPress video, or not an iframe, is left alone.
+		$this->assertNull( VideoPress_Initializer::maybe_pre_oembed_inline_player( null, 'https://www.youtube.com/watch?v=abc' ) );
+		$this->assertFalse( VideoPress_Initializer::maybe_render_oembed_inline_player( false, $url, array(), 0 ) );
 	}
 
 	/** Tests that the fallback filter is cleaned up after rendering. */

--- a/projects/packages/videopress/tests/php/Inline_Player_Test.php
+++ b/projects/packages/videopress/tests/php/Inline_Player_Test.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Tests for Automattic\Jetpack\VideoPress\Inline_Player.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use WorDBless\BaseTestCase;
+
+/**
+ * Class Inline_Player_Test
+ *
+ * Runs in separate processes because rendering loads Jwt_Token_Bridge, which
+ * Uploader_Test replaces with a Mockery alias mock that requires the real
+ * class to not be loaded yet.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class Inline_Player_Test extends BaseTestCase {
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		delete_option( 'videopress_inline_player_enabled' );
+		delete_option( 'videopress_player_preload_disabled' );
+		remove_all_filters( 'jetpack_videopress_player_use_iframe' );
+		remove_all_filters( 'jetpack_videopress_inline_player_options' );
+		wp_dequeue_script( Inline_Player::PLAYER_HANDLE );
+		wp_dequeue_script( Inline_Player::BOOT_HANDLE );
+		wp_dequeue_style( Inline_Player::PLAYER_HANDLE );
+		parent::tear_down();
+	}
+
+	/**
+	 * Iframes stay the default; the option and the filter both switch to the inline player.
+	 */
+	public function test_is_enabled_follows_the_option_and_the_filter() {
+		$this->assertFalse( Inline_Player::is_enabled() );
+
+		update_option( 'videopress_inline_player_enabled', true );
+		$this->assertTrue( Inline_Player::is_enabled() );
+
+		// The filter still has the last word, in both directions.
+		add_filter( 'jetpack_videopress_player_use_iframe', '__return_true' );
+		$this->assertFalse( Inline_Player::is_enabled() );
+
+		remove_all_filters( 'jetpack_videopress_player_use_iframe' );
+		delete_option( 'videopress_inline_player_enabled' );
+		add_filter( 'jetpack_videopress_player_use_iframe', '__return_false' );
+		$this->assertTrue( Inline_Player::is_enabled() );
+	}
+
+	/**
+	 * Player options default like the iframe URL builder and map the block's attribute names.
+	 */
+	public function test_get_player_options_defaults_and_mapping() {
+		$defaults = Inline_Player::get_player_options();
+
+		$this->assertFalse( $defaults['autoPlay'] );
+		$this->assertTrue( $defaults['controls'] );
+		$this->assertTrue( $defaults['persistVolume'] );
+		$this->assertTrue( $defaults['useAverageColor'] );
+		$this->assertSame( 'metadata', $defaults['preloadContent'] );
+		$this->assertSame( 'v2', $defaults['chrome'] );
+		$this->assertArrayNotHasKey( 'poster', $defaults );
+		$this->assertArrayNotHasKey( 'at', $defaults );
+
+		$options = Inline_Player::get_player_options(
+			array(
+				'autoplay'            => true,
+				'controls'            => false,
+				'muted'               => true,
+				'preload'             => 'none',
+				'poster'              => 'https://example.com/poster.jpg',
+				'seekbarColor'        => 'red',
+				'seekbarPlayedColor'  => 'green',
+				'seekbarLoadingColor' => 'blue',
+				'at'                  => '12',
+			)
+		);
+
+		$this->assertTrue( $options['autoPlay'] );
+		$this->assertFalse( $options['controls'] );
+		$this->assertTrue( $options['muted'] );
+		$this->assertFalse( $options['persistVolume'] );
+		$this->assertSame( 'none', $options['preloadContent'] );
+		$this->assertSame( 'https://example.com/poster.jpg', $options['poster'] );
+		$this->assertSame( 'red', $options['seekbarColor'] );
+		$this->assertSame( 'green', $options['seekbarPlayedColor'] );
+		$this->assertSame( 'blue', $options['seekbarLoadedColor'] );
+		$this->assertSame( 12, $options['at'] );
+	}
+
+	/**
+	 * The site-wide preload opt-out overrides the embed's own preload value, and the options filter applies.
+	 */
+	public function test_get_player_options_honors_site_preload_opt_out_and_filter() {
+		update_option( 'videopress_player_preload_disabled', true );
+		$this->assertSame( 'none', Inline_Player::get_player_options( array( 'preload' => 'auto' ) )['preloadContent'] );
+
+		add_filter(
+			'jetpack_videopress_inline_player_options',
+			function ( $options ) {
+				$options['chrome'] = 'v1';
+				return $options;
+			}
+		);
+		$this->assertSame( 'v1', Inline_Player::get_player_options()['chrome'] );
+	}
+
+	/**
+	 * Embed URL query strings are read back into attributes, including entity-encoded ampersands.
+	 */
+	public function test_get_attributes_from_embed_url() {
+		$this->assertSame( array(), Inline_Player::get_attributes_from_embed_url( 'https://videopress.com/v/abcDEF12' ) );
+
+		$attributes = Inline_Player::get_attributes_from_embed_url(
+			'https://videopress.com/embed/abcDEF12?autoPlay=1&amp;controls=0&amp;preloadContent=none&amp;posterUrl=https%3A%2F%2Fexample.com%2Fp.jpg&amp;sbc=red&amp;at=7&amp;cover=1'
+		);
+
+		$this->assertTrue( $attributes['autoplay'] );
+		$this->assertFalse( $attributes['controls'] );
+		$this->assertSame( 'none', $attributes['preload'] );
+		$this->assertSame( 'https://example.com/p.jpg', $attributes['poster'] );
+		$this->assertSame( 'red', $attributes['seekbarColor'] );
+		$this->assertSame( 7, $attributes['at'] );
+		$this->assertTrue( $attributes['cover'] );
+	}
+
+	/**
+	 * Rendering emits a placeholder carrying the GUID, the options and the aspect ratio, and enqueues the shared assets once.
+	 */
+	public function test_render_outputs_a_placeholder_and_enqueues_assets_once() {
+		$html = Inline_Player::render(
+			'abcDEF12',
+			array(
+				'muted'  => true,
+				'chrome' => 'v2',
+			),
+			56.25
+		);
+
+		$this->assertStringContainsString( 'class="jetpack-videopress-player__inline"', $html );
+		$this->assertStringContainsString( 'data-videopress-guid="abcDEF12"', $html );
+		$this->assertStringContainsString( 'aspect-ratio:100 / 56.25', $html );
+		$this->assertStringContainsString( '&quot;muted&quot;:true', $html );
+		$this->assertStringNotContainsString( '<iframe', $html );
+		$this->assertStringNotContainsString( '<script', $html );
+
+		// A second render shares the same assets.
+		Inline_Player::render( 'ghiJKL34' );
+
+		$this->assertTrue( wp_script_is( Inline_Player::PLAYER_HANDLE, 'enqueued' ) );
+		$this->assertTrue( wp_script_is( Inline_Player::BOOT_HANDLE, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( Inline_Player::PLAYER_HANDLE, 'enqueued' ) );
+		$this->assertSame( Inline_Player::PLAYER_SCRIPT_URL, wp_scripts()->registered[ Inline_Player::PLAYER_HANDLE ]->src );
+		$this->assertContains( Inline_Player::PLAYER_HANDLE, wp_scripts()->registered[ Inline_Player::BOOT_HANDLE ]->deps );
+		$this->assertStringContainsString( 'build/lib/inline-player.js', wp_scripts()->registered[ Inline_Player::BOOT_HANDLE ]->src );
+		$this->assertTrue( wp_script_is( Jwt_Token_Bridge::SCRIPT_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * Unknown aspect ratios fall back to 16:9, and invalid GUIDs render nothing.
+	 */
+	public function test_render_edge_cases() {
+		$this->assertStringContainsString( 'aspect-ratio:100 / 56.25', Inline_Player::render( 'abcDEF12' ) );
+		$this->assertStringContainsString( 'aspect-ratio:100 / 100', Inline_Player::render( 'abcDEF12', array(), 100 ) );
+		$this->assertSame( '', Inline_Player::render( 'not a guid' ) );
+		$this->assertSame( '', Inline_Player::render( '' ) );
+	}
+}

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Settings_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Settings_Test.php
@@ -191,4 +191,21 @@ class VideoPress_Rest_Api_V1_Settings_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'videopress_player_preload_disabled', $data );
 		$this->assertTrue( $data['videopress_player_preload_disabled'] );
 	}
+
+	/**
+	 * Test that the inline player setting round-trips through the endpoint.
+	 */
+	public function test_inline_player_setting_round_trips() {
+		delete_option( 'videopress_inline_player_enabled' );
+
+		$response = $this->update_settings( array( 'videopress_inline_player_enabled' => true ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( boolval( get_option( 'videopress_inline_player_enabled' ) ) );
+
+		$request  = new WP_REST_Request( 'GET', '/videopress/v1/settings' );
+		$response = $this->server->dispatch( $request );
+		$this->assertTrue( $response->get_data()['videopress_inline_player_enabled'] );
+
+		delete_option( 'videopress_inline_player_enabled' );
+	}
 }

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -122,6 +122,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'videopress_videos_private_for_site', $data );
 		$this->assertArrayHasKey( 'videopress_auto_subtitles_disabled', $data );
 		$this->assertArrayHasKey( 'videopress_player_preload_disabled', $data );
+		$this->assertArrayHasKey( 'videopress_inline_player_enabled', $data );
 		$this->assertArrayHasKey( 'site_is_private', $data );
 		$this->assertArrayHasKey( 'site_type', $data );
 	}
@@ -135,11 +136,13 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		delete_option( 'videopress_private_enabled_for_site' );
 		delete_option( 'videopress_auto_subtitles_disabled' );
 		delete_option( 'videopress_player_preload_disabled' );
+		delete_option( 'videopress_inline_player_enabled' );
 
 		$request = new \WP_REST_Request( 'POST', self::ROUTE_SETTINGS );
 		$request->set_param( 'videopress_videos_private_for_site', true );
 		$request->set_param( 'videopress_auto_subtitles_disabled', true );
 		$request->set_param( 'videopress_player_preload_disabled', true );
+		$request->set_param( 'videopress_inline_player_enabled', true );
 
 		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
 		$response = $endpoint->videopress_update_settings( $request );
@@ -150,6 +153,8 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$this->assertTrue( (bool) get_option( 'videopress_private_enabled_for_site' ) );
 		$this->assertTrue( (bool) get_option( 'videopress_auto_subtitles_disabled' ) );
 		$this->assertTrue( (bool) get_option( 'videopress_player_preload_disabled' ) );
+		$this->assertTrue( (bool) get_option( 'videopress_inline_player_enabled' ) );
+		delete_option( 'videopress_inline_player_enabled' );
 	}
 
 	/**

--- a/projects/packages/videopress/webpack.config.js
+++ b/projects/packages/videopress/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = [
 
 			'lib/token-bridge': './src/client/lib/token-bridge/index.ts',
 			'lib/player-bridge': './src/client/lib/player-bridge/index.ts',
+			'lib/inline-player': './src/client/lib/inline-player/index.ts',
 
 			// VideoPress dashboard page
 			'admin/index': './src/client/admin/index.jsx',

--- a/projects/plugins/jetpack/changelog/add-videopress-inline-player
+++ b/projects/plugins/jetpack/changelog/add-videopress-inline-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: Add a setting to render players in the page from one shared player script instead of one frame per video.

--- a/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
+++ b/projects/plugins/jetpack/modules/videopress/class.videopress-player.php
@@ -1,4 +1,5 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+use Automattic\Jetpack\VideoPress\Inline_Player;
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -635,20 +636,8 @@ class VideoPress_Player {
 		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && stristr( sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ), 'Trident/7.0; rv:11.0' ) ) {
 			$iframe_embed = false;
 		} else {
-
-			/**
-			 * Filter the VideoPress iframe embed
-			 *
-			 * This filter allows you to control whether the videos will be embedded using an iframe.
-			 * Set this to false in order to use an in-page embed rather than an iframe.
-			 *
-			 * @module videopress
-			 *
-			 * @since 3.7.0
-			 *
-			 * @param boolean $videopress_player_use_iframe
-			 */
-			$iframe_embed = apply_filters( 'jetpack_videopress_player_use_iframe', true );
+			// The site setting and the `jetpack_videopress_player_use_iframe` filter decide; see Inline_Player::is_enabled().
+			$iframe_embed = ! Inline_Player::is_enabled();
 		}
 
 		if ( ! array_key_exists( 'hd', $this->options ) ) {
@@ -726,21 +715,26 @@ class VideoPress_Player {
 				. " allow='clipboard-write; presentation'></iframe>";
 
 		} else {
-			$videopress_options = wp_json_encode( $videopress_options, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-			$js_url             = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.js';
-			$css_url            = 'https://s0.wp.com/wp-content/plugins/video/assets/js/videojs/videopress.css';
-			$guid_js            = wp_json_encode( (string) $this->video->guid, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-			$selector_js        = wp_json_encode( '#' . $video_container_id, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
-
-			// Without the player styles the <video> renders at its native size and overflows the page.
-			wp_enqueue_style( 'videopress-videojs', $css_url, array(), JETPACK__VERSION );
-			wp_enqueue_script( 'videopress-videojs', $js_url, array(), JETPACK__VERSION, true );
-			wp_add_inline_script(
-				'videopress-videojs',
-				"videopress({$guid_js}, document.querySelector({$selector_js}), {$videopress_options});"
+			$attributes = array(
+				'autoplay'        => $videopress_options['autoPlay'] ?? false,
+				'controls'        => $videopress_options['controls'] ?? true,
+				'loop'            => $videopress_options['loop'] ?? false,
+				'muted'           => $videopress_options['muted'] ?? false,
+				'playsinline'     => $videopress_options['playsinline'] ?? false,
+				'useAverageColor' => $videopress_options['useAverageColor'] ?? true,
+				'cover'           => $videopress_options['cover'],
+				'hd'              => $videopress_options['hd'],
+				'at'              => $videopress_options['at'] ?? 0,
+				'preload'         => $videopress_options['preloadContent'] ?? 'metadata',
+				'defaultLangCode' => $videopress_options['defaultLangCode'] ?? '',
 			);
+			$ratio      = $videopress_options['width'] > 0
+				? ( $videopress_options['height'] / $videopress_options['width'] ) * 100
+				: null;
 
-			return "<div id='" . esc_attr( $video_container_id ) . "'></div>";
+			return "<div id='" . esc_attr( $video_container_id ) . "'>"
+				. Inline_Player::render( (string) $this->video->guid, Inline_Player::get_player_options( $attributes ), $ratio )
+				. '</div>';
 		}
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/VideoPress_Player_Test.php
@@ -98,36 +98,44 @@ class VideoPress_Player_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * With the iframe embed disabled, the VideoJS player script should be
-	 * enqueued only once while each video still attaches its own inline
-	 * initialization. See #35926.
+	 * With the iframe embed disabled, the player script should be enqueued
+	 * only once while each video gets its own placeholder for the boot
+	 * script to mount. See #35926.
 	 */
-	public function test_non_iframe_path_enqueues_videojs_once_with_per_video_init() {
+	public function test_non_iframe_path_enqueues_player_once_with_a_placeholder_per_video() {
 		$use_iframe = '__return_false';
 		add_filter( 'jetpack_videopress_player_use_iframe', $use_iframe );
 
-		( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
-		( new VideoPress_Player( 'otherguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+		$first  = ( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+		$second = ( new VideoPress_Player( 'otherguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
 
 		remove_filter( 'jetpack_videopress_player_use_iframe', $use_iframe );
 
 		$enqueued = array_keys( wp_scripts()->queue, 'videopress-videojs', true );
 		$this->assertCount( 1, $enqueued, 'videopress-videojs should be enqueued exactly once.' );
 
+		$boot = array_keys( wp_scripts()->queue, 'videopress-inline-player', true );
+		$this->assertCount( 1, $boot, 'The inline player boot script should be enqueued exactly once.' );
+
 		$styles = array_keys( wp_styles()->queue, 'videopress-videojs', true );
 		$this->assertCount( 1, $styles, 'The videopress-videojs stylesheet should be enqueued exactly once.' );
 
-		$inline = wp_scripts()->get_data( 'videopress-videojs', 'after' );
-		$inline = is_array( $inline ) ? implode( "\n", $inline ) : (string) $inline;
-		$this->assertStringContainsString(
-			'videopress("testguid", document.querySelector("#v-testguid")',
-			$inline,
-			'The first video should get its own inline initialization.'
-		);
-		$this->assertStringContainsString(
-			'videopress("otherguid", document.querySelector("#v-otherguid")',
-			$inline,
-			'The second video should get its own inline initialization.'
-		);
+		$this->assertStringContainsString( 'data-videopress-guid="testguid"', $first );
+		$this->assertStringContainsString( 'data-videopress-guid="otherguid"', $second );
+		$this->assertStringNotContainsString( '<iframe', $first . $second );
+	}
+
+	/**
+	 * The site setting alone switches the shortcode to the inline player.
+	 */
+	public function test_inline_player_setting_disables_the_iframe() {
+		update_option( 'videopress_inline_player_enabled', true );
+
+		$html = ( new VideoPress_Player( 'testguid', 0, array( 'cover' => true ) ) )->html5_dynamic_next();
+
+		delete_option( 'videopress_inline_player_enabled' );
+
+		$this->assertStringNotContainsString( '<iframe', $html );
+		$this->assertStringContainsString( 'data-videopress-guid="testguid"', $html );
 	}
 }

--- a/projects/plugins/videopress/changelog/add-videopress-inline-player
+++ b/projects/plugins/videopress/changelog/add-videopress-inline-player
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a setting to render players in the page from one shared player script instead of one frame per video.


### PR DESCRIPTION
Fixes N/A — follow-up to #51991 for Linear [VIDP-384](https://linear.app/a8c/issue/VIDP-384/videopress-add-a-site-wide-setting-to-turn-off-player) (stacked on that branch; only the last commit is this PR).

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* **Why:** every `videopress.com/embed/` iframe downloads and runs its own copy of the player — `videopress-routes.min.js` (~950 KB, it bundles the whole player), `videopress.css` (~200 KB) and three transmuxer worker blobs — so PageSpeed reports the same "unused JavaScript" once per video on a page. Cross-origin iframes cannot share a module, so the only way to load it once is to render the players in the page.
* **New `Inline_Player` class** (`packages/videopress`): enqueues `videopress.js` and `videopress.css` from `videopress.com` once (the `videopress-videojs` handles the Jetpack plugin's dormant in-page branch already used, so dequeue hooks keep working) plus a 3.8 KB boot script (`build/lib/inline-player.js`) that mounts `videopress( guid, el, options )` on each `.jetpack-videopress-player__inline` placeholder. Placeholders reserve their aspect ratio inline, so there is no layout shift while the player mounts.
* **Options** are mapped from the block's attributes, the shortcode's attributes, or an embed URL's query string (same names the routes script accepts). The site-wide preload opt-out from #51991 applies, the skin defaults to `v2` like embed pages, and a new `jetpack_videopress_inline_player_options` filter lets sites adjust them.
* **Gate:** a new `videopress_inline_player_enabled` site option (off by default) exposed through both settings endpoints and a "Load the player once per page instead of once per video" toggle in the VideoPress Settings tab. The existing `jetpack_videopress_player_use_iframe` filter keeps the last word in both directions.
* **Wired into** the video block (skipping oEmbed entirely), both `[videopress]`/`[wpvideo]` handlers (package and Jetpack plugin), and oEmbedded VideoPress URLs: `pre_oembed_result` short-circuits the remote fetch and `embed_oembed_html` swaps iframes already cached in post meta. The iframe API script is no longer enqueued in inline mode.
* **Kept on iframes:** the playlist block, and video blocks with preview-on-hover (it drives the player through the iframe API).
* **Token bridge** now answers same-window requests, so private videos still get a playback token when the player runs in the page (iframe requests must still come from VideoPress origins).
* The Jetpack plugin's legacy `jetpack_videopress_player_use_iframe => false` branch delegates to `Inline_Player` instead of printing one inline `<script>` per video.
* **Repeated embeds of one video:** the player bundle names its element after the GUID and adopts any element already carrying that id, so a page with the same video several times mounted every instance onto the first placeholder (each iframe used to be its own document). The boot script hands the earlier holder of that id a unique one before each mount. The companion player change (linked from the Linear issue) that makes the bundle pick unique ids itself has since merged and is live on `v0.wordpress.com`, so the guard is now a safety net for any cached older bundle.

Trace of the four-video test post through the Jurassic Tube site, main frame only:

| | iframes (before) | inline (after) |
|---|---|---|
| frames | 5 | 1 |
| `videopress-routes.min.js` | 4 × ~950 KB | — |
| `videopress.js` | — | 1 × ~950 KB |
| `videopress.css` | 4 | 1 |
| worker blobs | 12 × 97 KB | — |
| per-embed `videopress-iframe.js` tags | 4 | 0 |
| mounted players | 4 | 4 (v2 chrome, no console errors) |

Known limitations, on purpose for a first, opt-in iteration: the inline player's UI strings are not localized (embed pages get their translations injected server-side), and theme CSS can now reach the player.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: [VIDP-384](https://linear.app/a8c/issue/VIDP-384/videopress-add-a-site-wide-setting-to-turn-off-player)
* Base PR: #51991

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No. One new boolean site option, not synced to WordPress.com.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Setup: a Jetpack-connected site with VideoPress (Jurassic Ninja or `jp docker` behind a tunnel, since offline mode skips the shortcode), `jp build packages/videopress plugins/jetpack`, and a page with a few VideoPress video blocks, a `[videopress <guid>]` shortcode, and a pasted `https://videopress.com/v/<guid>` URL.

* Load the page with the setting off: DevTools → Network shows one `videopress-routes.min.js` request per video, one iframe each.
* Go to **Jetpack → VideoPress → Settings**, switch on "Load the player once per page instead of once per video", reload the page: no `videopress.com/embed` iframes; one `videopress.com/js/videojs/videopress.js`, one `videopress.css`, one `inline-player.js`; every video renders and plays in the page with the v2 chrome; no console errors. The block's own attributes (muted, loop, poster, seek-bar colors) and the shortcode's still apply.
* Add the **same** video three or more times on one page (blocks or shortcodes), reload: every placeholder gets its own player (`div.video-js` ids `videopress-player-<guid>`, `…-2`, `…-3`) and each plays independently; nothing piles up in the first one.
* Set a video to private, reload: it still plays (the token bridge answers the in-page request).
* Add a video block with "Preview on hover" enabled: that block keeps its iframe. The playlist block keeps its iframe too.
* `add_filter( 'jetpack_videopress_player_use_iframe', '__return_true' )` brings iframes back even with the setting on; `'__return_false'` enables inline mode with the setting off.
* Switch the setting off, reload: iframes again, including for the pasted URL (its cached oEmbed markup is used as before).
* Automated: `jp test php packages/videopress`, `jp test js packages/videopress`. `VideoPress_Player_Test` in the Jetpack plugin was updated for the new markup; I could not run that Docker-only suite locally (its bootstrap fails on an unrelated missing class in this checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L84aNxBedd6AWnbWFAVkq4



