### PR TITLE
Jetpack AI: lock the AI Features tab for an admin with no linked account

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -147,14 +147,15 @@ export function visibleSections( sections, features ) {
 /**
  * A single feature row: toggle + description + optional action link.
  *
- * @param {object}   props               - Component props.
- * @param {object}   props.feature       - Entry from SECTIONS[].features.
- * @param {object}   props.reported      - This feature's object from the settings response.
- * @param {boolean}  props.checked       - Whether the feature is enabled.
- * @param {boolean}  props.isSaving      - Whether this toggle is being saved.
- * @param {boolean}  props.masterEnabled - Whether the site-wide AI master switch is on.
- * @param {boolean}  props.isConnected   - Whether the AI connection gate passes (connected owner, not offline).
- * @param {Function} props.onChange      - Called with (key, enabled) on toggle.
+ * @param {object}   props                 - Component props.
+ * @param {object}   props.feature         - Entry from SECTIONS[].features.
+ * @param {object}   props.reported        - This feature's object from the settings response.
+ * @param {boolean}  props.checked         - Whether the feature is enabled.
+ * @param {boolean}  props.isSaving        - Whether this toggle is being saved.
+ * @param {boolean}  props.masterEnabled   - Whether the site-wide AI master switch is on.
+ * @param {boolean}  props.isConnected     - Whether the AI connection gate passes (connected owner, not offline).
+ * @param {boolean}  props.isUserConnected - Whether the current user's own WordPress.com account is linked.
+ * @param {Function} props.onChange        - Called with (key, enabled) on toggle.
  * @return {object} Component markup.
  */
 function FeatureRow( {
@@ -164,6 +165,7 @@ function FeatureRow( {
 	isSaving,
 	masterEnabled,
 	isConnected,
+	isUserConnected,
 	onChange,
 } ) {
 	const handleChange = useCallback(
@@ -172,12 +174,16 @@ function FeatureRow( {
 	);
 
 	const action = ( checked ? feature.enabledAction : feature.disabledAction ) ?? feature.action;
-	// The toggle keeps showing the SAVED value but can't be used while the
-	// connection gate fails (no feature can load without it), while the master
-	// switch is off (the saved choice returns when master does), or while the
-	// plan doesn't include the individual feature. There is deliberately no
-	// site-wide plan gate here: every connected site can run the free tier.
-	const isDisabled = isSaving || ! isConnected || ! masterEnabled || !! reported?.requires_upgrade;
+	// The toggle keeps showing the SAVED value but can't be used while the site
+	// or user connection gate fails, while the master switch is off, or while
+	// the plan doesn't include the feature. There is deliberately no site-wide
+	// plan gate here: every connected site can run the free tier.
+	const isDisabled =
+		isSaving ||
+		! isConnected ||
+		! isUserConnected ||
+		! masterEnabled ||
+		!! reported?.requires_upgrade;
 
 	return (
 		<Stack direction="column" gap="xs" className="jetpack-ai-features__row">
@@ -189,7 +195,7 @@ function FeatureRow( {
 				help={ feature.description }
 				onChange={ handleChange }
 			/>
-			{ action && masterEnabled && isConnected && (
+			{ action && masterEnabled && isConnected && isUserConnected && (
 				<Link
 					className="jetpack-ai-features__action"
 					href={ action.href }
@@ -222,6 +228,9 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 	// case no AI feature can load. Saved values stay visible but inert, and
 	// the connection ask comes before any upgrade messaging.
 	const isConnected = settings?.is_connected !== false;
+	// The user gate is separate: the site can be connected while this admin's
+	// own account is not.
+	const isUserConnected = settings?.is_user_connected !== false;
 	// There is no site-wide plan gate: a plan without paid Jetpack AI still has
 	// the free tier, so a connected site can always run the free-tier features.
 	// Paid-only features are gated per-feature via requires_upgrade instead.
@@ -272,6 +281,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 			isSaving={ savingKeys.has( feature.key ) }
 			masterEnabled={ masterEnabled }
 			isConnected={ isConnected }
+			isUserConnected={ isUserConnected }
 			onChange={ handleToggle }
 		/>
 	);
@@ -290,6 +300,19 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 						) }{ ' ' }
 						<Link href="admin.php?page=my-jetpack#/connection">
 							{ __( 'Connect Jetpack', 'jetpack' ) }
+						</Link>
+					</Notice.Description>
+				</Notice.Root>
+			) }
+			{ isConnected && ! isUserConnected && (
+				// One ask at a time: a disconnected site gets the site notice above.
+				<Notice.Root intent="warning">
+					<Notice.Title>
+						{ __( 'Your WordPress.com account isn’t connected.', 'jetpack' ) }
+					</Notice.Title>
+					<Notice.Description>
+						<Link href="admin.php?page=my-jetpack#/connection">
+							{ __( 'Connect your user account to manage AI features.', 'jetpack' ) }
 						</Link>
 					</Notice.Description>
 				</Notice.Root>
@@ -318,6 +341,7 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 												{ section.title }
 											</Text>
 											{ isConnected &&
+												isUserConnected &&
 												section.features.some( f => features[ f.key ]?.requires_upgrade ) && (
 													<Popover.Root>
 														{ /* A popover rather than a tooltip: click opens it, touch

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -215,6 +215,44 @@ describe( 'AiFeatures rendering', () => {
 		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'user not linked: connect notice, toggles keep saved values but disable, links and badge hidden', () => {
+		renderFeatures( { is_connected: true, is_user_connected: false } );
+
+		expect( screen.getByText( 'Your WordPress.com account isn’t connected.' ) ).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'Connect your user account to manage AI features.' } )
+		).toHaveAttribute( 'href', 'admin.php?page=my-jetpack#/connection' );
+		// The site is connected, so the site-level ask must not show as well.
+		expect(
+			screen.queryByText( 'Jetpack is not connected to WordPress.com.' )
+		).not.toBeInTheDocument();
+
+		const toggle = screen.getByRole( 'checkbox', { name: /Writing Assistant/ } );
+		expect( toggle ).toBeChecked();
+		expect( toggle ).toBeDisabled();
+
+		expect( screen.queryByText( 'Requires upgrade' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'is_user_connected absent: no user notice, toggles stay usable', () => {
+		renderFeatures( { is_connected: true } );
+
+		expect(
+			screen.queryByText( 'Your WordPress.com account isn’t connected.' )
+		).not.toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) ).toBeEnabled();
+	} );
+
+	test( 'site and user both unlinked: only the site notice shows', () => {
+		renderFeatures( { is_connected: false, is_user_connected: false } );
+
+		expect( screen.getByText( 'Jetpack is not connected to WordPress.com.' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Your WordPress.com account isn’t connected.' )
+		).not.toBeInTheDocument();
+	} );
+
 	// A plan without paid Jetpack AI still has the free tier (every connected
 	// site gets free requests), so the paid-plan signal must not lock the page:
 	// no site-wide notice, and the free-tier features stay usable.
@@ -267,6 +305,7 @@ describe( 'AiFeatures rendering', () => {
 	// Gated toggles must be inert, not merely styled disabled.
 	test.each( [
 		[ 'not connected', { is_connected: false } ],
+		[ 'user not linked', { is_user_connected: false } ],
 		[ 'master off', { master_enabled: false } ],
 	] )( '%s fires no save and no Tracks event', async ( _label, overrides ) => {
 		analytics.tracks.recordEvent.mockClear();

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -265,6 +265,22 @@ describe( 'AI admin page (main.jsx)', () => {
 		} );
 	} );
 
+	test( 'features tab: an unlinked user gets the connect ask and locked switches', async () => {
+		// The page-level flag says linked: the tab must read the endpoint's field.
+		window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: true };
+		mockApiFetch( { featureGet: { ...enabledSettings(), is_user_connected: false } } );
+
+		render( <App /> );
+
+		await expect(
+			screen.findByText( 'Your WordPress.com account isn’t connected.', IGNORE_A11Y )
+		).resolves.toBeInTheDocument();
+		expect(
+			screen.getByRole( 'link', { name: 'Connect your user account to manage AI features.' } )
+		).toHaveAttribute( 'href', 'admin.php?page=my-jetpack#/connection' );
+		expect( screen.getByRole( 'checkbox', { name: /Writing Assistant/ } ) ).toBeDisabled();
+	} );
+
 	test( 'save-confirmation: a successful AI-settings save shows a success snackbar', async () => {
 		mockApiFetch( { featurePost: () => Promise.resolve( enabledSettings() ) } );
 

--- a/projects/plugins/jetpack/changelog/fix-forno-518-hub-gate-disconnected-user
+++ b/projects/plugins/jetpack/changelog/fix-forno-518-hub-gate-disconnected-user
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: AI Hub: ask an admin whose WordPress.com account is not connected to connect it on the AI Features tab, and lock the switches until they do. The tab is not released yet.
+


### PR DESCRIPTION
Fixes FORNO-518

## Proposed changes

* Show the "Your WordPress.com account isn’t connected" notice on the **AI Features** tab when the site is connected but the current admin's own WordPress.com account is not. It is the Overview notice, with a **Connect your user account to manage AI features** link to the same My Jetpack connection screen.
* Disable the feature switches at their saved values while that admin is unlinked, and hide the row links and the "Requires upgrade" badge. This matches how the tab already renders for a site without a connected owner.
* Read the user gate from the feature-settings endpoint's existing `is_user_connected` field, the way the tab already reads `is_connected`.
* Add React coverage for the unlinked-user state.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Use a self-hosted site with the Jetpack build from this PR and two administrator accounts: admin A, who owns the Jetpack connection, and admin B, who has never linked a WordPress.com account.

### Owner disconnected (existing behaviour, no change expected)

1. Log in as admin A. Connect Jetpack and link A's WordPress.com account.
2. Disconnect A's account (Settings → Connectors → Disconnect your user, or My Jetpack → Connection).
3. Go to **Jetpack → Jetpack AI → Overview**. Confirm the "Your WordPress.com account isn’t connected" notice shows.
4. Open **AI Features**. Confirm the "Jetpack is not connected to WordPress.com" notice shows and every switch is greyed out at its saved value.

### Second admin, not linked (the fix)

5. Reconnect A's account.
6. Log in as admin B in a private window. Do not link a WordPress.com account.
7. Go to **Jetpack → Jetpack AI → Overview**. Confirm the "Your WordPress.com account isn’t connected" notice shows, as before.
8. Open **AI Features**. Confirm the same notice shows with a **Connect your user account to manage AI features** link, every switch is greyed out at its saved value, and no row links or "Requires upgrade" badge show. On trunk this tab shows no notice and the switches can be changed.
9. Select the link. Confirm the My Jetpack connection screen opens, the same one Overview links to.
10. Link B's account and reload **AI Features**. Confirm the notice is gone and the switches work.

