### PR TITLE
My Jetpack: test the product cards' primary action across the plan matrix

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/action-button/test/plan-matrix.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/action-button/test/plan-matrix.test.tsx
@@ -1,0 +1,176 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { PRODUCT_STATUSES } from '../../../constants';
+import ActionButton from '../index';
+
+const mockUseProduct = jest.fn();
+const mockUseProductsByOwnership = jest.fn();
+
+jest.mock( '../../../data/products/use-product', () => ( {
+	__esModule: true,
+	default: ( ...args ) => mockUseProduct( ...args ),
+} ) );
+
+jest.mock( '../../../data/products/use-products-by-ownership', () => ( {
+	__esModule: true,
+	default: () => mockUseProductsByOwnership(),
+} ) );
+
+/*
+ * Every hook below returns one closure-captured value. Handing back a fresh object or
+ * function per call changes the identity ActionButton's useMemo/useEffect chain keys on,
+ * which re-renders forever and takes the Jest worker's heap with it.
+ */
+jest.mock( '../../../data/products/use-activate-plugins', () => {
+	const result = { activate: () => {}, isPending: false };
+	return { __esModule: true, default: () => result };
+} );
+
+jest.mock( '../../../data/products/use-install-plugins', () => {
+	const result = { install: () => {}, isPending: false };
+	return { __esModule: true, default: () => result };
+} );
+
+jest.mock( '../../../hooks/use-my-jetpack-connection', () => {
+	const result = { siteIsRegistering: false, isRegistered: true, isUserConnected: true };
+	return { __esModule: true, default: () => result };
+} );
+
+jest.mock( '../../../hooks/use-my-jetpack-navigate', () => {
+	const navigate = () => {};
+	return { __esModule: true, default: () => navigate };
+} );
+
+jest.mock( '../../../hooks/use-analytics', () => {
+	const result = { recordEvent: () => {} };
+	return { __esModule: true, default: () => result };
+} );
+
+jest.mock( '../../../hooks/use-outside-alerter', () => ( {
+	__esModule: true,
+	default: () => {},
+} ) );
+
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	getUserConnectionUrl: () => 'https://example.org/connect',
+} ) );
+
+jest.mock( '@wordpress/ui', () => {
+	const react = jest.requireActual( 'react' );
+	const asElement =
+		tag =>
+		( { children, ...props } ) => {
+			// Component-only props that shouldn't land on the DOM node.
+			delete props.variant;
+			delete props.tone;
+			delete props.size;
+			delete props.openInNewTab;
+			delete props.nativeButton;
+			delete props.loading;
+			delete props.loadingAnnouncement;
+			return react.createElement( tag, props, children );
+		};
+
+	return {
+		Button: asElement( 'button' ),
+		Link: asElement( 'a' ),
+		LinkButton: asElement( 'a' ),
+	};
+} );
+
+/**
+ * The action every status has to offer, per the state table in JETPACK-2392.
+ *
+ * The plan states that reach each status are covered by tests/php/Plan_Matrix_Test.php; this
+ * is the other half of the same contract, and the status string is the join between them.
+ */
+const MATRIX: Array< { status: string; isOwned: boolean; label: string } > = [
+	{ status: PRODUCT_STATUSES.ACTIVE, isOwned: true, label: 'View' },
+	{ status: PRODUCT_STATUSES.INACTIVE, isOwned: true, label: 'Activate' },
+	{ status: PRODUCT_STATUSES.MODULE_DISABLED, isOwned: true, label: 'Activate' },
+	{ status: PRODUCT_STATUSES.NEEDS_ACTIVATION, isOwned: true, label: 'Activate' },
+	{ status: PRODUCT_STATUSES.ABSENT, isOwned: false, label: 'Learn more' },
+	{ status: PRODUCT_STATUSES.NEEDS_PLAN, isOwned: false, label: 'Learn more' },
+	{ status: PRODUCT_STATUSES.NEEDS_FIRST_SITE_CONNECTION, isOwned: false, label: 'Learn more' },
+	{ status: PRODUCT_STATUSES.CAN_UPGRADE, isOwned: false, label: 'Upgrade' },
+	{ status: PRODUCT_STATUSES.EXPIRING_SOON, isOwned: true, label: 'Renew my plan' },
+	{ status: PRODUCT_STATUSES.EXPIRED, isOwned: true, label: 'Resume my plan' },
+	{ status: PRODUCT_STATUSES.SITE_CONNECTION_ERROR, isOwned: true, label: 'Connect' },
+	{ status: PRODUCT_STATUSES.USER_CONNECTION_ERROR, isOwned: true, label: 'Connect' },
+	{ status: PRODUCT_STATUSES.NEEDS_ATTENTION__ERROR, isOwned: true, label: 'Troubleshoot' },
+	{ status: PRODUCT_STATUSES.NEEDS_ATTENTION__WARNING, isOwned: true, label: 'Troubleshoot' },
+];
+
+/**
+ * Statuses Plan_Matrix_Test says a site that owns the product can be in. None of them may
+ * put an upsell on the card -- that is the whole of the JETPACK-2392 correctness metric.
+ */
+const OWNED_STATUSES = [
+	PRODUCT_STATUSES.ACTIVE,
+	PRODUCT_STATUSES.INACTIVE,
+	PRODUCT_STATUSES.MODULE_DISABLED,
+	PRODUCT_STATUSES.NEEDS_ACTIVATION,
+	PRODUCT_STATUSES.ABSENT_WITH_PLAN,
+];
+
+const UPSELL_LABELS = [ 'Learn more', 'Get plan' ];
+
+const primaryActionFor = ( status: string, isOwned: boolean ) => {
+	mockUseProduct.mockReturnValue( {
+		detail: {
+			status,
+			manageUrl: 'https://example.org/manage',
+			purchaseUrl: 'https://example.org/purchase',
+			managePaidPlanPurchaseUrl: 'https://example.org/manage-plan',
+			renewPaidPlanPurchaseUrl: 'https://example.org/renew',
+			requiresUserConnection: false,
+		},
+		isLoading: false,
+		isRefetching: false,
+	} );
+	mockUseProductsByOwnership.mockReturnValue( {
+		data: { ownedProducts: isOwned ? [ 'videopress' ] : [] },
+	} );
+
+	render( <ActionButton slug="videopress" tracksIdentifier="test_card" /> );
+
+	// The card renders one control, as a link or a button depending on whether the action navigates.
+	return screen.queryByRole( 'link' ) ?? screen.getByRole( 'button' );
+};
+
+/**
+ * Exact-match the whole label. toHaveTextContent's string form matches substrings, which
+ * would let "Activate" pass against "Install and activate".
+ *
+ * @param {string} label - The full label the card should render.
+ * @return {RegExp} Anchored matcher for that label.
+ */
+const exactly = ( label: string ) => new RegExp( `^${ label }$` );
+
+describe( 'the product card primary action', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it.each( MATRIX )( 'offers "$label" for $status', ( { status, isOwned, label } ) => {
+		expect( primaryActionFor( status, isOwned ) ).toHaveTextContent( exactly( label ) );
+	} );
+
+	it.each( OWNED_STATUSES )( 'never upsells a site that owns the product: %s', status => {
+		const action = primaryActionFor( status, true );
+
+		UPSELL_LABELS.forEach( upsell => {
+			expect( action ).not.toHaveTextContent( exactly( upsell ) );
+		} );
+	} );
+
+	/*
+	 * Owning a standalone product without the plugin should take one press to fix, not two.
+	 * Remove the .failing once JETPACK-2393 lands.
+	 */
+	it.failing( 'offers to install and activate a standalone product the site owns', () => {
+		expect( primaryActionFor( PRODUCT_STATUSES.ABSENT_WITH_PLAN, true ) ).toHaveTextContent(
+			exactly( 'Install and activate' )
+		);
+	} );
+} );

--- a/projects/packages/my-jetpack/changelog/add-plan-matrix-test-JETPACK-2392
+++ b/projects/packages/my-jetpack/changelog/add-plan-matrix-test-JETPACK-2392
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Test the product cards' primary action across the plan matrix.

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -1,0 +1,577 @@
+<?php
+/**
+ * Plan matrix for the product cards' primary action.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\My_Jetpack\Products\Anti_Spam;
+use Automattic\Jetpack\My_Jetpack\Products\Backup;
+use Automattic\Jetpack\My_Jetpack\Products\Boost;
+use Automattic\Jetpack\My_Jetpack\Products\Crm;
+use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
+use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Forms;
+use Automattic\Jetpack\My_Jetpack\Products\Protect;
+use Automattic\Jetpack\My_Jetpack\Products\Search;
+use Automattic\Jetpack\My_Jetpack\Products\Social;
+use Automattic\Jetpack\My_Jetpack\Products\Stats;
+use Automattic\Jetpack\My_Jetpack\Products\Videopress;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+
+/**
+ * Drives Product::get_status() across the plan matrix.
+ *
+ * The status asserted here is the value the REST API ships to the Products page, which
+ * the card turns into its primary action. The status-to-action half of that contract is
+ * covered by _inc/components/action-button/test/plan-matrix.test.tsx, and the two halves
+ * are pinned to a shared vocabulary by Status_Vocabulary_Parity_Test.
+ *
+ * Runs in its own process: get_site_features_from_wpcom() memoizes its answer in a static,
+ * so any earlier test class that reaches it without a seeded transient answers this one too.
+ *
+ * @covers \Automattic\Jetpack\My_Jetpack\Product::get_status
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[CoversMethod( Product::class, 'get_status' )]
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class Plan_Matrix_Test extends TestCase {
+
+	/**
+	 * No plan of any kind covers the product.
+	 */
+	private const OWNERSHIP_NONE = 'none';
+
+	/**
+	 * The product is covered by a bundle the site owns, such as Complete.
+	 */
+	private const OWNERSHIP_BUNDLE = 'bundle';
+
+	/**
+	 * The site owns the product's own paid plan directly.
+	 */
+	private const OWNERSHIP_DIRECT = 'direct';
+
+	/**
+	 * The product's standalone plugin is not installed at all.
+	 */
+	private const ACTIVATION_PLUGIN_ABSENT = 'plugin_absent';
+
+	/**
+	 * Everything the product needs is installed, but the product is switched off.
+	 */
+	private const ACTIVATION_OFF = 'off';
+
+	/**
+	 * The product is installed and switched on.
+	 */
+	private const ACTIVATION_ON = 'on';
+
+	/**
+	 * Standalone mock plugin assets, keyed by the product's $plugin_slug.
+	 *
+	 * @var array<string, string>
+	 */
+	private const STANDALONE_MOCKS = array(
+		'akismet'            => 'akismet-mock-plugin.txt',
+		'jetpack-backup'     => 'backup-mock-plugin.txt',
+		'jetpack-boost'      => 'boost-mock-plugin.txt',
+		'zero-bs-crm'        => 'crm-mock-plugin.txt',
+		'jetpack-protect'    => 'protect-mock-plugin.txt',
+		'jetpack-search'     => 'search-mock-plugin.txt',
+		'jetpack-social'     => 'social-mock-plugin.txt',
+		'jetpack-videopress' => 'videopress-mock-plugin.txt',
+	);
+
+	/**
+	 * Jetpack modules that must be registered as available before Modules::get_active()
+	 * will report any of them as active.
+	 *
+	 * @var array<string, string>
+	 */
+	private const AVAILABLE_MODULES = array(
+		'ai'           => '1.0',
+		'contact-form' => '1.0',
+		'protect'      => '1.0',
+		'publicize'    => '1.0',
+		'search'       => '1.0',
+		'stats'        => '1.0',
+		'videopress'   => '1.0',
+	);
+
+	/**
+	 * The status each cell of the plan matrix must produce, keyed by
+	 * "<product> => <ownership>/<activation>".
+	 *
+	 * Ownership is the axis the upsell bug lives on: a bundle owner and a direct-plan owner
+	 * are the same customer as far as a product card is concerned, so their rows must match.
+	 *
+	 * @var array<string, array<string, string>>
+	 */
+	private const MATRIX = array(
+		'anti-spam'     => array(
+			'none/plugin_absent'   => Products::STATUS_PLUGIN_ABSENT,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+			'bundle/off'           => Products::STATUS_INACTIVE,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+			'direct/off'           => Products::STATUS_INACTIVE,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		// Backup runs from the Jetpack plugin, so its standalone plugin's state never gates it.
+		'backup'        => array(
+			'none/plugin_absent'   => Products::STATUS_NEEDS_PLAN,
+			'none/off'             => Products::STATUS_NEEDS_PLAN,
+			'none/on'              => Products::STATUS_NEEDS_PLAN,
+			'bundle/plugin_absent' => Products::STATUS_ACTIVE,
+			'bundle/off'           => Products::STATUS_ACTIVE,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_ACTIVE,
+			'direct/off'           => Products::STATUS_ACTIVE,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'boost'         => array(
+			'none/plugin_absent'   => Products::STATUS_PLUGIN_ABSENT,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+			'bundle/off'           => Products::STATUS_INACTIVE,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+			'direct/off'           => Products::STATUS_INACTIVE,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'crm'           => array(
+			'none/plugin_absent'   => Products::STATUS_PLUGIN_ABSENT,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_PLUGIN_ABSENT_WITH_PLAN,
+			'bundle/off'           => Products::STATUS_INACTIVE,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+		),
+		'jetpack-ai'    => array(
+			'none/plugin_absent'   => Products::STATUS_MODULE_DISABLED,
+			'none/off'             => Products::STATUS_MODULE_DISABLED,
+			'none/on'              => Products::STATUS_ACTIVE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'jetpack-forms' => array(
+			'none/plugin_absent'   => Products::STATUS_MODULE_DISABLED,
+			'none/off'             => Products::STATUS_MODULE_DISABLED,
+			'none/on'              => Products::STATUS_ACTIVE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+		),
+		'protect'       => array(
+			'none/plugin_absent'   => Products::STATUS_NEEDS_PLAN,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'search'        => array(
+			'none/plugin_absent'   => Products::STATUS_NEEDS_PLAN,
+			'none/off'             => Products::STATUS_NEEDS_PLAN,
+			'none/on'              => Products::STATUS_NEEDS_PLAN,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'social'        => array(
+			'none/plugin_absent'   => Products::STATUS_NEEDS_ACTIVATION,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'stats'         => array(
+			'none/plugin_absent'   => Products::STATUS_MODULE_DISABLED,
+			'none/off'             => Products::STATUS_MODULE_DISABLED,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+		'videopress'    => array(
+			'none/plugin_absent'   => Products::STATUS_NEEDS_PLAN,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
+			'none/on'              => Products::STATUS_CAN_UPGRADE,
+			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'bundle/off'           => Products::STATUS_MODULE_DISABLED,
+			'bundle/on'            => Products::STATUS_ACTIVE,
+			'direct/plugin_absent' => Products::STATUS_MODULE_DISABLED,
+			'direct/off'           => Products::STATUS_MODULE_DISABLED,
+			'direct/on'            => Products::STATUS_ACTIVE,
+		),
+	);
+
+	/**
+	 * Cells the matrix does not hold today, and the issue that will make them hold.
+	 *
+	 * Search declares $requires_plan, and get_status() reads that flag before it reads
+	 * whether a plan exists -- so an owner whose module is off is told to buy the plan
+	 * they already have.
+	 *
+	 * @var array<string, string>
+	 */
+	private const KNOWN_BROKEN = array(
+		'search / bundle / plugin_absent' => 'JETPACK-2381',
+		'search / bundle / off'           => 'JETPACK-2381',
+		'search / direct / plugin_absent' => 'JETPACK-2381',
+		'search / direct / off'           => 'JETPACK-2381',
+	);
+
+	/**
+	 * Every product that renders a card on the Products page.
+	 *
+	 * @return array<string, class-string<Product>>
+	 */
+	private static function card_products(): array {
+		return array(
+			'anti-spam'     => Anti_Spam::class,
+			'backup'        => Backup::class,
+			'boost'         => Boost::class,
+			'crm'           => Crm::class,
+			'jetpack-ai'    => Jetpack_Ai::class,
+			'jetpack-forms' => Jetpack_Forms::class,
+			'protect'       => Protect::class,
+			'search'        => Search::class,
+			'social'        => Social::class,
+			'stats'         => Stats::class,
+			'videopress'    => Videopress::class,
+		);
+	}
+
+	/**
+	 * Set up a connected site with the Jetpack plugin installed and active.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Other test classes install standalone plugins and leave them behind, which would
+		// answer this matrix's "plugin absent" cells.
+		$this->uninstall_standalone_plugins();
+
+		$this->install_jetpack_plugin();
+		require_once WP_PLUGIN_DIR . '/jetpack/jetpack.php';
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( $user_id, 'test.test.' . $user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+		Jetpack_Options::update_option( 'available_modules', array( JETPACK__VERSION => self::AVAILABLE_MODULES ) );
+
+		/*
+		 * get_site_features_from_wpcom() memoizes a WP_Error in a static on its first failed
+		 * HTTP attempt, so seed the transient before any product in the process reads it.
+		 */
+		$this->set_site_features( array() );
+
+		activate_plugin( 'jetpack/jetpack.php' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		$this->uninstall_standalone_plugins();
+		\Jetpack::$active_modules = array();
+
+		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
+		delete_transient( Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY );
+		delete_transient( Backup::BACKUP_STATUS_TRANSIENT_KEY );
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The status the Products page shows for one cell of the plan matrix.
+	 *
+	 * @param string $slug       Product slug.
+	 * @param string $ownership  One of the OWNERSHIP_* constants.
+	 * @param string $activation One of the ACTIVATION_* constants.
+	 * @param string $expected   The status the card needs in order to offer the right action.
+	 *
+	 * @dataProvider provide_matrix
+	 */
+	#[DataProvider( 'provide_matrix' )]
+	public function test_status_across_the_plan_matrix( string $slug, string $ownership, string $activation, string $expected ) {
+		$class = self::card_products()[ $slug ];
+		$this->apply_state( $class, $ownership, $activation );
+
+		$actual = $class::get_status();
+		$broken = self::KNOWN_BROKEN[ "$slug / $ownership / $activation" ] ?? null;
+
+		if ( null !== $broken ) {
+			$this->assertNotSame(
+				$expected,
+				$actual,
+				'This cell is recorded as broken, but get_status() now returns the expected status. Drop it from KNOWN_BROKEN so the matrix starts enforcing it.'
+			);
+			$this->markTestIncomplete( "Returns '$actual' where the card needs '$expected'. Fixed by $broken." );
+		}
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * The project's correctness metric, stated against the matrix itself: an owner is never
+	 * told to buy. Without this, a future failure could be "fixed" by relaxing a cell back to
+	 * an upsell status, and the matrix would go green having lost the thing it exists to check.
+	 */
+	public function test_owners_never_expect_an_upsell_status() {
+		$upsell_statuses = array( Products::STATUS_NEEDS_PLAN, Products::STATUS_PLUGIN_ABSENT );
+
+		foreach ( self::MATRIX as $slug => $cells ) {
+			foreach ( $cells as $state => $expected ) {
+				if ( 0 === strpos( $state, self::OWNERSHIP_NONE . '/' ) ) {
+					continue;
+				}
+
+				$this->assertNotContains( $expected, $upsell_statuses, "$slug / $state expects an upsell status for a site that owns the product." );
+			}
+		}
+	}
+
+	/**
+	 * Every cell of the plan matrix, with the status the card needs to offer the right action.
+	 *
+	 * @return iterable<string, array{0: string, 1: string, 2: string, 3: string}>
+	 */
+	public static function provide_matrix(): iterable {
+		foreach ( self::MATRIX as $slug => $cells ) {
+			foreach ( $cells as $state => $expected ) {
+				list( $ownership, $activation ) = explode( '/', $state );
+				yield "$slug / $ownership / $activation" => array( $slug, $ownership, $activation, $expected );
+			}
+		}
+	}
+
+	/**
+	 * Put the site into the requested ownership and activation state for one product.
+	 *
+	 * @param string $class      Product class name.
+	 * @param string $ownership  One of the OWNERSHIP_* constants.
+	 * @param string $activation One of the ACTIVATION_* constants.
+	 */
+	private function apply_state( string $class, string $ownership, string $activation ) {
+		$this->apply_ownership( $class, $ownership );
+
+		if ( self::ACTIVATION_PLUGIN_ABSENT !== $activation ) {
+			$this->install_standalone_plugin( $class );
+		}
+
+		if ( self::ACTIVATION_ON === $activation ) {
+			$this->activate_standalone_plugin( $class );
+			$this->activate_module( $class );
+		}
+
+		// Backup reads a separate transient for its health; a clean one keeps the
+		// NEEDS_ATTENTION statuses from masking what the plan matrix produces.
+		set_transient( Backup::BACKUP_STATUS_TRANSIENT_KEY, 'no_errors', HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Seed the site features and purchases that make a product owned or unowned.
+	 *
+	 * @param string $class     Product class name.
+	 * @param string $ownership One of the OWNERSHIP_* constants.
+	 */
+	private function apply_ownership( string $class, string $ownership ) {
+		if ( self::OWNERSHIP_NONE === $ownership ) {
+			$this->set_site_features( array() );
+			return;
+		}
+
+		/*
+		 * wpcom reports the features a plan grants whether it is the product's own plan or a
+		 * bundle, so both owned cases seed the same feature and differ only in the purchase.
+		 */
+		$this->set_site_features( array_filter( array( $class::$feature_identifying_paid_plan ) ) );
+
+		$direct_plans = $class::get_paid_plan_product_slugs();
+		$product_slug = self::OWNERSHIP_BUNDLE === $ownership ? 'jetpack_complete' : reset( $direct_plans );
+
+		set_transient(
+			Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY,
+			array(
+				(object) array(
+					'product_slug'  => $product_slug,
+					'expiry_status' => 'active',
+					'expiry_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 year' ) ),
+				),
+			),
+			HOUR_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Seed the site features transient.
+	 *
+	 * @param array<string> $active Feature slugs the site's plan grants.
+	 */
+	private function set_site_features( array $active ) {
+		set_transient(
+			Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY,
+			array(
+				'active'    => $active,
+				// Left empty so get_paid_bundles_that_include_product() returns before
+				// reaching Current_Plan::refresh_from_wpcom() and its HTTP request.
+				'available' => array(),
+			),
+			HOUR_IN_SECONDS
+		);
+	}
+
+	/**
+	 * Copy the Jetpack mock plugin into place.
+	 */
+	private function install_jetpack_plugin() {
+		if ( ! file_exists( WP_PLUGIN_DIR . '/jetpack' ) ) {
+			mkdir( WP_PLUGIN_DIR . '/jetpack', 0777, true );
+		}
+		copy( __DIR__ . '/assets/jetpack-mock-plugin.txt', WP_PLUGIN_DIR . '/jetpack/jetpack.php' );
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+
+	/**
+	 * Copy a product's standalone mock plugin into place, if it has one.
+	 *
+	 * @param string $class Product class name.
+	 */
+	private function install_standalone_plugin( string $class ) {
+		$filename = $this->standalone_filename( $class );
+		if ( null === $filename ) {
+			return;
+		}
+
+		$target = WP_PLUGIN_DIR . '/' . $filename;
+		if ( ! file_exists( dirname( $target ) ) ) {
+			mkdir( dirname( $target ), 0777, true );
+		}
+		copy( __DIR__ . '/assets/' . self::STANDALONE_MOCKS[ $class::$plugin_slug ], $target );
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+
+	/**
+	 * Activate a product's standalone plugin, if it has one installed.
+	 *
+	 * @param string $class Product class name.
+	 */
+	private function activate_standalone_plugin( string $class ) {
+		$filename = $this->standalone_filename( $class );
+		if ( null !== $filename ) {
+			activate_plugin( $filename );
+		}
+	}
+
+	/**
+	 * Switch a product's Jetpack module on, in both places a module's state is read:
+	 * the option that Modules::is_active() consults for Hybrid_Product, and the mock
+	 * Jetpack class that Module_Product::is_module_active() consults.
+	 *
+	 * @param string $class Product class name.
+	 */
+	private function activate_module( string $class ) {
+		if ( ! $class::$module_name ) {
+			return;
+		}
+
+		$active = Jetpack_Options::get_option( 'active_modules', array() );
+		if ( ! in_array( $class::$module_name, $active, true ) ) {
+			$active[] = $class::$module_name;
+		}
+		Jetpack_Options::update_option( 'active_modules', $active );
+
+		\Jetpack::$active_modules[] = $class::$module_name;
+	}
+
+	/**
+	 * The first declared filename for a product's standalone plugin, or null when the
+	 * product ships only inside the Jetpack plugin.
+	 *
+	 * @param string $class Product class name.
+	 * @return string|null
+	 */
+	private function standalone_filename( string $class ): ?string {
+		$filenames = $this->standalone_filenames( $class );
+		return $filenames ? reset( $filenames ) : null;
+	}
+
+	/**
+	 * Every filename a product's standalone plugin can be installed under. Products declare
+	 * several, and other test classes install them under names this one does not pick.
+	 *
+	 * @param string $class Product class name.
+	 * @return array<string>
+	 */
+	private function standalone_filenames( string $class ): array {
+		$plugin_slug = $class::$plugin_slug;
+		if ( ! $plugin_slug || ! isset( self::STANDALONE_MOCKS[ $plugin_slug ] ) ) {
+			return array();
+		}
+
+		return (array) $class::$plugin_filename;
+	}
+
+	/**
+	 * Remove every standalone mock plugin, so an "absent" cell in one test isn't
+	 * answered by a file another test left behind.
+	 */
+	private function uninstall_standalone_plugins() {
+		foreach ( self::card_products() as $class ) {
+			foreach ( $this->standalone_filenames( $class ) as $filename ) {
+				$target = WP_PLUGIN_DIR . '/' . $filename;
+				if ( file_exists( $target ) ) {
+					unlink( $target );
+				}
+			}
+		}
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -249,10 +249,10 @@ class Plan_Matrix_Test extends TestCase {
 	 * @var array<string, string>
 	 */
 	private const KNOWN_BROKEN = array(
-		'search / bundle / plugin_absent' => 'JETPACK-2381',
-		'search / bundle / off'           => 'JETPACK-2381',
-		'search / direct / plugin_absent' => 'JETPACK-2381',
-		'search / direct / off'           => 'JETPACK-2381',
+		'search / bundle / plugin_absent' => 'JETPACK-2528',
+		'search / bundle / off'           => 'JETPACK-2528',
+		'search / direct / plugin_absent' => 'JETPACK-2528',
+		'search / direct / off'           => 'JETPACK-2528',
 	);
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -317,6 +317,7 @@ class Plan_Matrix_Test extends TestCase {
 	 */
 	public function tearDown(): void {
 		$this->uninstall_standalone_plugins();
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
 		\Jetpack::$active_modules = array();
 
 		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
@@ -528,6 +529,7 @@ class Plan_Matrix_Test extends TestCase {
 		}
 		Jetpack_Options::update_option( 'active_modules', $active );
 
+		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
 		\Jetpack::$active_modules[] = $class::$module_name;
 	}
 

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -22,8 +22,6 @@ use Automattic\Jetpack\My_Jetpack\Products\Videopress;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -36,17 +34,9 @@ use WorDBless\Users as WorDBless_Users;
  * covered by _inc/components/action-button/test/plan-matrix.test.tsx, and the two halves
  * are pinned to a shared vocabulary by Status_Vocabulary_Parity_Test.
  *
- * Runs in its own process: get_site_features_from_wpcom() memoizes its answer in a static,
- * so any earlier test class that reaches it without a seeded transient answers this one too.
- *
  * @covers \Automattic\Jetpack\My_Jetpack\Product::get_status
- *
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 #[CoversMethod( Product::class, 'get_status' )]
-#[RunTestsInSeparateProcesses]
-#[PreserveGlobalState( false )]
 class Plan_Matrix_Test extends TestCase {
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Status_Vocabulary_Parity_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Status_Vocabulary_Parity_Test.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Parity between the PHP and JavaScript product status vocabularies.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * The status string is the join between the two halves of the product card contract:
+ * Plan_Matrix_Test asserts which status each plan state produces, and the Products page
+ * asserts which action each status produces. Adding a status to one side and not the
+ * other silently drops a card into ActionButton's "Learn more" default, so pin the two
+ * vocabularies to each other here.
+ *
+ * @covers \Automattic\Jetpack\My_Jetpack\Products
+ */
+#[CoversClass( Products::class )]
+class Status_Vocabulary_Parity_Test extends TestCase {
+
+	/**
+	 * The TypeScript constants file the Products page reads its statuses from.
+	 */
+	private const CONSTANTS_PATH = __DIR__ . '/../../_inc/constants.ts';
+
+	/**
+	 * Every status PHP can put on a product.
+	 */
+	public function test_php_and_javascript_declare_the_same_statuses() {
+		$this->assertSame(
+			$this->php_statuses(),
+			$this->javascript_statuses(),
+			'PRODUCT_STATUSES in _inc/constants.ts no longer matches the STATUS_* constants on the Products class.'
+		);
+	}
+
+	/**
+	 * Every STATUS_* constant on the Products class, sorted by value.
+	 *
+	 * @return array<string>
+	 */
+	private function php_statuses(): array {
+		$statuses = array();
+		foreach ( ( new ReflectionClass( Products::class ) )->getConstants() as $name => $value ) {
+			if ( 0 === strpos( $name, 'STATUS_' ) ) {
+				$statuses[] = $value;
+			}
+		}
+
+		sort( $statuses );
+		return $statuses;
+	}
+
+	/**
+	 * Every value in the PRODUCT_STATUSES object in _inc/constants.ts, sorted.
+	 *
+	 * @return array<string>
+	 */
+	private function javascript_statuses(): array {
+		$source = file_get_contents( self::CONSTANTS_PATH ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a checked-in source file, not a remote resource.
+		$this->assertNotFalse( $source, 'Could not read ' . self::CONSTANTS_PATH );
+
+		preg_match( '/export const PRODUCT_STATUSES = \{(.*?)\};/s', $source, $block );
+		$this->assertNotEmpty( $block, 'Could not find the PRODUCT_STATUSES declaration in _inc/constants.ts.' );
+
+		preg_match_all( "/:\s*'([^']+)'/", $block[1], $values );
+
+		$statuses = $values[1];
+		sort( $statuses );
+		return $statuses;
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/assets/akismet-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/akismet-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Akismet Plugin
+ *
+ * Plugin Name:       Akismet Anti-spam
+ * Description:       Akismet mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */

--- a/projects/packages/my-jetpack/tests/php/assets/crm-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/crm-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Jetpack CRM Plugin
+ *
+ * Plugin Name:       Jetpack CRM
+ * Description:       Jetpack CRM mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */


### PR DESCRIPTION
Fixes JETPACK-2392

## Proposed changes

A test across the plan matrix that asserts what each product card offers, so a product the site already owns can never show an upsell CTA.

The contract spans two languages, so the test does too, joined by the status string the REST API ships to the Products page:

* **`tests/php/Plan_Matrix_Test.php`** — 93 cells driving the real `Product::get_status()` across 11 card products x 3 ownership states (unowned, owned via a Complete bundle, owned via the product's own plan) x 3 activation states. Ownership is seeded the way wpcom actually reports it — the site-features transient plus a matching purchase — so a Complete customer is a real Complete customer rather than a mock shaped like the expected answer.
* **`_inc/components/action-button/test/plan-matrix.test.tsx`** — renders the real `ActionButton` for every status and asserts the exact label, plus a rule that no status an owner can reach may produce an upsell.
* **`tests/php/Status_Vocabulary_Parity_Test.php`** — pins `Products::STATUS_*` against `PRODUCT_STATUSES` in `_inc/constants.ts`. Adding a status on one side only would otherwise drop a card into `ActionButton`'s "Learn more" default with both matrices still green.

I wrote the PHP matrix as a probe first and took every expectation from observed output rather than from my reading of `get_status()`.

### What it found

**Search tells an owner to buy the plan they already have.** `get_status()` reads `$requires_plan` before it reads whether a plan exists, so a Complete customer whose Search module is off gets `needs_plan`, which the card renders as "Get plan". Four cells: bundle and direct ownership, each with the standalone plugin absent and merely inactive.

Those four assert the target (`module_disabled`) and are marked incomplete against JETPACK-2528. They are guarded with `assertNotSame` first, so the moment the behavior is fixed they turn red and force the flip rather than sitting amber forever. CI stays green today because `failOnIncomplete` is not set.

Everything else is already correct, including the products I expected to fail: VideoPress, Social, Protect and Stats all give bundle owners `module_disabled`, which the card renders as "Activate".

The JS side carries one `it.failing`: `plugin_absent_with_plan` should offer "Install and activate" rather than today's "Install Plugin" (JETPACK-2393). That one flips on its own when 2393 lands.

I checked that both expected-failures genuinely flip, by temporarily changing each assertion to today's behavior and confirming it errors. A test that passes by failing is worthless if it is failing for the wrong reason.

There is also a guard asserting that no owned cell in the matrix expects an upsell status, so a future failure cannot be quietly resolved by relaxing an expectation.

### Runtime

`Plan_Matrix_Test` originally needed `RunTestsInSeparateProcesses`, because `Product::get_site_features_from_wpcom()` memoized a `WP_Error` for the life of the process and checked that memo before the transient — so one failed lookup in an earlier test class answered every later call, and exactly the 31 bundle-ownership cells reported the wrong status.

That is fixed on trunk by JETPACK-2527 (PR 52009), which reads the transient first and expires the failure memo. Trunk is merged in here and the attribute is gone. Measured on this branch, same code, attribute the only difference:

| | Package PHP suite |
| -- | -- |
| With isolation | 72.3s |
| Without | 8.7s |

The two new classes account for about 1s of that; the other 199 tests in the package take roughly 7.7s on their own.

## Related product discussion/links

* JETPACK-2392
* JETPACK-2527 — the caching bug that forced the process isolation, fixed in PR 52009
* JETPACK-2528 — the Search upsell bug the four incomplete cells record
* JETPACK-2381 — the broader Products page upsell work these sit under
* JETPACK-2393 — install-and-activate, which will flip the JS `it.failing`

## Does this pull request change what data or activity we track or use?

No. Tests only.

## Testing instructions

No runtime code changes; this is test-only.

* `cd projects/packages/my-jetpack`
* `composer phpunit` — 294 tests, 640 assertions, 0 failures, 4 incomplete (the Search cells), exit code 0.
* `pnpm run test` — 25 suites, 221 tests, all passing.
* `pnpm run typecheck` — clean.

To see the bug the matrix records, remove `'search / bundle / off'` from `KNOWN_BROKEN` in `Plan_Matrix_Test.php` and re-run: the cell fails with `needs_plan` where the card needs `module_disabled`.

To confirm the expected-failures flip rather than sitting amber, change the `it.failing` expectation in `plan-matrix.test.tsx` from `'Install and activate'` to `'Install Plugin'` and re-run: Jest reports "Failing test passed even though it was supposed to fail."

