### PR TITLE
Backup: fix a stray comma and give the finished download a button

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2504-backup-copy-and-download-button-cleanups
+++ b/projects/packages/backup/changelog/jetpack-2504-backup-copy-and-download-button-cleanups
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: drop a stray comma from the Site database description on the Restore and Download screens, and render the finished archive's download link as a button rather than plain underlined text. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: tidy two copy errors in the Restore and Download checklist (a stray comma, and an unhyphenated "non-WordPress"), and render the finished archive's download link as a button rather than plain underlined text. No-op when the filter is off.
 
 

--- a/projects/packages/backup/changelog/jetpack-2504-backup-copy-and-download-button-cleanups
+++ b/projects/packages/backup/changelog/jetpack-2504-backup-copy-and-download-button-cleanups
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: drop a stray comma from the Site database description on the Restore and Download screens, and render the finished archive's download link as a button rather than plain underlined text. No-op when the filter is off.
+
+

--- a/projects/packages/backup/routes/download/style.scss
+++ b/projects/packages/backup/routes/download/style.scss
@@ -29,10 +29,11 @@
 		gap: 16px;
 	}
 
-	// Card.Root lays its children out as a flex column, so a `<Button>`
-	// child stretches to fill the cross-axis (the full card width) by
-	// default. Pin the Generate action to its content width.
-	&__confirm {
+	// Card.Root and the success Stack both lay children out as a flex
+	// column, so a `<Button>` child stretches to fill the cross-axis
+	// (the full card width). Pin both actions to their content width.
+	&__confirm,
+	&__link {
 		align-self: flex-start;
 
 		// wp-admin's global `svg { fill: … }` is unlayered and beats
@@ -42,9 +43,5 @@
 		svg {
 			fill: currentColor;
 		}
-	}
-
-	&__link {
-		font-weight: 600;
 	}
 }

--- a/projects/packages/backup/src/dashboard/components/restore-items-checklist/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/restore-items-checklist/index.tsx
@@ -24,7 +24,7 @@ const ITEMS: ItemDef[] = [
 	{
 		key: 'roots',
 		label: __( 'WordPress root', 'jetpack-backup-pkg' ),
-		description: __( 'Includes wp-config.php and any non WordPress files.', 'jetpack-backup-pkg' ),
+		description: __( 'Includes wp-config.php and any non-WordPress files.', 'jetpack-backup-pkg' ),
 	},
 	{
 		key: 'contents',

--- a/projects/packages/backup/src/dashboard/components/restore-items-checklist/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/restore-items-checklist/index.tsx
@@ -34,7 +34,7 @@ const ITEMS: ItemDef[] = [
 	{
 		key: 'sqls',
 		label: __( 'Site database', 'jetpack-backup-pkg' ),
-		description: __( 'Includes pages, and posts.', 'jetpack-backup-pkg' ),
+		description: __( 'Includes pages and posts.', 'jetpack-backup-pkg' ),
 	},
 	{
 		key: 'uploads',

--- a/projects/packages/backup/src/dashboard/screens/download.tsx
+++ b/projects/packages/backup/src/dashboard/screens/download.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/el
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, arrowLeft } from '@wordpress/icons';
 import { Link, useParams, useSearch } from '@wordpress/route';
-import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { Button, Card, LinkButton, Stack, Text } from '@wordpress/ui';
 import DashboardLayout from '../components/dashboard-layout';
 import InvalidRewindId from '../components/invalid-rewind-id';
 import RestoreItemsChecklist from '../components/restore-items-checklist';
@@ -205,14 +205,16 @@ export default function DownloadScreen() {
 							<Notice status="success" isDismissible={ false }>
 								{ __( 'Your download is ready.', 'jetpack-backup-pkg' ) }
 							</Notice>
-							<a
+							<LinkButton
 								className="jpb-download__link"
+								variant="solid"
 								href={ state.downloadUrl }
 								download
 								rel="noreferrer"
 							>
+								<Icon icon={ downloadIcon } size={ 18 } />
 								{ __( 'Download the file', 'jetpack-backup-pkg' ) }
-							</a>
+							</LinkButton>
 							{ /*
 							 * WPCOM signs the archive URL with an expiry. Saying
 							 * when it lapses is the difference between coming back

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -469,6 +469,7 @@ describe( 'Download screen with a file selection', () => {
 
 		const link = await screen.findByRole( 'link', { name: 'Download the file' }, SETTLE );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/archive.zip' );
+		expect( link ).toHaveAttribute( 'download' );
 		// `Notice` also speaks its text through `wp.a11y.speak`, which
 		// mirrors the string into a live region — so an unscoped query
 		// matches twice. The visible notice is the one under assertion.


### PR DESCRIPTION
Fixes #

Part of [JETPACK-2504](https://linear.app/a8c/issue/JETPACK-2504) — **items 1 and 4 of four.** Items 2 and 3 both live in files that #51955 is rewriting, so they are held back until it lands. The issue stays open for them.

## Proposed changes

* **Two copy fixes** in the restore/download checklist, both modernized-dashboard-only msgids that exist nowhere else in the monorepo — so retranslating them costs a UI nobody has been shown yet:
  * *"Includes pages, and posts."* → *"Includes pages and posts."* (the item JETPACK-2504 asked for)
  * *"…any non WordPress files."* → *"…any non-WordPress files."* (found in review, two lines up, same defect class)
* **The finished archive's download link is now a button.** Every other primary action on that screen — **Generate download**, **Try again** — is already one, and this link is the screen's entire purpose.

`LinkButton` is `@wordpress/ui`'s component for exactly this ("a link that looks like a `Button`"). It keeps the element a real `<a>`, so `href`, `download` and the `link` role all survive, while `variant="solid"` resolves against the Button union. The existing `getByRole( 'link', { name: 'Download the file' } )` assertion passes unchanged, and the PR now also asserts the `download` attribute the swap is meant to preserve.

### The two rules a WPDS button needs on this dashboard

The first draft moved the markup and left the route stylesheet alone, which would have shipped a full-width bar with a black icon. Both hazards are already documented in this codebase — five separate rules carry `svg { fill: currentColor }` — so the fix widens the existing `&__confirm` selector rather than copying it:

* **Stretch.** `Card.Root` and the success `Stack` both lay children out as a flex column, so a WPDS button child fills the cross-axis. `align-self: flex-start` pins it.
* **Icon colour.** wp-admin's global `svg { fill: … }` is *unlayered*, and every `@wordpress/ui` rule sits inside `@layer wp-ui`, so the global wins and the icon renders black on the blue background. `fill: currentColor` forces it to inherit.

The now-redundant `font-weight: 600` is dropped — WPDS sets it through `--wp-ui-button-font-weight`.

**One judgment call:** the button carries the same `downloadIcon` as **Generate download**, so two primary actions in one flow don't differ by an icon. Not something JETPACK-2504 asked for — say the word and I'll drop it.

## Related product discussion/links

* [JETPACK-2504](https://linear.app/a8c/issue/JETPACK-2504) — filed from the pre-flag-flip sweep

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**The copy** — at **Jetpack → Backup**, open **Restore to this point** or **Download backup** from any activity row. Under **Site database**: *"Includes pages and posts."* Under **WordPress root**: *"…any non-WordPress files."* Confirm on both screens.

**The button** — append `?jpb_sim=download-success`, open **Download backup**, then **Generate download**. **Download the file** should render as a solid brand button with a white download icon, sized to its content rather than spanning the card. Check keyboard reachability, and RTL now that an icon sits beside the label.

Measured on the built dashboard: button width **156px** in a **354px** card (`align-self: flex-start` holding), icon `fill: rgb(239,240,242)` matching the label colour rather than black, `href` and `download` both present, accessible name still `Download the file`.

**Automated:** `jp test js packages/backup` — 782 tests, all passing.

> Note for reviewers: browsers ignore `download` on cross-origin URLs, and `state.downloadUrl` is a WPCOM-signed URL. The archive downloads via `Content-Disposition`, not the attribute. Pre-existing, but it makes "the `download` attribute survives" a weaker guarantee than it sounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy
