### PR TITLE
Backup: wrap the file preview instead of scrolling it sideways

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2506-backup-preview-wraps
+++ b/projects/packages/backup/changelog/jetpack-2506-backup-preview-wraps
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: wrap long lines in the file preview so they stay readable instead of scrolling sideways. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -46,9 +46,9 @@
 		// `anywhere` breaks the unbroken runs — minified JS, base64 — that
 		// `pre-wrap` alone will not.
 		overflow-wrap: anywhere;
-		// The scroller stays here rather than on the panel, which is
-		// `overflow-x: hidden`: an RTL panel cannot scroll to a `dir="ltr"`
-		// box's inline-start overflow.
+		// Belt behind the wrapping, and it lives here rather than on the
+		// card's panel (`overflow-x: hidden`): an RTL panel cannot scroll to
+		// a `dir="ltr"` box's inline-start overflow.
 		overflow-x: auto;
 		color: var(--wp-components-color-foreground, #1e1e1e);
 	}

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -42,10 +42,12 @@
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 		font-size: 12px;
 		line-height: 1.5;
-		white-space: pre;
-		// The `<pre>` is `dir="ltr"`, so inside an RTL panel it overflows past
-		// the panel's inline-start edge, which Chrome never makes scrollable.
-		overflow-x: auto;
+		// Wrapping rather than a horizontal scroller: the `<pre>` is `dir="ltr"`,
+		// so inside an RTL panel it overflowed past the panel's inline-start
+		// edge, which Chrome never makes scrollable. `anywhere` catches the
+		// unbroken runs — minified JS, base64 — that `pre-wrap` alone would not.
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
 		color: var(--wp-components-color-foreground, #1e1e1e);
 	}
 }

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -42,12 +42,14 @@
 		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 		font-size: 12px;
 		line-height: 1.5;
-		// Wrapping rather than a horizontal scroller: the `<pre>` is `dir="ltr"`,
-		// so inside an RTL panel it overflowed past the panel's inline-start
-		// edge, which Chrome never makes scrollable. `anywhere` catches the
-		// unbroken runs — minified JS, base64 — that `pre-wrap` alone would not.
 		white-space: pre-wrap;
+		// `anywhere` breaks the unbroken runs — minified JS, base64 — that
+		// `pre-wrap` alone will not.
 		overflow-wrap: anywhere;
+		// The scroller stays here rather than on the panel, which is
+		// `overflow-x: hidden`: an RTL panel cannot scroll to a `dir="ltr"`
+		// box's inline-start overflow.
+		overflow-x: auto;
 		color: var(--wp-components-color-foreground, #1e1e1e);
 	}
 }

--- a/projects/packages/backup/src/dashboard/components/file-info-dialog/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-dialog/index.tsx
@@ -76,11 +76,7 @@ export default function FileInfoDialog( { file, onClose }: Props ) {
 				</Dialog.Header>
 				<Dialog.Content className="jpb-file-info-dialog__body">
 					<FileInfoMeta modified={ modified } size={ size } mimeType={ mimeType } hash={ hash } />
-					{ /*
-					 * The gray surface has to be the scrollport, not the `<pre>`: a
-					 * `<pre>` that only paints a background lets long lines render
-					 * past it, onto a `Dialog.Content` that clips without scrolling.
-					 */ }
+					{ /* Focusable because `handleReveal` hands focus here. */ }
 					<div
 						ref={ previewRef }
 						className="jpb-file-info-dialog__preview"

--- a/projects/packages/backup/tests/file-browser-narrow-preview.test.tsx
+++ b/projects/packages/backup/tests/file-browser-narrow-preview.test.tsx
@@ -230,8 +230,8 @@ it( 'measures the menu by the room it takes, not the edge it takes it from', asy
 	expect( popup.style.getPropertyValue( '--jpb-admin-menu-width' ) ).toBe( '160px' );
 } );
 
-// A scrollport nothing can focus cannot be scrolled by keyboard, and long code
-// lines are the whole reason the dialog exists.
+// The reveal click unmounts the button holding focus, and this region is where
+// the dialog hands it back.
 it( 'gives the dialog preview a named region focus can enter, as the card has', async () => {
 	panel = mockPanelWidth( 480 );
 


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2506](https://linear.app/a8c/issue/JETPACK-2506), split out of [JETPACK-2499](https://linear.app/a8c/issue/JETPACK-2499) during review of [#51964](https://github.com/Automattic/jetpack/pull/51964).

## Proposed changes

The preview `<pre>` had `white-space: pre`, so any line wider than the panel forced a horizontal scroller across the whole preview. It now wraps.

```diff
-		white-space: pre;
+		white-space: pre-wrap;
+		overflow-wrap: anywhere;
 		overflow-x: auto;
```

`pre-wrap` keeps the indentation and newlines that make a config file readable, and adds soft wrapping. `overflow-wrap: anywhere` covers what `pre-wrap` alone will not — a minified JS bundle or a base64 blob is one unbroken run with no wrap opportunity, and those are the files where sideways scrolling was worst.

### `overflow-x: auto` stays

An earlier revision deleted it as unreachable code, on backwards reasoning. Short version, since the durable home for this is the SCSS comment:

[#51962](https://github.com/Automattic/jetpack/pull/51962) made a **pair** of edits, not one:

```diff
 &__preview {              // the panel
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
 &__code {                 // the <pre>
+  overflow-x: auto;
```

The unscrollable box was the *panel*, not the `<pre>`. An LTR `<pre>` overflows at the physical right; inside an RTL panel that is the container's inline-**start**, which Chrome leaves out of the scrollable overflow region entirely — measured there as `scrollWidth === clientWidth`. Moving the scrollport onto the `dir="ltr"` `<pre>` makes the same physical overflow that box's inline-**end**, and therefore reachable. The panel was demoted to `overflow-x: hidden` in the same breath *because* the `<pre>` had taken the job over.

So the scroller was for RTL specifically, and deleting it while leaving the panel at `overflow-x: hidden` would have left anything that still overflowed clipped with no way to reach it — reintroducing the exact bug #51962 fixed. Wrapping makes it redundant, not wrong; with `pre-wrap` + `anywhere` it should never paint, and it costs nothing to keep as the card chrome's only horizontal escape.

The dialog's own `&__preview { overflow-x: auto }` stays, but **not** because it is that chrome's only horizontal scroller — an earlier draft of this body said so and was wrong. The dialog renders the same `.jpb-file-info__code`, which carries its own `overflow-x: auto`, so that chrome has two nested horizontal scrollports and after this change neither can engage. It is belt-and-braces behind the `<pre>`'s own scroller. Recording the correction so the next edit does not act on the wrong reason.

### On the absent test

`jest/config.base.js` maps `.scss` to a stub, so no stylesheet reaches jsdom and `getComputedStyle` can never observe wrapping. The only proxy is the class name, which asserts nothing. Verified in a browser instead.

## Related product discussion/links

* [JETPACK-2506](https://linear.app/a8c/issue/JETPACK-2506)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

At **Jetpack → Backup**, open a backup's file browser and preview a file with long lines — a minified `.js`, or any `.php` with a long single-line array. The preview should wrap inside the panel with no horizontal scrollbar and no content cut off at either edge.

Check three ways:
* **Wide panel** (card beside the tree) and **narrow panel** (dialog chrome) — both render the same `<pre>`.
* **RTL** (`العربية`) — nothing should sit past the panel's leading edge.

> **On testing the RTL scroller:** "no horizontal scrollbar appears" is now unfalsifiable — after `pre-wrap` + `anywhere` no file can produce one, so seeing none proves nothing about whether the scroller #51962 added still works. The only way to exercise it during a manual pass is to comment out the two wrapping declarations first. Flagging it so the box is not ticked on absent evidence.
* Indentation should still be preserved; `pre-wrap` is not `normal`.

**Automated:** `jp test js packages/backup` — 856 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy


