### PR TITLE
Premium Analytics: fix Enablement_Setting redeclare when the package is vendored twice

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-pa-enablement-setting-redeclare
+++ b/projects/packages/premium-analytics/changelog/change-pa-enablement-setting-redeclare
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard sections: stop requiring Enablement_Setting by path, which fataled on sites that vendor this package into more than one plugin.

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -14,7 +14,6 @@ require_once __DIR__ . '/dashboard-layout.php';
 require_once __DIR__ . '/dashboard-grammar.php';
 require_once __DIR__ . '/class-dashboard-section.php';
 require_once __DIR__ . '/class-dashboard-section-registry.php';
-require_once __DIR__ . '/class-enablement-setting.php';
 
 /**
  * Filter through which WooCommerce section availability is resolved.


### PR DESCRIPTION
## Proposed changes

* `dashboard-sections.php` no longer does `require_once __DIR__ . '/class-enablement-setting.php'`. The class comes from the classmap autoloader instead.

`require_once` dedupes by file path, not by class name. On WordPress.com Simple, `automattic/jetpack-premium-analytics` is vendored under both the Jetpack plugin and jetpack-mu-wpcom, so the same class file exists at two paths. `Enablement_Setting` is the only class in the package referenced from outside it (`plugins/jetpack/class.jetpack.php` and `packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php` both call `class_exists()` on it at `rest_api_init`), so it gets autoloaded from whichever copy that plugin's autoloader resolves. When `dashboard-sections.php` then runs from the other copy, line 17 loads a second file declaring the same class:

```
PHP Fatal error: Cannot redeclare class Automattic\Jetpack\PremiumAnalytics\Enablement_Setting
  (previously declared in .../jetpack-plugin/sun/.../src/class-enablement-setting.php:27)
  in .../jetpack-mu-wpcom-plugin/sun/.../src/class-enablement-setting.php on line 27
```

The line was added in #51979. Every other class in the package stays reachable only from inside it, so the remaining `require_once` calls keep all of them pinned to one copy, which is what makes the package safe to vendor twice. Removing those as well is what breaks it, see "Open questions".

## Related product discussion/links

* Found while investigating a red WordPress.com sunrise PR: 14 PHPUnit suites failed at bootstrap, all on this one fatal.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The fatal only appears when the package is present at two paths at once, so a single Jetpack install cannot show it. To reproduce:

1. Copy `projects/packages/premium-analytics/src/` to two directories, `plugin-a/src` and `plugin-b/src`.
2. Register an autoloader that resolves `Automattic\Jetpack\PremiumAnalytics\*` to `plugin-a` only. This stands in for the Jetpack plugin's autoloader winning.
3. Call `class_exists( 'Automattic\Jetpack\PremiumAnalytics\Enablement_Setting' )`, the way `class.jetpack.php` and `class-jetpack-mu-wpcom.php` both do.
4. `require_once 'plugin-b/src/dashboard-sections.php'`, the way `plugin-b`'s own `class-analytics.php` does.

On trunk step 4 fatals with the message above. With this branch it loads, and the classes resolve as expected: `Enablement_Setting` from `plugin-a`, `Dashboard_Section`, `Dashboard_Section_Registry`, `Widget_Type` and `Widget_Type_Registry` from `plugin-b`.

What I did not test: a real WordPress.com Simple site. The two-copies layout only exists there after a Jetpack sun build, so the end to end proof is the next sunrise going green rather than anything runnable from this repo.

## How it was verified

| Claim | How | Result |
|---|---|---|
| The redeclare fatal is gone | Standalone two-copies reproduction, before and after | Fatal on trunk, clean on this branch |
| No class silently moves to the other copy | Same script prints the declaring file for all five classes | Only `Enablement_Setting` resolves through the autoloader, as intended |
| Nothing else in the package regressed | `jp test php packages/premium-analytics` | Pass |
| No new static analysis or style issues | `jp phan packages/premium-analytics`, `composer phpcs:changed` | 0 issues, 0 violations |

`pnpm run lint-changed` was not run: no JS or TS files are touched.

## Findings fixed during validation

The first version of this change removed all five `require_once` calls for class files, on the reasoning that `"autoload": { "classmap": ["src/"] }` already covers them. The reproduction script showed that this does not fix the bug, it relocates it:

```
PHP Fatal error: Cannot redeclare function Automattic\Jetpack\PremiumAnalytics\get_dashboard_name_pattern()
  (previously declared in .../plugin-b/src/dashboard-grammar.php:23)
  in .../plugin-a/src/dashboard-grammar.php on line 23
```

Once `Dashboard_Section_Registry` is autoloadable it resolves to `plugin-a`, and `class-dashboard-section-registry.php` requires its own sibling `dashboard-grammar.php`, whose functions `plugin-b` had already declared. Function files cannot be autoloaded, so the explicit requires are what keep them consistent. That version was dropped for the narrow one in this PR.

## Open questions

* This fixes the reachable case, not the shape that allows it. Eleven function and const files under `src/` are still loaded by path and would each redeclare if a second copy ever reached them. Today none can, because every symbol they define is referenced only from inside the package. That invariant is not enforced anywhere, and the next class or function exported to a plugin will reintroduce this bug. Worth deciding separately whether the package should be made vendor-twice safe properly, or whether jetpack-mu-wpcom should stop shipping its own copy.
* Changelog entry is on the package only. Per AGENTS.md, what a Simple site owner notices belongs in the package entry rather than in `mu-wpcom-plugin`, and self-hosted Jetpack users cannot hit this, so `plugins/jetpack` gets no entry. Happy to add one if you read that differently.

## Stages not run

* No second reviewer pass in a separate context, and no real-site verification. Both are called out above.

## Risk: Medium

The diff is a single deleted line, the change is trivially revertible, and there is no data, schema, auth or wire-format involvement. Medium rather than Low because the first attempt at this fix was wrong in a way only the reproduction caught, and because nothing here was verified on a real WordPress.com site. The line worth a reviewer's eyes is why the other four `require_once` calls stay.
