### PR TITLE
Premium Analytics: normalize store report bucket bounds in the sanitizer

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2077-bucket-stamp
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2077-bucket-stamp
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor: store report bucket bounds are normalized once, in the sanitizer.
+
+

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -14,7 +14,7 @@
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "PA_TEST_GROUPS=1 TZ=UTC jest --config=tests/jest.config.cjs",
 		"test-coverage": "pnpm run test --coverage",
-		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing/stats packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card routes/detail-header routes/post-detail/components/post-header-slots routes/video-detail/components/video-header-slots || exit 1; done",
+		"test-tz": "for tz in America/Los_Angeles Asia/Tokyo; do TZ=$tz jest --config=tests/jest.config.cjs packages/datetime packages/data/src/processing packages/routing/src/hooks/use-report-date-filters packages/widgets-toolkit/src/components/post-highlight-card routes/detail-header routes/post-detail/components/post-header-slots routes/video-detail/components/video-header-slots || exit 1; done",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -99,8 +99,8 @@ export function useReport<
 		primary,
 		comparison,
 		hasComparison: comparisonEnabled,
-		// The zone both queries were built and normalized under, so a consumer
-		// reads the report it has rather than asking the environment again.
+		// Store reports ignore `params.timezone`: Woo buckets server-side in the
+		// site zone, so only the Stats queries can be built under a named zone.
 		timezone: resolveReportTimeZone( params.timezone ),
 		isLoading,
 		isFetching,

--- a/projects/packages/premium-analytics/packages/data/src/processing/__tests__/bucket-stamps.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/__tests__/bucket-stamps.test.ts
@@ -5,7 +5,12 @@ import { localTZDate } from '@jetpack-premium-analytics/datetime';
 /**
  * Internal dependencies
  */
+import { sanitizeReportBookingsResponse } from '../bookings';
+import { sanitizeReportConversionRateResponse } from '../conversion-rate';
+import { sanitizeReportCouponsByDateResponse } from '../coupons-by-date';
+import { sanitizeReportCustomersByDateResponse } from '../customers-by-date';
 import { sanitizeReportOrderAttributionSummaryResponse } from '../order-attribution';
+import { sanitizeReportOrdersResponse } from '../orders';
 import { withBucketStamps } from '../utils';
 import { sanitizeReportVisitorsResponse } from '../visitors';
 
@@ -32,6 +37,32 @@ describe( 'withBucketStamps', () => {
 	} );
 } );
 
+type BoundedReport = {
+	summary: { date_start: string; date_end: string };
+	data: Array< { date_start: string; date_end: string } >;
+};
+
+// A `Z` bound, so an assertion on it only holds when the sanitizer threaded the
+// reporting zone: stripping the offset textually would leave 00:00 in place.
+const zoneThreadingSanitizers = [
+	[ 'bookings', sanitizeReportBookingsResponse ],
+	[ 'conversion rate', sanitizeReportConversionRateResponse ],
+	[ 'coupons by date', sanitizeReportCouponsByDateResponse ],
+	[ 'customers by date', sanitizeReportCustomersByDateResponse ],
+	[ 'orders', sanitizeReportOrdersResponse ],
+	[ 'visitors', sanitizeReportVisitorsResponse ],
+] as Array< [ string, ( response: never, zone: string ) => BoundedReport ] >;
+
+describe.each( zoneThreadingSanitizers )( '%s sanitizer', ( _name, sanitize ) => {
+	it( 'resolves both bounds in the reporting zone', () => {
+		const row = wooRow( '2026-06-15', 'Z' );
+		const report = sanitize( { data: [ row ], summary: row } as never, SITE_ZONE );
+
+		expect( report.data[ 0 ].date_start ).toBe( '2026-06-15T08:00:00' );
+		expect( report.summary.date_end ).toBe( '2026-06-16T07:59:59' );
+	} );
+} );
+
 describe( 'store report sanitizers', () => {
 	it( 'strips the offset from rows and from the summary', () => {
 		const report = sanitizeReportVisitorsResponse(
@@ -44,8 +75,8 @@ describe( 'store report sanitizers', () => {
 		expect( report.summary.date_start ).toBe( '2026-06-15T00:00:00' );
 	} );
 
-	// #51499 removed the fabricated `+00:00`, which is the only offset that is not
-	// the site's own and so the only one that moves a bucket when it is resolved.
+	// No store endpoint writes this today; an offset that is not the site's own is
+	// the only one that moves a bucket when it is resolved.
 	it( 'resolves a fabricated UTC stamp into the site wall time', () => {
 		const report = sanitizeReportVisitorsResponse(
 			{ data: [ wooRow( '2026-06-15', 'Z' ) ], summary: wooRow( '2026-06-15', 'Z' ) },

--- a/projects/packages/premium-analytics/packages/data/src/processing/__tests__/bucket-stamps.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/__tests__/bucket-stamps.test.ts
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import { localTZDate } from '@jetpack-premium-analytics/datetime';
+/**
+ * Internal dependencies
+ */
+import { sanitizeReportOrderAttributionSummaryResponse } from '../order-attribution';
+import { withBucketStamps } from '../utils';
+import { sanitizeReportVisitorsResponse } from '../visitors';
+
+const SITE_ZONE = 'Asia/Taipei';
+
+// The shape wpcom's `format( 'c' )` writes: the site's own offset, not UTC.
+const wooRow = ( timeInterval: string, offset = '+08:00' ) => ( {
+	time_interval: timeInterval,
+	date_start: `${ timeInterval }T00:00:00${ offset }`,
+	date_end: `${ timeInterval }T23:59:59${ offset }`,
+	active_sessions: '3',
+	visitors: '2',
+} );
+
+describe( 'withBucketStamps', () => {
+	it( 'normalizes both bounds and leaves the rest of the row alone', () => {
+		expect( withBucketStamps( wooRow( '2026-06-15' ), SITE_ZONE ) ).toEqual( {
+			time_interval: '2026-06-15',
+			date_start: '2026-06-15T00:00:00',
+			date_end: '2026-06-15T23:59:59',
+			active_sessions: '3',
+			visitors: '2',
+		} );
+	} );
+} );
+
+describe( 'store report sanitizers', () => {
+	it( 'strips the offset from rows and from the summary', () => {
+		const report = sanitizeReportVisitorsResponse(
+			{ data: [ wooRow( '2026-06-15' ) ], summary: wooRow( '2026-06-15' ) },
+			SITE_ZONE
+		);
+
+		expect( report.data[ 0 ].date_start ).toBe( '2026-06-15T00:00:00' );
+		expect( report.data[ 0 ].date_end ).toBe( '2026-06-15T23:59:59' );
+		expect( report.summary.date_start ).toBe( '2026-06-15T00:00:00' );
+	} );
+
+	// #51499 removed the fabricated `+00:00`, which is the only offset that is not
+	// the site's own and so the only one that moves a bucket when it is resolved.
+	it( 'resolves a fabricated UTC stamp into the site wall time', () => {
+		const report = sanitizeReportVisitorsResponse(
+			{ data: [ wooRow( '2026-06-15', 'Z' ) ], summary: wooRow( '2026-06-15', 'Z' ) },
+			SITE_ZONE
+		);
+
+		expect( report.data[ 0 ].date_start ).toBe( '2026-06-15T08:00:00' );
+	} );
+
+	// The offset the server writes is the site's own, so the reader resolves the
+	// stripped stamp to the instant it resolved the offset-bearing one to.
+	it( 'leaves the instant a reader resolves unchanged', () => {
+		const raw = wooRow( '2026-06-15' );
+		const report = sanitizeReportVisitorsResponse( { data: [ raw ], summary: raw }, SITE_ZONE );
+
+		expect( localTZDate( report.data[ 0 ].date_start, SITE_ZONE ).getTime() ).toBe(
+			localTZDate( raw.date_start, SITE_ZONE ).getTime()
+		);
+	} );
+
+	it( 'keeps an empty default bound empty', () => {
+		const report = sanitizeReportVisitorsResponse(
+			{ data: [], summary: { active_sessions: '0', visitors: '0', date_start: '', date_end: '' } },
+			SITE_ZONE
+		);
+
+		expect( report.summary.date_start ).toBe( '' );
+	} );
+
+	// This one lists its output fields instead of spreading, so it drifts on its own.
+	it( 'stamps order attribution intervals in both periods', () => {
+		const period = {
+			value: '10',
+			intervals: [
+				{
+					time_interval: '2026-06-15',
+					date_start: '2026-06-15T00:00:00+08:00',
+					date_end: '2026-06-15T23:59:59+08:00',
+					net_sales: '10',
+				},
+			],
+		};
+		const report = sanitizeReportOrderAttributionSummaryResponse(
+			{
+				view: 'channel',
+				order_by: 'net_sales',
+				data: [ { item: 'direct', current_period: period, previous_period: period } ],
+			},
+			SITE_ZONE
+		);
+
+		expect( report.data[ 0 ].current_period.intervals[ 0 ].date_start ).toBe(
+			'2026-06-15T00:00:00'
+		);
+		expect( report.data[ 0 ].previous_period.intervals[ 0 ].date_end ).toBe(
+			'2026-06-15T23:59:59'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/bookings/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/bookings/index.ts
@@ -3,6 +3,7 @@
  */
 import { fetchReportBookings } from '../../api/report-bookings-fetch';
 import { safeParseInt } from '../../utils/parsing';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsBookingsByDateResponse = Awaited< ReturnType< typeof fetchReportBookings > >;
@@ -39,9 +40,12 @@ type SanitizedBookingsSummaryItem = Override<
 	}
 >;
 
-function sanitizeBookingItem( item: RawBookingsReportDataItem ): SanitizedBookingsByDateItem {
+function sanitizeBookingItem(
+	item: RawBookingsReportDataItem,
+	zone: string
+): SanitizedBookingsByDateItem {
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		status_unpaid: safeParseInt( item.status_unpaid ),
 		status_pending_confirmation: safeParseInt( item.status_pending_confirmation ),
 		status_confirmed: safeParseInt( item.status_confirmed ),
@@ -55,10 +59,11 @@ function sanitizeBookingItem( item: RawBookingsReportDataItem ): SanitizedBookin
 }
 
 function sanitizeBookingSummaryItem(
-	item: RawBookingsReportSummaryItem
+	item: RawBookingsReportSummaryItem,
+	zone: string
 ): SanitizedBookingsSummaryItem {
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		status_unpaid: safeParseInt( item.status_unpaid ),
 		status_pending_confirmation: safeParseInt( item.status_pending_confirmation ),
 		status_confirmed: safeParseInt( item.status_confirmed ),
@@ -81,10 +86,11 @@ type SanitizedBookingsByDateResponse = {
  * so we use different sanitizer functions for each.
  */
 export const sanitizeReportBookingsResponse = (
-	response: ReportsBookingsByDateResponse
+	response: ReportsBookingsByDateResponse,
+	zone: string
 ): SanitizedBookingsByDateResponse => {
 	return {
-		summary: sanitizeBookingSummaryItem( response.summary ),
-		data: response.data.map( sanitizeBookingItem ),
+		summary: sanitizeBookingSummaryItem( response.summary, zone ),
+		data: response.data.map( item => sanitizeBookingItem( item, zone ) ),
 	};
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/conversion-rate/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/conversion-rate/index.ts
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { fetchReportConversionRate } from '../../api/report-conversion-rate-fetch';
 import { safeParseInt } from '../../utils/parsing';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsConversionRateByDateResponse = Awaited<
@@ -26,7 +27,8 @@ type SanitizedConversionRateByDateItem = Override<
 >;
 
 function sanitizeConversionRateItem(
-	item: RawConversionRateReportDataItem
+	item: RawConversionRateReportDataItem,
+	zone: string
 ): SanitizedConversionRateByDateItem {
 	const activeSessionsNum = safeParseInt( item.active_sessions );
 	const visitorsNum = safeParseInt( item.visitors );
@@ -39,7 +41,7 @@ function sanitizeConversionRateItem(
 	const conversionRate = activeSessionsNum > 0 ? completedCheckoutNum / activeSessionsNum : 0;
 
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		active_sessions: activeSessionsNum,
 		visitors: visitorsNum,
 		with_cart_addition: withCartAdditionNum,
@@ -68,7 +70,8 @@ type SanitizedConversionRateByDateResponse = {
  * as the `data` array items, so we can use the same mapper function for both.
  */
 export const sanitizeReportConversionRateResponse = (
-	response: ReportsConversionRateByDateResponse
+	response: ReportsConversionRateByDateResponse,
+	zone: string
 ): SanitizedConversionRateByDateResponse => {
 	// Handle cases where response might not have the expected structure
 	const defaultSummary = {
@@ -81,7 +84,7 @@ export const sanitizeReportConversionRateResponse = (
 		date_end: '',
 	};
 
-	const sanitizedSummary = sanitizeConversionRateItem( response?.summary || defaultSummary );
+	const sanitizedSummary = sanitizeConversionRateItem( response?.summary || defaultSummary, zone );
 
 	const steps: FunnelStep[] = [
 		{
@@ -121,7 +124,9 @@ export const sanitizeReportConversionRateResponse = (
 
 	return {
 		summary: sanitizedSummary,
-		data: response?.data ? response.data.map( sanitizeConversionRateItem ) : [],
+		data: response?.data
+			? response.data.map( item => sanitizeConversionRateItem( item, zone ) )
+			: [],
 		steps,
 		overallRate: sanitizedSummary.conversion_rate,
 	};

--- a/projects/packages/premium-analytics/packages/data/src/processing/coupons-by-date/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/coupons-by-date/index.ts
@@ -3,6 +3,7 @@
  */
 import { fetchReportCouponsByDate } from '../../api/report-coupons-by-date-fetch';
 import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsCouponsByDateResponse = Awaited< ReturnType< typeof fetchReportCouponsByDate > >;
@@ -44,9 +45,9 @@ type SanitizedCouponsByDateResponse = {
 	data: SanitizedCouponsByDateDataItem[];
 };
 
-function sanitizeItem( item: RawDataItem ): SanitizedCouponsByDateDataItem {
+function sanitizeItem( item: RawDataItem, zone: string ): SanitizedCouponsByDateDataItem {
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		total_orders: safeParseInt( item.total_orders ),
 		orders_with_coupon: safeParseInt( item.orders_with_coupon ),
 		orders_without_coupon: safeParseInt( item.orders_without_coupon ),
@@ -59,12 +60,12 @@ function sanitizeItem( item: RawDataItem ): SanitizedCouponsByDateDataItem {
 	};
 }
 
-function sanitizeSummary( summary: RawSummary ): SanitizedCouponsByDateSummary {
+function sanitizeSummary( summary: RawSummary, zone: string ): SanitizedCouponsByDateSummary {
 	// safeParseFloat/safeParseInt fall back to 0 for missing fields (e.g. an
 	// empty-range response with an empty `summary`), so the widget reaches its
 	// empty state instead of charting NaN values.
 	return {
-		...summary,
+		...withBucketStamps( summary, zone ),
 		total_orders: safeParseInt( summary.total_orders ),
 		orders_with_coupon: safeParseInt( summary.orders_with_coupon ),
 		orders_without_coupon: safeParseInt( summary.orders_without_coupon ),
@@ -78,10 +79,11 @@ function sanitizeSummary( summary: RawSummary ): SanitizedCouponsByDateSummary {
 }
 
 export const sanitizeReportCouponsByDateResponse = (
-	response: ReportsCouponsByDateResponse
+	response: ReportsCouponsByDateResponse,
+	zone: string
 ): SanitizedCouponsByDateResponse => {
 	return {
-		summary: sanitizeSummary( response.summary ),
-		data: response.data.map( sanitizeItem ),
+		summary: sanitizeSummary( response.summary, zone ),
+		data: response.data.map( item => sanitizeItem( item, zone ) ),
 	};
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/customers-by-date/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/customers-by-date/index.ts
@@ -3,6 +3,7 @@
  */
 import { fetchReportCustomersByDate } from '../../api/report-customers-by-date-fetch';
 import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsCustomersByDateResponse = Awaited< ReturnType< typeof fetchReportCustomersByDate > >;
@@ -63,10 +64,13 @@ export type SanitizedCustomersByDateResponse = {
 	data: SanitizedCustomersByDateItem[];
 };
 
-function sanitizeCustomerByDateItem( item: RawCustomersByDateItem ): SanitizedCustomersByDateItem {
+function sanitizeCustomerByDateItem(
+	item: RawCustomersByDateItem,
+	zone: string
+): SanitizedCustomersByDateItem {
 	const totalCustomers = safeParseInt( item.total_customers );
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		total_customers: totalCustomers,
 		new_customers: safeParseInt( item.new_customers ),
 		returning_customers: safeParseInt( item.returning_customers ),
@@ -82,14 +86,15 @@ function sanitizeCustomerByDateItem( item: RawCustomersByDateItem ): SanitizedCu
 }
 
 function sanitizeCustomerByDateSummary(
-	summary: RawCustomersByDateSummary
+	summary: RawCustomersByDateSummary,
+	zone: string
 ): SanitizedCustomersByDateSummary {
 	// safeParseFloat/safeParseInt fall back to 0 for missing fields (e.g. an
 	// empty-range response with an empty `summary`), so the widget reaches its
 	// empty state instead of charting NaN values.
 	const totalCustomers = safeParseInt( summary.total_customers );
 	return {
-		...summary,
+		...withBucketStamps( summary, zone ),
 		total_net_sales: safeParseFloat( summary.total_net_sales ),
 		total_gross_sales: safeParseFloat( summary.total_gross_sales ),
 		total_discounts: safeParseFloat( summary.total_discounts ),
@@ -124,10 +129,11 @@ function sanitizeCustomerByDateSummary(
 }
 
 export const sanitizeReportCustomersByDateResponse = (
-	response: ReportsCustomersByDateResponse
+	response: ReportsCustomersByDateResponse,
+	zone: string
 ): SanitizedCustomersByDateResponse => {
 	return {
-		summary: sanitizeCustomerByDateSummary( response.summary ),
-		data: response.data.map( sanitizeCustomerByDateItem ),
+		summary: sanitizeCustomerByDateSummary( response.summary, zone ),
+		data: response.data.map( item => sanitizeCustomerByDateItem( item, zone ) ),
 	};
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/order-attribution/sanitize-order-attribution-summary-response.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/order-attribution/sanitize-order-attribution-summary-response.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { fetchReportOrderAttributionSummary } from '../../api/report-order-attribution-summary-fetch';
-import { sanitizeStringNumber } from '../utils';
+import { sanitizeStringNumber, withBucketStamps } from '../utils';
 
 type OrderAttributionSummaryResponse = Awaited<
 	ReturnType< typeof fetchReportOrderAttributionSummary >
@@ -53,41 +53,49 @@ export type SanitizedOrderAttributionSummaryResponse = {
 };
 
 function sanitizeOrderAttributionInterval(
-	interval: OrderAttributionInterval
+	interval: OrderAttributionInterval,
+	zone: string
 ): SanitizedOrderAttributionInterval {
+	const { date_start, date_end } = withBucketStamps( interval, zone );
+
 	return {
 		time_interval: interval.time_interval,
-		date_start: interval.date_start,
-		date_end: interval.date_end,
+		date_start,
+		date_end,
 		net_sales: sanitizeStringNumber( interval.net_sales ),
 	};
 }
 
 function sanitizeOrderAttributionPeriod(
-	period: OrderAttributionPeriod
+	period: OrderAttributionPeriod,
+	zone: string
 ): SanitizedOrderAttributionPeriod {
 	return {
 		value: sanitizeStringNumber( period.value ),
-		intervals: period.intervals.map( sanitizeOrderAttributionInterval ),
+		intervals: period.intervals.map( interval =>
+			sanitizeOrderAttributionInterval( interval, zone )
+		),
 	};
 }
 
 function sanitizeOrderAttributionSummaryItem(
-	item: OrderAttributionSummaryItem
+	item: OrderAttributionSummaryItem,
+	zone: string
 ): SanitizedOrderAttributionSummaryItem {
 	return {
 		item: item.item,
-		current_period: sanitizeOrderAttributionPeriod( item.current_period ),
-		previous_period: sanitizeOrderAttributionPeriod( item.previous_period ),
+		current_period: sanitizeOrderAttributionPeriod( item.current_period, zone ),
+		previous_period: sanitizeOrderAttributionPeriod( item.previous_period, zone ),
 	};
 }
 
 export function sanitizeReportOrderAttributionSummaryResponse(
-	response: OrderAttributionSummaryResponse
+	response: OrderAttributionSummaryResponse,
+	zone: string
 ): SanitizedOrderAttributionSummaryResponse {
 	return {
 		view: response.view,
 		order_by: response.order_by,
-		data: response.data.map( sanitizeOrderAttributionSummaryItem ),
+		data: response.data.map( item => sanitizeOrderAttributionSummaryItem( item, zone ) ),
 	};
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/orders/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/orders/index.ts
@@ -3,6 +3,7 @@
  */
 import { fetchReportOrders } from '../../api/report-orders-fetch';
 import { safeParseFloat, safeParseInt } from '../../utils/parsing';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsOrdersByDateResponse = Awaited< ReturnType< typeof fetchReportOrders > >;
@@ -28,9 +29,12 @@ type SanitizedOrdersByDateItem = Override<
 	}
 >;
 
-function sanitizeOrderItem( item: RawOrdersReportDataItem ): SanitizedOrdersByDateItem {
+function sanitizeOrderItem(
+	item: RawOrdersReportDataItem,
+	zone: string
+): SanitizedOrdersByDateItem {
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		average_order_value: safeParseFloat( item.average_order_value ),
 		avg_items: safeParseFloat( item.avg_items ),
 		cogs_amount: safeParseFloat( item.cogs_amount ),
@@ -59,10 +63,11 @@ type SanitizedOrdersByDateResponse = {
  * mapper.
  */
 export const sanitizeReportOrdersResponse = (
-	response: ReportsOrdersByDateResponse
+	response: ReportsOrdersByDateResponse,
+	zone: string
 ): SanitizedOrdersByDateResponse => {
 	return {
-		summary: sanitizeOrderItem( response.summary ),
-		data: response.data.map( sanitizeOrderItem ),
+		summary: sanitizeOrderItem( response.summary, zone ),
+		data: response.data.map( item => sanitizeOrderItem( item, zone ) ),
 	};
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/utils.ts
@@ -9,7 +9,7 @@ export function sanitizeStringNumber( value: string ): number {
 	return isNaN( parsed ) ? 0 : parsed;
 }
 
-type BucketBounds = { date_start: string; date_end: string };
+export type BucketBounds = { date_start: string; date_end: string };
 
 /**
  * Re-stamp a store report row's bucket bounds into the one shape reports carry.

--- a/projects/packages/premium-analytics/packages/data/src/processing/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/utils.ts
@@ -1,5 +1,27 @@
+/**
+ * External dependencies
+ */
+import { toBucketStamp } from '@jetpack-premium-analytics/datetime';
+
 /** Parses a numeric string from the API, falling back to 0 when it is not a number. */
 export function sanitizeStringNumber( value: string ): number {
 	const parsed = parseFloat( value );
 	return isNaN( parsed ) ? 0 : parsed;
+}
+
+type BucketBounds = { date_start: string; date_end: string };
+
+/**
+ * Re-stamp a store report row's bucket bounds into the one shape reports carry.
+ *
+ * @param row  - The row as the API returned it.
+ * @param zone - The report's reporting timezone.
+ * @return The row, with its bounds as timezone-naive wall times.
+ */
+export function withBucketStamps< T extends BucketBounds >( row: T, zone: string ): T {
+	return {
+		...row,
+		date_start: toBucketStamp( row.date_start, zone ),
+		date_end: toBucketStamp( row.date_end, zone ),
+	};
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/visitors/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/visitors/index.ts
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { fetchReportVisitors } from '../../api/report-visitors-fetch';
+import { withBucketStamps } from '../utils';
 import type { Override } from '../../utils/types';
 
 type ReportsVisitorsByDateResponse = Awaited< ReturnType< typeof fetchReportVisitors > >;
@@ -32,9 +33,12 @@ type SanitizeVisitorsItemArg = Override<
 	}
 >;
 
-function sanitizeVisitorsItem( item: SanitizeVisitorsItemArg ): SanitizedVisitorsByDateItem {
+function sanitizeVisitorsItem(
+	item: SanitizeVisitorsItemArg,
+	zone: string
+): SanitizedVisitorsByDateItem {
 	return {
-		...item,
+		...withBucketStamps( item, zone ),
 		active_sessions: parseInt( item.active_sessions, 10 ),
 		visitors: parseInt( item.visitors, 10 ),
 	};
@@ -50,7 +54,8 @@ type SanitizedVisitorsByDateResponse = {
  * as the `data` array items, so we can use the same mapper function for both.
  */
 export const sanitizeReportVisitorsResponse = (
-	response: ReportsVisitorsByDateResponse
+	response: ReportsVisitorsByDateResponse,
+	zone: string
 ): SanitizedVisitorsByDateResponse => {
 	const defaultSummary = {
 		active_sessions: '0',
@@ -60,7 +65,7 @@ export const sanitizeReportVisitorsResponse = (
 	};
 
 	return {
-		summary: sanitizeVisitorsItem( response?.summary ?? defaultSummary ),
-		data: response?.data ? response.data.map( sanitizeVisitorsItem ) : [],
+		summary: sanitizeVisitorsItem( response?.summary ?? defaultSummary, zone ),
+		data: response?.data ? response.data.map( item => sanitizeVisitorsItem( item, zone ) ) : [],
 	};
 };

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/report-query-timezone.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/report-query-timezone.test.ts
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { resolveReportTimeZone } from '../../utils/report-timezone';
+import { reportVisitorsQuery } from '../report-visitors-query';
+
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../../utils/report-timezone', () => ( {
+	resolveReportTimeZone: jest.fn(),
+} ) );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+const mockResolveZone = resolveReportTimeZone as jest.MockedFunction<
+	typeof resolveReportTimeZone
+>;
+
+const PARAMS = { from: '2026-06-01', to: '2026-06-07', interval: 'day' as const };
+
+beforeEach( () => {
+	mockResolveZone.mockReturnValue( 'Asia/Taipei' );
+	mockApiFetch.mockResolvedValue( {
+		data: [
+			{
+				time_interval: '2026-06-15',
+				date_start: '2026-06-15T00:00:00Z',
+				date_end: '2026-06-15T23:59:59Z',
+				active_sessions: '3',
+				visitors: '2',
+			},
+		],
+		summary: { date_start: '', date_end: '', active_sessions: '3', visitors: '2' },
+	} );
+} );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'reportVisitorsQuery', () => {
+	it( 'carries the reporting zone in the query key', () => {
+		expect( reportVisitorsQuery( PARAMS ).queryKey ).toContain( 'Asia/Taipei' );
+	} );
+
+	// The key has to change with the zone, or a report normalized under the old one
+	// is served after a change.
+	it( 'keys a different zone separately', () => {
+		const taipei = reportVisitorsQuery( PARAMS ).queryKey;
+
+		mockResolveZone.mockReturnValue( 'America/New_York' );
+
+		expect( reportVisitorsQuery( PARAMS ).queryKey ).not.toEqual( taipei );
+	} );
+
+	it( 'normalizes the response under that same zone', async () => {
+		const queryFn = reportVisitorsQuery( PARAMS ).queryFn as () => Promise< unknown >;
+
+		await expect( queryFn() ).resolves.toMatchObject( {
+			data: [ { date_start: '2026-06-15T08:00:00' } ],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-bookings-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-bookings-query.ts
@@ -7,6 +7,7 @@
  */
 import { fetchReportBookings } from '../api';
 import { sanitizeReportBookingsResponse } from '../processing/bookings';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { ReportDataMap } from '../types';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -18,11 +19,13 @@ const getReportBookingsQueryKey = ( p: RequestReportBookingsParams ) =>
 export function reportBookingsQuery(
 	params: RequestReportBookingsParams
 ): UseQueryOptions< ReportDataMap[ 'bookings' ] > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportBookingsQueryKey( params ),
+		queryKey: [ ...getReportBookingsQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportBookings( params );
-			return sanitizeReportBookingsResponse( response );
+			return sanitizeReportBookingsResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-conversion-rate-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-conversion-rate-query.ts
@@ -7,6 +7,7 @@
  */
 import { fetchReportConversionRate } from '../api/report-conversion-rate-fetch';
 import { sanitizeReportConversionRateResponse } from '../processing/conversion-rate';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { RequestReportConversionRateParams } from '../api/report-conversion-rate-fetch';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -16,11 +17,13 @@ const getReportConversionRateQueryKey = ( p: RequestReportConversionRateParams )
 export function reportConversionRateQuery(
 	params: RequestReportConversionRateParams
 ): UseQueryOptions< ReturnType< typeof sanitizeReportConversionRateResponse > > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportConversionRateQueryKey( params ),
+		queryKey: [ ...getReportConversionRateQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportConversionRate( params );
-			return sanitizeReportConversionRateResponse( response );
+			return sanitizeReportConversionRateResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-coupons-by-date-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-coupons-by-date-query.ts
@@ -8,6 +8,7 @@
 import { fetchReportCouponsByDate } from '../api';
 import { sanitizeReportCouponsByDateResponse } from '../processing/coupons-by-date';
 import { FilterCondition } from '../types/filter-condition';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { ReportDataMap } from '../types';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -21,11 +22,13 @@ const getQueryKey = ( p: RequestReportCouponsByDateParams ) =>
 export function reportCouponsByDateQuery(
 	params: RequestReportCouponsByDateParams
 ): UseQueryOptions< ReportDataMap[ 'couponsByDate' ] > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getQueryKey( params ),
+		queryKey: [ ...getQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportCouponsByDate( params );
-			return sanitizeReportCouponsByDateResponse( response );
+			return sanitizeReportCouponsByDateResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-customers-by-date-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-customers-by-date-query.ts
@@ -7,6 +7,7 @@
  */
 import { fetchReportCustomersByDate } from '../api/report-customers-by-date-fetch';
 import { sanitizeReportCustomersByDateResponse } from '../processing/customers-by-date';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { ReportDataMap } from '../types';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -18,11 +19,13 @@ const getReportCustomersByDateQueryKey = ( p: RequestReportCustomersByDateParams
 export function reportCustomersByDateQuery(
 	params: RequestReportCustomersByDateParams
 ): UseQueryOptions< ReportDataMap[ 'customersByDate' ] > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportCustomersByDateQueryKey( params ),
+		queryKey: [ ...getReportCustomersByDateQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportCustomersByDate( params );
-			return sanitizeReportCustomersByDateResponse( response );
+			return sanitizeReportCustomersByDateResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-order-attribution-summary-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-order-attribution-summary-query.ts
@@ -8,6 +8,7 @@ import {
 	type SanitizedOrderAttributionSummaryResponse,
 } from '../processing/order-attribution';
 import { hasProductFilters } from '../utils/product-filters';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { FilterCondition } from '../types/filter-condition';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -46,8 +47,10 @@ const getReportOrderAttributionQueryKey = ( params: ReportOrderAttributionSummar
 export function reportOrderAttributionSummaryQuery(
 	params: ReportOrderAttributionSummaryParams
 ): UseQueryOptions< SanitizedOrderAttributionSummaryResponse > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportOrderAttributionQueryKey( params ),
+		queryKey: [ ...getReportOrderAttributionQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const hasProductFiltersValue = hasProductFilters( params.filters );
 
@@ -87,12 +90,12 @@ export function reportOrderAttributionSummaryQuery(
 					previousResponse
 				);
 
-				return sanitizeReportOrderAttributionSummaryResponse( normalizedResponse );
+				return sanitizeReportOrderAttributionSummaryResponse( normalizedResponse, timezone );
 			}
 
 			// Regular API path: Returns both primary and comparison in one response
 			const response = await fetchReportOrderAttributionSummary( params );
-			return sanitizeReportOrderAttributionSummaryResponse( response );
+			return sanitizeReportOrderAttributionSummaryResponse( response, timezone );
 		},
 
 		// `view` is required by the order attribution endpoints.

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-orders-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-orders-query.ts
@@ -7,6 +7,7 @@
  */
 import { fetchReportOrders } from '../api';
 import { sanitizeReportOrdersResponse } from '../processing/orders';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { ReportDataMap } from '../types';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -25,11 +26,13 @@ const getReportOrdersQueryKey = ( p: RequestReportOrdersParams ) => [
 export function reportOrdersQuery(
 	params: RequestReportOrdersParams
 ): UseQueryOptions< ReportDataMap[ 'orders' ] > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportOrdersQueryKey( params ),
+		queryKey: [ ...getReportOrdersQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportOrders( params );
-			return sanitizeReportOrdersResponse( response );
+			return sanitizeReportOrdersResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/data/src/queries/report-visitors-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/report-visitors-query.ts
@@ -7,6 +7,7 @@
  */
 import { fetchReportVisitors } from '../api';
 import { sanitizeReportVisitorsResponse } from '../processing/visitors';
+import { resolveReportTimeZone } from '../utils/report-timezone';
 import type { ReportDataMap } from '../types';
 import type { UseQueryOptions } from '@tanstack/react-query';
 
@@ -18,11 +19,13 @@ const getReportVisitorsQueryKey = ( p: RequestReportVisitorsParams ) =>
 export function reportVisitorsQuery(
 	params: RequestReportVisitorsParams
 ): UseQueryOptions< ReportDataMap[ 'visitors' ] > {
+	const timezone = resolveReportTimeZone();
+
 	return {
-		queryKey: getReportVisitorsQueryKey( params ),
+		queryKey: [ ...getReportVisitorsQueryKey( params ), timezone ],
 		queryFn: async () => {
 			const response = await fetchReportVisitors( params );
-			return sanitizeReportVisitorsResponse( response );
+			return sanitizeReportVisitorsResponse( response, timezone );
 		},
 
 		enabled: !! ( params.from && params.to && params.interval ),

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-stamp.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-stamp.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { toBucketStamp } from '../bucket-stamp';
+
+describe( 'toBucketStamp', () => {
+	it( 'keeps a wall time as written', () => {
+		expect( toBucketStamp( '2026-06-15 00:00:00', 'Asia/Taipei' ) ).toBe( '2026-06-15T00:00:00' );
+		expect( toBucketStamp( '2026-06-15T13:45:07', 'Asia/Taipei' ) ).toBe( '2026-06-15T13:45:07' );
+	} );
+
+	it( 'reads a bare date as the start of its day', () => {
+		expect( toBucketStamp( '2026-06-15', 'Asia/Taipei' ) ).toBe( '2026-06-15T00:00:00' );
+	} );
+
+	it( "drops the offset Woo stamps, which is the site's own", () => {
+		expect( toBucketStamp( '2026-06-15T00:00:00+08:00', 'Asia/Taipei' ) ).toBe(
+			'2026-06-15T00:00:00'
+		);
+	} );
+
+	it( "resolves an offset that is not the site's own into the site wall time", () => {
+		expect( toBucketStamp( '2026-06-15T00:00:00Z', 'Asia/Taipei' ) ).toBe( '2026-06-15T08:00:00' );
+	} );
+
+	// A zone, not a fixed offset: the same report can span both sides of a transition.
+	it( 'reads each stamp at the offset in effect on its own day', () => {
+		expect( toBucketStamp( '2026-06-15T04:00:00Z', 'America/New_York' ) ).toBe(
+			'2026-06-15T00:00:00'
+		);
+		expect( toBucketStamp( '2026-12-15T05:00:00Z', 'America/New_York' ) ).toBe(
+			'2026-12-15T00:00:00'
+		);
+	} );
+
+	it( 'passes through a value it does not recognize as a timestamp', () => {
+		expect( toBucketStamp( '', 'Asia/Taipei' ) ).toBe( '' );
+		expect( toBucketStamp( 'not a date', 'Asia/Taipei' ) ).toBe( 'not a date' );
+		expect( toBucketStamp( '2026-02-31 00:00:00', 'Asia/Taipei' ) ).toBe( '2026-02-31 00:00:00' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-stamp.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-stamp.test.ts
@@ -38,4 +38,18 @@ describe( 'toBucketStamp', () => {
 		expect( toBucketStamp( 'not a date', 'Asia/Taipei' ) ).toBe( 'not a date' );
 		expect( toBucketStamp( '2026-02-31 00:00:00', 'Asia/Taipei' ) ).toBe( '2026-02-31 00:00:00' );
 	} );
+
+	// `toLocalTZ` would read a missing bound as the current instant.
+	it( 'empties a bound that is not a string rather than stamping it with today', () => {
+		expect( toBucketStamp( undefined, 'Asia/Taipei' ) ).toBe( '' );
+	} );
+
+	// A zone that does not resolve leaves every bound of every report as written,
+	// so pin the shape rather than leaving that exit undocumented.
+	it( 'leaves the bound alone when the zone does not resolve', () => {
+		expect( toBucketStamp( '2026-06-15T00:00:00+08:00', 'Not/AZone' ) ).toBe(
+			'2026-06-15T00:00:00+08:00'
+		);
+		expect( toBucketStamp( '2026-06-15T00:00:00+08:00', '' ) ).toBe( '2026-06-15T00:00:00+08:00' );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/datetime/src/bucket-stamp.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/bucket-stamp.ts
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { format, isValid } from 'date-fns';
+/**
+ * Internal dependencies
+ */
+import { toLocalTZ } from './tz';
+
+const BUCKET_STAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+/**
+ * Normalize a bucket bound into the one shape a report carries: a naive wall time.
+ *
+ * Woo stamps its bounds with the site's own offset, so it is resolved and dropped
+ * here rather than left for each reader to decide about. An unrecognized value is
+ * returned as written, so an empty default bound stays empty.
+ *
+ * @param raw  - The bound as the API wrote it.
+ * @param zone - The report's reporting timezone.
+ * @return The bound as a timezone-naive wall time.
+ */
+export function toBucketStamp( raw: string, zone: string ): string {
+	// `toLocalTZ` reads a missing value as the current instant, which would stamp
+	// a malformed row with today rather than leaving it alone.
+	if ( typeof raw !== 'string' ) {
+		return raw;
+	}
+
+	const date = toLocalTZ( raw, zone );
+
+	return isValid( date ) ? format( date, BUCKET_STAMP_FORMAT ) : raw;
+}

--- a/projects/packages/premium-analytics/packages/datetime/src/bucket-stamp.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/bucket-stamp.ts
@@ -5,29 +5,29 @@ import { format, isValid } from 'date-fns';
 /**
  * Internal dependencies
  */
+import { formatDatePartWithTime } from './date';
 import { toLocalTZ } from './tz';
-
-const BUCKET_STAMP_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
 /**
  * Normalize a bucket bound into the one shape a report carries: a naive wall time.
  *
- * Woo stamps its bounds with the site's own offset, so it is resolved and dropped
- * here rather than left for each reader to decide about. An unrecognized value is
- * returned as written, so an empty default bound stays empty.
+ * A stated offset is resolved and dropped, where `parseBucketStart` ignores one.
+ * Woo stamps the site's own offset, so no endpoint writes a bound this shifts today.
  *
  * @param raw  - The bound as the API wrote it.
  * @param zone - The report's reporting timezone.
- * @return The bound as a timezone-naive wall time.
+ * @return The bound as a naive wall time; an unrecognized string as written.
  */
-export function toBucketStamp( raw: string, zone: string ): string {
+export function toBucketStamp( raw: string | undefined, zone: string ): string {
 	// `toLocalTZ` reads a missing value as the current instant, which would stamp
-	// a malformed row with today rather than leaving it alone.
+	// a malformed row with today.
 	if ( typeof raw !== 'string' ) {
-		return raw;
+		return '';
 	}
 
 	const date = toLocalTZ( raw, zone );
 
-	return isValid( date ) ? format( date, BUCKET_STAMP_FORMAT ) : raw;
+	return isValid( date )
+		? formatDatePartWithTime( format( date, 'yyyy-MM-dd' ), format( date, 'HH:mm:ss' ) )
+		: raw;
 }

--- a/projects/packages/premium-analytics/packages/datetime/src/index.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/index.ts
@@ -28,6 +28,8 @@ export { drillDateRange } from './drill-date-range';
 
 export { parseBucketStart } from './bucket-start';
 
+export { toBucketStamp } from './bucket-stamp';
+
 export { parseSiteDateTime } from './site-datetime';
 
 export { readSiteTimestamp, type SiteTimestamp, type TimestampParts } from './site-timestamp';


### PR DESCRIPTION

## Proposed changes

Woo's report endpoints stamp a bucket bound with the site's own UTC offset; the rest stamp a bare wall time. This PR moves the decision about that offset out of the readers and into the seven sanitizers, so every bound reaching a chart has one shape.

* Normalize `date_start` and `date_end` values from Woo store reports when the response is sanitized. The values are resolved in the reporting timezone and stored as offset-free site wall times.
* Pass the reporting timezone into the affected store-report queries and include it in their query keys, so cached data is not reused after a timezone change.
* Return an empty bound when `toBucketStamp` is handed a non-string, so a malformed row cannot be stamped with today. An unrecognized string is still returned as written.
* Add coverage for rows, summaries, and order-attribution intervals, including runs in multiple machine timezones. Every by-date sanitizer is asserted against a bound stamped in another zone, so the assertion only holds if that sanitizer threaded the reporting timezone rather than stripping the offset textually.

## Related product discussion/links

* WOOA7S-2077

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

No visible change is expected. Verify with:

* `jp test js packages/premium-analytics` (the affected areas were run locally: 157 suites and 1,449 tests passed).
* Review `packages/data/src/processing/__tests__/bucket-stamps.test.ts`, which verifies that offsets are normalized in report rows and summaries while resolving to the same instant in the reporting timezone.
* `packages/data/src/queries/__tests__/report-query-timezone.test.ts` covers the query layer: the resolved zone reaches the query key, a different zone keys separately, and `queryFn` normalizes under that same zone.
* Run the affected tests with `TZ=America/Los_Angeles`, `TZ=Asia/Tokyo`, and `TZ=Pacific/Kiritimati`; they pass without using the machine timezone.
* On a store site, open the Store performance and Visitors over time widgets and confirm their chart x-axes are unchanged.

