### PR TITLE
Premium Analytics: drop the dead time-series date_start passthrough

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2077-drop-dead-passthrough
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2077-drop-dead-passthrough
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Internal refactor: drop the dead time-series date_start passthrough.
+
+

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -225,14 +225,6 @@ function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: strin
 		return getHourIntervalFields( rawPeriod, row.hour );
 	}
 
-	if ( typeof row.date_start === 'string' && typeof row.date_end === 'string' ) {
-		return {
-			time_interval: row.date_start,
-			date_start: row.date_start,
-			date_end: row.date_end,
-		};
-	}
-
 	if ( unit === 'hour' && typeof rawPeriod === 'string' ) {
 		const packed = rawPeriod.match( packedHourlyPeriod );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-start.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/bucket-start.test.ts
@@ -28,8 +28,6 @@ describe( 'parseBucketStart', () => {
 		);
 	} );
 
-	// The passthrough copies `date_start` from the API verbatim, and the offset it
-	// carries is nominal: honouring it would move the bucket off its own midnight.
 	it.each( [ '2026-06-15T00:00:00+00:00', '2026-06-15T00:00:00Z', '2026-06-15T00:00:00-07:00' ] )(
 		'ignores the nominal offset on %s',
 		stamp => {

--- a/projects/packages/premium-analytics/packages/datetime/src/bucket-start.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/bucket-start.ts
@@ -8,8 +8,8 @@ import { createTZDateFromParts } from './tz';
 /**
  * Read a Stats bucket's stamp as the instant it names in the site's timezone.
  *
- * Any stated offset is ignored: the time-series passthrough copies `date_start`
- * from the API verbatim, so a bucket can carry a nominal offset that would shift it.
+ * Any stated offset is ignored: a bucket stamp names a site-local calendar
+ * bucket, so honouring an offset would move it off its own midnight.
  *
  * @param value - The bucket's `date_start`.
  * @return The instant, or `undefined` when the value is missing or malformed.


### PR DESCRIPTION

## Proposed changes
* Remove the unreachable `date_start`/`date_end` passthrough branch in `getRowIntervalFields` (`packages/data/src/processing/stats/time-series.ts`).
* Correct `parseBucketStart`'s docblock, which justified ignoring a stated offset by citing that passthrough.
* Drop the same dead justification from the `bucket-start` test comment; the test name already says what it asserts.

No Stats endpoint returns `date_start` on a row: matrix payloads put `period` at `fields[0]`, and `days` maps key each bucket by its start day as `Y-m-d`. This sanitizer only handles Stats endpoints, since Woo store reports go through separate sanitizers under `packages/data/src/processing/{visitors,orders,bookings,...}`. The branch was also the only route by which an API-stated offset could reach a normalized Stats report, which is why the `parseBucketStart` comment needed correcting. `isStatsTimeSeriesPayload` still reads `firstRow.date_start` and is left alone: that is payload detection, a different job.

## Related product discussion/links
* WOOA7S-2077

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
This is an internal refactor with no user-visible change, so the evidence is the instrumented run plus the gates.

* Confirm the branch is dead. On `trunk`, add an `fs.appendFileSync` call inside the `date_start`/`date_end` branch of `getRowIntervalFields`, then run the whole package suite from `projects/packages/premium-analytics`:
  `PA_TEST_GROUPS=1 TZ=UTC npx jest --config=tests/jest.config.cjs`
  156 suites and 3103 tests pass, and the log file is never created. A throwaway test that feeds a row carrying `date_start` and `date_end` does write to it, so the instrumentation was live.
* Confirm the fallthrough. A hypothetical row carrying only `date_start: '2026-06-15T00:00:00-07:00'` now falls through to `getTimeSeriesIntervalFields`, producing `date_start: '2026-06-15T00:00:00'` and `date_end: '2026-06-15T23:59:59'`, the same timezone-naive wall times every other branch emits. `time_interval` keeps the raw stamp.
* Gates on this branch, all from `projects/packages/premium-analytics` unless noted:
  * `PA_TEST_GROUPS=1 TZ=UTC npx jest --config=tests/jest.config.cjs` : 156 suites, 3103 tests, all passing, identical to the pre-change run.
  * `npx tsc --noEmit -p tsconfig.json` : exit 0.
  * ESLint on the three changed files, from the monorepo root: clean.
