### PR TITLE
Forms: cap the rating scale when rendering a response

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-rating-scale-oom
+++ b/projects/packages/forms/changelog/fix-forms-rating-scale-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Cap the rating scale when rendering a response so a malformed value cannot exhaust memory.

--- a/projects/packages/forms/changelog/fix-forms-rating-scale-oom
+++ b/projects/packages/forms/changelog/fix-forms-rating-scale-oom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Cap the rating scale when rendering a response so a malformed value cannot exhaust memory.
+Rating field: Cap the scale when rendering a form or a response so a malformed value cannot exhaust memory.

--- a/projects/packages/forms/src/blocks/field-rating/rating-icons.js
+++ b/projects/packages/forms/src/blocks/field-rating/rating-icons.js
@@ -31,7 +31,10 @@ export function renderRatingIconsHtml( rating, maxRating, iconStyle, screenReade
 		? `<span class="screen-reader-text">${ screenReaderText }</span>`
 		: '';
 
-	for ( let i = 1; i <= maxRating; i++ ) {
+	// The scale reaches here from submitted data, so cap it before it becomes a loop bound.
+	const cappedMax = Math.min( maxRating, MAX_RATING_ICONS );
+
+	for ( let i = 1; i <= cappedMax; i++ ) {
 		const filledClass = i <= rating ? 'is-filled' : '';
 		iconsHtml += `<svg class="field-rating__icon ${ filledClass }" viewBox="0 0 24 24" aria-hidden="true"><path d="${ iconPath }"></path></svg>`;
 	}

--- a/projects/packages/forms/src/blocks/field-rating/rating-icons.js
+++ b/projects/packages/forms/src/blocks/field-rating/rating-icons.js
@@ -1,6 +1,7 @@
 /**
  * Maximum number of rating icons to render.
  * Used to prevent DOM bloat from malformed or excessively large values.
+ * Mirrored by `Feedback_Field::MAX_RATING_ICONS`, which a PHP test pins to this value.
  */
 export const MAX_RATING_ICONS = 10;
 
@@ -31,7 +32,6 @@ export function renderRatingIconsHtml( rating, maxRating, iconStyle, screenReade
 		? `<span class="screen-reader-text">${ screenReaderText }</span>`
 		: '';
 
-	// The scale reaches here from submitted data, so cap it before it becomes a loop bound.
 	const cappedMax = Math.min( maxRating, MAX_RATING_ICONS );
 
 	for ( let i = 1; i <= cappedMax; i++ ) {

--- a/projects/packages/forms/src/blocks/input-rating/edit.jsx
+++ b/projects/packages/forms/src/blocks/input-rating/edit.jsx
@@ -1,9 +1,11 @@
 import { useBlockProps } from '@wordpress/block-editor';
 import { RatingIcon } from '../field-rating/rating-icon.jsx';
+import { MAX_RATING_ICONS } from '../field-rating/rating-icons.js';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
 
 export default function RatingInputEdit( { context, clientId } ) {
-	const max = context?.[ 'jetpack/field-rating-max' ] || 5;
+	// The scale control caps new values, but markup can already carry any number.
+	const max = Math.min( context?.[ 'jetpack/field-rating-max' ] || 5, MAX_RATING_ICONS );
 	const defaultValue = context?.[ 'jetpack/field-rating-default' ] || 0;
 	const iconStyle = context?.[ 'jetpack/field-rating-iconStyle' ] || 'stars';
 	const onChangeDefault = context?.[ 'jetpack/field-rating-onChangeDefault' ] || ( () => {} );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -3716,6 +3716,8 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		// Read block attributes needed for rendering.
 		$max_attr   = $this->get_attribute( 'max' );
 		$max_rating = is_numeric( $max_attr ) && (int) $max_attr > 0 ? (int) $max_attr : 5;
+		// The editor caps this, but a hand-edited block or shortcode attribute does not.
+		$max_rating = min( $max_rating, Feedback_Field::MAX_RATING_ICONS );
 
 		$initial_rating = (int) $value ? (int) $value : 0;
 

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -18,6 +18,15 @@ class Feedback_Field {
 	use Country_Code_Utils;
 
 	/**
+	 * Maximum number of rating icons to render.
+	 *
+	 * Keep in sync with MAX_RATING_ICONS in blocks/field-rating/rating-icons.js.
+	 *
+	 * @var int
+	 */
+	const MAX_RATING_ICONS = 10;
+
+	/**
 	 * Cached admin theme color.
 	 *
 	 * @var string|null
@@ -380,6 +389,11 @@ class Feedback_Field {
 		if ( $rating > $max ) {
 			return $this->value;
 		}
+
+		// The scale is submitted, not derived, so cap it before the renderers loop over it.
+		$max    = min( $max, self::MAX_RATING_ICONS );
+		$rating = min( $rating, $max );
+
 		// Get icon style from meta data (defaults to 'stars').
 		$icon_style = $this->get_meta_key_value( 'iconStyle' );
 		if ( empty( $icon_style ) ) {
@@ -636,6 +650,10 @@ class Feedback_Field {
 		if ( $max <= 0 ) {
 			return $this->render_email_default();
 		}
+
+		// The scale is submitted, not derived, so cap it before it becomes a loop bound.
+		$max    = min( $max, self::MAX_RATING_ICONS );
+		$rating = min( $rating, $max );
 
 		$stars = '';
 		for ( $i = 1; $i <= $max; $i++ ) {

--- a/projects/packages/forms/src/contact-form/class-feedback-field.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-field.php
@@ -20,7 +20,10 @@ class Feedback_Field {
 	/**
 	 * Maximum number of rating icons to render.
 	 *
-	 * Keep in sync with MAX_RATING_ICONS in blocks/field-rating/rating-icons.js.
+	 * A rating submits "<selected>/<max>", so the scale is visitor input and every renderer
+	 * that loops over it needs this bound. Keep in sync with `MAX_RATING_ICONS` in
+	 * `blocks/field-rating/rating-icons.js`; `test_rating_icon_ceiling_matches_the_js_constant`
+	 * fails if they drift.
 	 *
 	 * @var int
 	 */
@@ -390,7 +393,6 @@ class Feedback_Field {
 			return $this->value;
 		}
 
-		// The scale is submitted, not derived, so cap it before the renderers loop over it.
 		$max    = min( $max, self::MAX_RATING_ICONS );
 		$rating = min( $rating, $max );
 
@@ -651,9 +653,7 @@ class Feedback_Field {
 			return $this->render_email_default();
 		}
 
-		// The scale is submitted, not derived, so cap it before it becomes a loop bound.
-		$max    = min( $max, self::MAX_RATING_ICONS );
-		$rating = min( $rating, $max );
+		$max = min( $max, self::MAX_RATING_ICONS );
 
 		$stars = '';
 		for ( $i = 1; $i <= $max; $i++ ) {

--- a/projects/packages/forms/tests/js/blocks/field-rating/rating-icons.test.js
+++ b/projects/packages/forms/tests/js/blocks/field-rating/rating-icons.test.js
@@ -1,0 +1,27 @@
+import {
+	MAX_RATING_ICONS,
+	renderRatingIconsHtml,
+} from '../../../../src/blocks/field-rating/rating-icons';
+
+const countIcons = markup => ( markup.match( /<svg/g ) || [] ).length;
+
+const countFilled = markup => ( markup.match( /is-filled/g ) || [] ).length;
+
+describe( 'renderRatingIconsHtml', () => {
+	it( 'renders one icon per point on a normal scale', () => {
+		expect( countIcons( renderRatingIconsHtml( 3, 5, 'stars' ) ) ).toBe( 5 );
+	} );
+
+	it( 'fills icons up to the rating', () => {
+		expect( countFilled( renderRatingIconsHtml( 3, 5, 'stars' ) ) ).toBe( 3 );
+	} );
+
+	// The scale arrives from submitted data, so a forged one must not become a loop bound.
+	it( 'caps a forged scale at MAX_RATING_ICONS', () => {
+		expect( countIcons( renderRatingIconsHtml( 3, 5000, 'stars' ) ) ).toBe( MAX_RATING_ICONS );
+	} );
+
+	it( 'caps a scale large enough to hang the browser', () => {
+		expect( countIcons( renderRatingIconsHtml( 1, 50000000, 'stars' ) ) ).toBe( MAX_RATING_ICONS );
+	} );
+} );

--- a/projects/packages/forms/tests/js/blocks/field-rating/rating-icons.test.js
+++ b/projects/packages/forms/tests/js/blocks/field-rating/rating-icons.test.js
@@ -7,6 +7,7 @@ const countIcons = markup => ( markup.match( /<svg/g ) || [] ).length;
 
 const countFilled = markup => ( markup.match( /is-filled/g ) || [] ).length;
 
+// The scale arrives from submitted data, so a forged one must not become a loop bound.
 describe( 'renderRatingIconsHtml', () => {
 	it( 'renders one icon per point on a normal scale', () => {
 		expect( countIcons( renderRatingIconsHtml( 3, 5, 'stars' ) ) ).toBe( 5 );
@@ -16,7 +17,6 @@ describe( 'renderRatingIconsHtml', () => {
 		expect( countFilled( renderRatingIconsHtml( 3, 5, 'stars' ) ) ).toBe( 3 );
 	} );
 
-	// The scale arrives from submitted data, so a forged one must not become a loop bound.
 	it( 'caps a forged scale at MAX_RATING_ICONS', () => {
 		expect( countIcons( renderRatingIconsHtml( 3, 5000, 'stars' ) ) ).toBe( MAX_RATING_ICONS );
 	} );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Field_Test.php
@@ -1682,4 +1682,23 @@ class Contact_Form_Field_Test extends BaseTestCase {
 			),
 		);
 	}
+
+	/**
+	 * A rating scale above the cap only reaches this renderer through a shortcode or
+	 * hand-edited markup, since the editor control has always capped it.
+	 */
+	public function test_rating_field_render_caps_the_scale() {
+		$field = $this->get_new_field_instance(
+			array(
+				'type' => 'rating',
+				'id'   => 'rating-id',
+				'max'  => '5000',
+			)
+		);
+
+		$this->assertSame(
+			Feedback_Field::MAX_RATING_ICONS,
+			substr_count( $field->render(), 'class="jetpack-field-rating__input' )
+		);
+	}
 } // end class

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -775,6 +775,7 @@ class Feedback_Field_Test extends BaseTestCase {
 
 		$value = $field->get_render_value( 'web' );
 
+		$this->assertIsArray( $value );
 		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['maxRating'] );
 		$this->assertSame( 3, $value['rating'] );
 	}
@@ -788,6 +789,7 @@ class Feedback_Field_Test extends BaseTestCase {
 
 		$value = $field->get_render_value( 'web' );
 
+		$this->assertIsArray( $value );
 		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['maxRating'] );
 		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['rating'] );
 	}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -742,6 +742,56 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertStringNotContainsString( '&#9733;', $value );
 	}
 
+	/**
+	 * A visitor picks a rating from radio inputs whose value is "<selected>/<max>",
+	 * so the scale is POST data and a forged one must not become a loop bound.
+	 */
+	public function test_rating_field_clamps_forged_scale_in_email_html_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '3/5000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
+	}
+
+	/**
+	 * The production OOM: a scale large enough to exhaust the memory limit while
+	 * concatenating one span per icon.
+	 */
+	public function test_rating_field_with_huge_scale_does_not_exhaust_memory() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '1/50000000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
+	}
+
+	/**
+	 * The structured value feeds the web/API renderers, which loop over maxRating
+	 * in JavaScript, so it needs the same bound the email path has.
+	 */
+	public function test_rating_field_clamps_forged_scale_in_web_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '3/5000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'web' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['maxRating'] );
+		$this->assertSame( 3, $value['rating'] );
+	}
+
+	/**
+	 * Clamping the scale must also pull the selected value down with it, or a
+	 * "3000/5000" submission renders every icon filled on a 10-icon scale.
+	 */
+	public function test_rating_field_clamps_selected_value_to_clamped_scale() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '3000/5000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'web' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['maxRating'] );
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['rating'] );
+	}
+
 	// ─── Email HTML rendering tests ───
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Field_Test.php
@@ -743,30 +743,6 @@ class Feedback_Field_Test extends BaseTestCase {
 	}
 
 	/**
-	 * A visitor picks a rating from radio inputs whose value is "<selected>/<max>",
-	 * so the scale is POST data and a forged one must not become a loop bound.
-	 */
-	public function test_rating_field_clamps_forged_scale_in_email_html_context() {
-		$field = new Feedback_Field( 'rating_key', 'Rating', '3/5000', 'rating', array( 'iconStyle' => 'stars' ) );
-
-		$value = $field->get_render_value( 'email_html' );
-
-		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
-	}
-
-	/**
-	 * The production OOM: a scale large enough to exhaust the memory limit while
-	 * concatenating one span per icon.
-	 */
-	public function test_rating_field_with_huge_scale_does_not_exhaust_memory() {
-		$field = new Feedback_Field( 'rating_key', 'Rating', '1/50000000', 'rating', array( 'iconStyle' => 'stars' ) );
-
-		$value = $field->get_render_value( 'email_html' );
-
-		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
-	}
-
-	/**
 	 * The structured value feeds the web/API renderers, which loop over maxRating
 	 * in JavaScript, so it needs the same bound the email path has.
 	 */
@@ -794,7 +770,54 @@ class Feedback_Field_Test extends BaseTestCase {
 		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, $value['rating'] );
 	}
 
+	/**
+	 * The clamp is a rendering bound, so the response keeps the scale it was
+	 * submitted with for the CSV and plain-text fallbacks.
+	 */
+	public function test_rating_field_clamping_leaves_the_submitted_value_intact() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '3000/5000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'web' );
+
+		$this->assertIsArray( $value );
+		$this->assertSame( '3000/5000', $value['displayValue'] );
+		$this->assertSame( '3000/5000', $field->get_render_value( 'csv' ) );
+	}
+
+	/**
+	 * The PHP and JS ceilings bound the same rating scale on either side of a
+	 * submission, so a drift between them reopens the scale to unbounded loops.
+	 */
+	public function test_rating_icon_ceiling_matches_the_js_constant() {
+		$source = file_get_contents( __DIR__ . '/../../../src/blocks/field-rating/rating-icons.js' );
+
+		$this->assertIsString( $source );
+		$this->assertSame( 1, preg_match( '/export const MAX_RATING_ICONS = (\\d+);/', $source, $matches ) );
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, (int) $matches[1] );
+	}
+
 	// ─── Email HTML rendering tests ───
+
+	/**
+	 * A visitor picks a rating from radio inputs whose value is "<selected>/<max>",
+	 * so the scale is POST data and a forged one must not become a loop bound.
+	 */
+	public function test_rating_field_clamps_forged_scale_in_email_html_context() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '3/5000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
+		$this->assertSame( 3, substr_count( $value, '#e6a117' ) );
+	}
+
+	public function test_rating_field_with_huge_scale_does_not_exhaust_memory() {
+		$field = new Feedback_Field( 'rating_key', 'Rating', '1/50000000', 'rating', array( 'iconStyle' => 'stars' ) );
+
+		$value = $field->get_render_value( 'email_html' );
+
+		$this->assertSame( Feedback_Field::MAX_RATING_ICONS, substr_count( $value, '&#9733;' ) );
+	}
 
 	/**
 	 * Test get_icon_name_for_type maps known types and falls back to field-text.

--- a/projects/plugins/jetpack/changelog/fix-forms-rating-scale-oom
+++ b/projects/plugins/jetpack/changelog/fix-forms-rating-scale-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Cap the rating scale when rendering a response so a malformed value cannot exhaust memory.

--- a/projects/plugins/jetpack/changelog/fix-forms-rating-scale-oom
+++ b/projects/plugins/jetpack/changelog/fix-forms-rating-scale-oom
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Forms: Cap the rating scale when rendering a response so a malformed value cannot exhaust memory.
+Forms: Cap the rating scale when rendering a form or a response so a malformed value cannot exhaust memory.


### PR DESCRIPTION
Fixes the OOM fatals alerted on for Jetpack Forms, reported at `class-feedback-field.php:645`.

## Proposed changes

The rating field renders one radio input per point, and each input's value carries the scale as well as the selection:

```php
// class-contact-form-field.php:3746
value="%3$s/%4$s"   // "<selected>/<max>"
```

So the scale is POST data, not something the server derives. `render_email_rating()` used it directly as a loop bound, guarded only against `max <= 0`, and appended a `<span>` per star. A submission of `1/50000000` exhausts the memory limit. Line 645 is the gray-star branch, which runs for nearly every iteration when the selected value is low, which is why the alert points there.

Reproduced through the real class, matching the alert's stack:

```
php -d memory_limit=128M  ->  Allowed memory size exhausted ... class-feedback-field.php on line 645
  #0 render_email_rating()  #1 get_render_email_html_value()  #2 get_render_value('email_html')
```

Two more renderers had the same unbounded loop over the same untrusted value:

* `renderRatingIconsHtml()` in `rating-icons.js`, used on the post-submission screen. Same input throws `RangeError: Invalid string length`, V8's version of the same failure.
* `render_rating_field()` in `class-contact-form-field.php`, which loops the block's `max` attribute. The scale control caps that at 10, but a hand-edited block or a `[contact-field type="rating" max="..."]` shortcode does not.
* `input-rating/edit.jsx`, the editor's own render of the same block, which loops `max` straight from block context. Same escape hatch, and capping only the front end would leave the editor and the front end disagreeing about one block.

`MAX_RATING_ICONS` (10) already existed in `rating-icons.js` and was honored by the block editor and the responses dashboard, but by no PHP path. This mirrors it as a constant on `Feedback_Field` and clamps all four loops, plus `get_rating_value()`, which feeds the structured value to the web and API renderers. A test reads the ceiling back out of the JS so the two constants cannot drift apart unnoticed.

Clamping rather than rescaling matches what the dashboard already does, so both surfaces render the same submission the same way.

Two things worth knowing for review:

* The feedback post is inserted (`class-contact-form.php:3305`) before the email is built (`:3318`), so a poisoned submission was already stored and every resend re-triggered the fatal. Because this clamps at render time, those existing rows now display fine. No data cleanup needed.
* Clamping rather than rescaling means a forged `3000/5000` displays as a full 10 of 10 rather than as 60%. That matches what the responses dashboard has always done with the same value, and `displayValue` still carries the true `3000/5000` into the CSV export and the plain-text email, which a test now pins. Flagging it because it is a deliberate choice, not an oversight.
* This fixes the crash, not the underlying trust problem. The scale still comes from the submitted string rather than the field's own `maxRating` meta, so a forged `9/9` against a max-5 field still displays nine icons. That is cosmetic, and it needs product calls about missing meta on legacy responses and about changing how historical responses display, so it is filed separately in Linear under the Jetpack Forms team as "Rating field trusts the submitted scale instead of the field's own max". Left in triage deliberately.

## Related product discussion/links

* Grafana alert dashboard for the fatals (internal).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated coverage is the fastest check. Both suites contain tests that fail without this change:

```
jp test php packages/forms
jp test js packages/forms
```

`Feedback_Field_Test` gains four cases, including the exact production value (`1/50000000`), and `rating-icons.test.js` covers the JS loop. Reverting either source file makes them fail (PHP OOMs, JS throws `RangeError`).

To confirm by hand on a site:

1. Add a form with a Rating field, leave the scale at 5, and publish it.
2. Submit the form normally and confirm the notification email and the responses dashboard both show 5 icons with your selection filled. Nothing about normal submissions should change.
3. Now forge the scale. In devtools, edit one rating radio's `value` from `3/5` to `3/50000000`, then submit.
4. Before this change, the submission fatals on an OOM and no notification email is sent. After it, the submission completes, the email arrives, and the rating renders capped at 10 icons.
5. Open the response in Jetpack -> Forms -> Responses and confirm the post-submission screen and the dashboard both render it without hanging the browser.

Note the full forms PHP suite has one unrelated pre-existing failure, `Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname`, which also fails on a clean trunk checkout locally.

