### PR TITLE
My Jetpack: stop telling a Search owner to buy the plan they already have

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-search-owner-upsell-JETPACK-2528
+++ b/projects/packages/my-jetpack/changelog/fix-search-owner-upsell-JETPACK-2528
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Offer to activate Search, rather than to buy a plan, when the site already owns it and the module is switched off.

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -917,7 +917,7 @@ abstract class Product {
 			// Getting a plan set up should help resolve any connection issues
 			// However if the standalone plugin for this product is active, then we will defer to showing errors that prevent the module from being active
 			// This is because if a standalone plugin is installed, we expect the product to not show as "inactive" on My Jetpack
-			if ( static::$requires_plan || ( ! static::has_any_plan_for_product() && static::$has_standalone_plugin && ! self::is_plugin_active() ) ) {
+			if ( ! static::has_any_plan_for_product() && ( static::$requires_plan || ( static::$has_standalone_plugin && ! self::is_plugin_active() ) ) ) {
 				$status = static::is_owned() && static::$has_free_offering && ! static::$requires_plan ? Products::STATUS_NEEDS_ACTIVATION : Products::STATUS_NEEDS_PLAN;
 			} elseif ( static::$requires_site_connection && ! ( new Connection_Manager() )->is_connected() ) {
 				// Site has never been connected before and product is not owned

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -232,18 +232,9 @@ class Plan_Matrix_Test extends TestCase {
 	/**
 	 * Cells the matrix does not hold today, and the issue that will make them hold.
 	 *
-	 * Search declares $requires_plan, and get_status() reads that flag before it reads
-	 * whether a plan exists -- so an owner whose module is off is told to buy the plan
-	 * they already have.
-	 *
 	 * @var array<string, string>
 	 */
-	private const KNOWN_BROKEN = array(
-		'search / bundle / plugin_absent' => 'JETPACK-2528',
-		'search / bundle / off'           => 'JETPACK-2528',
-		'search / direct / plugin_absent' => 'JETPACK-2528',
-		'search / direct / off'           => 'JETPACK-2528',
-	);
+	private const KNOWN_BROKEN = array();
 
 	/**
 	 * Every product that renders a card on the Products page.

--- a/projects/plugins/jetpack/changelog/fix-search-owner-upsell-JETPACK-2528
+++ b/projects/plugins/jetpack/changelog/fix-search-owner-upsell-JETPACK-2528
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Offer to activate Search, rather than to buy a plan, when the site already owns it and the module is switched off.

--- a/projects/plugins/search/changelog/fix-search-owner-upsell-JETPACK-2528
+++ b/projects/plugins/search/changelog/fix-search-owner-upsell-JETPACK-2528
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Offer to activate Search, rather than to buy a plan, when the site already owns it and the module is switched off.


### PR DESCRIPTION
Fixes JETPACK-2528

**Stacked on #52005** — base is `handoff-plan-matrix-test`, because the four cells this fixes live in that PR's `Plan_Matrix_Test`. Review/merge that one first.

## Proposed changes

* `Product::get_status()` tested `$requires_plan` on its own, before anything asked whether the site actually has a plan. Search is the only card product that sets that flag alongside a `$module_name`, so an owner whose Search module was switched off fell through to `STATUS_NEEDS_PLAN` — the card offering "Get plan" for the plan they already hold — instead of `STATUS_MODULE_DISABLED` and "Activate".
* Read the flag and the plan together instead. Only `$requires_plan` **and** an existing plan changes outcome; every other combination is byte-for-byte what it was. Backup is the only other product that sets `$requires_plan`, and it has no `$module_name`, so this branch never runs for it — Search is the only product affected.
* Dropped those four cells from `Plan_Matrix_Test::KNOWN_BROKEN`. The matrix now enforces all 93 cells with nothing marked incomplete.

I did not touch the `isOwned ? 'Get plan' : 'Learn more'` branch in `ActionButton`, which the issue flagged as possibly a workaround for this bug. It isn't: `isOwned` comes from `Product::is_owned()`, which is also true when the standalone plugin is installed or the module was historically active — no plan required. The `search / none / off` cell is exactly that shape (Search plugin installed, no plan, status `needs_plan`, owned), and "Get plan" is the correct call to action there. Removing the branch would regress it to "Learn more".

## Related product discussion/links

* JETPACK-2528, blocking JETPACK-2392

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated — the matrix is the point of this change:

```
jetpack test php packages/my-jetpack
```

`Plan_Matrix_Test` runs 94 tests and should report no failures and no incomplete tests. To see the bug, revert the one-line change in `class-product.php` and re-run: exactly four cells fail, all Search, all owned-and-switched-off, each returning `needs_plan` where the card needs `module_disabled`.

Manually, on a site with a Complete plan (or Search's own plan) and the Jetpack plugin active:

1. Deactivate the Search module (`wp jetpack module deactivate search`).
2. Go to Jetpack → My Jetpack.
3. The Search card offers **Activate**. Before this change it offered **Get plan**.

## Note for reviewers

The `Static analysis` failure that was on the base branch is fixed there, in `handoff-plan-matrix-test` — two `@phan-suppress-next-line PhanUndeclaredStaticProperty` annotations on `\Jetpack::$active_modules`, matching what `Jetpack_Ai_Product_Test` already carries for the same property. Phan parses the real `class.jetpack.php`, which does not declare it; the test's mock in `assets/jetpack-mock-plugin.txt` does, and Phan never sees that file.
