### PR TITLE
Backup: stop a background refetch blurring the reader out of the list

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2535-backup-activity-list-inert-focus
+++ b/projects/packages/backup/changelog/jetpack-2535-backup-activity-list-inert-focus
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: keep the activity rows reachable while a finished backup refreshes the list, instead of dropping keyboard focus. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -138,12 +138,21 @@ function DescriptionCell( { item }: { item: ActivityItem } ) {
  */
 export default function ActivityList( { selectedId, onSelect, view, onChangeView }: Props ) {
 	const { page, pageSize, sortOrder } = activityQueryArgs( view );
-	const { items, totalItems, totalPages, isLoading, isFetching, isPaused, error, refetch } =
-		useActivityLog( {
-			page,
-			pageSize,
-			sortOrder,
-		} );
+	const {
+		items,
+		totalItems,
+		totalPages,
+		isLoading,
+		isFetching,
+		isPlaceholderData,
+		isPaused,
+		error,
+		refetch,
+	} = useActivityLog( {
+		page,
+		pageSize,
+		sortOrder,
+	} );
 
 	// DataViews' `SortDirectionControl` spreads `...view` and replaces only
 	// `sort`, so without this a reorder strands the reader on page 3 of an
@@ -248,10 +257,14 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 	// This cannot swallow the `empty` slot: DataViews initialises
 	// `hasInitiallyLoaded` to `!isLoading` and latches it true on the first
 	// non-loading render, and the spinner branch that would replace the
-	// `empty` slot is gated on `!hasInitiallyLoaded`. Past the first load a
-	// truthy `isLoading` only reaches the footer, which marks itself inert
-	// while the next page is fetched.
-	const isBusy = isLoading || isFetching;
+	// `empty` slot is gated on `!hasInitiallyLoaded`.
+	//
+	// Placeholder data is the qualifier, not `isFetching` alone: DataViews
+	// puts `inert` on the composite that owns every row, so reporting a
+	// background refetch — the one a finished backup triggers — would blur
+	// the reader out of the list mid-read. A page or sort change is the
+	// reader's own action and their focus is on the control they used.
+	const isBusy = isLoading || ( isFetching && isPlaceholderData );
 
 	return (
 		<Card.Root className="jpb-activity-list" aria-busy={ isBusy }>

--- a/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/activity-list/index.tsx
@@ -262,8 +262,10 @@ export default function ActivityList( { selectedId, onSelect, view, onChangeView
 	// Placeholder data is the qualifier, not `isFetching` alone: DataViews
 	// puts `inert` on the composite that owns every row, so reporting a
 	// background refetch — the one a finished backup triggers — would blur
-	// the reader out of the list mid-read. A page or sort change is the
-	// reader's own action and their focus is on the control they used.
+	// the reader out of the list mid-read. A page or sort change still
+	// inerts them, and the footer's own copy of this flag inerts the
+	// control the reader just used; DataViews offers no way to separate
+	// those, so that case is unchanged rather than fixed.
 	const isBusy = isLoading || ( isFetching && isPlaceholderData );
 
 	return (

--- a/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-activity-log.ts
@@ -33,6 +33,12 @@ type Result = {
 	 */
 	isFetching: boolean;
 	/**
+	 * True while `keepPreviousData` is standing in for a key that has not
+	 * answered yet — so it separates a page or sort change, which the reader
+	 * asked for, from a background refetch, which they did not.
+	 */
+	isPlaceholderData: boolean;
+	/**
 	 * True when React Query parked the request instead of sending it, which
 	 * `networkMode: 'online'` does for an offline browser. Neither fetching nor
 	 * errored — so callers that read an absence as an answer need this to tell
@@ -140,6 +146,7 @@ export function useActivityLog( { page, pageSize, sortOrder }: Args ): Result {
 		totalPages,
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
+		isPlaceholderData: query.isPlaceholderData,
 		isPaused: query.isPaused,
 		error,
 		refetch: retry,

--- a/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
+++ b/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
@@ -1,0 +1,128 @@
+// JETPACK-2535 — DataViews puts `inert` on the composite that owns every row,
+// so what the list reports as loading decides whether a reader keeps their place.
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+// Imports must come after the jest.mock factory above.
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import ActivityList from '../src/dashboard/components/activity-list';
+import { keys, queryClient } from '../src/dashboard/data/query-client';
+import QueryClientProvider from '../src/dashboard/providers/query-client-provider';
+import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
+import type { View } from '@wordpress/dataviews';
+
+const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
+const SETTLE = { timeout: 10000 };
+
+const row = ( id: string ) => ( {
+	activity_id: id,
+	name: 'rewind__backup_complete_full',
+	gridicon: 'cloud',
+	rewind_id: id,
+	published: '2026-08-20T10:00:00+00:00',
+	summary: `Backup ${ id }`,
+	is_rewindable: true,
+} );
+
+const PAGE = { current: { orderedItems: [ row( '1786600000' ) ] }, totalItems: 40, totalPages: 4 };
+
+/**
+ * Whether the rows' own container is inert. The footer carries its own.
+ *
+ * @return True while the rows are out of the accessibility tree.
+ */
+function rowsAreInert(): boolean {
+	return !! document.querySelector( '.dataviews-view-list[inert], [role="grid"][inert]' );
+}
+
+/** No-op selection handler; these tests never act on a choice. */
+function noop() {}
+
+/**
+ * Render the list in controlled state, so its own pagination drives the view.
+ *
+ * @return The rendered list.
+ */
+function ListHarness() {
+	const [ view, setView ] = useState< View >( INITIAL_VIEW );
+	return (
+		<ActivityList selectedId={ null } onSelect={ noop } view={ view } onChangeView={ setView } />
+	);
+}
+
+/**
+ * Hold the next response open so an in-flight fetch can be observed.
+ *
+ * @return A function that releases the held response.
+ */
+function freezeNextFetch(): ( value: unknown ) => void {
+	let release: ( value: unknown ) => void = () => {};
+	mockApiFetch.mockImplementationOnce(
+		() =>
+			new Promise( resolve => {
+				release = resolve;
+			} )
+	);
+	return ( value: unknown ) => release( value );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	mockApiFetch.mockReset();
+	mockApiFetch.mockResolvedValue( PAGE );
+	window.JP_CONNECTION_INITIAL_STATE = {
+		connectionStatus: CONNECTED,
+	} as unknown as typeof window.JP_CONNECTION_INITIAL_STATE;
+} );
+
+it( 'keeps the rows reachable through a background refetch', async () => {
+	render(
+		<QueryClientProvider>
+			<ListHarness />
+		</QueryClientProvider>
+	);
+	await expect(
+		screen.findByRole( 'button', { name: /^Backup 1786600000/ }, SETTLE )
+	).resolves.toBeInTheDocument();
+
+	const release = freezeNextFetch();
+	await act( async () => {
+		queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
+	} );
+	await waitFor( () => expect( mockApiFetch.mock.calls.length ).toBeGreaterThan( 1 ) );
+
+	// The refetch is in flight right now — this is the window that used to
+	// blur a reader out of the list.
+	expect( rowsAreInert() ).toBe( false );
+
+	await act( async () => {
+		release( PAGE );
+	} );
+} );
+
+it( 'still reports the page change the reader asked for', async () => {
+	render(
+		<QueryClientProvider>
+			<ListHarness />
+		</QueryClientProvider>
+	);
+	await expect(
+		screen.findByRole( 'button', { name: /^Backup 1786600000/ }, SETTLE )
+	).resolves.toBeInTheDocument();
+
+	const release = freezeNextFetch();
+	await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
+	await waitFor( () => expect( rowsAreInert() ).toBe( true ) );
+
+	await act( async () => {
+		release( PAGE );
+	} );
+} );

--- a/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
+++ b/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
@@ -75,7 +75,9 @@ function freezeNextFetch(): ( value: unknown ) => void {
 
 beforeEach( () => {
 	queryClient.clear();
-	queryClient.setDefaultOptions( { queries: { retry: false } } );
+	queryClient.setDefaultOptions( {
+		queries: { ...queryClient.getDefaultOptions().queries, retry: false },
+	} );
 	mockApiFetch.mockReset();
 	mockApiFetch.mockResolvedValue( PAGE );
 	window.JP_CONNECTION_INITIAL_STATE = {
@@ -93,11 +95,14 @@ it( 'keeps the rows reachable through a background refetch', async () => {
 		screen.findByRole( 'button', { name: /^Backup 1786600000/ }, SETTLE )
 	).resolves.toBeInTheDocument();
 
+	// Mount fires two queries of its own, so only a rise from here proves
+	// the invalidation's refetch is the one in flight below.
+	const before = mockApiFetch.mock.calls.length;
 	const release = freezeNextFetch();
 	await act( async () => {
 		queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
 	} );
-	await waitFor( () => expect( mockApiFetch.mock.calls.length ).toBeGreaterThan( 1 ) );
+	await waitFor( () => expect( mockApiFetch.mock.calls.length ).toBeGreaterThan( before ) );
 
 	// The refetch is in flight right now — this is the window that used to
 	// blur a reader out of the list.

--- a/projects/packages/backup/tests/stale-rows-feedback.test.tsx
+++ b/projects/packages/backup/tests/stale-rows-feedback.test.tsx
@@ -9,14 +9,10 @@
 // just left. Clicking to page 2 changed nothing on screen until the
 // response landed.
 //
-// The fix reports `isLoading || isFetching`. That it cannot swallow the
-// error state is not obvious and is worth stating: DataViews 17.3.0
-// initialises `hasInitiallyLoaded` to `!isLoading` and latches it true
-// on the first non-loading render, and the spinner branch that would
-// replace the `empty` slot — where `QueryError` lives — is gated on
-// `!hasInitiallyLoaded`. After the first load that branch is dead, so a
-// truthy `isLoading` only reaches the footer. What the error slot does
-// across a retry is held by `error-persists-during-retry.test.tsx`.
+// What the list reports, and why it cannot swallow the error slot, is
+// owned by the comment on `isBusy` in `activity-list/index.tsx`. What the
+// error slot does across a retry is held by
+// `error-persists-during-retry.test.tsx`.
 
 const mockApiFetch = jest.fn();
 


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2535](https://linear.app/a8c/issue/JETPACK-2535). Found in second-round accessibility review of [#52016](https://github.com/Automattic/jetpack/pull/52016); pre-existing on trunk.

## Proposed changes

A keyboard or screen-reader user reading down the activity list lost their place whenever a backup finished.

`activity-list/index.tsx` reported `isLoading || isFetching` to DataViews. In `@wordpress/dataviews@18.1.0`'s list layout that flag lands on `compositeProps` — **the composite that owns every row** — as `inert`, and marking an ancestor inert blurs the focused element to `<body>` with no announcement.

The trigger is not hypothetical: `refetchOnWindowFocus` is off, so the live one is `useRefreshActivityOnBackupComplete` invalidating the log when a backup completes — exactly when someone is likely to be on the page watching it.

### The comment that was load-bearing, and wrong

The rationale in the code said:

> Past the first load a truthy `isLoading` only reaches the footer, which marks itself inert while the next page is fetched.

The footer *does* inert itself, but on `isRefreshing`, which DataViews derives internally. The `isLoading` prop separately inerts the rows. So the justification for widening to `isFetching` described a consequence that was only half of what it did.

### Why not simply pass `isLoading`

Because the rest of that comment is right: `placeholderData: keepPreviousData` keeps the previous rows on a page change, so React Query is "not pending" and plain `isLoading` tells DataViews nothing is happening while the reader looks at the page they just left. Dropping to `isLoading` would fix the focus theft by reintroducing that.

DataViews exposes one flag for both, so the fix is to qualify *which* fetch gets reported:

```ts
const isBusy = isLoading || ( isFetching && isPlaceholderData );
```

`isPlaceholderData` is true precisely while `keepPreviousData` stands in for a key that has not answered — a page or sort change, which the reader asked for and during which their focus is on the control they used. A background invalidation refetches the *same* key, so it is false, and the rows stay reachable.

## Related product discussion/links

* [JETPACK-2535](https://linear.app/a8c/issue/JETPACK-2535)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

**Automated** — `jp test js packages/backup` (858). `tests/activity-list-busy-scope.test.tsx` holds a response open to observe the in-flight window. Restore `isBusy` to `isLoading || isFetching` and the first case reddens with `Expected: false, Received: true`; the second passes either way, which is the guard against over-correcting into "never report busy".

**By hand** — at **Jetpack → Backup**, Tab into the activity rows and leave focus on one. Trigger **Back up now** and wait for it to finish, which invalidates the log. Focus should stay on the row; before this it jumped to the top of the document. Then click **Next page** and confirm the list still dims and the pagination still goes inert while the page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy
