### PR TITLE
Premium Analytics: show the onboarding again after switching the new Traffic tab back on

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-onboarding-on-reactivation
+++ b/projects/packages/premium-analytics/changelog/update-pa-onboarding-on-reactivation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: show the onboarding again to a reader who switches the new Traffic tab back on.

--- a/projects/packages/premium-analytics/src/class-enablement-setting.php
+++ b/projects/packages/premium-analytics/src/class-enablement-setting.php
@@ -39,6 +39,22 @@ class Enablement_Setting {
 	const ENABLED_OPTION = 'jetpack_premium_analytics_enabled';
 
 	/**
+	 * Preferences scope the dashboard stores its per-user state under. Mirrors
+	 * `routes/dashboard/hooks/constants.ts`.
+	 *
+	 * @since $$next-version$$
+	 */
+	const PREFERENCES_SCOPE = 'jetpack-premium-analytics/dashboard';
+
+	/**
+	 * Preferences key the dashboard sets once a reader has been through the onboarding. Mirrors
+	 * `routes/dashboard/hooks/constants.ts`.
+	 *
+	 * @since $$next-version$$
+	 */
+	const ONBOARDING_KEY = 'onboardingCompletedAt';
+
+	/**
 	 * Declare the setting so core's settings route exposes it.
 	 *
 	 * Call on `rest_api_init`: core builds the settings route from the registered settings at
@@ -61,6 +77,7 @@ class Enablement_Setting {
 				'description'       => __( 'Whether the Premium Analytics dashboard is enabled for this site.', 'jetpack-premium-analytics-pkg' ),
 			)
 		);
+		add_action( 'update_option_' . self::ENABLED_OPTION, array( __CLASS__, 'reset_onboarding_on_reactivation' ), 10, 2 );
 	}
 
 	/**
@@ -78,5 +95,46 @@ class Enablement_Setting {
 	 */
 	public static function sanitize_enabled( $value ) {
 		return (int) rest_sanitize_boolean( $value );
+	}
+
+	/**
+	 * Forget that the reader switching the dashboard back on has seen the onboarding.
+	 *
+	 * Someone who switched off and came back gets the tour again; a first activation, a
+	 * switch-off, and everyone else's preference are left alone. Riding on the option write means
+	 * only writes made while the setting is registered count, which is every product path: the
+	 * classic Stats banner and menu, and the dashboard's own switch-off, all go through REST.
+	 *
+	 * The preference lives in core's persisted preferences user meta, whose client-side layer
+	 * keeps a localStorage copy and takes whichever is newer, so `_modified` moves with the change.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $old_value Previous option value.
+	 * @param mixed $value     New option value.
+	 * @return void
+	 */
+	public static function reset_onboarding_on_reactivation( $old_value, $value ) {
+		if ( (bool) $old_value || ! (bool) $value ) {
+			return;
+		}
+
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return;
+		}
+
+		global $wpdb;
+		$meta_key    = $wpdb->get_blog_prefix() . 'persisted_preferences';
+		$preferences = get_user_meta( $user_id, $meta_key, true );
+
+		if ( ! is_array( $preferences ) || ! isset( $preferences[ self::PREFERENCES_SCOPE ][ self::ONBOARDING_KEY ] ) ) {
+			return;
+		}
+
+		unset( $preferences[ self::PREFERENCES_SCOPE ][ self::ONBOARDING_KEY ] );
+		$preferences['_modified'] = gmdate( 'Y-m-d\TH:i:s\Z' );
+
+		update_user_meta( $user_id, $meta_key, $preferences );
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Enablement_Setting_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Enablement_Setting_Test.php
@@ -55,6 +55,7 @@ class Enablement_Setting_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_premium_analytics_enabled' );
 		remove_action( 'rest_api_init', array( Enablement_Setting::class, 'register' ) );
 		remove_action( 'rest_api_init', array( $this, 'register_core_settings_route' ), 99 );
+		remove_action( 'update_option_' . Enablement_Setting::ENABLED_OPTION, array( Enablement_Setting::class, 'reset_onboarding_on_reactivation' ) );
 		wp_set_current_user( 0 );
 
 		parent::tear_down();
@@ -208,6 +209,94 @@ class Enablement_Setting_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Store a reader's persisted preferences the way core's client layer writes them.
+	 *
+	 * @param int   $user_id     User to write for.
+	 * @param array $preferences Preferences, scope-keyed.
+	 * @return string The meta key written.
+	 */
+	private function seed_preferences( int $user_id, array $preferences ): string {
+		global $wpdb;
+		$meta_key = $wpdb->get_blog_prefix() . 'persisted_preferences';
+		update_user_meta( $user_id, $meta_key, $preferences );
+
+		return $meta_key;
+	}
+
+	/**
+	 * A reader's preferences as seeded for these tests: onboarding done, one unrelated key.
+	 *
+	 * @return array
+	 */
+	private function seen_onboarding_preferences(): array {
+		return array(
+			Enablement_Setting::PREFERENCES_SCOPE => array(
+				Enablement_Setting::ONBOARDING_KEY => '2026-09-01T10:00:00.000Z',
+				'dashboardGridSettings'            => array( 'columnCount' => 4 ),
+			),
+			'core/edit-post'                      => array( 'welcomeGuide' => false ),
+			'_modified'                           => '2026-09-01T10:00:00.000Z',
+		);
+	}
+
+	public function test_switching_on_again_forgets_the_onboarding_for_the_reader_who_did_it() {
+		$user_id  = $this->log_in_as_admin();
+		$meta_key = $this->seed_preferences( $user_id, $this->seen_onboarding_preferences() );
+		update_option( Enablement_Setting::ENABLED_OPTION, 0 );
+
+		$this->assertSame( 200, $this->post_enabled( true )->get_status() );
+
+		$preferences = get_user_meta( $user_id, $meta_key, true );
+		$this->assertArrayNotHasKey( Enablement_Setting::ONBOARDING_KEY, $preferences[ Enablement_Setting::PREFERENCES_SCOPE ] );
+		$this->assertSame( array( 'columnCount' => 4 ), $preferences[ Enablement_Setting::PREFERENCES_SCOPE ]['dashboardGridSettings'] );
+		$this->assertSame( array( 'welcomeGuide' => false ), $preferences['core/edit-post'] );
+		// The client layer takes whichever copy is newer, so the server's has to be.
+		$this->assertGreaterThan( strtotime( '2026-09-01T10:00:00.000Z' ), strtotime( $preferences['_modified'] ) );
+	}
+
+	public function test_switching_off_leaves_the_onboarding_alone() {
+		$user_id  = $this->log_in_as_admin();
+		$meta_key = $this->seed_preferences( $user_id, $this->seen_onboarding_preferences() );
+		update_option( Enablement_Setting::ENABLED_OPTION, 1 );
+
+		$this->assertSame( 200, $this->post_enabled( false )->get_status() );
+
+		$this->assertSame( $this->seen_onboarding_preferences(), get_user_meta( $user_id, $meta_key, true ) );
+	}
+
+	public function test_a_first_activation_leaves_preferences_without_the_key_alone() {
+		$user_id     = $this->log_in_as_admin();
+		$preferences = array(
+			'core/edit-post' => array( 'welcomeGuide' => false ),
+			'_modified'      => '2026-09-01T10:00:00.000Z',
+		);
+		$meta_key    = $this->seed_preferences( $user_id, $preferences );
+
+		$this->assertSame( 200, $this->post_enabled( true )->get_status() );
+
+		$this->assertSame( $preferences, get_user_meta( $user_id, $meta_key, true ) );
+	}
+
+	public function test_switching_on_again_touches_no_other_reader() {
+		global $wpdb;
+		$other_id = wp_insert_user(
+			array(
+				'user_login' => 'pa-other-admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		$meta_key = $this->seed_preferences( $other_id, $this->seen_onboarding_preferences() );
+		$this->log_in_as_admin();
+		update_option( Enablement_Setting::ENABLED_OPTION, 0 );
+
+		$this->assertSame( 200, $this->post_enabled( true )->get_status() );
+
+		$this->assertSame( $this->seen_onboarding_preferences(), get_user_meta( $other_id, $wpdb->get_blog_prefix() . 'persisted_preferences', true ) );
+		$this->assertSame( $meta_key, $wpdb->get_blog_prefix() . 'persisted_preferences' );
+	}
+
+	/**
 	 * Both hosts may register, so a second call has to leave a single, unchanged declaration.
 	 */
 	public function test_register_is_idempotent() {
@@ -220,5 +309,6 @@ class Enablement_Setting_Test extends BaseTestCase {
 		$this->assertArrayHasKey( Enablement_Setting::ENABLED_OPTION, $registered );
 		$this->assertSame( 'boolean', $registered[ Enablement_Setting::ENABLED_OPTION ]['type'] );
 		$this->assertTrue( $registered[ Enablement_Setting::ENABLED_OPTION ]['show_in_rest'] );
+		$this->assertSame( 10, has_action( 'update_option_' . Enablement_Setting::ENABLED_OPTION, array( Enablement_Setting::class, 'reset_onboarding_on_reactivation' ) ) );
 	}
 }

--- a/projects/plugins/jetpack/changelog/update-pa-onboarding-on-reactivation
+++ b/projects/plugins/jetpack/changelog/update-pa-onboarding-on-reactivation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: show the onboarding again to a reader who switches the new Traffic tab back on.

--- a/projects/plugins/premium-analytics/changelog/update-pa-onboarding-on-reactivation
+++ b/projects/plugins/premium-analytics/changelog/update-pa-onboarding-on-reactivation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Dashboard: show the onboarding again to a reader who switches the new Traffic tab back on.

--- a/projects/plugins/wpcomsh/changelog/update-pa-onboarding-on-reactivation
+++ b/projects/plugins/wpcomsh/changelog/update-pa-onboarding-on-reactivation
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: show the onboarding again to a reader who switches the new Traffic tab back on.


### PR DESCRIPTION
Follow-up to #52025. Part of WOOA7S-2094.

## Proposed changes

Someone who switches the new Traffic tab off and later comes back lands on the dashboard as if they had never left: the welcome modal and the tour are marked as `done` in their preferences, so nothing introduces the UI again.

This makes a switch-on a fresh start for the reader who does it.

* `Enablement_Setting::register()` hooks the option's off→on transition (`update_option_jetpack_premium_analytics_enabled`) and clears `onboardingCompletedAt` from the current user's persisted preferences, under the dashboard's own scope.

`_modified` moves with the change, because core's preferences persistence keeps a localStorage copy and takes whichever is newer.

* Per user, not per site:
A first activation, a switch-off, and everyone else's preference are left alone.

The preference is the same `{prefix}persisted_preferences` user meta that core's `wp-preferences` persists the store into, which is where the dashboard already keeps its layout and grid settings.

* Only REST writes count, since the hook rides on the setting's registration

The classic Stats banner, the modules menu entry coming in wp-calypso, and the dashboard's own switch-off all go through `wp/v2/settings`. `wp option update` does not trigger it, by design.

* Changelog entries for the package and for the plugins that surface the dashboard (Jetpack, Premium Analytics, wpcomsh).

## Related product discussion/links

* WOOA7S-2094
* #52025

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build with...

```bash
jetpack build packages/premium-analytics
```

... and open Stats v2 as an administrator on a site that has been through the onboarding, so the welcome modal no longer shows on load.

* Switch the preview off from the page options menu ("Switch off the preview") and confirm. You land on classic Stats.

* Switch it back on through REST as the same administrator, for example, from the browser console:

```js
wp.apiFetch( { path: '/wp/v2/settings', method: 'POST', data: { jetpack_premium_analytics_enabled: true } } );
```

* Open Stats v2 again: the welcome modal shows, then the tour. Finish or dismiss it, reload, and ensure it stays away.

* As a second administrator who had already been through the onboarding, ensure nothing changed for them after the first one switched the dashboard back on.

* Restore with `jetpack docker wp --allow-root --path=/var/www/html option update jetpack_premium_analytics_enabled 1` instead and ensure the onboarding does not come back: WP-CLI writes are not a product path.

* `jetpack test php packages/premium-analytics` (or `vendor/bin/phpunit-select-config phpunit.#.xml.dist --filter Enablement_Setting_Test` inside the package).
