### PR TITLE
Backup: stop the file-info card uppercasing the filename

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2503-backup-file-info-title-case
+++ b/projects/packages/backup/changelog/jetpack-2503-backup-file-info-title-case
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: show the file browser's filename in its own case instead of uppercasing it. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -73,7 +73,7 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				justify="space-between"
 				className="jpb-file-info-card__header"
 			>
-				<Text variant="heading-sm" render={ <h3 /> }>
+				<Text variant="heading-md" render={ <h3 /> }>
 					{ /* A filename is LTR data even on an RTL page. */ }
 					<span dir="ltr">{ file.name }</span>
 				</Text>


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2503](https://linear.app/a8c/issue/JETPACK-2503).

## Proposed changes

Opening `readme.html` in the file browser titled the card `README.HTML`; `wp-config.php` became `WP-CONFIG.PHP`. The DOM held the right name — the transform was purely presentational.

`heading-sm` turns out to be the **only** one of `@wordpress/ui`'s nine text variants carrying `text-transform: uppercase`. It is an eyebrow-label treatment at 11px/600 — so the card was asking for a small-heading *style* and getting a *label* treatment that happens to destroy case.

Filenames are case-sensitive on the filesystems these backups restore to, and this card's whole job is saying exactly which file you are looking at, next to its hash.

Swapped to `heading-md`: same 600 weight and heading family, 13px instead of 11px, no transform. The element stays an `<h3>`, so [JETPACK-2369](https://linear.app/a8c/issue/JETPACK-2369)'s heading outline is untouched — `tests/heading-outline.test.tsx` pins it to `parentLevel + 1` and would catch any drift.

### Why `heading-md` and not a body variant

Within the heading family the non-uppercase options are 13/15/20/32px, and the parent `<h2>` in `backup-detail` is itself `heading-md` — so anything larger would render the nested `<h3>` bigger than the card containing it. `heading-md` is the only heading variant that is neither uppercase nor larger than its parent.

Against `body-md`/`body-sm`: the tree row beside the card renders the same filename at 13px/400. `body-md` would make the card *title* pixel-identical to a tree *row*, and `body-sm` would make it smaller than the row it names. `heading-md` matches the row's size and separates by weight.

**No SCSS.** The issue suggested "`body-sm` plus a local weight". An earlier draft of this body justified skipping that by a collision with [JETPACK-2506](https://linear.app/a8c/issue/JETPACK-2506) — that was wrong, since 2506 only touches `&__code` and the title lives in the header. The real reason is simply that a variant already carrying the right weight beats a component overriding a token it does not mean.

**The cost, stated plainly:** the `<h3>` now renders at exactly its parent `<h2>`'s size, and larger than the "Files" section label between them (11px/500/uppercase, hand-rolled in `backup-detail/style.scss`). The heading scale offers nothing between 11px-uppercase and 13px, so there is no token that avoids this. The cleaner long-term fix is making that label a real `heading-sm` rather than changing the card — worth a follow-up, not worth blocking an uppercase filename on.

Line-height goes 16px → 20px, which still clears the 24px `size="small"` close button the header row is centred against, so nothing moves.

### On the absent test

Under jest the variant stylesheet is never injected — `text.mjs` guards `registerStyle` on `NODE_ENV !== 'test'` — so no computed-style assertion is reachable by any route.

Structural proxies *do* exist, and this package uses them elsewhere (`route-styles-include-admin-shell.test.ts` greps SCSS; `heading-outline.test.tsx` reads tag selectors). I skipped one here because the only available guard pins the *variant name* rather than the absence of the transform, which is a weaker thing than it looks. That is a trade, not an impossibility — flagging it so the choice is reviewable. Verified in a browser instead.

## Related product discussion/links

* [JETPACK-2503](https://linear.app/a8c/issue/JETPACK-2503) — filed from the pre-flip sweep

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

At **Jetpack → Backup**, open any backup, expand the file browser and click a file with lowercase or mixed-case letters — `readme.html`, `wp-config.php`, `.htaccess`. The card title should read exactly as the tree row does. Compare against the row beside it, which was already correct.

The dialog chrome on a narrow panel was already fine — `Dialog.Title` hardcodes `heading-xl`, which has no transform — so this is card-only.

**Automated:** `jp test js packages/backup` — 856 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy

