### PR TITLE
jetpack-mu-wpcom: enable the Extensible Site Editor experiment via blog sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-extensible-site-editor-sticker
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-extensible-site-editor-sticker
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Site editor: Allow sites with the gutenberg-extensible-site-editor sticker to opt into the Extensible Site Editor Gutenberg experiment.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -141,8 +141,12 @@ class Jetpack_Mu_Wpcom {
 		// Gated here rather than inside the filter: Gutenberg reads the option once per
 		// gutenberg_is_experiment_enabled() call, dozens of times per request.
 		if ( wpcom_has_blog_sticker( 'gutenberg-extensible-site-editor', get_wpcom_blog_id() ) ) {
+			// `option_` fires when the option exists in the DB, `default_option_` when it does not.
 			add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ) );
-			add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ) );
+
+			// Priority 20 because register_setting() hooks core's filter_default_option() at 10,
+			// and that callback discards the value it is handed and returns the registered default.
+			add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ), 20 );
 		}
 
 		/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -137,6 +137,14 @@ class Jetpack_Mu_Wpcom {
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 
+		// Enable the Extensible Site Editor Gutenberg experiment on opted-in sites.
+		// Gated here rather than inside the filter: Gutenberg reads the option once per
+		// gutenberg_is_experiment_enabled() call, dozens of times per request.
+		if ( wpcom_has_blog_sticker( 'gutenberg-extensible-site-editor', get_wpcom_blog_id() ) ) {
+			add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ) );
+			add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ) );
+		}
+
 		/**
 		 * Runs right after the Jetpack_Mu_Wpcom package is initialized.
 		 *
@@ -1015,6 +1023,24 @@ class Jetpack_Mu_Wpcom {
 		}
 
 		return in_array( $matches[1], self::REACT_19_INCOMPATIBLE_GUTENBERG, true );
+	}
+
+	/**
+	 * Add `gutenberg-extensible-site-editor` to the list of enabled Gutenberg experiments.
+	 *
+	 * Only registered on sites holding the sticker, so this does not re-check it. The
+	 * experiment's new screen misses WordPress.com behaviour keyed on `site-editor.php`.
+	 *
+	 * @param mixed $experiments The current value of the gutenberg-experiments option.
+	 * @return array The experiments, with the extensible site editor enabled.
+	 */
+	public static function enable_extensible_site_editor_experiment( $experiments ) {
+		if ( ! is_array( $experiments ) ) {
+			$experiments = array();
+		}
+
+		$experiments['gutenberg-extensible-site-editor'] = true;
+		return $experiments;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -137,11 +137,7 @@ class Jetpack_Mu_Wpcom {
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 
-		// Enable the Extensible Site Editor Gutenberg experiment on opted-in sites.
-		// Gated here rather than inside the filter: Gutenberg reads the option once per
-		// gutenberg_is_experiment_enabled() call, dozens of times per request.
 		if ( wpcom_has_blog_sticker( 'gutenberg-extensible-site-editor', get_wpcom_blog_id() ) ) {
-			// `option_` fires when the option exists in the DB, `default_option_` when it does not.
 			add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_extensible_site_editor_experiment' ) );
 
 			// Priority 20 because register_setting() hooks core's filter_default_option() at 10,
@@ -1032,8 +1028,7 @@ class Jetpack_Mu_Wpcom {
 	/**
 	 * Add `gutenberg-extensible-site-editor` to the list of enabled Gutenberg experiments.
 	 *
-	 * Only registered on sites holding the sticker, so this does not re-check it. The
-	 * experiment's new screen misses WordPress.com behaviour keyed on `site-editor.php`.
+	 * Only registered on sites holding the sticker, so this does not re-check it.
 	 *
 	 * @param mixed $experiments The current value of the gutenberg-experiments option.
 	 * @return array The experiments, with the extensible site editor enabled.


### PR DESCRIPTION
## Proposed changes

* Sites carrying the `gutenberg-extensible-site-editor` blog sticker get Gutenberg's Extensible Site Editor experiment enabled, on both Simple and Atomic.
* The experiment is under consideration for stable, and it serves the site editor from a new screen that WordPress.com behaviour keyed on the old one does not reach. The sticker lets a handful of sites opt in so that gap can be measured before the decision.
* The sticker is checked once at registration rather than inside the option filter, which Gutenberg triggers dozens of times per request. An equivalent gate for the Classic block inserter shipped in this package in May and was removed in August once that experiment concluded, which is why the neighbouring React 19 filter now looks like the only pattern here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a sandboxed WordPress.com site, confirm Appearance → Editor opens the current site editor (`site-editor.php`).
* Add the `gutenberg-extensible-site-editor` blog sticker to that site.
* Reload wp-admin. Appearance → Design should now open `admin.php?page=site-editor-v2`.
* Remove the sticker and confirm Appearance → Editor goes back to the current site editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
