### PR TITLE
Backup: keep the file-info close button inside the card

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2536-backup-file-info-header-shrink
+++ b/projects/packages/backup/changelog/jetpack-2536-backup-file-info-header-shrink
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the rsm_jetpack_ui_modernization_backup filter: keep the file details close button reachable when the filename is long. No-op when the filter is off.
+
+

--- a/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/index.tsx
@@ -73,11 +73,12 @@ export default function FileInfoCard( { file, onClose }: Props ) {
 				justify="space-between"
 				className="jpb-file-info-card__header"
 			>
-				<Text variant="heading-md" render={ <h3 /> }>
+				<Text variant="heading-md" className="jpb-file-info-card__header-title" render={ <h3 /> }>
 					{ /* A filename is LTR data even on an RTL page. */ }
 					<span dir="ltr">{ file.name }</span>
 				</Text>
 				<Button
+					className="jpb-file-info-card__header-close"
 					variant="minimal"
 					tone="neutral"
 					size="small"

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -63,6 +63,18 @@
 	&__header {
 		padding-bottom: 8px;
 		border-bottom: 1px solid var(--wp-components-color-gray-200, #e0e0e0);
+
+		// A filename offers no break opportunity at `.` or `_`, so at the
+		// card's fixed 280px track a long stem pushes the close button past
+		// `Card.Root`'s `overflow: clip` and out of reach of the mouse.
+		> :first-child {
+			min-width: 0;
+			overflow-wrap: anywhere;
+		}
+
+		> :last-child {
+			flex-shrink: 0;
+		}
 	}
 
 	&__preview {

--- a/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-card/style.scss
@@ -63,18 +63,17 @@
 	&__header {
 		padding-bottom: 8px;
 		border-bottom: 1px solid var(--wp-components-color-gray-200, #e0e0e0);
+	}
 
-		// A filename offers no break opportunity at `.` or `_`, so at the
-		// card's fixed 280px track a long stem pushes the close button past
-		// `Card.Root`'s `overflow: clip` and out of reach of the mouse.
-		> :first-child {
-			min-width: 0;
-			overflow-wrap: anywhere;
-		}
+	// Filenames offer no break at `.` or `_`, so a long stem pushes the close
+	// button past `Card.Root`'s `overflow: clip` and out of reach.
+	&__header-title {
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
 
-		> :last-child {
-			flex-shrink: 0;
-		}
+	&__header-close {
+		flex-shrink: 0;
 	}
 
 	&__preview {

--- a/projects/packages/backup/src/dashboard/components/file-info-dialog/index.tsx
+++ b/projects/packages/backup/src/dashboard/components/file-info-dialog/index.tsx
@@ -69,7 +69,7 @@ export default function FileInfoDialog( { file, onClose }: Props ) {
 				style={ { '--jpb-admin-menu-width': `${ adminMenuWidth }px` } as CSSProperties }
 			>
 				<Dialog.Header>
-					<Dialog.Title>
+					<Dialog.Title className="jpb-file-info-dialog__title">
 						<span dir="ltr">{ file.name }</span>
 					</Dialog.Title>
 					<Dialog.CloseIcon label={ __( 'Close preview', 'jetpack-backup-pkg' ) } />

--- a/projects/packages/backup/src/dashboard/components/file-info-dialog/style.scss
+++ b/projects/packages/backup/src/dashboard/components/file-info-dialog/style.scss
@@ -15,6 +15,13 @@
 		}
 	}
 
+	// Same shape as the card's header, in the chrome that has less room:
+	// `Dialog.Header`'s close icon cannot shrink, and `.popup` hides overflow.
+	&__title {
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+
 	&__body {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
Fixes #

Fixes [JETPACK-2536](https://linear.app/a8c/issue/JETPACK-2536). Found in second-round visual review of [#52017](https://github.com/Automattic/jetpack/pull/52017); pre-existing on trunk.

## Proposed changes

A long filename with no break opportunity could push the file-info card's close button out of the card entirely — leaving the card **unclosable by mouse**.

The header is a flex row with `justify-content: space-between` and no gap. The `<h3>` is a flex item at the default `min-width: auto`, so it cannot shrink below its longest **unbreakable** run — and filenames break at `-` (UAX #14 class HY) but not at `.` or `_`. Past ~203px of title space, `space-between` degrades to `flex-start`, the button is pushed out, and `Card.Root`'s `overflow: clip` cuts it off.

The card column is fixed: `file-browser/style.scss` sizes it `minmax(0, 280px)`, and below a 640px panel the dialog renders instead — so there is no narrower state, and no wider one either. 280px is the only case.

This is the guard `backup-detail/style.scss` already carries one component up (`&__header-title { min-width: 0; flex: 1 1 auto; }`); the card header is the same pattern without it.

## Measured, on the built dashboard

With `a3f5c9e1b7d2486fa0c4e8b1d637902f5ac8e14b.log` (44 unbreakable characters) as the filename:

| | close button right edge | card right edge | |
| --- | --- | --- | --- |
| without the guard | 1525px | 1484px | **41px outside — clipped** |
| with the guard | 1467px | 1484px | inside |

No jest test can cover this — jsdom performs no layout — so the numbers above are the evidence. The close button measures 46px wide, not the 24px its `size="small"` height suggests.

## Related product discussion/links

* [JETPACK-2536](https://linear.app/a8c/issue/JETPACK-2536)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind `rsm_jetpack_ui_modernization_backup`, **off by default**:

```php
add_filter( 'jetpack_feature_flag_enabled_rsm_jetpack_ui_modernization_backup', '__return_true' );
```

At **Jetpack → Backup**, open a backup and widen the window until the file details render as a **card beside the tree** rather than a dialog — the split is at a 640px panel. Open any file, then rename the title in devtools to something with a long unbreakable stem (a 40-character hash plus an extension):

* The title should wrap inside the card.
* The **×** button should stay on the first line, at the card's trailing edge, and stay clickable.

Worth a pass in RTL too — the guard uses no physical properties, and the button should sit at the leading edge there.

Real filenames of this shape do occur: dated SQL dumps, hash-named logs, and `wp-content/uploads` originals with long slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkqeJ4gcSKCLJKsdmvxfKy
