### PR TITLE
CI: disable the new PHP 8.6 trim() PHPCompatibility rule in the dev run

### DIFF
--- a/.github/files/phpcompatibility-dev-phpcs.xml
+++ b/.github/files/phpcompatibility-dev-phpcs.xml
@@ -9,5 +9,9 @@
 		<!-- Doesn't hurt anything, earlier versions ignore attributes. -->
 		<exclude name="PHPCompatibility.Attributes.NewAttributes.Found" />
 		<exclude name="PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound" />
+
+		<!-- We're not ready for 8.6 yet, and pinning 480 call sites to the pre-8.6 character
+		     set is worse than letting them pick up \f. https://wiki.php.net/rfc/trim_form_feed -->
+		<exclude name="PHPCompatibility.ParameterValues.NewTrimCharactersDefault.NotSet" />
 	</rule>
 </ruleset>


### PR DESCRIPTION
## Proposed changes

* Excludes `PHPCompatibility.ParameterValues.NewTrimCharactersDefault.NotSet` from the PHP Compatibility dev run.

PHPCompatibility merged #2068 into `develop` on 2026-09-05, adding a sniff for PHP 8.6's change to the default `$characters` of `trim()`, `rtrim()` and `ltrim()` (it gains `\f`, see https://wiki.php.net/rfc/trim_form_feed). Our workflow installs `dev-develop` unpinned and scans the whole monorepo, so from the next run onward every PR that touches a `.php` file fails:

```
480 errors, 220 files, 37 projects
PHPCompatibility.ParameterValues.NewTrimCharactersDefault.NotSet
```

Nothing in the repo changed. Runs on 2026-09-05 before the merge passed; every run since where the job was not skipped has failed, on unrelated branches too.

This follows #36673, which disabled the 8.4 implicitly-nullable-param sniff for the same reason: the sniff is warning about a PHP version we do not support yet, and the "fix" it asks for is worse than the warning. Writing `trim( $x, " \n\r\t\v\x00" )` at 480 call sites pins every one of them to pre-8.6 behavior forever, across 37 projects and 37 changelog entries, to preserve a form feed that none of this code wants to keep. In `csstidy` it would actively be wrong: `\f` is CSS whitespace, so stripping it is the correct behavior.

Worth revisiting when Jetpack actually targets 8.6.

## Related product discussion/links

* None. CI-only change.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

CI is the test: the **dev branch for PHP 8.0** job on this PR should pass, where it fails on every other open PR that touches PHP.

To check locally, reproduce the workflow's steps from the repo root:

```bash
export COMPOSER_ROOT_VERSION=dev-trunk
composer install
composer remove --dev --no-update automattic/jetpack-codesniffer
composer require --dev --no-update "phpcompatibility/php-compatibility=dev-develop as 9.9999.9999"
composer require --dev --no-update phpcompatibility/phpcompatibility-wp=dev-master
composer update
vendor/bin/phpcs --config-set installed_paths "$(vendor/bin/phpcs --config-show | sed -n 's/^installed_paths: //p'),../../../projects/packages/codesniffer"
php -d memory_limit=4G vendor/bin/phpcs -s --report=emacs --standard=.github/files/phpcompatibility-dev-phpcs.xml
```

The raised `memory_limit` is not in the workflow; locally the default 128M runs out partway through the scan. Afterwards, `git checkout composer.json composer.lock`.

## How it was verified

Ran exactly those steps locally, once with the ruleset at trunk and once with this branch's:

| Ruleset | `NewTrimCharactersDefault` errors | Total errors |
|---|---|---|
| trunk | 480 | 480 |
| this branch | 0 | 0 |
