### PR TITLE
Premium Analytics: lay the post and video detail pages out on the three-column grid

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-detail-pages-three-columns
+++ b/projects/packages/premium-analytics/changelog/update-pa-detail-pages-three-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Post and video detail pages: lay the widgets out on the three-column grid the dashboard uses.

--- a/projects/packages/premium-analytics/routes/detail-grid.ts
+++ b/projects/packages/premium-analytics/routes/detail-grid.ts
@@ -1,0 +1,17 @@
+import { DEFAULT_GRID, ROW_HEIGHT_PRESETS } from '@wordpress/widget-dashboard';
+
+/**
+ * The detail pages are designed on three columns, like the main dashboard
+ * (WOOA7S-2032), one fewer than the widget-dashboard package default.
+ */
+export const DETAIL_COLUMN_COUNT = 3;
+
+/**
+ * Grid for the fixed detail-page compositions. Kept apart from the customizable
+ * main-dashboard preference so a settings control can't stretch these tiles.
+ */
+export const DETAIL_GRID = {
+	...DEFAULT_GRID,
+	columns: DETAIL_COLUMN_COUNT,
+	rowHeight: ROW_HEIGHT_PRESETS.small,
+};

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -73,7 +73,7 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'composes Email clicks as a trend chart beside Platforms, Clients beside the Locations map, then a full-width links row', () => {
+	it( 'composes Email clicks as a full-width trend chart over the full-width Locations map, then Platforms, Clients and Top links side by side', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ] ).toMatchObject( [
 			{
 				uuid: 'email-clicks-highlights',
@@ -85,31 +85,31 @@ describe( 'post detail tab layouts', () => {
 				uuid: 'email-clicks-trend',
 				type: 'jpa/email-time-series--total-clicks',
 				attributes: { metric: 'clicks' },
-				placement: { width: 2, height: 2, order: 2 },
-			},
-			{
-				uuid: 'email-clicks-devices',
-				type: 'jpa/email-breakdown--platforms-clicks',
-				attributes: { view: 'devices', metric: 'clicks' },
-				placement: { width: 1, height: 2, order: 3 },
-			},
-			{
-				uuid: 'email-clicks-clients',
-				type: 'jpa/email-breakdown--clients-clicks',
-				attributes: { view: 'clients', metric: 'clicks' },
-				placement: { width: 1, height: 2, order: 4 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 			},
 			{
 				uuid: 'email-clicks-countries',
 				type: 'jpa/email-breakdown--location-clicks',
 				attributes: { view: 'countries', metric: 'clicks', showMap: true },
-				placement: { width: 2, height: 2, order: 5 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 3 },
+			},
+			{
+				uuid: 'email-clicks-devices',
+				type: 'jpa/email-breakdown--platforms-clicks',
+				attributes: { view: 'devices', metric: 'clicks' },
+				placement: { width: 1, height: 2, order: 4 },
+			},
+			{
+				uuid: 'email-clicks-clients',
+				type: 'jpa/email-breakdown--clients-clicks',
+				attributes: { view: 'clients', metric: 'clicks' },
+				placement: { width: 1, height: 2, order: 5 },
 			},
 			{
 				uuid: 'email-clicks-links',
 				type: 'jpa/email-breakdown--top-links',
 				attributes: { view: 'links', metric: 'clicks' },
-				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
+				placement: { width: 1, height: 2, order: 6 },
 			},
 		] );
 	} );

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -73,7 +73,7 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'composes Email clicks as a full-width trend chart over the full-width Locations map, then Platforms, Clients and Top links side by side', () => {
+	it( 'composes Email clicks as a two-column trend chart beside Platforms, Clients beside the two-column Locations map, then a two-column Top links', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ] ).toMatchObject( [
 			{
 				uuid: 'email-clicks-highlights',
@@ -85,36 +85,36 @@ describe( 'post detail tab layouts', () => {
 				uuid: 'email-clicks-trend',
 				type: 'jpa/email-time-series--total-clicks',
 				attributes: { metric: 'clicks' },
-				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
-			},
-			{
-				uuid: 'email-clicks-countries',
-				type: 'jpa/email-breakdown--location-clicks',
-				attributes: { view: 'countries', metric: 'clicks', showMap: true },
-				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 3 },
+				placement: { width: 2, height: 2, order: 2 },
 			},
 			{
 				uuid: 'email-clicks-devices',
 				type: 'jpa/email-breakdown--platforms-clicks',
 				attributes: { view: 'devices', metric: 'clicks' },
-				placement: { width: 1, height: 2, order: 4 },
+				placement: { width: 1, height: 2, order: 3 },
 			},
 			{
 				uuid: 'email-clicks-clients',
 				type: 'jpa/email-breakdown--clients-clicks',
 				attributes: { view: 'clients', metric: 'clicks' },
-				placement: { width: 1, height: 2, order: 5 },
+				placement: { width: 1, height: 2, order: 4 },
+			},
+			{
+				uuid: 'email-clicks-countries',
+				type: 'jpa/email-breakdown--location-clicks',
+				attributes: { view: 'countries', metric: 'clicks', showMap: true },
+				placement: { width: 2, height: 2, order: 5 },
 			},
 			{
 				uuid: 'email-clicks-links',
 				type: 'jpa/email-breakdown--top-links',
 				attributes: { view: 'links', metric: 'clicks' },
-				placement: { width: 1, height: 2, order: 6 },
+				placement: { width: 2, height: 2, order: 6 },
 			},
 		] );
 	} );
 
-	it( 'fills every row of the three-column grid without leaving a gap', () => {
+	it( 'never wraps a tile past a partly filled row of the three-column grid', () => {
 		for ( const layout of Object.values( POST_DETAIL_TAB_LAYOUTS ) ) {
 			let used = 0;
 			for ( const widget of layout ) {
@@ -123,10 +123,10 @@ describe( 'post detail tab layouts', () => {
 				expect( typeof width ).toBe( 'number' );
 				const span = width as number;
 				// A tile that does not fit wraps and strands the columns before it.
+				// The last row may stay open (Email clicks ends on a two-column tile).
 				expect( used + span ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
 				used = ( used + span ) % DETAIL_COLUMN_COUNT;
 			}
-			expect( used ).toBe( 0 );
 		}
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -2,7 +2,7 @@ import { DETAIL_COLUMN_COUNT } from '../../detail-grid';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as a full-width highlights row, a Post views chart beside Likes, Comments, then a full-width Traffic activity over UTM', () => {
+	it( 'composes Post traffic as full-width highlights and Post views rows, Likes, Comments and UTM side by side, then a full-width Traffic activity', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
@@ -12,7 +12,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'post-views',
 				type: 'jpa/post-views',
-				placement: { width: 2, height: 2, order: 2 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 			},
 			{
 				uuid: 'post-likes',
@@ -25,15 +25,15 @@ describe( 'post detail tab layouts', () => {
 				placement: { width: 1, height: 2, order: 4 },
 			},
 			{
-				uuid: 'post-traffic-activity',
-				type: 'jpa/post-traffic-activity',
-				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 5 },
-			},
-			{
 				uuid: 'post-utm',
 				type: 'jpa/utm-insights--utm',
 				attributes: { utmDimension: 'utm_source,utm_medium', showReportLink: false },
-				placement: { width: 1, height: 2, order: 6 },
+				placement: { width: 1, height: 2, order: 5 },
+			},
+			{
+				uuid: 'post-traffic-activity',
+				type: 'jpa/post-traffic-activity',
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
 			},
 		] );
 	} );
@@ -114,11 +114,16 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'keeps every tile within the three-column grid', () => {
+	it( 'fills every row of the three-column grid without leaving a gap', () => {
 		for ( const layout of Object.values( POST_DETAIL_TAB_LAYOUTS ) ) {
+			let used = 0;
 			for ( const widget of layout ) {
-				expect( widget.placement?.width ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
+				const width = widget.placement?.width ?? 1;
+				// A tile that does not fit wraps and strands the columns before it.
+				expect( used + width ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
+				used = ( used + width ) % DETAIL_COLUMN_COUNT;
 			}
+			expect( used ).toBe( 0 );
 		}
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -1,13 +1,13 @@
-import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
+import { DETAIL_COLUMN_COUNT } from '../../detail-grid';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as a full-width highlights row, a Post views chart beside the interaction cards, then Traffic activity beside UTM', () => {
+	it( 'composes Post traffic as a full-width highlights row, a Post views chart beside Likes, Comments, then a full-width Traffic activity over UTM', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
 				type: 'jpa/post-detail-highlights',
-				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 			},
 			{
 				uuid: 'post-views',
@@ -27,7 +27,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'post-traffic-activity',
 				type: 'jpa/post-traffic-activity',
-				placement: { width: 3, height: 2, order: 5 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 5 },
 			},
 			{
 				uuid: 'post-utm',
@@ -38,19 +38,19 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'composes Email opens as a highlights row over a three-column trend chart with Locations beside it', () => {
+	it( 'composes Email opens as a highlights row over a full-width trend chart, then Locations, Platforms and Clients side by side', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'email-opens' ] ).toMatchObject( [
 			{
 				uuid: 'email-opens-highlights',
 				type: 'jpa/email-top-row',
 				attributes: { metric: 'opens' },
-				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 			},
 			{
 				uuid: 'email-opens-trend',
 				type: 'jpa/email-time-series--total-opens',
 				attributes: { metric: 'opens' },
-				placement: { width: 3, height: 2, order: 2 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 			},
 			{
 				uuid: 'email-opens-countries',
@@ -73,13 +73,13 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'composes Email clicks as a trend chart beside Platforms and Clients, over the Locations and links rows', () => {
+	it( 'composes Email clicks as a trend chart beside Platforms, Clients beside the Locations map, then a full-width links row', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ] ).toMatchObject( [
 			{
 				uuid: 'email-clicks-highlights',
 				type: 'jpa/email-top-row',
 				attributes: { metric: 'clicks' },
-				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 			},
 			{
 				uuid: 'email-clicks-trend',
@@ -109,8 +109,16 @@ describe( 'post detail tab layouts', () => {
 				uuid: 'email-clicks-links',
 				type: 'jpa/email-breakdown--top-links',
 				attributes: { view: 'links', metric: 'clicks' },
-				placement: { width: 2, height: 2, order: 6 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
 			},
 		] );
+	} );
+
+	it( 'keeps every tile within the three-column grid', () => {
+		for ( const layout of Object.values( POST_DETAIL_TAB_LAYOUTS ) ) {
+			for ( const widget of layout ) {
+				expect( widget.placement?.width ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
+			}
+		}
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -118,10 +118,13 @@ describe( 'post detail tab layouts', () => {
 		for ( const layout of Object.values( POST_DETAIL_TAB_LAYOUTS ) ) {
 			let used = 0;
 			for ( const widget of layout ) {
-				const width = widget.placement?.width ?? 1;
+				// Every detail tile declares a numeric span, never `fill` or `full`.
+				const width = widget.placement?.width;
+				expect( typeof width ).toBe( 'number' );
+				const span = width as number;
 				// A tile that does not fit wraps and strands the columns before it.
-				expect( used + width ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
-				used = ( used + width ) % DETAIL_COLUMN_COUNT;
+				expect( used + span ).toBeLessThanOrEqual( DETAIL_COLUMN_COUNT );
+				used = ( used + span ) % DETAIL_COLUMN_COUNT;
 			}
 			expect( used ).toBe( 0 );
 		}

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -90,32 +90,32 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-clicks-trend',
 			type: 'jpa/email-time-series--total-clicks',
 			attributes: { metric: 'clicks' },
-			placement: { width: 2, height: 2, order: 2 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
+		},
+		{
+			uuid: 'email-clicks-countries',
+			// Full width: the map unmounts below a 720px container floor.
+			type: 'jpa/email-breakdown--location-clicks',
+			attributes: { view: 'countries', metric: 'clicks', showMap: true },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 3 },
 		},
 		{
 			uuid: 'email-clicks-devices',
 			type: 'jpa/email-breakdown--platforms-clicks',
 			attributes: { view: 'devices', metric: 'clicks' },
-			placement: { width: 1, height: 2, order: 3 },
+			placement: { width: 1, height: 2, order: 4 },
 		},
 		{
 			uuid: 'email-clicks-clients',
 			type: 'jpa/email-breakdown--clients-clicks',
 			attributes: { view: 'clients', metric: 'clicks' },
-			placement: { width: 1, height: 2, order: 4 },
-		},
-		{
-			uuid: 'email-clicks-countries',
-			// Keep width: 2 — the map unmounts below a 720px container floor.
-			type: 'jpa/email-breakdown--location-clicks',
-			attributes: { view: 'countries', metric: 'clicks', showMap: true },
-			placement: { width: 2, height: 2, order: 5 },
+			placement: { width: 1, height: 2, order: 5 },
 		},
 		{
 			uuid: 'email-clicks-links',
 			type: 'jpa/email-breakdown--top-links',
 			attributes: { view: 'links', metric: 'clicks' },
-			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
+			placement: { width: 1, height: 2, order: 6 },
 		},
 	],
 };

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -90,32 +90,33 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-clicks-trend',
 			type: 'jpa/email-time-series--total-clicks',
 			attributes: { metric: 'clicks' },
-			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
-		},
-		{
-			uuid: 'email-clicks-countries',
-			// Full width: the map unmounts below a 720px container floor.
-			type: 'jpa/email-breakdown--location-clicks',
-			attributes: { view: 'countries', metric: 'clicks', showMap: true },
-			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 3 },
+			placement: { width: 2, height: 2, order: 2 },
 		},
 		{
 			uuid: 'email-clicks-devices',
 			type: 'jpa/email-breakdown--platforms-clicks',
 			attributes: { view: 'devices', metric: 'clicks' },
-			placement: { width: 1, height: 2, order: 4 },
+			placement: { width: 1, height: 2, order: 3 },
 		},
 		{
 			uuid: 'email-clicks-clients',
 			type: 'jpa/email-breakdown--clients-clicks',
 			attributes: { view: 'clients', metric: 'clicks' },
-			placement: { width: 1, height: 2, order: 5 },
+			placement: { width: 1, height: 2, order: 4 },
+		},
+		{
+			uuid: 'email-clicks-countries',
+			// Keep width: 2 — the map unmounts below a 720px container floor.
+			type: 'jpa/email-breakdown--location-clicks',
+			attributes: { view: 'countries', metric: 'clicks', showMap: true },
+			placement: { width: 2, height: 2, order: 5 },
 		},
 		{
 			uuid: 'email-clicks-links',
+			// Two of three columns, per the design; the last row is left open.
 			type: 'jpa/email-breakdown--top-links',
 			attributes: { view: 'links', metric: 'clicks' },
-			placement: { width: 1, height: 2, order: 6 },
+			placement: { width: 2, height: 2, order: 6 },
 		},
 	],
 };

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -1,10 +1,11 @@
-import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
+import { DETAIL_COLUMN_COUNT } from '../../detail-grid';
 import type { PostDetailTabId } from './tabs';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
  * Fixed widget composition for each post-detail tab (not user-customizable,
  * WOOA7S-1622); a tab stays hidden only while its composition is empty.
+ * Widths fill the three-column detail grid.
  */
 export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[] > = {
 	'post-traffic': [
@@ -12,7 +13,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'post-detail-highlights',
 			// Full-width row, matching the email highlights layout.
 			type: 'jpa/post-detail-highlights',
-			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
 			uuid: 'post-views',
@@ -31,8 +32,9 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		},
 		{
 			uuid: 'post-traffic-activity',
+			// Full width: the heatmap lays a whole year out across its columns.
 			type: 'jpa/post-traffic-activity',
-			placement: { width: 3, height: 2, order: 5 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 5 },
 		},
 		{
 			uuid: 'post-utm',
@@ -50,13 +52,13 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-opens-highlights',
 			type: 'jpa/email-top-row',
 			attributes: { metric: 'opens' },
-			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
 			uuid: 'email-opens-trend',
 			type: 'jpa/email-time-series--total-opens',
 			attributes: { metric: 'opens' },
-			placement: { width: 3, height: 2, order: 2 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 		},
 		{
 			uuid: 'email-opens-countries',
@@ -82,7 +84,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-clicks-highlights',
 			type: 'jpa/email-top-row',
 			attributes: { metric: 'clicks' },
-			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
 			uuid: 'email-clicks-trend',
@@ -113,7 +115,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-clicks-links',
 			type: 'jpa/email-breakdown--top-links',
 			attributes: { view: 'links', metric: 'clicks' },
-			placement: { width: 2, height: 2, order: 6 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
 		},
 	],
 };

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -18,7 +18,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		{
 			uuid: 'post-views',
 			type: 'jpa/post-views',
-			placement: { width: 2, height: 2, order: 2 },
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 		},
 		{
 			uuid: 'post-likes',
@@ -31,12 +31,6 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			placement: { width: 1, height: 2, order: 4 },
 		},
 		{
-			uuid: 'post-traffic-activity',
-			// Full width: the heatmap lays a whole year out across its columns.
-			type: 'jpa/post-traffic-activity',
-			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 5 },
-		},
-		{
 			uuid: 'post-utm',
 			// The alias carries the mock's "UTM" card title; the registry's
 			// global "UTM Insights" title is owned by the copy spreadsheet work.
@@ -44,7 +38,13 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			// No "View all" action: this page is the terminal page, and the
 			// site-wide UTM report would drop this post's scope.
 			attributes: { utmDimension: 'utm_source,utm_medium', showReportLink: false },
-			placement: { width: 1, height: 2, order: 6 },
+			placement: { width: 1, height: 2, order: 5 },
+		},
+		{
+			uuid: 'post-traffic-activity',
+			// Full width: the heatmap lays a whole year out across its columns.
+			type: 'jpa/post-traffic-activity',
+			placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 6 },
 		},
 	],
 	'email-opens': [

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -21,8 +21,9 @@ import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useParams } from '@wordpress/route';
-import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
+import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { DETAIL_GRID } from '../detail-grid';
 import { useDetailBreadcrumbs } from '../use-detail-breadcrumbs';
 import { useDetailDateControls } from '../use-detail-date-controls';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
@@ -32,10 +33,6 @@ import { useEmailTabScope, usePostDetailTabs, usePostSummary } from './hooks';
 import { route } from './package.json';
 
 const ROUTE_FROM = route.path;
-
-// Fixed composition (WOOA7S-1622): grid stays independent from the
-// customizable main-dashboard preference so it can't be stretched.
-const POST_DETAIL_GRID = { ...DEFAULT_GRID, rowHeight: ROW_HEIGHT_PRESETS.small };
 
 // The layout is fixed, so the change callback never fires; the dashboard
 // still requires one because it owns a staging copy internally.
@@ -134,7 +131,7 @@ function PostDetail(): JSX.Element {
 				resolveWidgetModule={ resolveWidgetModuleWithI18n }
 				layout={ layout }
 				onLayoutChange={ noopLayoutChange }
-				gridSettings={ POST_DETAIL_GRID }
+				gridSettings={ DETAIL_GRID }
 			>
 				<DetailPageShell
 					visual={ <StatsPageIcon /> }

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
@@ -1,4 +1,4 @@
-import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
+import { DETAIL_COLUMN_COUNT } from '../../detail-grid';
 import { VIDEO_DETAIL_LAYOUT } from './layout';
 
 describe( 'video detail layout', () => {
@@ -16,17 +16,17 @@ describe( 'video detail layout', () => {
 
 	// The composition is fixed (WOOA7S-1625): assert the exact arrangement so an
 	// accidental reshuffle surfaces here, not in the rendered dashboard.
-	it( 'composes the full-width performance chart above the three-column embeds list', () => {
+	it( 'composes the full-width performance chart above the full-width embeds list', () => {
 		expect( VIDEO_DETAIL_LAYOUT ).toEqual( [
 			{
 				uuid: 'video-detail-views-performance',
 				type: 'jpa/video-detail-views-performance',
-				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 2, order: 1 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 1 },
 			},
 			{
 				uuid: 'video-detail-embeds',
 				type: 'jpa/video-detail-embeds',
-				placement: { width: 3, height: 2, order: 2 },
+				placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 			},
 		] );
 	} );

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
@@ -1,21 +1,19 @@
-import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
+import { DETAIL_COLUMN_COUNT } from '../../detail-grid';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
  * Fixed widget composition for the video detail page (not user-customizable,
- * WOOA7S-1625). The "Used on posts & pages" list stops at three columns
- * because a full-width leaderboard hits its max content width and leaves
- * trailing empty space.
+ * WOOA7S-1625): two full-width rows on the three-column detail grid.
  */
 export const VIDEO_DETAIL_LAYOUT: DashboardWidget[] = [
 	{
 		uuid: 'video-detail-views-performance',
 		type: 'jpa/video-detail-views-performance',
-		placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 2, order: 1 },
+		placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 1 },
 	},
 	{
 		uuid: 'video-detail-embeds',
 		type: 'jpa/video-detail-embeds',
-		placement: { width: 3, height: 2, order: 2 },
+		placement: { width: DETAIL_COLUMN_COUNT, height: 2, order: 2 },
 	},
 ];

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -18,11 +18,12 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Link, useParams, useSearch } from '@wordpress/route';
-import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
+import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
+import { DETAIL_GRID } from '../detail-grid';
 import { useDetailBreadcrumbs } from '../use-detail-breadcrumbs';
 import { useDetailDateControls } from '../use-detail-date-controls';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
@@ -32,11 +33,6 @@ import { useVideoSummary } from './hooks';
 import { route } from './package.json';
 
 const ROUTE_FROM = route.path;
-
-// The composition is fixed (WOOA7S-1625), so keep its grid independent from the
-// customizable main-dashboard preference — a future settings control must not
-// stretch these tiles out of proportion.
-const VIDEO_DETAIL_GRID = { ...DEFAULT_GRID, rowHeight: ROW_HEIGHT_PRESETS.small };
 
 // The layout is fixed, so the change callback never fires; the dashboard
 // still requires one because it owns a staging copy internally.
@@ -129,7 +125,7 @@ function VideoDetail(): JSX.Element {
 			resolveWidgetModule={ resolveWidgetModuleWithI18n }
 			layout={ layout }
 			onLayoutChange={ noopLayoutChange }
-			gridSettings={ VIDEO_DETAIL_GRID }
+			gridSettings={ DETAIL_GRID }
 		>
 			<DetailPageShell
 				visual={ <StatsPageIcon /> }

--- a/projects/plugins/jetpack/changelog/update-pa-detail-pages-three-columns
+++ b/projects/plugins/jetpack/changelog/update-pa-detail-pages-three-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: lay the post and video detail pages out on the three-column grid the dashboard uses.

--- a/projects/plugins/premium-analytics/changelog/update-pa-detail-pages-three-columns
+++ b/projects/plugins/premium-analytics/changelog/update-pa-detail-pages-three-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Post and video detail pages: lay the widgets out on the three-column grid the dashboard uses.

--- a/projects/plugins/wpcomsh/changelog/update-pa-detail-pages-three-columns
+++ b/projects/plugins/wpcomsh/changelog/update-pa-detail-pages-three-columns
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Premium Analytics: lay the post and video detail pages out on the three-column grid the dashboard uses.

--- a/projects/plugins/wpcomsh/changelog/update-pa-detail-pages-three-columns
+++ b/projects/plugins/wpcomsh/changelog/update-pa-detail-pages-three-columns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: lay the post and video detail pages out on the three-column grid the dashboard uses.


### PR DESCRIPTION
Fixes WOOA7S-2104. Follow-up to #51873 (WOOA7S-2032).

## Proposed changes

* The dashboard moves to three columns in #51873, but the post and video detail pages build their own grid from `DEFAULT_GRID` and never read `useDashboardGridSettings`, so they would stay at four columns with tiles narrower than the dashboard's. This PR moves them to three as well, matching the updated design.
* Add `routes/detail-grid.ts` with one shared `DETAIL_GRID` (`columns: 3`, small row height) and `DETAIL_COLUMN_COUNT`; both detail stages use it. The grid stays separate from the customizable dashboard preference, as before, so the fixed compositions cannot be stretched.
* Re-author the fixed compositions for three columns:
  * **Post traffic**: Highlights full width; Views performance full width; Latest likes, Latest comments and UTM one column each; All-time traffic full width.
  * **Email opens**: highlights full width; trend full width; Locations, Platforms and Clients one column each.
  * **Email clicks**: highlights full width; trend two columns beside Platforms; Clients beside the two-column Locations map; Top links two columns, with the last column open, per the updated prototype.
  * **Video**: Video performance and Used on posts & pages both full width.
* Update the layout tests to the new widths, plus a guard that no tile wraps past a partly filled row.

The email tabs follow the updated three-column prototype; the Post traffic middle row is a proposal for design to confirm, also noted on the Linear card.

Once #51873 lands, `DETAIL_COLUMN_COUNT` can fold into its `PA_COLUMN_COUNT` if we want one constant for the whole package.

## Related product discussion/links

* Linear: WOOA7S-2104 (this change), WOOA7S-2032 (the three-column dashboard).
* #51873 (the dashboard's move to three columns).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package: `jetpack build --deps packages/premium-analytics`.
* Open Stats v2, then a post's detail page from All pages.
  * **Post traffic**: Highlights and Views performance each span the row; Latest likes, Latest comments and UTM share one row; All-time traffic spans the row.
  * **Email opens** (a post that was sent as a newsletter): highlights and the trend chart each span the row, then Locations, Platforms and Clients share one row.
  * **Email clicks**: the trend chart takes two columns with Platforms beside it, Clients sits beside the two-column Locations map, and Top links takes two columns with the last column empty.
* Open a video's detail page from the Videos report (a site running VideoPress): Video performance and Used on posts & pages each span the row.
* Narrow the window: the grid steps down to two columns under 960px of container width and one under 600px, and every tile still fits.
* Unit tests, from the package: `pnpm run test -- routes/post-detail routes/video-detail`.

### Before / after

#### Post traffic
| Before (trunk, four columns) | After (this branch, three columns) |
| --- | --- |
| <img width="1301" height="901" alt="截圖 2026-09-07 晚上11 52 00" src="https://github.com/user-attachments/assets/2b500455-8298-4ab4-9b2f-c2e5d5d01ee8" /> | <img width="1303" height="901" alt="截圖 2026-09-08 凌晨12 00 22" src="https://github.com/user-attachments/assets/31807b76-7eaf-438f-a331-2cb803724ea8" /> |
| <img width="1300" height="908" alt="截圖 2026-09-07 晚上11 52 10" src="https://github.com/user-attachments/assets/645c4550-160e-4472-a884-a189ce75ba1b" /> | <img width="1303" height="901" alt="截圖 2026-09-08 凌晨12 00 30" src="https://github.com/user-attachments/assets/2f328f5c-9ca1-4e56-9259-04b29b640774" /> |

#### Email opens
| Before (trunk, four columns) | After (this branch, three columns) |
| --- | --- |
| <img width="1301" height="902" alt="截圖 2026-09-07 晚上11 52 20" src="https://github.com/user-attachments/assets/7646b01e-2534-4c2a-b98e-c2b3c25c3493" /> | <img width="1303" height="903" alt="截圖 2026-09-07 晚上11 44 52" src="https://github.com/user-attachments/assets/e45fc329-d2d8-482d-a58e-6144657865b3" /> |
| <img width="1301" height="900" alt="截圖 2026-09-07 晚上11 52 30" src="https://github.com/user-attachments/assets/2a31e9a6-2d20-4a24-b5ec-b79d07c9b72a" /> | <img width="1308" height="896" alt="截圖 2026-09-07 晚上11 44 59" src="https://github.com/user-attachments/assets/a13fd090-1290-4774-a4c6-97e202c88ffb" /> |

#### Email clicks
| Before (trunk, four columns) | After (this branch, three columns) |
| --- | --- |
| <img width="1301" height="904" alt="截圖 2026-09-07 晚上11 52 38" src="https://github.com/user-attachments/assets/7b297e85-625a-4d0a-85f0-c65c70b53a8a" /> | <img width="1304" height="904" alt="截圖 2026-09-08 凌晨1 08 34" src="https://github.com/user-attachments/assets/79c39028-31d0-4057-867a-7b19a70793f6" /> |
| <img width="1305" height="906" alt="截圖 2026-09-07 晚上11 52 46" src="https://github.com/user-attachments/assets/b937ae8e-4efb-4bf1-8450-4c33b71f6327" /> | <img width="1306" height="901" alt="截圖 2026-09-08 凌晨1 08 44" src="https://github.com/user-attachments/assets/8b85130a-2057-4314-9eb9-c09a05001964" /> |

#### Video
| Before (trunk, four columns) | After (this branch, three columns) |
| --- | --- |
| <img width="1304" height="896" alt="截圖 2026-09-07 晚上11 53 04" src="https://github.com/user-attachments/assets/d27c638c-75c2-4261-808f-ac69cbfc7594" /> | <img width="1305" height="897" alt="截圖 2026-09-07 晚上11 44 24" src="https://github.com/user-attachments/assets/47188576-dd99-48a5-bc19-d72fcc45164c" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvDnZcF1hiCCeCMpGbtJBe



