### PR TITLE
Backup: bidi-isolate the actor name in the detail panes

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2505-backup-bidi-isolate-display-names
+++ b/projects/packages/backup/changelog/jetpack-2505-backup-bidi-isolate-display-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: bidi-isolate the user display name in both activity detail panes, so a name whose direction differs from the surrounding text no longer reorders the sentence around it. No-op when the filter is off.
+
+

--- a/projects/packages/backup/changelog/jetpack-2505-backup-bidi-isolate-display-names
+++ b/projects/packages/backup/changelog/jetpack-2505-backup-bidi-isolate-display-names
@@ -1,5 +1,5 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: bidi-isolate the user display name in both activity detail panes, so a name whose direction differs from the surrounding text no longer reorders the sentence around it. No-op when the filter is off.
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: bidi-isolate the user display name in both activity detail panes, so a name that mixes scripts resolves its own direction instead of inheriting the sentence's and rendering its parts out of order. No-op when the filter is off.
 
 

--- a/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-detail/index.tsx
@@ -26,7 +26,7 @@ export default function ActivityDetail( { item }: Props ) {
 					<Text variant="body-sm" className="jpb-text-muted">
 						{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
 						{ ' · ' }
-						{ item.actor.name }
+						<bdi>{ item.actor.name }</bdi>
 					</Text>
 					{ item.summary && <Text dir="auto">{ item.summary }</Text> }
 				</Stack>

--- a/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/backup-detail/index.tsx
@@ -1,5 +1,5 @@
 import { dateI18n } from '@wordpress/date';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, cloud, download as downloadIcon, rotateLeft } from '@wordpress/icons';
 import { Link } from '@wordpress/route';
@@ -143,11 +143,14 @@ export default function BackupDetail( { item }: Props ) {
 					{ item.stats }
 				</Text>
 				<Text variant="body-sm" className="jpb-text-muted jpb-backup-detail__by">
-					{ sprintf(
-						/* translators: %1$s formatted date+time, %2$s actor name */
-						__( '%1$s by %2$s', 'jetpack-backup-pkg' ),
-						dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ),
-						item.actor.name
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %1$s formatted date+time, %2$s actor name */
+							__( '%1$s by %2$s', 'jetpack-backup-pkg' ),
+							dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ),
+							'<Actor />'
+						),
+						{ Actor: <bdi>{ item.actor.name }</bdi> }
 					) }
 				</Text>
 				<div className="jpb-backup-detail__files">

--- a/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
+++ b/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
@@ -66,7 +66,7 @@ const ACTIVITY_ITEM: NonBackupActivityItem = {
 	kind: 'plugin-update',
 	title: 'Plugin updated',
 	publishedAt: '2026-08-13T18:08:56+00:00',
-	actor: { type: 'Person', name: 'Bob Sacramento' },
+	actor: { type: 'Person', name: 'أحمد Smith' },
 	summary: STATS,
 };
 
@@ -232,13 +232,8 @@ describe( 'bidi isolation on LTR data', () => {
 	} );
 } );
 
-// Machine data above has a direction known in advance. A person's display
-// name does not, and misrenders in both directions — so it needs `<bdi>`,
-// not a `dir` value.
 describe( 'bidi isolation on names of unknown direction', () => {
 	it( 'isolates the actor name interpolated into the backup detail sentence', () => {
-		// The pane mounts a file browser, which fetches its root listing on
-		// mount. Nothing here reads those rows.
 		mockApiFetch.mockResolvedValue( {} );
 
 		const { container } = render(

--- a/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
+++ b/projects/packages/backup/tests/rtl-bidi-isolation.test.tsx
@@ -1,4 +1,4 @@
-/* eslint jest/expect-expect: [ "warn", { assertFunctionNames: [ "expect", "expectIsolated" ] } ] */
+/* eslint jest/expect-expect: [ "warn", { assertFunctionNames: [ "expect", "expectIsolated", "expectBidiIsolated" ] } ] */
 
 const mockApiFetch = jest.fn();
 
@@ -81,6 +81,18 @@ const ACTIVITY_ITEM: NonBackupActivityItem = {
  */
 function expectIsolated( text: string, expected: 'ltr' | 'auto' ): void {
 	expect( screen.getByText( text ) ).toHaveAttribute( 'dir', expected );
+}
+
+/**
+ * Assert that the element directly owning `text` is a `<bdi>`.
+ *
+ * No fixed `dir` can stand in: a display name's direction is per-value and
+ * unknown, and `<bdi>` alone isolates it while still letting it resolve.
+ *
+ * @param text - The exact rendered string.
+ */
+function expectBidiIsolated( text: string ): void {
+	expect( screen.getByText( text ).tagName ).toBe( 'BDI' );
 }
 
 beforeEach( () => {
@@ -217,5 +229,32 @@ describe( 'bidi isolation on LTR data', () => {
 		await expect( screen.findByText( SOURCE ) ).resolves.toBeInTheDocument();
 
 		expectIsolated( SOURCE, 'ltr' );
+	} );
+} );
+
+// Machine data above has a direction known in advance. A person's display
+// name does not, and misrenders in both directions — so it needs `<bdi>`,
+// not a `dir` value.
+describe( 'bidi isolation on names of unknown direction', () => {
+	it( 'isolates the actor name interpolated into the backup detail sentence', () => {
+		// The pane mounts a file browser, which fetches its root listing on
+		// mount. Nothing here reads those rows.
+		mockApiFetch.mockResolvedValue( {} );
+
+		const { container } = render(
+			<QueryClientProvider>
+				<BackupDetail item={ BACKUP_ITEM } />
+			</QueryClientProvider>
+		);
+
+		expectBidiIsolated( BACKUP_ITEM.actor.name );
+		// Isolating the name must not cost the sentence built around it.
+		expect( container ).toHaveTextContent( `by ${ BACKUP_ITEM.actor.name }` );
+	} );
+
+	it( 'isolates the actor name on the non-backup detail pane', () => {
+		render( <ActivityDetail item={ ACTIVITY_ITEM } /> );
+
+		expectBidiIsolated( ACTIVITY_ITEM.actor.name );
 	} );
 } );


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2505](https://linear.app/a8c/issue/JETPACK-2505).

## Proposed changes

Two places print `item.actor.name` — a **user-supplied display name, of unknown direction** — with no bidi isolation, so the name's base direction is inherited from the sentence instead of resolved from its own content:

* `activity-detail/index.tsx`, after the timestamp and a `·` separator.
* `backup-detail/index.tsx`, interpolated into the translated `'%1$s by %2$s'`.

Both now wrap the name in `<bdi>`.

**The msgid is untouched.** `'%1$s by %2$s'` is unchanged byte-for-byte — the `<Actor />` token goes in as a `sprintf` *argument*, not into the translated string, so `createInterpolateElement` can place the `<bdi>` without starting a fresh GlotPress cycle or stranding existing translations. The `translators:` comment stays directly above the `__()` call. There is monorepo precedent for this exact shape in `packages/publicize/_inc/components/customize-and-preview/customization-section/index.tsx`.

### What this actually fixes — narrower than the issue claims

The Linear issue says an RTL name "drags the surrounding neutral characters, so the *sentence* reorders". **That is not what happens here, and an earlier draft of this PR repeated it.** In both templates the name is in *final* position, so there is nothing after it to drag. Measured in Chrome on the built dashboard, across ten realistic name/template combinations:

| Display name | Without `<bdi>` | With `<bdi>` |
| --- | --- | --- |
| `مرحبا` | `… by مرحبا` | `… by مرحبا` — no change |
| `مرحبا 2` | `… by مرحبا 2` | `… by مرحبا 2` — no change |
| `Bob مرحبا` | `… by Bob مرحبا` | `… by Bob مرحبا` — no change |
| `أحمد Smith` | `… by أحمد Smith` | **`… by Smith أحمد`** |
| `مرحبا (admin)` | `… by مرحبا (admin)` | **`… by (admin) مرحبا`** |

The isolation changes rendering only when the name's **first strong character is RTL and something follows it** — another script, or neutrals like parentheses. Then the name's own parts render in the order its owner typed them, instead of being laid out at the paragraph's level. A purely RTL name, or one that merely ends in digits, renders identically either way.

Also worth correcting: `<bdi>` is **not** uniquely capable here. `<span dir="auto">` produced byte-identical output in all eleven shapes tested — HTML's UA stylesheet gives any `[dir]` element `unicode-bidi: isolate`, so the two are equivalent. `<bdi>` is still the right choice because it is the purpose-built element and carries `dir=auto` implicitly, but the justification is semantics, not capability.

The fix is worth shipping regardless: isolating an interpolated value of unknown direction is the correct default, and it is what stops this becoming a visible bug the moment anything is appended after the name or a translation reorders the sentence.

### Checked and deliberately left alone

`src/js/components/Backups.jsx:346-350` interpolates a **site title** into `'Backing up %s'` with the same defect. That is the legacy dashboard, which JETPACK-2505 does not cover and [JETPACK-2314](https://linear.app/a8c/issue/JETPACK-2314) is set to delete. `git grep actor -- src/dashboard` confirms these two components are the only modernized sites.

## Related product discussion/links

* [JETPACK-2505](https://linear.app/a8c/issue/JETPACK-2505) — split out of [#51962](https://github.com/Automattic/jetpack/pull/51962) review, where it was deliberately not bundled

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Automated** — `jp test js packages/backup` (784 tests). Reverting either source file turns the two new cases in `tests/rtl-bidi-isolation.test.tsx` red with `Unable to find an element with the text`: without `<bdi>` the name is a bare text node merged into its parent, so `getByText` has nothing to own.

**By hand** — use a **mixed-script** display name; a purely RTL one will show no difference (see the table above). Set a user's display name to `أحمد Smith`, then make a change as that user so it lands in the activity log. At **Jetpack → Backup**, select that row: the backup pane should read `… by Smith أحمد`, with the name's own parts right-to-left. Before this change it read `أحمد Smith`.

Verified on the built dashboard by swapping the name into the live `<bdi>` and then removing the element: order changed from `by Smith أحمد` to `by أحمد Smith`, confirming the isolation is what does it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy
