### PR TITLE
Jetpack AI: hide gated views on WordPress VIP

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -275,9 +275,10 @@ class Jetpack_AI_Page {
 		$config = apply_filters(
 			'jetpack_ai_admin_config',
 			array(
-				// The Overview and Features views launch on self-hosted sites first.
+				// The Overview and Features views launch on non-VIP self-hosted sites first.
 				// Keep this filterable so hosts can close them independently.
-				'showGatedViews'  => ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ),
+				'showGatedViews'  => ! $host->is_vip_site()
+					&& ( ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ) ),
 				'showA12sBadge'   => $host->is_woa_site() && $is_internal_test,
 				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
 				'mcpSettingsApi'  => array(

--- a/projects/plugins/jetpack/changelog/vip-ai-hub-mcp-only
+++ b/projects/plugins/jetpack/changelog/vip-ai-hub-mcp-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Jetpack AI: Hide the Overview and AI Features views on WordPress VIP sites.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -3,7 +3,7 @@
  * Tests for the Jetpack AI admin page script data.
  *
  * The Overview and AI Features views are public on self-hosted sites, gated on
- * Atomic, and remain filterable by the host.
+ * Atomic and VIP, and remain filterable by the host.
  *
  * @package automattic/jetpack
  */
@@ -292,6 +292,20 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$this->assertFalse( $settings['showFeaturesView'] );
 		$this->assertFalse( $settings['showA12sBadge'] );
 		$this->assertFalse( $settings['isTest'] );
+	}
+
+	/**
+	 * The views remain hidden from VIP sites, including internal requests.
+	 */
+	public function test_features_view_flag_is_off_for_vip_site() {
+		$this->given_woa( false );
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertFalse( $settings['showFeaturesView'] );
+		$this->assertTrue( $settings['isTest'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* Hide the Jetpack AI Overview and AI Features views on WordPress VIP sites.
* Keep the existing MCP and Connectors view, AI module state, and runtime feature settings unchanged.

## Related product discussion/links

* Follow-up to #51994.

## Does this pull request change what data or activity we track or use?

No.

## Automated checks

* Jetpack PHP tests: 38 passed, 118 assertions.
* Jetpack AI React tests: 34 passed.
* Jetpack development build passed.
* Phan, PHPCS, changelog, PHP syntax, and diff checks passed.
* Claude and security reviews completed with no unresolved findings.

## Testing instructions

### WordPress VIP

1. Install the Jetpack build from this PR on a connected WordPress VIP test site.
2. Go to **Jetpack → Jetpack AI**.
3. Confirm the page opens on **MCP and Connectors** and does not show the **Overview** or **AI Features** tabs.
4. Open the block editor and confirm Writing Tools and AI SEO remain available when their existing module, plan, and feature settings allow them.

### Self-hosted

1. Install and activate the Jetpack build from this PR on a connected self-hosted test site.
2. Go to **Jetpack → Jetpack AI**.
3. Confirm **Overview**, **AI Features**, and **MCP and Connectors** remain available.
