### PR TITLE
AI Assistant: Point the WordPress Agent notice at the "Agent" button

### DIFF
--- a/projects/plugins/jetpack/changelog/update-wordpress-agent-notice-button-label
+++ b/projects/plugins/jetpack/changelog/update-wordpress-agent-notice-button-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Assistant: Update the WordPress Agent notice to point at the "Agent" button.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -255,7 +255,7 @@ const DEFAULT_FEATURES = [
 const withFeatures = ( features: string[] ) =>
 	jest.mocked( getFeatureAvailability ).mockImplementation( f => features.includes( f ) );
 const AGENT_NOTICE_TEXT =
-	'AI tools have moved to the WordPress Agent. Look for the "Ask AI" button at the top of the screen.';
+	'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.';
 
 describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -255,7 +255,7 @@ const DEFAULT_FEATURES = [
 const withFeatures = ( features: string[] ) =>
 	jest.mocked( getFeatureAvailability ).mockImplementation( f => features.includes( f ) );
 const AGENT_NOTICE_TEXT =
-	'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.';
+	'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.';
 
 describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/index.test.tsx
@@ -254,8 +254,9 @@ const DEFAULT_FEATURES = [
 ];
 const withFeatures = ( features: string[] ) =>
 	jest.mocked( getFeatureAvailability ).mockImplementation( f => features.includes( f ) );
+const AGENT_NOTICE_START = 'AI tools have moved';
 const AGENT_NOTICE_TEXT =
-	'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.';
+	'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.';
 
 describe( 'AiAssistantPluginSidebar', () => {
 	beforeEach( () => {
@@ -289,14 +290,20 @@ describe( 'AiAssistantPluginSidebar', () => {
 			render( <AiAssistantPluginSidebar /> );
 
 			expect(
-				within( screen.getByTestId( 'jetpack-sidebar' ) ).getByText( AGENT_NOTICE_TEXT )
-			).toBeInTheDocument();
+				within( screen.getByTestId( 'jetpack-sidebar' ) ).getByText( AGENT_NOTICE_START, {
+					exact: false,
+				} )
+			).toHaveTextContent( AGENT_NOTICE_TEXT );
 			expect(
-				within( screen.getByTestId( 'document-panel' ) ).getByText( AGENT_NOTICE_TEXT )
-			).toBeInTheDocument();
+				within( screen.getByTestId( 'document-panel' ) ).getByText( AGENT_NOTICE_START, {
+					exact: false,
+				} )
+			).toHaveTextContent( AGENT_NOTICE_TEXT );
 			expect(
-				within( screen.getByTestId( 'pre-publish-panel' ) ).getByText( AGENT_NOTICE_TEXT )
-			).toBeInTheDocument();
+				within( screen.getByTestId( 'pre-publish-panel' ) ).getByText( AGENT_NOTICE_START, {
+					exact: false,
+				} )
+			).toHaveTextContent( AGENT_NOTICE_TEXT );
 		} );
 
 		it( 'takes the place of the AI tools rather than sitting beside them', () => {
@@ -390,7 +397,7 @@ describe( 'AiAssistantPluginSidebar', () => {
 
 			render( <AiAssistantPluginSidebar /> );
 
-			expect( screen.queryByText( AGENT_NOTICE_TEXT ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( AGENT_NOTICE_START, { exact: false } ) ).not.toBeInTheDocument();
 			expect(
 				within( screen.getByTestId( 'document-panel' ) ).getByText( 'Get Feedback' )
 			).toBeInTheDocument();

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -112,7 +112,7 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 
 	const openAgent = () => {
 		tracks.recordEvent( 'jetpack_big_sky_agent_notice_click', eventProperties );
-		// Reset the view first, as the editor's Ask AI button does, so the chat
+		// Reset the view first, as the editor's Agent button does, so the chat
 		// always opens on the same screen however it was last left.
 		resumeWordPressAgentChat();
 		setWordPressAgentChatOpen( true );
@@ -138,9 +138,9 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 			<Notice.Description>
 				{ createInterpolateElement(
 					// translators: <icon /> is replaced with the WordPress Agent's icon, so keep the tag
-					// as written. "Ask AI" is the label on a button in the editor toolbar.
+					// as written. "Agent" is the label on a button in the editor toolbar.
 					__(
-						'AI tools have moved to the WordPress Agent. Look for the "Ask AI" <icon /> button at the top of the screen.',
+						'AI tools have moved to the WordPress Agent. Look for the "Agent" <icon /> button at the top of the screen.',
 						'jetpack'
 					),
 					{

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -140,7 +140,7 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 					// translators: <icon /> is replaced with the WordPress Agent's icon, so keep the tag
 					// as written. "Agent" is the label on a button in the editor toolbar.
 					__(
-						'AI tools have moved to the WordPress Agent. Look for the <icon /> "Agent" button at the top of the screen.',
+						'AI tools have moved to the WordPress Agent. Look for the "<icon /> Agent" button at the top of the screen.',
 						'jetpack'
 					),
 					{

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -137,9 +137,7 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 		>
 			<Notice.Description>
 				{ createInterpolateElement(
-					// translators: <icon/> is replaced with the WordPress Agent's icon and <label></label> keeps
-					// the quoted button label on one line, so keep both tags as written. "Agent" is the label
-					// on a button in the editor toolbar.
+					// translators: <icon/> is the WordPress Agent's icon. "Agent" is the label on an editor toolbar button.
 					__(
 						'AI tools have moved to the WordPress Agent. Look for the <label>"<icon/>Agent"</label> button at the top of the screen.',
 						'jetpack'

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -140,7 +140,7 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 					// translators: <icon /> is replaced with the WordPress Agent's icon, so keep the tag
 					// as written. "Agent" is the label on a button in the editor toolbar.
 					__(
-						'AI tools have moved to the WordPress Agent. Look for the "Agent" <icon /> button at the top of the screen.',
+						'AI tools have moved to the WordPress Agent. Look for the <icon /> "Agent" button at the top of the screen.',
 						'jetpack'
 					),
 					{

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/index.tsx
@@ -137,15 +137,21 @@ export default function WordPressAgentNotice( { placement }: WordPressAgentNotic
 		>
 			<Notice.Description>
 				{ createInterpolateElement(
-					// translators: <icon /> is replaced with the WordPress Agent's icon, so keep the tag
-					// as written. "Agent" is the label on a button in the editor toolbar.
+					// translators: <icon/> is replaced with the WordPress Agent's icon and <label></label> keeps
+					// the quoted button label on one line, so keep both tags as written. "Agent" is the label
+					// on a button in the editor toolbar.
 					__(
-						'AI tools have moved to the WordPress Agent. Look for the "<icon /> Agent" button at the top of the screen.',
+						'AI tools have moved to the WordPress Agent. Look for the <label>"<icon/>Agent"</label> button at the top of the screen.',
 						'jetpack'
 					),
 					{
+						label: <span style={ { whiteSpace: 'nowrap' } } />,
 						icon: (
-							<Icon icon={ bigSkyIcon } size={ 16 } style={ { verticalAlign: 'text-bottom' } } />
+							<Icon
+								icon={ bigSkyIcon }
+								size={ 16 }
+								style={ { verticalAlign: 'text-bottom', marginInlineEnd: '0.25em' } }
+							/>
 						),
 					}
 				) }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
@@ -152,11 +152,9 @@ describe( 'WordPressAgentNotice', () => {
 		it( 'still says where the AI tools went', () => {
 			render( <WordPressAgentNotice placement="document-settings" /> );
 
-			expect(
-				screen.getByText(
-					'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.'
-				)
-			).toBeInTheDocument();
+			expect( screen.getByText( 'AI tools have moved', { exact: false } ) ).toHaveTextContent(
+				'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
+			);
 		} );
 
 		it( 'offers no action it cannot carry out', () => {
@@ -195,11 +193,9 @@ describe( 'WordPressAgentNotice', () => {
 	it( 'tells the reader where the AI tools went', () => {
 		render( <WordPressAgentNotice placement="document-settings" /> );
 
-		expect(
-			screen.getByText(
-				'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.'
-			)
-		).toBeInTheDocument();
+		expect( screen.getByText( 'AI tools have moved', { exact: false } ) ).toHaveTextContent(
+			'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
+		);
 	} );
 
 	it( 'shows the Agent icon in the description, hidden from screen readers', () => {

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
@@ -154,7 +154,7 @@ describe( 'WordPressAgentNotice', () => {
 
 			expect(
 				screen.getByText(
-					'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
+					'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.'
 				)
 			).toBeInTheDocument();
 		} );
@@ -197,7 +197,7 @@ describe( 'WordPressAgentNotice', () => {
 
 		expect(
 			screen.getByText(
-				'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
+				'AI tools have moved to the WordPress Agent. Look for the " Agent" button at the top of the screen.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/wordpress-agent-notice/test/index.test.tsx
@@ -154,7 +154,7 @@ describe( 'WordPressAgentNotice', () => {
 
 			expect(
 				screen.getByText(
-					'AI tools have moved to the WordPress Agent. Look for the "Ask AI" button at the top of the screen.'
+					'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
 				)
 			).toBeInTheDocument();
 		} );
@@ -197,7 +197,7 @@ describe( 'WordPressAgentNotice', () => {
 
 		expect(
 			screen.getByText(
-				'AI tools have moved to the WordPress Agent. Look for the "Ask AI" button at the top of the screen.'
+				'AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.'
 			)
 		).toBeInTheDocument();
 	} );


### PR DESCRIPTION
Fixes #

## Proposed changes
* The WordPress Agent notice in the AI Assistant sidebar now says to look for the "Agent" button. The toolbar button was renamed from "Ask AI".

<img width="281" height="417" alt="Screenshot 2026-09-07 at 13 43 23" src="https://github.com/user-attachments/assets/1e0ea8af-366c-4a4f-bc83-e91793e44337" />

 

## Related product discussion/links
* p1788542079582249-slack-C099E99B4MR

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with the WordPress Agent, open the post editor.
* Open the Jetpack AI sidebar.
* Check the notice reads: AI tools have moved to the WordPress Agent. Look for the "Agent" button at the top of the screen.
