### PR TITLE
Jetpack AI: send VIP sites to the Jetpack connection screen from the …

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -194,6 +194,7 @@ export default function App() {
 		upgradeUrl,
 		planName,
 		isUserConnected,
+		userConnectionUrl = 'admin.php?page=my-jetpack#/connection',
 		showFeaturesView = false,
 		showA12sBadge = false,
 	} = window?.jetpackAiSettings ?? {};
@@ -437,7 +438,7 @@ export default function App() {
 							</Notice.Root>
 						) }
 
-						{ showConnectNotice && <McpConnectCallout /> }
+						{ showConnectNotice && <McpConnectCallout userConnectionUrl={ userConnectionUrl } /> }
 
 						{ ! isLoading && ! error && !! blogId && ! userUnlinked && ! hasMcpAccess && (
 							<McpUpsell />

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/connect-callout.jsx
@@ -13,9 +13,11 @@ import './style.scss';
 /**
  * Connect-account callout card.
  *
+ * @param {object} props                   - Component props.
+ * @param {string} props.userConnectionUrl - URL for connecting the current user.
  * @return {object} Component markup.
  */
-export default function McpConnectCallout() {
+export default function McpConnectCallout( { userConnectionUrl } ) {
 	// Announce like the notice this replaces: the design system does it via speak().
 	useEffect( () => {
 		speak( __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) );
@@ -36,7 +38,7 @@ export default function McpConnectCallout() {
 				<p className="jetpack-ai-mcp__upsell-callout-description">
 					{ __( 'A user connection lets agents securely act on your behalf.', 'jetpack' ) }
 				</p>
-				<Button variant="primary" href="admin.php?page=my-jetpack#/connection">
+				<Button variant="primary" href={ userConnectionUrl }>
 					{ __( 'Connect your user account', 'jetpack' ) }
 				</Button>
 			</div>

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -474,6 +474,26 @@ describe( 'AI admin page (main.jsx)', () => {
 			);
 		} );
 
+		test( 'the connect card uses the supplied connection screen', async () => {
+			window.jetpackAiSettings = {
+				showFeaturesView: true,
+				blogId: 1,
+				isUserConnected: false,
+				userConnectionUrl: 'admin.php?page=jetpack#/connect-user',
+			};
+			mockApiFetch( { mcpGet: { has_mcp_access: false, mcp_abilities: {} } } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText( CONNECT_CARD_TEXT, IGNORE_A11Y )
+			).resolves.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Connect your user account' } ) ).toHaveAttribute(
+				'href',
+				'admin.php?page=jetpack#/connect-user'
+			);
+		} );
+
 		test( 'site connected, has plan: shows the connect card and not the hub', async () => {
 			window.jetpackAiSettings = { showFeaturesView: true, blogId: 1, isUserConnected: false };
 			mockApiFetch( { mcpGet: connectedMcpGet() } );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -277,11 +277,15 @@ class Jetpack_AI_Page {
 			array(
 				// The Overview and Features views launch on non-VIP self-hosted sites first.
 				// Keep this filterable so hosts can close them independently.
-				'showGatedViews'  => ! $host->is_vip_site()
+				'showGatedViews'    => ! $host->is_vip_site()
 					&& ( ! $host->is_wpcom_platform() || ( $host->is_woa_site() && $is_internal_test ) ),
-				'showA12sBadge'   => $host->is_woa_site() && $is_internal_test,
-				'isUserConnected' => ( new Connection_Manager() )->is_user_connected(),
-				'mcpSettingsApi'  => array(
+				'showA12sBadge'     => $host->is_woa_site() && $is_internal_test,
+				'isUserConnected'   => ( new Connection_Manager() )->is_user_connected(),
+				// My Jetpack is removed on VIP, so that route dead-ends there.
+				'userConnectionUrl' => $host->is_vip_site()
+					? 'admin.php?page=jetpack#/connect-user'
+					: 'admin.php?page=my-jetpack#/connection',
+				'mcpSettingsApi'    => array(
 					'path'   => '/wpcom/v2/jetpack-ai/mcp-settings',
 					'format' => 'jetpack',
 				),
@@ -293,39 +297,40 @@ class Jetpack_AI_Page {
 		$plan_info = $show_gated_views ? self::get_ai_plan_info() : array( 'name' => '' );
 
 		$settings = array(
-			'blogId'           => $blog_id ? (int) $blog_id : 0,
-			'activityLogUrl'   => $activity_log_url,
-			'seoSettingsUrl'   => $seo_settings_url,
-			'siteAdminUrl'     => admin_url(),
-			'apiRoot'          => esc_url_raw( rest_url() ),
-			'apiNonce'         => wp_create_nonce( 'wp_rest' ),
-			'pluginUrl'        => plugins_url( '', JETPACK__PLUGIN_FILE ),
+			'blogId'            => $blog_id ? (int) $blog_id : 0,
+			'activityLogUrl'    => $activity_log_url,
+			'seoSettingsUrl'    => $seo_settings_url,
+			'siteAdminUrl'      => admin_url(),
+			'userConnectionUrl' => esc_url_raw( $config['userConnectionUrl'] ),
+			'apiRoot'           => esc_url_raw( rest_url() ),
+			'apiNonce'          => wp_create_nonce( 'wp_rest' ),
+			'pluginUrl'         => plugins_url( '', JETPACK__PLUGIN_FILE ),
 			// The redirect entry bakes in the jetpack_ai_yearly product and
 			// a post-checkout return to this page, so both can be
 			// retargeted without shipping a code change.
-			'upgradeUrl'       => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
+			'upgradeUrl'        => Redirect::get_url( 'jetpack-ai-hub-upgrade' ),
 			// The purchase granting AI — the usage card only uses it to pick
 			// the right loading-skeleton shape before the usage fetch lands.
 			// Only looked up when a gated view can render the card.
-			'planName'         => $plan_info['name'],
-			'showFeaturesView' => $show_gated_views,
-			'showA12sBadge'    => ! empty( $config['showA12sBadge'] ),
+			'planName'          => $plan_info['name'],
+			'showFeaturesView'  => $show_gated_views,
+			'showA12sBadge'     => ! empty( $config['showA12sBadge'] ),
 			// The tab and its Agents Manager sidebar ship disabled by default.
-			'featureFlags'     => array(
+			'featureFlags'      => array(
 				Jetpack_AI_Feature_Flags::SCHEDULED_TASKS => $show_scheduled_tasks_view,
 			),
 			// The usage endpoint proxies as the current user, which needs
 			// their own WordPress.com account linked — not just the site.
-			'isUserConnected'  => ! empty( $config['isUserConnected'] ),
+			'isUserConnected'   => ! empty( $config['isUserConnected'] ),
 			// Tracks audience properties for the jetpack_mcp_* events, per the
 			// Tracks standards for AI product events (AIINT-586). The client
 			// sends them as the strings 'true'/'false' (AIINT-576).
-			'isA11n'           => self::is_current_user_automattician(),
-			'isTest'           => $is_internal_test,
+			'isA11n'            => self::is_current_user_automattician(),
+			'isTest'            => $is_internal_test,
 			// Identity for Tracks; the lookup can call WordPress.com on a
 			// cache miss, so it shares the sender's guard.
-			'tracksUserData'   => $can_send_tracks ? self::get_tracks_user_data() : null,
-			'mcpSettingsApi'   => $config['mcpSettingsApi'],
+			'tracksUserData'    => $can_send_tracks ? self::get_tracks_user_data() : null,
+			'mcpSettingsApi'    => $config['mcpSettingsApi'],
 		);
 
 		wp_add_inline_script(

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-vip-connect-link
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-vip-connect-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: send VIP sites to the Jetpack user connection screen from the MCP connect card.

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-vip-connect-link
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-vip-connect-link
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Jetpack AI: send VIP sites to the Jetpack user connection screen from the MCP connect card.
+Jetpack AI: Send VIP sites to the Jetpack user connection screen from the MCP connect card.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -263,8 +263,20 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 		$this->assertTrue( $settings['showFeaturesView'] );
 		$this->assertFalse( $settings['showA12sBadge'] );
 		$this->assertFalse( $settings['isTest'] );
+		$this->assertSame( 'admin.php?page=my-jetpack#/connection', $settings['userConnectionUrl'] );
 		$this->assertArrayHasKey( 'featureFlags', $settings );
 		$this->assertFalse( $settings['featureFlags'][ Jetpack_AI_Feature_Flags::SCHEDULED_TASKS ] );
+	}
+
+	/**
+	 * VIP sites connect users through the legacy Jetpack connection screen.
+	 */
+	public function test_vip_site_uses_jetpack_user_connection_url() {
+		Constants::set_constant( 'WPCOM_IS_VIP_ENV', true );
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertSame( 'admin.php?page=jetpack#/connect-user', $settings['userConnectionUrl'] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Pulled  @kat3samsin's code from from #51994 - that one also covers AI Answers, the feature-settings endpoint, and the other connection links; none of it is included here. The only edits are dropping those parts, resolving her conflict with #52006 in favour of trunk, one comment, and the changelog entry.

* Send VIP sites to the Jetpack user connection screen from the MCP connect card.
* Keep the My Jetpack route on every other host.
* Supply the destination once as `userConnectionUrl` in the Jetpack AI page data.

My Jetpack is not reachable on VIP. The card's only button goes there, so the page is a dead end for an admin who has not linked an account. On VIP that is the normal state: the site connection is owned by a machine user, so admins arrive unlinked.

The card is new in 16.2. Overview and AI Features are hidden on VIP as of #52006, so MCP is where this is reachable.

Taken from #51994, which also covers AI Answers and the other connection links. Those are unchanged here.

## Related product discussion/links

* FORNO-517
* #51994
* #51822

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need two sites and, on each, an administrator whose WordPress.com account is not linked.

### WordPress VIP

1. Install the build from this PR.
2. Sign in as the unlinked administrator.
3. Go to **Jetpack → Jetpack AI**. It opens on **MCP and Connectors**.
4. Select **Connect your user account**.
5. Confirm the Jetpack user connection screen opens. On trunk it shows "Sorry, you are not allowed to access this page."

### Self-hosted

1. Install the build from this PR.
2. Repeat the steps above.
3. Confirm the button still opens My Jetpack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)