### PR TITLE
My Jetpack: stop a failed site-features lookup from poisoning the request

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-site-features-failure-cache
+++ b/projects/packages/my-jetpack/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/packages/my-jetpack/changelog/fix-site-features-failure-cache
+++ b/projects/packages/my-jetpack/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Stop offering upgrades for products the site already owns when a plan lookup fails.
+Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -37,11 +37,47 @@ class Wpcom_Products {
 	const MY_JETPACK_PURCHASES_TRANSIENT_KEY = 'my-jetpack-purchases';
 
 	/**
-	 * Store the data on failed WPCOM requests.
+	 * How long, in seconds, a purchases lookup is reused before WPCOM is asked again
+	 *
+	 * @var int
+	 */
+	const MY_JETPACK_PURCHASES_CACHE_DURATION = 5;
+
+	/**
+	 * How long, in seconds, a failed WPCOM request answers later callers before it is retried
+	 *
+	 * @var int
+	 */
+	const WPCOM_REQUEST_FAILURE_CACHE_DURATION = 5;
+
+	/**
+	 * The request label the site purchases lookup records its failures under
+	 *
+	 * @var string
+	 */
+	const PURCHASES_REQUEST_LABEL = 'get_site_current_purchases';
+
+	/**
+	 * Store the data on failed WPCOM requests, each with the time it stops answering.
 	 *
 	 * @var array
 	 */
 	private static $wpcom_request_failures = array();
+
+	/**
+	 * A successful purchases lookup, kept so one WPCOM request serves a whole render
+	 * even when the transient write does not retain (e.g. an object cache evicting under load)
+	 *
+	 * @var mixed
+	 */
+	private static $site_purchases = null;
+
+	/**
+	 * Unix time at which the memo above stops being used
+	 *
+	 * @var int
+	 */
+	private static $site_purchases_expires = 0;
 
 	/**
 	 * Fetches the list of products from WPCOM
@@ -310,19 +346,21 @@ class Wpcom_Products {
 	 * @return Object|WP_Error
 	 */
 	public static function get_site_current_purchases() {
-		static $purchases = null;
-
-		if ( $purchases !== null ) {
-			return $purchases;
-		}
-
-		// Check for a cached value before doing lookup
+		// Read the cache first, so a memo can never outrank a warm lookup.
 		$stored_purchases = get_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY );
 		if ( $stored_purchases !== false ) {
 			return $stored_purchases;
 		}
 
-		$request_failure = static::get_request_failure( 'get_site_current_purchases' );
+		/*
+		 * Checked after the transient so it can never outrank a warm cache, but kept so a
+		 * dashboard render still makes a single WPCOM request when the transient write is dropped.
+		 */
+		if ( self::$site_purchases !== null && time() < self::$site_purchases_expires ) {
+			return self::$site_purchases;
+		}
+
+		$request_failure = static::get_request_failure( self::PURCHASES_REQUEST_LABEL );
 		if ( null !== $request_failure ) {
 			return $request_failure;
 		}
@@ -338,14 +376,17 @@ class Wpcom_Products {
 		);
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			$error = new WP_Error( 'purchases_state_fetch_failed' );
-			static::set_request_failure( 'get_site_current_purchases', $error );
+			static::set_request_failure( self::PURCHASES_REQUEST_LABEL, $error );
 			return $error;
 		}
 
 		$body      = wp_remote_retrieve_body( $response );
 		$purchases = json_decode( $body );
 		// Set short transient to help with repeated lookups on the same page load
-		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, 5 );
+		set_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY, $purchases, self::MY_JETPACK_PURCHASES_CACHE_DURATION );
+
+		self::$site_purchases         = $purchases;
+		self::$site_purchases_expires = time() + self::MY_JETPACK_PURCHASES_CACHE_DURATION;
 
 		return $purchases;
 	}
@@ -377,6 +418,19 @@ class Wpcom_Products {
 	}
 
 	/**
+	 * Forget the cached site purchases — the in-process memo, the memoized failure, and the
+	 * transient — so the next call asks WPCOM again.
+	 *
+	 * @return void
+	 */
+	public static function reset_purchases_cache() {
+		self::$site_purchases         = null;
+		self::$site_purchases_expires = 0;
+		unset( static::$wpcom_request_failures[ self::PURCHASES_REQUEST_LABEL ] );
+		delete_transient( self::MY_JETPACK_PURCHASES_TRANSIENT_KEY );
+	}
+
+	/**
 	 * Record the request failure to prevent repeated requests.
 	 *
 	 * @param string   $request_label The request label.
@@ -385,7 +439,10 @@ class Wpcom_Products {
 	 * @return void
 	 */
 	private static function set_request_failure( $request_label, WP_Error $error ) {
-		static::$wpcom_request_failures[ $request_label ] = $error;
+		static::$wpcom_request_failures[ $request_label ] = array(
+			'error'   => $error,
+			'expires' => time() + self::WPCOM_REQUEST_FAILURE_CACHE_DURATION,
+		);
 	}
 
 	/**
@@ -396,10 +453,16 @@ class Wpcom_Products {
 	 * @return null|WP_Error
 	 */
 	private static function get_request_failure( $request_label ) {
-		if ( array_key_exists( $request_label, static::$wpcom_request_failures ) ) {
-			return static::$wpcom_request_failures[ $request_label ];
+		if ( ! isset( static::$wpcom_request_failures[ $request_label ] ) ) {
+			return null;
 		}
 
-		return null;
+		// Expire rather than answer for the life of the process, which can outlast the outage.
+		if ( time() >= static::$wpcom_request_failures[ $request_label ]['expires'] ) {
+			unset( static::$wpcom_request_failures[ $request_label ] );
+			return null;
+		}
+
+		return static::$wpcom_request_failures[ $request_label ]['error'];
 	}
 }

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -87,6 +87,27 @@ abstract class Product {
 	const MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY = 'my-jetpack-site-features';
 
 	/**
+	 * How long, in seconds, a site features lookup is reused before WPCOM is asked again
+	 *
+	 * @var int
+	 */
+	const MY_JETPACK_SITE_FEATURES_CACHE_DURATION = 15;
+
+	/**
+	 * A failed site features lookup, kept so one outage does not fire a request per product
+	 *
+	 * @var WP_Error|null
+	 */
+	private static $site_features_failure = null;
+
+	/**
+	 * Unix time at which the memoized failure above stops being used
+	 *
+	 * @var int
+	 */
+	private static $site_features_failure_expires = 0;
+
+	/**
 	 * Whether this module is a Jetpack feature
 	 *
 	 * @var boolean
@@ -317,24 +338,23 @@ abstract class Product {
 	 * @return WP_Error|array
 	 */
 	public static function get_site_features_from_wpcom() {
-		static $features = null;
-
-		if ( $features !== null ) {
-			return $features;
-		}
-
-		// Check for a cached value before doing lookup
+		// Read the cache first, so a memoized failure can never outrank a warm lookup.
 		$stored_features = get_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
 		if ( $stored_features !== false ) {
 			return $stored_features;
+		}
+
+		if ( self::$site_features_failure !== null && time() < self::$site_features_failure_expires ) {
+			return self::$site_features_failure;
 		}
 
 		$site_id  = Jetpack_Options::get_option( 'id' );
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d/features', $site_id ), '1.1' );
 
 		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			$features = new WP_Error( 'site_features_fetch_failed' );
-			return $features;
+			self::$site_features_failure         = new WP_Error( 'site_features_fetch_failed' );
+			self::$site_features_failure_expires = time() + self::MY_JETPACK_SITE_FEATURES_CACHE_DURATION;
+			return self::$site_features_failure;
 		}
 
 		$body           = wp_remote_retrieve_body( $response );
@@ -344,10 +364,21 @@ abstract class Product {
 			'active'    => $feature_return->active,
 			'available' => $feature_return->available,
 		);
+
 		// set a short transient to help with multiple lookups on the same page load.
-		set_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, $features, 15 );
+		set_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, $features, self::MY_JETPACK_SITE_FEATURES_CACHE_DURATION );
 
 		return $features;
+	}
+
+	/**
+	 * Forget a memoized failed site features lookup so the next call asks WPCOM again.
+	 *
+	 * @return void
+	 */
+	public static function reset_site_features_failure() {
+		self::$site_features_failure         = null;
+		self::$site_features_failure_expires = 0;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -398,8 +398,8 @@ abstract class Product {
 	}
 
 	/**
-	 * Forget the in-process site features memo, failed and successful lookups alike, so the
-	 * next call asks WPCOM again. The transient is a separate cache layer and is left untouched.
+	 * Forget the cached site features — both in-process memos and the transient — so the next
+	 * call asks WPCOM again.
 	 *
 	 * @return void
 	 */
@@ -408,6 +408,7 @@ abstract class Product {
 		self::$site_features_failure_expires = 0;
 		self::$site_features_success         = null;
 		self::$site_features_success_expires = 0;
+		delete_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -108,6 +108,21 @@ abstract class Product {
 	private static $site_features_failure_expires = 0;
 
 	/**
+	 * A successful site features lookup, kept so one WPCOM request serves a whole render
+	 * even when the transient write does not retain (e.g. an object cache evicting under load)
+	 *
+	 * @var array|null
+	 */
+	private static $site_features_success = null;
+
+	/**
+	 * Unix time at which the memoized success above stops being used
+	 *
+	 * @var int
+	 */
+	private static $site_features_success_expires = 0;
+
+	/**
 	 * Whether this module is a Jetpack feature
 	 *
 	 * @var boolean
@@ -344,6 +359,14 @@ abstract class Product {
 			return $stored_features;
 		}
 
+		/*
+		 * Checked after the transient so it can never outrank a warm cache, but kept so a
+		 * dashboard render still makes a single WPCOM request when the transient write is dropped.
+		 */
+		if ( self::$site_features_success !== null && time() < self::$site_features_success_expires ) {
+			return self::$site_features_success;
+		}
+
 		if ( self::$site_features_failure !== null && time() < self::$site_features_failure_expires ) {
 			return self::$site_features_failure;
 		}
@@ -368,17 +391,23 @@ abstract class Product {
 		// set a short transient to help with multiple lookups on the same page load.
 		set_transient( self::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, $features, self::MY_JETPACK_SITE_FEATURES_CACHE_DURATION );
 
+		self::$site_features_success         = $features;
+		self::$site_features_success_expires = time() + self::MY_JETPACK_SITE_FEATURES_CACHE_DURATION;
+
 		return $features;
 	}
 
 	/**
-	 * Forget a memoized failed site features lookup so the next call asks WPCOM again.
+	 * Forget the in-process site features memo, failed and successful lookups alike, so the
+	 * next call asks WPCOM again. The transient is a separate cache layer and is left untouched.
 	 *
 	 * @return void
 	 */
-	public static function reset_site_features_failure() {
+	public static function reset_site_features_cache() {
 		self::$site_features_failure         = null;
 		self::$site_features_failure_expires = 0;
+		self::$site_features_success         = null;
+		self::$site_features_success_expires = 0;
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WP_Error;
+
+/**
+ * Unit tests for the caching in Product::get_site_features_from_wpcom().
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Product::get_site_features_from_wpcom
+ */
+class Product_Site_Features_Test extends TestCase {
+
+	/**
+	 * How many outbound HTTP requests the current test has attempted.
+	 *
+	 * @var int
+	 */
+	private $http_calls = 0;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test' );
+		Jetpack_Options::update_option( 'id', 123 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$this->http_calls = 0;
+		Product::reset_site_features_failure();
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
+		remove_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
+		Product::reset_site_features_failure();
+
+		WorDBless_Options::init()->clear_options();
+	}
+
+	/**
+	 * Fails every outbound HTTP request and tallies how many were attempted.
+	 *
+	 * @return WP_Error
+	 */
+	public function fail_http_request() {
+		++$this->http_calls;
+		return new WP_Error( 'http_request_failed', 'Simulated WPCOM failure.' );
+	}
+
+	/**
+	 * Answers every outbound HTTP request with a 200 carrying one active feature.
+	 *
+	 * @return array
+	 */
+	public function succeed_http_request() {
+		++$this->http_calls;
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode(
+				array(
+					'active'    => array( 'backups' ),
+					'available' => array(),
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+		);
+	}
+
+	/**
+	 * A failed lookup answers later callers rather than firing one request per product.
+	 */
+	public function test_failed_lookup_is_only_attempted_once() {
+		add_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
+
+		$first  = Product::get_site_features_from_wpcom();
+		$second = Product::get_site_features_from_wpcom();
+
+		$this->assertInstanceOf( WP_Error::class, $first );
+		$this->assertInstanceOf( WP_Error::class, $second );
+		$this->assertSame( 1, $this->http_calls );
+	}
+
+	/**
+	 * A successful lookup answers later callers from the transient.
+	 */
+	public function test_successful_lookup_is_only_attempted_once() {
+		add_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+
+		$first  = Product::get_site_features_from_wpcom();
+		$second = Product::get_site_features_from_wpcom();
+
+		$this->assertSame( array( 'backups' ), $first['active'] );
+		$this->assertSame( $first, $second );
+		$this->assertSame( 1, $this->http_calls );
+	}
+
+	/**
+	 * A failed lookup must not keep answering once the cache is warm again, or a site that
+	 * owns a product is offered an upsell for it for the rest of the request.
+	 */
+	public function test_warm_transient_outranks_a_failed_lookup() {
+		add_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
+		$this->assertInstanceOf( WP_Error::class, Product::get_site_features_from_wpcom() );
+
+		set_transient(
+			Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY,
+			array(
+				'active'    => array( 'backups' ),
+				'available' => array(),
+			),
+			Product::MY_JETPACK_SITE_FEATURES_CACHE_DURATION
+		);
+
+		$features = Product::get_site_features_from_wpcom();
+
+		$this->assertIsArray( $features );
+		$this->assertSame( array( 'backups' ), $features['active'] );
+		$this->assertTrue( Product::does_site_have_feature( 'backups' ) );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
@@ -47,7 +47,7 @@ class Product_Site_Features_Test extends TestCase {
 
 		remove_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
 		remove_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
-		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
+		remove_filter( 'pre_set_transient_' . Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, '__return_false' );
 		Product::reset_site_features_cache();
 
 		WorDBless_Options::init()->clear_options();
@@ -108,6 +108,23 @@ class Product_Site_Features_Test extends TestCase {
 		$first  = Product::get_site_features_from_wpcom();
 		$second = Product::get_site_features_from_wpcom();
 
+		$this->assertSame( array( 'backups' ), $first['active'] );
+		$this->assertSame( $first, $second );
+		$this->assertSame( 1, $this->http_calls );
+	}
+
+	/**
+	 * When the transient write does not retain — an object cache evicting under load — the
+	 * in-process memo still holds a dashboard render to a single WPCOM request.
+	 */
+	public function test_successful_lookup_is_only_attempted_once_when_the_transient_does_not_retain() {
+		add_filter( 'pre_set_transient_' . Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, '__return_false' );
+		add_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+
+		$first  = Product::get_site_features_from_wpcom();
+		$second = Product::get_site_features_from_wpcom();
+
+		$this->assertFalse( get_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY ), 'The transient retained, so this test would pass without the memo.' );
 		$this->assertSame( array( 'backups' ), $first['active'] );
 		$this->assertSame( $first, $second );
 		$this->assertSame( 1, $this->http_calls );

--- a/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Product_Site_Features_Test.php
@@ -36,7 +36,7 @@ class Product_Site_Features_Test extends TestCase {
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 
 		$this->http_calls = 0;
-		Product::reset_site_features_failure();
+		Product::reset_site_features_cache();
 	}
 
 	/**
@@ -48,7 +48,7 @@ class Product_Site_Features_Test extends TestCase {
 		remove_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
 		remove_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
 		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
-		Product::reset_site_features_failure();
+		Product::reset_site_features_cache();
 
 		WorDBless_Options::init()->clear_options();
 	}

--- a/projects/packages/my-jetpack/tests/php/Wpcom_Products_Purchases_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Wpcom_Products_Purchases_Test.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WP_Error;
+
+/**
+ * Unit tests for the caching in Wpcom_Products::get_site_current_purchases().
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\Wpcom_Products::get_site_current_purchases
+ */
+class Wpcom_Products_Purchases_Test extends TestCase {
+
+	/**
+	 * How many outbound HTTP requests the current test has attempted.
+	 *
+	 * @var int
+	 */
+	private $http_calls = 0;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test' );
+		Jetpack_Options::update_option( 'id', 123 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+		$this->http_calls = 0;
+		Wpcom_Products::reset_purchases_cache();
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
+		remove_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+		remove_filter( 'pre_set_transient_' . Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY, '__return_false' );
+		Wpcom_Products::reset_purchases_cache();
+
+		WorDBless_Options::init()->clear_options();
+	}
+
+	/**
+	 * Fails every outbound HTTP request and tallies how many were attempted.
+	 *
+	 * @return WP_Error
+	 */
+	public function fail_http_request() {
+		++$this->http_calls;
+		return new WP_Error( 'http_request_failed', 'Simulated WPCOM failure.' );
+	}
+
+	/**
+	 * Answers every outbound HTTP request with a 200 carrying one purchase.
+	 *
+	 * @return array
+	 */
+	public function succeed_http_request() {
+		++$this->http_calls;
+		return array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => wp_json_encode(
+				array( array( 'product_slug' => 'jetpack_complete' ) ),
+				JSON_UNESCAPED_SLASHES
+			),
+		);
+	}
+
+	/**
+	 * The product slugs in a purchases response, narrowed the way the product classes narrow it.
+	 *
+	 * @param mixed $purchases The get_site_current_purchases() return value.
+	 * @return string[]
+	 */
+	private function product_slugs( $purchases ) {
+		$slugs = array();
+
+		if ( is_array( $purchases ) ) {
+			foreach ( $purchases as $purchase ) {
+				$slugs[] = $purchase->product_slug;
+			}
+		}
+
+		return $slugs;
+	}
+
+	/**
+	 * A failed lookup answers later callers rather than firing one request per product.
+	 */
+	public function test_failed_lookup_is_only_attempted_once() {
+		add_filter( 'pre_http_request', array( $this, 'fail_http_request' ) );
+
+		$first  = Wpcom_Products::get_site_current_purchases();
+		$second = Wpcom_Products::get_site_current_purchases();
+
+		$this->assertInstanceOf( WP_Error::class, $first );
+		$this->assertInstanceOf( WP_Error::class, $second );
+		$this->assertSame( 1, $this->http_calls );
+	}
+
+	/**
+	 * When the transient write does not retain — an object cache evicting under load — the
+	 * in-process memo still holds a dashboard render to a single WPCOM request.
+	 */
+	public function test_successful_lookup_is_only_attempted_once_when_the_transient_does_not_retain() {
+		add_filter( 'pre_set_transient_' . Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY, '__return_false' );
+		add_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+
+		$first  = Wpcom_Products::get_site_current_purchases();
+		$second = Wpcom_Products::get_site_current_purchases();
+
+		$this->assertFalse( get_transient( Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY ), 'The transient retained, so this test would pass without the memo.' );
+		$this->assertSame( array( 'jetpack_complete' ), $this->product_slugs( $first ) );
+		$this->assertEquals( $first, $second );
+		$this->assertSame( 1, $this->http_calls );
+	}
+
+	/**
+	 * A memoized lookup must not keep answering once the cache holds a newer plan, or the
+	 * dashboard reports a stale purchase for the rest of the request.
+	 */
+	public function test_warm_transient_outranks_a_stale_memo() {
+		add_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+		$first = Wpcom_Products::get_site_current_purchases();
+		remove_filter( 'pre_http_request', array( $this, 'succeed_http_request' ) );
+
+		$this->assertSame( array( 'jetpack_complete' ), $this->product_slugs( $first ) );
+
+		set_transient(
+			Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY,
+			array( (object) array( 'product_slug' => 'jetpack_security_t1' ) ),
+			Wpcom_Products::MY_JETPACK_PURCHASES_CACHE_DURATION
+		);
+
+		$purchases = Wpcom_Products::get_site_current_purchases();
+
+		$this->assertSame( array( 'jetpack_security_t1' ), $this->product_slugs( $purchases ) );
+	}
+}

--- a/projects/packages/videopress/changelog/fix-site-features-failure-cache
+++ b/projects/packages/videopress/changelog/fix-site-features-failure-cache
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove process isolation from the features REST API tests now that a failed My Jetpack lookup no longer leaks across tests.
+
+

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -9,8 +9,6 @@ namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\My_Jetpack\Product;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -92,12 +90,7 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 
 	/**
 	 * Test that authenticated requests succeed.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	public function test_authenticated_request_succeeds() {
 		wp_set_current_user( $this->user_id );
 
@@ -194,18 +187,13 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	 * Test that the endpoint correctly maps WPCOM features to VideoPress feature flags.
 	 *
 	 * This test seeds the My Jetpack transient cache with mock data, then dispatches
-	 * a REST request to the endpoint. Each test runs in a separate process to avoid
-	 * static cache pollution from Product::get_site_features_from_wpcom().
+	 * a REST request to the endpoint.
 	 *
 	 * @param array $active_features Features that would be returned by WPCOM API.
 	 * @param array $expected Expected feature flags from the endpoint.
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
 	 * @dataProvider feature_flag_mapping_provider
 	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
 	#[DataProvider( 'feature_flag_mapping_provider' )]
 	public function test_feature_flag_mapping( array $active_features, array $expected ) {
 		wp_set_current_user( $this->user_id );

--- a/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Rest_Api_V1_Features_Test.php
@@ -38,6 +38,10 @@ class VideoPress_Rest_Api_V1_Features_Test extends BaseTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
+		// A test here that does not seed the transient would otherwise inherit a failure
+		// memoized by an earlier test for up to 15s, flaking only in full-suite runs.
+		Product::reset_site_features_cache();
+
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server();
 		$this->server   = $wp_rest_server;

--- a/projects/plugins/backup/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/backup/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/backup/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/backup/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/boost/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/boost/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/boost/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/boost/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/jetpack/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/jetpack/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/jetpack/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/jetpack/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/protect/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/protect/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/protect/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/protect/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/search/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/search/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/search/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/search/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/social/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/social/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/social/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/social/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/stats/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/stats/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/stats/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/stats/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.

--- a/projects/plugins/videopress/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/videopress/changelog/fix-site-features-failure-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.

--- a/projects/plugins/videopress/changelog/fix-site-features-failure-cache
+++ b/projects/plugins/videopress/changelog/fix-site-features-failure-cache
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: Stop offering upgrades for products the site already owns when a plan lookup fails.
+My Jetpack: Show the right product status as soon as fresher plan data is available, instead of reusing an earlier lookup.


### PR DESCRIPTION
Fixes JETPACK-2527

## Proposed changes

* `Product::get_site_features_from_wpcom()` memoized its result in a function-level static and checked that static *before* the transient. Once a lookup failed, the resulting `WP_Error` answered every later call in the same PHP process — including calls made after the transient had been populated, because the static won.
* `has_paid_plan_for_product()` opens with `does_site_have_feature()`, which returns false on a `WP_Error`. So a single failed features request could make owned products look unowned for the rest of the request: a site paying for Complete gets "Get plan" or "Learn more" on products it already owns.
* The fix reads the transient first. Behind it sit two in-process memos, each carrying a 15s expiry: a failure memo, so one outage does not fire a request per product, and a success memo, so a single WPCOM request still serves a whole dashboard render even when the transient write does not retain (an object cache evicting under load — the WoA setup where these dashboards render). Both are checked *after* the transient, so neither can outrank a warm cache, and neither survives the life of a long-running process.
* Adds `MY_JETPACK_SITE_FEATURES_CACHE_DURATION` so the transient TTL and the memo windows are the same named number, and `reset_site_features_cache()`, which forgets both memos **and** the transient, so the next call really does ask WPCOM again.
* `Wpcom_Products::get_site_current_purchases()` had the same shape — a `static $purchases` checked before the transient and never expiring, plus a failure memo with no expiry — and it decides purchase status for most of the dashboard. It gets the same treatment: transient, then a success memo, then a failure memo, both expiring with the transient's 5s window. The shared failure store now carries an expiry for every request label, and `reset_purchases_cache()` is the counterpart to `reset_site_features_cache()`.
* Removes the `RunInSeparateProcess` isolation from `VideoPress_Rest_Api_V1_Features_Test`, whose docblock named this static as the reason for it. This change is what retires it: `Initial_State_Chapters_Editor_Test` runs earlier in the same process, blocks HTTP, and poisons the static, so on trunk the memoized error outranked the seeded transient — removing the isolation against trunk's `class-product.php` fails 8 tests in a full-suite run. (An earlier revision of this description claimed the isolation was already unnecessary. That was wrong, and it came from checking with `--filter`, which never runs the class that does the poisoning.) Its `setUp()` now calls `reset_site_features_cache()` so the removal stays robust rather than incidentally safe — a future test in that class that does not seed the transient would otherwise inherit a failure memoized by an earlier test.

Note on scope: JETPACK-2527 also asks for `Plan_Matrix_Test` to pass without process isolation. That test does not exist on trunk yet — this issue *blocks* JETPACK-2392, which is where it gets written — so that part has to be checked off there.

### New tests

`Product_Site_Features_Test` in the My Jetpack package, exercising the real `Client::wpcom_json_api_request_as_blog` path with a mock connection and a `pre_http_request` filter:

* a failed lookup is attempted once, not once per caller;
* a successful lookup is attempted once, not once per caller;
* a successful lookup is *still* attempted once when the transient write does not retain — the case that measures the memo rather than the transient;
* **a warm transient outranks a failed lookup**, asserted through `does_site_have_feature()` — the customer-visible symptom.

`Wpcom_Products_Purchases_Test` covers the purchases half the same way, including **a warm transient outranking a stale success memo**.

Every one of these was confirmed to be a real regression test by reverting only the behavior it covers and watching it go red — check order, success memo, and failure memo each independently.

## Related product discussion/links

* JETPACK-2527, blocking JETPACK-2392

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated, run from a checkout with `tools/php-test-env` and each package installed:

* `jp test php packages/my-jetpack` — 192 tests.
* `jp test php packages/videopress` — 319 tests, and the suite drops from ~15.2s to ~4.5s now that the features REST tests no longer fork a process each.
* `jp test php packages/backup` (407) and `jp test php packages/search` (756) — both depend on My Jetpack.
* Run the full suites, not `--filter`. `--filter` hides exactly the cross-test static pollution this PR is about.
* To see the regression the tests guard, swap the two blocks at the top of `get_site_features_from_wpcom()` so a memo is checked before `get_transient()`, and re-run: `test_warm_transient_outranks_a_failed_lookup` fails with the `WP_Error`. Same for `get_site_current_purchases()` and `test_warm_transient_outranks_a_stale_memo`.

Also clean: `composer phpcs:lint` and `composer phpcs:compatibility` on the touched files, and Phan against both packages' baselines.

Manual, on a site with a paid plan:

* Go to Jetpack → My Jetpack on a site that owns a product through its plan (e.g. a Complete site and VaultPress Backup).
* Reproduce the shared-cache race the memo used to lose. The `/sites/%d/features` transient is shared across PHP workers, so one worker can fail the lookup while another populates the transient. Simulate that inside a single request — fail the first lookup, then warm the transient by hand:

```php
add_filter( 'pre_http_request', fn() => new WP_Error( 'http_request_failed' ) );
Product::get_site_features_from_wpcom();          // first card asks, fails and memoizes
set_transient(
    Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY,
    array( 'active' => array( 'backups' ), 'available' => new stdClass() ),
    Product::MY_JETPACK_SITE_FEATURES_CACHE_DURATION
);
var_dump( Products\Backup::has_paid_plan_for_product() );
// trunk: false (the memoized failure wins) — this PR: true (the warm transient wins)
```

* On a live dashboard the symptom is that every product card renders as unowned ("Get plan" / "Learn more") for the rest of the request; after the fix, once the transient is warm the cards show the owned state again.

Note: an earlier version of these steps said to fail the first call and then "let later calls through." That does not reproduce the bug — after the first failure the in-process memo answers every later call before it reaches HTTP, so there are no later calls to let through. Warming the transient from a concurrent worker (or by hand, as above) is what exercises the fix.

### Scope, stated plainly

On a site **without** a persistent object cache, WP's `notoptions` cache means a second `get_transient()` in the same request cannot see another worker's write — `get_option()` short-circuits on `notoptions` once the first miss records the key. So the in-request recovery above needs an external object cache to happen at all.

What holds everywhere: a memoized result can no longer outrank fresher data, and no longer answers for the life of a long-running process. The changelog entries are worded to that, rather than promising the upsell is gone in every case.

