### PR TITLE
Backup: name each activity row by its own restore point

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2496-backup-activity-row-accessible-names
+++ b/projects/packages/backup/changelog/jetpack-2496-backup-activity-row-accessible-names
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: give each activity row an accessible name that includes its own date, so assistive tech and voice control can tell one restore point from another. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -91,6 +91,19 @@ function MediaCell( { item }: { item: ActivityItem } ) {
 }
 
 /**
+ * The row's timestamp, formatted once for both the name and the visible line.
+ *
+ * Drift between the two would announce a different restore point than the one
+ * on screen, on the control that picks what Restore and Download act on.
+ *
+ * @param item - The activity item.
+ * @return The formatted timestamp.
+ */
+function rowDate( item: ActivityItem ): string {
+	return dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined );
+}
+
+/**
  * Title cell — the visible summary, plus the timestamp for assistive tech.
  *
  * DataViews points the row's `aria-labelledby` at this cell alone, so without
@@ -106,9 +119,7 @@ function TitleCell( { item }: { item: ActivityItem } ) {
 		<>
 			{ item.title }
 			{ /* JSX drops the newline, and the name computation adds nothing back. */ }{ ' ' }
-			<span className="jpb-visually-hidden">
-				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
-			</span>
+			<span className="jpb-visually-hidden">{ rowDate( item ) }</span>
 		</>
 	);
 }
@@ -125,7 +136,7 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
 	return (
 		<Stack direction="row" align="center" gap="xs">
 			<Text variant="body-sm" className="jpb-text-muted jpb-activity-list__date">
-				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
+				{ rowDate( item ) }
 			</Text>
 			{ /*
 			 * `auto`, not `ltr`: WPCOM may legitimately translate this line into RTL.
@@ -238,9 +249,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				label: __( 'When', 'jetpack-backup-pkg' ),
 				render: DescriptionCell,
 				getValue: ( { item } ) =>
-					`${ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }${
-						item.summary ? ` ${ item.summary }` : ''
-					}`,
+					`${ rowDate( item ) }${ item.summary ? ` ${ item.summary }` : '' }`,
 				enableHiding: false,
 				filterBy: false,
 			},

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -91,6 +91,29 @@ function MediaCell( { item }: { item: ActivityItem } ) {
 }
 
 /**
+ * Title cell — the visible summary, plus the timestamp for assistive tech.
+ *
+ * DataViews points the row's `aria-labelledby` at this cell alone, so without
+ * the date every row announces the same sentence and a screen-reader user
+ * cannot tell which restore point they are about to open, download or restore.
+ *
+ * @param props      - Component props.
+ * @param props.item - The activity item.
+ * @return The rendered title.
+ */
+function TitleCell( { item }: { item: ActivityItem } ) {
+	return (
+		<>
+			{ item.title }
+			{ /* JSX drops the newline, and the name computation adds nothing back. */ }{ ' ' }
+			<span className="jpb-visually-hidden">
+				{ dateI18n( 'M j, Y, g:i A', item.publishedAt, undefined ) }
+			</span>
+		</>
+	);
+}
+
+/**
  * Descriptions cell — single muted line with the timestamp + optional
  * summary, joined by a thin separator.
  *
@@ -204,6 +227,7 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 				id: 'title',
 				type: 'text',
 				label: __( 'Title', 'jetpack-backup-pkg' ),
+				render: TitleCell,
 				getValue: ( { item } ) => item.title,
 				enableSorting: false,
 				filterBy: false,

--- a/projects/packages/backup/src/dashboard/utilities.scss
+++ b/projects/packages/backup/src/dashboard/utilities.scss
@@ -14,13 +14,13 @@
 }
 
 // Keeps an element in the accessibility tree while taking it out of the
-// visual layout. Used for a live region that has to stay mounted before
-// it has anything to say: assistive tech needs the region present in the
-// tree *before* its content changes, so a region that appears together
-// with its first message is unreliable — VoiceOver in particular often
-// misses it.
+// visual layout. Two uses: a live region that has to stay mounted before
+// it has anything to say — assistive tech needs the region present in the
+// tree *before* its content changes, so one that appears together with its
+// first message is unreliable, VoiceOver especially — and text that belongs
+// in a control's accessible name but not on screen.
 
-// `position: absolute` is doing more work than hiding here. These regions
+// `position: absolute` is doing more work than hiding here. The live regions
 // sit inside flex columns with a `gap`, and a gap applies between all
 // in-flow children no matter how small — so a zero-height placeholder
 // would still cost a full 16px of dead space on every render where the

--- a/projects/packages/backup/tests/activity-row-names.test.tsx
+++ b/projects/packages/backup/tests/activity-row-names.test.tsx
@@ -1,0 +1,86 @@
+// JETPACK-2496 — the rows are the entry point to Restore and Download, and
+// WordPress.com gives most of them the same summary. Two rows one minute apart
+// is the whole defect: identical names on the control that picks a restore point.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SUMMARY = 'Backup and scan complete';
+
+const row = ( id: string, published: string ) => ( {
+	activity_id: id,
+	name: 'rewind__backup_complete_full',
+	gridicon: 'cloud',
+	rewind_id: id,
+	published,
+	summary: SUMMARY,
+	is_rewindable: true,
+} );
+
+const PAGE = {
+	current: {
+		orderedItems: [
+			row( '1786600000', '2026-08-20T10:00:00+00:00' ),
+			row( '1786600060', '2026-08-19T22:30:00+00:00' ),
+		],
+	},
+	totalItems: 2,
+	totalPages: 1,
+};
+
+/** No-op selection handler; these tests never act on a choice. */
+function noop() {}
+
+/** Render the list with its real starting view. */
+function renderList() {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	render(
+		<QueryClientProvider client={ client }>
+			<ActivityList
+				selectedId={ null }
+				onSelect={ noop }
+				view={ INITIAL_VIEW }
+				onChangeView={ noop }
+			/>
+		</QueryClientProvider>
+	);
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( PAGE );
+	window.JP_CONNECTION_INITIAL_STATE = {
+		connectionStatus: CONNECTED,
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+it( 'names each row by its own restore point, not by the shared summary', async () => {
+	renderList();
+
+	await expect(
+		screen.findByRole( 'button', { name: `${ SUMMARY } Aug 20, 2026, 10:00 AM` } )
+	).resolves.toBeInTheDocument();
+	expect(
+		screen.getByRole( 'button', { name: `${ SUMMARY } Aug 19, 2026, 10:30 PM` } )
+	).toBeInTheDocument();
+} );
+
+it( 'no longer answers to the summary alone, which every row shares', async () => {
+	renderList();
+	await expect(
+		screen.findByRole( 'button', { name: /Aug 20, 2026/ } )
+	).resolves.toBeInTheDocument();
+
+	expect( screen.queryByRole( 'button', { name: SUMMARY } ) ).not.toBeInTheDocument();
+} );

--- a/projects/packages/backup/tests/activity-row-names.test.tsx
+++ b/projects/packages/backup/tests/activity-row-names.test.tsx
@@ -32,7 +32,7 @@ const PAGE = {
 	current: {
 		orderedItems: [
 			row( '1786600000', '2026-08-20T10:00:00+00:00' ),
-			row( '1786600060', '2026-08-19T22:30:00+00:00' ),
+			row( '1786600060', '2026-08-20T10:01:00+00:00' ),
 		],
 	},
 	totalItems: 2,
@@ -72,14 +72,14 @@ it( 'names each row by its own restore point, not by the shared summary', async 
 		screen.findByRole( 'button', { name: `${ SUMMARY } Aug 20, 2026, 10:00 AM` } )
 	).resolves.toBeInTheDocument();
 	expect(
-		screen.getByRole( 'button', { name: `${ SUMMARY } Aug 19, 2026, 10:30 PM` } )
+		screen.getByRole( 'button', { name: `${ SUMMARY } Aug 20, 2026, 10:01 AM` } )
 	).toBeInTheDocument();
 } );
 
 it( 'no longer answers to the summary alone, which every row shares', async () => {
 	renderList();
 	await expect(
-		screen.findByRole( 'button', { name: /Aug 20, 2026/ } )
+		screen.findByRole( 'button', { name: /Aug 20, 2026, 10:00 AM/ } )
 	).resolves.toBeInTheDocument();
 
 	expect( screen.queryByRole( 'button', { name: SUMMARY } ) ).not.toBeInTheDocument();

--- a/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
+++ b/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
@@ -52,8 +52,7 @@ function title( id: string ): string {
 }
 
 /**
- * The same row as a name matcher. A row's accessible name carries its
- * timestamp after the title, so an exact string never matches the button.
+ * The same row as a name matcher.
  *
  * @param id - The row's rewind id.
  * @return The matcher.

--- a/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
+++ b/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
@@ -51,6 +51,17 @@ function title( id: string ): string {
 	return `Backup ${ id }`;
 }
 
+/**
+ * The same row as a name matcher. A row's accessible name carries its
+ * timestamp after the title, so an exact string never matches the button.
+ *
+ * @param id - The row's rewind id.
+ * @return The matcher.
+ */
+function named( id: string ): RegExp {
+	return new RegExp( `^${ title( id ) } ` );
+}
+
 /** The log the fixture answers from, newest first. Grown mid-test to move a row to page 2. */
 let log: string[] = [];
 
@@ -142,7 +153,7 @@ function renderApp() {
  */
 async function roundTripViaDownload( view: ReturnType< typeof renderApp > ): Promise< string > {
 	const chosen = rewindId( PER_PAGE - 1 );
-	await userEvent.click( await screen.findByRole( 'button', { name: title( chosen ) }, SETTLE ) );
+	await userEvent.click( await screen.findByRole( 'button', { name: named( chosen ) }, SETTLE ) );
 	await waitFor( () => expect( view.state.location.search ).toEqual( { selected: chosen } ) );
 
 	await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ }, SETTLE ) );

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -76,6 +76,18 @@ function rowTitle( page: number, number: number ): string {
 }
 
 /**
+ * The same row as a name matcher. A row's accessible name carries its
+ * timestamp after the title, so an exact string never matches the button.
+ *
+ * @param page   - 1-indexed page number.
+ * @param number - Page size.
+ * @return The matcher.
+ */
+function rowNamed( page: number, number: number ): RegExp {
+	return new RegExp( `^${ rowTitle( page, number ) } ` );
+}
+
+/**
  * One rewindable-activity page, in WPCOM's shape.
  *
  * One row per page, so the row's own name says which page and page size produced it.
@@ -113,7 +125,7 @@ function activityPage( page: number, number: number ) {
  * @return The row button.
  */
 function row( page: number, number: number ): HTMLElement {
-	return screen.getByRole( 'button', { name: rowTitle( page, number ) } );
+	return screen.getByRole( 'button', { name: rowNamed( page, number ) } );
 }
 
 /**
@@ -126,7 +138,7 @@ function row( page: number, number: number ): HTMLElement {
 async function openOverview( page: number, number: number ) {
 	const view = render( <OverviewStage /> );
 	await expect(
-		screen.findByRole( 'button', { name: rowTitle( page, number ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( page, number ) }, SETTLE )
 	).resolves.toBeInTheDocument();
 	return view;
 }
@@ -226,11 +238,11 @@ async function roundTripFromPage2Of20( Stage: () => React.JSX.Element ): Promise
 	await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
 	await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
 	await expect(
-		screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
 	).resolves.toBeInTheDocument();
 	await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 	await expect(
-		screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
 	).resolves.toBeInTheDocument();
 
 	overview.unmount();
@@ -279,7 +291,7 @@ describe( 'The trip out to Download and back', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( row( 2, 10 ) );
@@ -304,7 +316,7 @@ describe( 'The trip out to Download and back', () => {
 			screen.findByRole( 'heading', { name: rowTitle( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );
-		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'heading', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
 	} );
 } );
@@ -316,7 +328,7 @@ describe( 'The trip out to Restore and back', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
 		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -325,9 +337,9 @@ describe( 'The trip out to Restore and back', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -339,7 +351,7 @@ describe( 'A gate verdict that changes under the reader', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		hasBackupPlan = false;
@@ -356,9 +368,9 @@ describe( 'A gate verdict that changes under the reader', () => {
 		} );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 10 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -369,7 +381,7 @@ describe( 'A fresh page load', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		overview.unmount();
 		await roundTripVia( DownloadStage );
@@ -381,10 +393,10 @@ describe( 'A fresh page load', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( row( 1, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' );
-		expect( screen.queryByRole( 'button', { name: rowTitle( 2, 10 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowNamed( 2, 10 ) } ) ).not.toBeInTheDocument();
 	} );
 } );
 
@@ -395,7 +407,7 @@ describe( 'A remembered place that no longer exists', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -410,7 +422,7 @@ describe( 'A remembered place that no longer exists', () => {
 		// The row is the positive: without the clamp the list asks for page 2 of a
 		// one-page log and DataViews renders "No results" with no footer.
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
 	} );
@@ -422,7 +434,7 @@ describe( 'A remembered place that no longer exists', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -434,7 +446,7 @@ describe( 'A remembered place that no longer exists', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
 	} );
@@ -500,9 +512,9 @@ describe( 'A remembered place the log cannot answer for', () => {
 		activityFails = false;
 		await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
-		expect( screen.queryByRole( 'button', { name: rowTitle( 1, 20 ) } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 20 ) } ) ).not.toBeInTheDocument();
 
 		view.unmount();
 	} );
@@ -534,7 +546,7 @@ describe( 'A remembered place asked for with no connection', () => {
 
 		// Page 2 is what resumes, so nothing moved the reader while they were offline.
 		await expect(
-			screen.findByRole( 'button', { name: rowTitle( 2, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
 		).resolves.toBeInTheDocument();
 		expect( activityRequests() ).not.toContain( '1/20' );
 
@@ -551,7 +563,7 @@ describe( 'Clearing a selection that came from memory', () => {
 		// page 1's newest backup, and would otherwise mask the clear.
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
-		await userEvent.click( await screen.findByRole( 'button', { name: rowTitle( 2, 10 ) } ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } ) );
 		// As above: `useSearch` is a mock, so this stands in for the router commit.
 		overview.rerender( <OverviewStage /> );
 		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );

--- a/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
+++ b/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
@@ -183,7 +183,9 @@ describe( 'a restore that has already ended', () => {
 			screen.findByText( "Restore didn't finish", undefined, SETTLE )
 		).resolves.toBeVisible();
 
-		expect( screen.getByText( RESTORE_RENDERED_AT ) ).toBeVisible();
+		expect(
+			screen.getByText( RESTORE_RENDERED_AT, { selector: '.jpb-activity-list__date' } )
+		).toBeVisible();
 		expect( screen.queryByText( RESTORE_READ_AS_LOCAL ) ).not.toBeInTheDocument();
 	} );
 

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -326,7 +326,7 @@ describe( 'Choosing a row', () => {
 
 		render( <OverviewStage /> );
 		await userEvent.click(
-			await screen.findByRole( 'button', { name: 'Post published' }, SETTLE )
+			await screen.findByRole( 'button', { name: /^Post published / }, SETTLE )
 		);
 
 		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2496](https://linear.app/a8c/issue/JETPACK-2496) — the last gating code item on the [JETPACK-2319](https://linear.app/a8c/issue/JETPACK-2319) pre-flip checklist.

## Proposed changes

Every row in the activity list is a `<button>`, and WordPress.com gives most of them the same summary — so ten restore points announced as ten identical *"Backup and scan complete"*. The rows are the entry point to **Restore to this point** and **Download backup**, both of which act on whichever row is selected, so a user who cannot tell them apart cannot verify which point they are about to act on.

The title cell now carries the row's timestamp alongside the visible summary, hidden from view but not from the accessibility tree.

**Precise about the standard:** this is WCAG **2.4.6 Labels (AA)** — ten identical labels on controls selecting ten different restore points do not describe their purpose. It is *not* a 4.1.2 failure; that criterion has no uniqueness requirement, and the buttons always had a name and a role. The concrete harm is rotor / elements-list navigation and verifying a destructive action's target, rather than voice control, which already disambiguates ambiguous names with numbered overlays.

The restore rows [#51955](https://github.com/Automattic/jetpack/pull/51955) added share this same `TitleCell`, so they are covered by the same change — which answers the open question JETPACK-2496 raised about them.

### Why it has to go in the title cell specifically

DataViews' list layout builds the row's accessible name from the **title field alone** — `aria-labelledby` points at that cell. It *does* also set `aria-describedby`, which looks like the natural home for a timestamp, but that attribute points at `dataviews-view-list__fields`, and the `descriptionField` renders outside it. Verified in a real render: the element is present and **empty**.

```
labelledby:  "view-list-0-…-label"        →  "Backup and scan complete Aug 20, 2026, 10:00 AM"
describedby: "view-list-0-…-description"  →  ""
```

So the date being on screen in the description cell buys nothing for assistive tech, and the only way into the announced name is the title cell.

### The blast radius, and why it is load-bearing

Changing an accessible name breaks every test that queried a row by its bare summary — **26 query sites across four files**, now matching a title prefix instead. **Five of those were absence assertions** (`queryByRole( … ).not.toBeInTheDocument()`). Left on the old exact string they would have kept passing forever, against a name that can no longer occur — green, and testing nothing.

One assertion changed for a different reason: the date now appears twice in the DOM (visibly in the description, hidden in the title), so `getByText` on it became ambiguous and is scoped to the visible cell.

## Related product discussion/links

* [JETPACK-2496](https://linear.app/a8c/issue/JETPACK-2496) — filed from the pre-flip sweep; flagged there as gating

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Automated** — `jp test js packages/backup` (858 tests). `tests/activity-row-names.test.tsx` is the direct witness: two rows **one minute apart** sharing a summary, so the case pins the time of day and not merely the date — shortening the format to `'M j, Y'` reddens it. Reverting `activity-list/index.tsx` reddens it too.

**By hand** — at **Jetpack → Backup**, tab through the activity rows with a screen reader (VoiceOver: VO-→; NVDA: browse mode). Each row should announce its summary *followed by its own date* rather than ten identical sentences. Rotor/elements-list navigation is the clearest check — that list shows names only.

Voice control is the other beneficiary: *"click Backup and scan complete"* previously matched ten targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy


