### PR TITLE
Revert "CI: raise job timeouts while pnpm/action-setup is slow"

### DIFF
--- a/.github/files/generate-ci-matrix.php
+++ b/.github/files/generate-ci-matrix.php
@@ -79,7 +79,7 @@ foreach ( array( 'previous', 'trunk' ) as $wp ) {
 		'script'  => 'test-php',
 		'php'     => $phpver,
 		'wp'      => $wp,
-		'timeout' => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~7 minutes.
+		'timeout' => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	);
 }
 
@@ -89,7 +89,7 @@ $matrix[] = array(
 	'script'           => 'test-php',
 	'php'              => '7.4',
 	'wp'               => 'latest',
-	'timeout'          => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~3 minutes.
+	'timeout'          => 15, // 2025-11-06: Successful runs seem to take ~3 minutes.
 	'with-woocommerce' => true,
 );
 
@@ -99,7 +99,7 @@ $matrix[] = array(
 	'script'       => 'test-php',
 	'php'          => '8.3',
 	'wp'           => 'latest',
-	'timeout'      => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~7 minutes.
+	'timeout'      => 15, // 2025-11-06: Successful runs seem to take ~7 minutes.
 	'with-wpcomsh' => true,
 );
 
@@ -107,7 +107,7 @@ $matrix[] = array(
 $matrix[] = array(
 	'name'    => 'JS tests',
 	'script'  => 'test-js',
-	'timeout' => 25, // 2026-09-04: Temporary +10 while pnpm/action-setup is slow. Successful runs seem to take ~5 minutes.
+	'timeout' => 15, // 2025-11-06: Successful runs seem to take ~5 minutes.
 );
 
 // Add Coverage tests. Split into PHP and JS groups so they run in parallel.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
   prepare:
     name: Prepare build matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2026-04-07: Should take about a minute.
     permissions:
       # actions/checkout
       contents: read

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
   create-test-matrix:
     name: "Determine tests matrix"
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-20: The pnpm install may take a few minutes on cache miss.
     # Only run tests in the main repository
     if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     outputs:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -30,7 +30,7 @@ jobs:
     name: "Manage labels and assignees"
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2026-05-21: Successful runs take 1–2 minutes.
 
     # See above.
     concurrency:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -253,7 +253,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     continue-on-error: ${{ matrix.experimental }}
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 3  # 2025-11-06: Successful runs seem to take ~1 minute
 
     strategy:
       fail-fast: false
@@ -297,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~2 minutes. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -325,7 +325,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc_php == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take ~1 minute. Leaving some extra for future expansion.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -355,7 +355,7 @@ jobs:
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.php_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Successful runs seem to take 30 seconds. Leaving some extra for future expansion.
 
     steps:
       # We don't need full git history, but phpcs-changed does need everything up to the merge-base.
@@ -393,7 +393,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 20  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 10  # 2025-11-06: Runs now take ~5 minutes due to now installing all JS deps to ensure valid linting.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -418,7 +418,7 @@ jobs:
     needs: changed_files
     if: github.event_name == 'pull_request' && needs.changed_files.outputs.js_excluded_files != '[]'
     continue-on-error: true
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 10  # 2025-11-06: Takes about a minute, but rarely runs.
 
     steps:
       # We don't need full git history, but eslint-changed does need everything up to the merge-base.
@@ -450,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.css == 'true' || needs.changed_files.outputs.misc_css == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Takes a bit more than a minute, so give a little wiggle room.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -474,7 +474,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.ghactionsfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -507,7 +507,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.excludelist == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 10  # 2025-11-06: The check itself takes 2 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -529,7 +529,7 @@ jobs:
     name: Changelogger use
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Takes a few seconds.
     steps:
       # We don't need full git history, but tools/check-changelogger-use.php does need everything up to the merge-base.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -554,7 +554,7 @@ jobs:
   changelogger_valid:
     name: Changelogger validity
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Takes less than a minute.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -576,7 +576,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take about 2 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -610,7 +610,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.lockfiles == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 7  # 2025-11-06: Takes a minute or two.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools
@@ -624,7 +624,7 @@ jobs:
   project_structure:
     name: Project structure
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5  # 2025-11-06: Takes a minute or two.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -680,7 +680,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: github.event_name == 'push' || needs.changed_files.outputs.js == 'true' || needs.changed_files.outputs.misc_js == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 10 # 2025-11-20: Takes around 3 minutes.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools

--- a/.github/workflows/phpcompatibility-dev.yml
+++ b/.github/workflows/phpcompatibility-dev.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changed_files
     if: needs.changed_files.outputs.php == 'true' || needs.changed_files.outputs.misc == 'true'
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 7  # 2025-11-06: Successful runs seem to take ~2 minutes.
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -324,7 +324,7 @@ jobs:
   publish-coverage-data:
     name: Publish coverage data
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 10 # 2025-11-20 Takes about 2 minutes.
     needs: run-tests
     if: always() && needs.run-tests.outputs.did-coverage == 'true' && github.repository == 'Automattic/jetpack' && ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name || github.event_name == 'push' && github.ref == 'refs/heads/trunk' )
     steps:
@@ -420,7 +420,7 @@ jobs:
   plugin-deps:
     name: Check plugin monorepo dep versions
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # 2026-09-04: Temporary, pnpm/action-setup is taking up to 7 minutes.
+    timeout-minutes: 5 # 2025-11-20: Takes less than a minute.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Setup tools


### PR DESCRIPTION
The issues were probably related to https://status.npmjs.org/incidents/l4f53bbr9200, which is resolved. Recent CI runs aren't showing the issue anymore.

Also, we've switched to the newer `pnpm/setup` action in #51989, which may help.

Reverts Automattic/jetpack#51977