### PR TITLE
Backup: cover the sensitive-preview gate on the dialog chrome

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2474-backup-dialog-gate-coverage
+++ b/projects/packages/backup/changelog/jetpack-2474-backup-dialog-gate-coverage
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Test-only: cover the sensitive-file preview gate on the modernized dashboard's dialog chrome. No behaviour change.
+Comment: Test-only: cover the sensitive-file preview gate on the modernized dashboard's dialog chrome. No behavior change.
 
 

--- a/projects/packages/backup/changelog/jetpack-2474-backup-dialog-gate-coverage
+++ b/projects/packages/backup/changelog/jetpack-2474-backup-dialog-gate-coverage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: cover the sensitive-file preview gate on the modernized dashboard's dialog chrome. No behaviour change.
+
+

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -22,6 +22,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FileInfoCard from '../src/dashboard/components/file-info-card';
+import FileInfoDialog from '../src/dashboard/components/file-info-dialog';
 import { queryClient } from '../src/dashboard/data/query-client';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
 import type { FileNodeFile } from '../src/dashboard/types/file-tree';
@@ -108,6 +109,20 @@ function renderCard( file: FileNodeFile ) {
 	return render(
 		<QueryClientProvider>
 			<FileInfoCard file={ file } onClose={ noop } />
+		</QueryClientProvider>
+	);
+}
+
+/**
+ * Render one file's dialog, the chrome a panel too narrow for the card uses.
+ *
+ * @param file - The file node to open.
+ * @return The Testing Library render result.
+ */
+function renderDialog( file: FileNodeFile ) {
+	return render(
+		<QueryClientProvider>
+			<FileInfoDialog file={ file } onClose={ noop } />
 		</QueryClientProvider>
 	);
 }
@@ -353,5 +368,29 @@ describe( 'sensitive preview gate', () => {
 		await expect( screen.findByText( HIDDEN ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
 		expect( fetchedContent() ).toBe( false );
+	} );
+} );
+
+// The dialog arrived after this gate did, and shares only the hook. Nothing
+// asserted the gate reached the second chrome until this.
+describe( 'the dialog chrome', () => {
+	it( 'gates a sensitive file there too, and still withholds the fetch', async () => {
+		mockEndpoints( SECRET );
+
+		renderDialog( fileAt( '/wp-config.php' ) );
+
+		await expect( screen.findByText( HIDDEN ) ).resolves.toBeVisible();
+		expect( screen.getByRole( 'button', { name: SHOW } ) ).toBeVisible();
+		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+		expect( fetchedContent() ).toBe( false );
+	} );
+
+	it( 'reveals on a second click, as the card does', async () => {
+		mockEndpoints( SECRET );
+
+		renderDialog( fileAt( '/wp-config.php' ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+
+		await expect( screen.findByText( SECRET ) ).resolves.toBeVisible();
 	} );
 } );

--- a/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
+++ b/projects/packages/backup/tests/sensitive-preview-gate.test.tsx
@@ -27,7 +27,7 @@ import { queryClient } from '../src/dashboard/data/query-client';
 import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
 import type { FileNodeFile } from '../src/dashboard/types/file-tree';
 
-/** Closing is irrelevant to these assertions; the card renders regardless. */
+/** Closing is irrelevant to these assertions; both chromes render regardless. */
 const noop = () => {};
 
 // Not a real credential — a marker whose only job is to be searched for.
@@ -369,28 +369,38 @@ describe( 'sensitive preview gate', () => {
 		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
 		expect( fetchedContent() ).toBe( false );
 	} );
-} );
 
-// The dialog arrived after this gate did, and shares only the hook. Nothing
-// asserted the gate reached the second chrome until this.
-describe( 'the dialog chrome', () => {
-	it( 'gates a sensitive file there too, and still withholds the fetch', async () => {
-		mockEndpoints( SECRET );
+	// The dialog shares only `useFileInfo` with the card, so the two surfaces
+	// can diverge without either one failing.
+	describe( 'the dialog chrome', () => {
+		it( 'gates a sensitive file there too, and still withholds the fetch', async () => {
+			mockEndpoints( SECRET );
 
-		renderDialog( fileAt( '/wp-config.php' ) );
+			renderDialog( WP_CONFIG );
 
-		await expect( screen.findByText( HIDDEN ) ).resolves.toBeVisible();
-		expect( screen.getByRole( 'button', { name: SHOW } ) ).toBeVisible();
-		expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
-		expect( fetchedContent() ).toBe( false );
-	} );
+			// The heading level is what separates the two chromes; without it
+			// `HIDDEN` alone would pass for a dialog delegating to the card.
+			await expect( screen.findByRole( 'dialog' ) ).resolves.toBeInTheDocument();
+			expect(
+				screen.getByRole( 'heading', { level: 2, name: 'wp-config.php' } )
+			).toBeInTheDocument();
 
-	it( 'reveals on a second click, as the card does', async () => {
-		mockEndpoints( SECRET );
+			expect( screen.getByText( HIDDEN ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'button', { name: SHOW } ) ).toBeInTheDocument();
+			expect( screen.queryByText( SECRET ) ).not.toBeInTheDocument();
+			expect( fetchedContent() ).toBe( false );
+		} );
 
-		renderDialog( fileAt( '/wp-config.php' ) );
-		await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+		it( 'reveals on a second click and hands focus to the preview, as the card does', async () => {
+			mockEndpoints( SECRET );
 
-		await expect( screen.findByText( SECRET ) ).resolves.toBeVisible();
+			renderDialog( WP_CONFIG );
+			await userEvent.click( await screen.findByRole( 'button', { name: SHOW } ) );
+
+			await expect( screen.findByText( SECRET ) ).resolves.toBeInTheDocument();
+			await waitFor( () =>
+				expect( screen.getByRole( 'region', { name: /Preview of wp-config.php/ } ) ).toHaveFocus()
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #

Test-only. Closes a coverage gap found while rebasing [#51954](https://github.com/Automattic/jetpack/pull/51954) — refs [JETPACK-2474](https://linear.app/a8c/issue/JETPACK-2474), which is already Done.

## Proposed changes

The sensitive-file reveal gate has two preview surfaces and only one of them was tested.

[#51964](https://github.com/Automattic/jetpack/pull/51964) added `FileInfoDialog` as the chrome for panels too narrow to hold the card beside the tree. It arrived **after** the gate did, and the two share nothing but the `useFileInfo` hook. The gate tests exercise `FileInfoCard`; the dialog tests ([`file-browser-narrow-preview`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/backup/tests/file-browser-narrow-preview.test.tsx)) exercise chrome selection, focus return and admin-menu offset. Nothing covered the intersection — a security gate on a surface that did not exist when the gate was written.

The wiring is in fact correct: the dialog imports the same hook and hands `awaitingReveal` to the shared `PreviewBody`. That is a property worth pinning rather than rediscovering.

Two cases, mirroring the card's:

* a sensitive file shows the reveal prompt, does not render the secret, **and does not fetch it** — the withheld-fetch property [#51868](https://github.com/Automattic/jetpack/pull/51868) established
* the second click reveals, exercising the dialog's own `handleReveal` and its focus move

### That the tests can fail

Pointing the dialog's `awaitingReveal` at `false` reddens exactly these two and nothing else:

```
● the dialog chrome › gates a sensitive file there too, and still withholds the fetch
● the dialog chrome › reveals on a second click and hands focus to the preview, as the card does
Tests: 2 failed, 31 passed, 33 total
```

They render `FileInfoDialog` directly, matching how the rest of the file renders `FileInfoCard`, so they need none of the `ResizeObserver` machinery the chrome-selection tests do.

## Related product discussion/links

* [JETPACK-2474](https://linear.app/a8c/issue/JETPACK-2474) — the gate these cover

## Does this pull request change what data or activity we track or use?

No — test-only.

## Testing instructions

`jp test js packages/backup` — 858 tests, all passing.

To confirm the coverage is real rather than incidental, edit `file-info-dialog/index.tsx` to pass `awaitingReveal={ false }` to `<PreviewBody>` and re-run: the two new cases fail, everything else stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy

