### PR TITLE
Boost: add Overview cards and history to the modern dashboard

### DIFF
--- a/projects/plugins/boost/README.md
+++ b/projects/plugins/boost/README.md
@@ -8,15 +8,9 @@ Jetpack Boost gives your site the same performance advantages as the world’s l
 
 ## Development
 
-### Live-reloading CSS
+### Building and watching assets
 
-The live-reload feature is configured to only reload CSS files. Currently the way our rollup/webpack combination is configured - every change results in a full rebuild of the JS files, so even style changes would trigger a full page refresh.
-
-If you want to use the live-reloading feature, you have to install the [Livereload extension](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en) (for Chrome) and then run
-
-```sh
-npm run devlive
-```
+See [Build the project](./docs/DEVELOPEMENT_GUIDE.md#build-the-project) for build and watch commands.
 
 ### Installation from Git repo
 

--- a/projects/plugins/boost/_inc/overview/history-chart-card.test.tsx
+++ b/projects/plugins/boost/_inc/overview/history-chart-card.test.tsx
@@ -1,0 +1,156 @@
+/* eslint-disable testing-library/prefer-user-event */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import HistoryChartCard, { buildHistorySeries, HistoryTooltip } from './history-chart-card';
+import type { PerformanceHistoryData } from './lib/use-performance-history';
+
+jest.mock( './upgrade-cta', () => ( {
+	__esModule: true,
+	default: () => <button>Upgrade now</button>,
+} ) );
+jest.mock( '../../app/assets/src/js/lib/utils/analytics', () => ( {
+	recordBoostEvent: jest.fn(),
+} ) );
+
+const timestamp = Date.UTC( 2026, 8, 1 );
+const dimensions = {
+	desktop_overall_score: 90,
+	mobile_overall_score: 80,
+	desktop_cls: 0.01,
+	desktop_lcp: 1.2,
+	desktop_tbt: 0.2,
+	mobile_cls: 0.03,
+	mobile_lcp: 2.4,
+	mobile_tbt: 0.4,
+};
+const history: NonNullable< PerformanceHistoryData > = {
+	startDate: timestamp,
+	endDate: timestamp + 86400000,
+	periods: [
+		{ timestamp, dimensions },
+		{ timestamp: timestamp + 86400000, dimensions },
+	],
+	annotations: [ { timestamp, text: 'Image CDN enabled' } ],
+};
+const callbacks = { onRetry: jest.fn(), onDismissFreshStart: jest.fn() };
+
+beforeAll( () => {
+	jest.spyOn( Element.prototype, 'getBoundingClientRect' ).mockReturnValue( {
+		x: 0,
+		y: 0,
+		top: 0,
+		left: 0,
+		right: 800,
+		bottom: 300,
+		width: 800,
+		height: 300,
+		toJSON: () => ( {} ),
+	} );
+	globalThis.ResizeObserver = class {
+		constructor( private callback: ResizeObserverCallback ) {}
+		observe( target: Element ) {
+			this.callback(
+				[ { target, contentRect: target.getBoundingClientRect() } as ResizeObserverEntry ],
+				this
+			);
+		}
+		unobserve() {}
+		disconnect() {}
+	};
+} );
+
+beforeEach( () => jest.clearAllMocks() );
+afterAll( () => jest.restoreAllMocks() );
+
+test( 'renders actual Charts lines and annotations using millisecond history dates', async () => {
+	const { container } = render( <HistoryChartCard data={ history } { ...callbacks } /> );
+	expect( screen.getByRole( 'grid', { name: /line chart/i } ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Desktop' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Mobile' ) ).toBeInTheDocument();
+	await expect( screen.findByText( 'Image CDN enabled' ) ).resolves.toBeTruthy();
+	for ( const color of [ '#1d4ed8', '#16a34a' ] ) {
+		// SVG series paths do not expose an accessible role.
+		// eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+		expect( container.querySelector( `path[stroke="${ color }"]` )?.getAttribute( 'd' ) ).toMatch(
+			/^M/
+		);
+	}
+	expect( buildHistorySeries( history )[ 0 ].data[ 0 ] ).toEqual( {
+		date: new Date( '2026-09-01T00:00:00Z' ),
+		value: 90,
+	} );
+} );
+
+test( 'renders visible glyphs for a single recorded period', async () => {
+	const { container } = render(
+		<HistoryChartCard data={ { ...history, periods: [ history.periods[ 0 ] ] } } { ...callbacks } />
+	);
+	await waitFor( () => {
+		for ( const color of [ '#1d4ed8', '#16a34a' ] ) {
+			// SVG series glyphs do not expose an accessible role.
+			// eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+			expect( container.querySelector( `circle[fill="${ color }"]` ) ).toHaveAttribute( 'r', '4' );
+		}
+	} );
+} );
+
+test( 'keeps the WordPress date and all eight history dimensions in the tooltip', () => {
+	render(
+		<HistoryTooltip
+			period={ { ...history.periods[ 0 ], timestamp: new Date( 2026, 8, 1, 12 ).getTime() } }
+		/>
+	);
+	for ( const value of [
+		'September 1, 2026',
+		'90 / 100',
+		'80 / 100',
+		'0.01',
+		'1.20s',
+		'0.20s',
+		'0.03',
+		'2.40s',
+		'0.40s',
+	] ) {
+		expect( screen.getByText( value ) ).toBeInTheDocument();
+	}
+} );
+
+test( 'offers the premium upgrade without rendering paid history', () => {
+	render( <HistoryChartCard data={ history } needsUpgrade { ...callbacks } /> );
+	expect( screen.getByRole( 'button', { name: 'Upgrade now' } ) ).toBeInTheDocument();
+	expect( screen.queryByRole( 'grid' ) ).not.toBeInTheDocument();
+} );
+
+test( 'dismisses the paid fresh-start notice', () => {
+	render( <HistoryChartCard data={ history } isFreshStart { ...callbacks } /> );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Okay, got it!' } ) );
+	expect( callbacks.onDismissFreshStart ).toHaveBeenCalledTimes( 1 );
+} );
+
+test( 'shows the history error message and offers retry', () => {
+	render(
+		<HistoryChartCard
+			isError
+			error={ new Error( 'History service unavailable' ) }
+			{ ...callbacks }
+		/>
+	);
+	expect( screen.getByText( 'History service unavailable' ) ).toBeInTheDocument();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+	expect( callbacks.onRetry ).toHaveBeenCalledTimes( 1 );
+} );
+
+test( 'waits for the initial fetch before showing the empty state', () => {
+	const { rerender } = render( <HistoryChartCard isLoading { ...callbacks } /> );
+	expect( screen.queryByText( /Performance history will appear/ ) ).not.toBeInTheDocument();
+	rerender( <HistoryChartCard { ...callbacks } /> );
+	expect( screen.getByText( /Performance history will appear/ ) ).toBeInTheDocument();
+} );
+
+test( 'transitions between upgrade, error, and paid history states', () => {
+	const { rerender } = render( <HistoryChartCard needsUpgrade { ...callbacks } /> );
+	expect( screen.getByRole( 'button', { name: 'Upgrade now' } ) ).toBeInTheDocument();
+	rerender( <HistoryChartCard isError { ...callbacks } /> );
+	expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toBeInTheDocument();
+	rerender( <HistoryChartCard data={ history } { ...callbacks } /> );
+	expect( screen.getByRole( 'grid', { name: /line chart/i } ) ).toBeInTheDocument();
+} );

--- a/projects/plugins/boost/_inc/overview/history-chart-card.tsx
+++ b/projects/plugins/boost/_inc/overview/history-chart-card.tsx
@@ -1,0 +1,209 @@
+import { LineChart } from '@automattic/charts';
+import '@automattic/charts/style.css';
+import { getScoreLetter } from '@automattic/jetpack-boost-score-api';
+import { Spinner } from '@wordpress/components';
+import { dateI18n } from '@wordpress/date';
+import { __, sprintf } from '@wordpress/i18n';
+import { Button, Card, Notice, Text } from '@wordpress/ui';
+import { useCallback, useMemo } from 'react';
+import UpgradeCTA from './upgrade-cta';
+import type { PerformanceHistoryData } from './lib/use-performance-history';
+import type { SeriesData } from '@automattic/charts';
+import type { ComponentProps } from 'react';
+
+type History = NonNullable< PerformanceHistoryData >;
+type Props = {
+	data?: PerformanceHistoryData | null;
+	isLoading?: boolean;
+	isError?: boolean;
+	error?: Error | null;
+	onRetry: () => void;
+	needsUpgrade?: boolean;
+	isFreshStart?: boolean;
+	onDismissFreshStart: () => void;
+};
+
+export function buildHistorySeries( data?: PerformanceHistoryData | null ): SeriesData[] {
+	if ( ! data?.periods.length ) {
+		return [];
+	}
+	return [
+		{
+			label: __( 'Desktop', 'jetpack-boost' ),
+			data: data.periods.map( period => ( {
+				date: new Date( period.timestamp ),
+				value: period.dimensions.desktop_overall_score,
+			} ) ),
+			options: { stroke: '#1d4ed8' },
+		},
+		{
+			label: __( 'Mobile', 'jetpack-boost' ),
+			data: data.periods.map( period => ( {
+				date: new Date( period.timestamp ),
+				value: period.dimensions.mobile_overall_score,
+			} ) ),
+			options: { stroke: '#16a34a' },
+		},
+	];
+}
+
+export function HistoryTooltip( { period }: { period: History[ 'periods' ][ number ] } ) {
+	const dimensions = period.dimensions;
+	return (
+		<div className="jetpack-boost-overview__history-tooltip">
+			<Text>{ dateI18n( 'F j, Y', new Date( period.timestamp ), false ) }</Text>
+			<dl>
+				<dt>{ __( 'Overall score', 'jetpack-boost' ) }</dt>
+				<dd>
+					{ getScoreLetter( dimensions.mobile_overall_score, dimensions.desktop_overall_score ) }
+				</dd>
+				{ ( [ 'desktop', 'mobile' ] as const ).map( device => (
+					<div key={ device }>
+						<dt>
+							{ device === 'desktop'
+								? __( 'Desktop score', 'jetpack-boost' )
+								: __( 'Mobile score', 'jetpack-boost' ) }
+						</dt>
+						<dd>
+							{ sprintf(
+								/* translators: %d is the performance score. */
+								__( '%d / 100', 'jetpack-boost' ),
+								dimensions[ `${ device }_overall_score` ]
+							) }
+						</dd>
+						<dt>{ __( 'Largest Contentful Paint', 'jetpack-boost' ) }</dt>
+						<dd>{ sprintf( '%.2fs', dimensions[ `${ device }_lcp` ] ) }</dd>
+						<dt>{ __( 'Total Blocking Time', 'jetpack-boost' ) }</dt>
+						<dd>{ sprintf( '%.2fs', dimensions[ `${ device }_tbt` ] ) }</dd>
+						<dt>{ __( 'Cumulative Layout Shift', 'jetpack-boost' ) }</dt>
+						<dd>{ sprintf( '%.2f', dimensions[ `${ device }_cls` ] ) }</dd>
+					</div>
+				) ) }
+			</dl>
+		</div>
+	);
+}
+
+export default function HistoryChartCard( {
+	data,
+	isLoading,
+	isError,
+	error,
+	onRetry,
+	needsUpgrade,
+	isFreshStart,
+	onDismissFreshStart,
+}: Props ) {
+	const series = useMemo( () => buildHistorySeries( data ), [ data ] );
+	const renderTooltip = useCallback<
+		NonNullable< ComponentProps< typeof LineChart >[ 'renderTooltip' ] >
+	>(
+		( { tooltipData } ) => {
+			const timestamp = tooltipData?.nearestDatum?.datum.date?.getTime();
+			const period = data?.periods.find( entry => entry.timestamp === timestamp );
+			return period ? <HistoryTooltip period={ period } /> : null;
+		},
+		[ data ]
+	);
+	// Supply text announcements so WordPress does not serialize action components with hooks.
+	let content;
+	if ( isLoading && ! data?.periods.length ) {
+		content = (
+			<div className="jetpack-boost-overview__chart-loading">
+				<Spinner />
+			</div>
+		);
+	} else if ( isError && ! isLoading ) {
+		content = (
+			<Notice.Root
+				intent="error"
+				spokenMessage={ __( 'Failed to load performance history', 'jetpack-boost' ) }
+			>
+				<Notice.Title>{ __( 'Failed to load performance history', 'jetpack-boost' ) }</Notice.Title>
+				<Notice.Description>{ error?.message }</Notice.Description>
+				<Notice.Actions>
+					<Button onClick={ onRetry }>{ __( 'Try again', 'jetpack-boost' ) }</Button>
+				</Notice.Actions>
+			</Notice.Root>
+		);
+	} else if ( needsUpgrade ) {
+		content = (
+			<Notice.Root
+				intent="info"
+				spokenMessage={ __( 'Unlock historical performance', 'jetpack-boost' ) }
+			>
+				<Notice.Title>{ __( 'Unlock historical performance', 'jetpack-boost' ) }</Notice.Title>
+				<Notice.Description>
+					{ __( 'Upgrade and learn more about your site performance over time.', 'jetpack-boost' ) }
+				</Notice.Description>
+				<Notice.Actions>
+					<UpgradeCTA />
+				</Notice.Actions>
+			</Notice.Root>
+		);
+	} else if ( isFreshStart ) {
+		content = (
+			<Notice.Root
+				intent="success"
+				spokenMessage={ __( 'Your scores will be recorded from now on.', 'jetpack-boost' ) }
+			>
+				<Notice.Title>
+					{ __( 'Hello there! Jetpack Boost premium has been activated.', 'jetpack-boost' ) }
+				</Notice.Title>
+				<Notice.Description>
+					{ __( 'Your scores will be recorded from now on.', 'jetpack-boost' ) }
+				</Notice.Description>
+				<Notice.Actions>
+					<Button onClick={ onDismissFreshStart }>
+						{ __( 'Okay, got it!', 'jetpack-boost' ) }
+					</Button>
+				</Notice.Actions>
+			</Notice.Root>
+		);
+	} else if ( ! data || ! series.length ) {
+		content = (
+			<Text>
+				{ __(
+					'Performance history will appear here once enough data has been collected.',
+					'jetpack-boost'
+				) }
+			</Text>
+		);
+	} else {
+		content = (
+			<div className="jetpack-boost-overview__chart-canvas">
+				<LineChart
+					data={ series }
+					height={ 240 }
+					showLegend
+					withGradientFill={ false }
+					withEndGlyphs={ data.periods.length === 1 }
+					renderTooltip={ renderTooltip }
+					options={ {
+						xScale: { domain: [ new Date( data.startDate ), new Date( data.endDate ) ] },
+						yScale: { domain: [ 0, 100 ], nice: false },
+					} }
+				>
+					<LineChart.AnnotationsOverlay>
+						{ data.annotations.map( ( annotation, index ) => (
+							<LineChart.Annotation
+								key={ `${ annotation.timestamp }-${ index }` }
+								datum={ { date: new Date( annotation.timestamp ), value: 100 } }
+								title={ annotation.text }
+								subjectType="line-vertical"
+							/>
+						) ) }
+					</LineChart.AnnotationsOverlay>
+				</LineChart>
+			</div>
+		);
+	}
+	return (
+		<Card.Root>
+			<Card.Header>
+				<Card.Title>{ __( 'Historical performance', 'jetpack-boost' ) }</Card.Title>
+			</Card.Header>
+			<Card.Content>{ content }</Card.Content>
+		</Card.Root>
+	);
+}

--- a/projects/plugins/boost/_inc/overview/overview.scss
+++ b/projects/plugins/boost/_inc/overview/overview.scss
@@ -1,0 +1,89 @@
+.jetpack-boost-overview {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-xl);
+	inline-size: 100%;
+	max-inline-size: 720px;
+	margin-inline: auto;
+	min-inline-size: 0;
+
+	&__score-row {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+
+		@media ( max-width: 600px ) {
+			grid-template-columns: minmax(0, 1fr);
+		}
+	}
+
+	&__score-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--wpds-dimension-gap-sm);
+		padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
+		min-inline-size: 0;
+	}
+
+	&__progress {
+		appearance: none;
+		border: 0;
+		border-radius: 2px;
+		block-size: 4px;
+		inline-size: 100%;
+		overflow: hidden;
+		background-color: var(--wpds-color-background-surface-neutral-weak);
+
+		&::-webkit-progress-bar {
+			background-color: var(--wpds-color-background-surface-neutral-weak);
+		}
+
+		&::-webkit-progress-value {
+			background-color: currentColor;
+		}
+
+		&::-moz-progress-bar {
+			background-color: currentColor;
+		}
+	}
+
+	&__progress--good,
+	&__delta--up {
+		color: var(--wpds-color-foreground-content-success);
+	}
+
+	&__progress--medium {
+		color: var(--wpds-color-foreground-content-warning);
+	}
+
+	&__progress--poor,
+	&__delta--down {
+		color: var(--wpds-color-foreground-content-error);
+	}
+
+	&__delta--neutral {
+		color: var(--wpds-color-foreground-content-neutral-weak);
+	}
+
+	&__chart-canvas {
+		min-inline-size: 0;
+	}
+
+	&__chart-loading {
+		display: grid;
+		place-items: center;
+		min-block-size: 240px;
+	}
+
+	&__history-tooltip {
+
+		dl {
+			margin-block: 8px 0;
+		}
+
+		dd {
+			margin-inline-start: 0;
+			margin-block-end: 8px;
+			font-weight: 600;
+		}
+	}
+}

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -1,0 +1,294 @@
+/* eslint-disable testing-library/prefer-user-event */
+import { requestSpeedScores } from '@automattic/jetpack-boost-score-api';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, renderHook, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
+import { useSpeedScores } from './lib/use-speed-scores';
+import Overview from './overview';
+import ScoreCards from './score-cards';
+
+jest.mock( '@automattic/jetpack-boost-score-api', () => ( {
+	...jest.requireActual( '@automattic/jetpack-boost-score-api' ),
+	requestSpeedScores: jest.fn(),
+} ) );
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '@react-spring/web', () => ( {
+	animated: { div: 'div' },
+	useSpring: ( { to }: { to: { right: string } } ) => ( {
+		visibility: to.right === '0%' ? 'visible' : 'hidden',
+	} ),
+} ) );
+jest.mock( '../../app/assets/src/js/lib/utils/analytics', () => ( {
+	recordBoostEvent: jest.fn(),
+} ) );
+jest.mock( './upgrade-cta', () => ( {
+	__esModule: true,
+	default: () => <button>Upgrade now</button>,
+} ) );
+
+const scores = {
+	current: { desktop: 91, mobile: 81 },
+	noBoost: { desktop: 81, mobile: 80 },
+	isStale: false,
+};
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	Object.assign( window, {
+		Jetpack_Boost: { site: { url: 'https://example.org', online: true } },
+		wpApiSettings: { root: 'https://example.org/wp-json/', nonce: 'wp-nonce' },
+		jetpack_boost_ds: {
+			rest_api: { value: 'https://example.org/wp-json/jetpack-boost-ds', nonce: 'wp-nonce' },
+			modules_state: {
+				nonce: 'modules-nonce',
+				value: { performance_history: { available: true, active: true } },
+			},
+			performance_history: { nonce: 'history-nonce' },
+			dismissed_alerts: { nonce: 'alerts-nonce', value: { performance_history_fresh_start: true } },
+		},
+	} );
+	jest.mocked( requestSpeedScores ).mockResolvedValue( scores );
+	jest.mocked( apiFetch ).mockImplementation( async ( { url, data } ) => ( {
+		status: 'success',
+		JSON: url?.includes( 'modules-state' )
+			? window.jetpack_boost_ds!.modules_state!.value
+			: url?.includes( 'dismissed-alerts' )
+			? data?.JSON ?? window.jetpack_boost_ds!.dismissed_alerts!.value
+			: null,
+	} ) );
+} );
+
+function renderOverview() {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	const view = render(
+		<QueryClientProvider client={ client }>
+			<Overview />
+		</QueryClientProvider>
+	);
+	return { ...view, client };
+}
+
+test( 'loads online scores and regenerates them with refresh tracking and history invalidation', async () => {
+	const { client } = renderOverview();
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	expect( requestSpeedScores ).toHaveBeenCalledWith(
+		false,
+		wpApiSettings.root,
+		Jetpack_Boost.site.url,
+		wpApiSettings.nonce
+	);
+	const invalidate = jest.spyOn( client, 'invalidateQueries' );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await waitFor( () =>
+		expect( requestSpeedScores ).toHaveBeenLastCalledWith(
+			true,
+			wpApiSettings.root,
+			Jetpack_Boost.site.url,
+			wpApiSettings.nonce
+		)
+	);
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'speed_score_refresh_clicked', {} );
+	await waitFor( () =>
+		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'performance_history' ] } )
+	);
+} );
+
+test( 'keeps offline sites out of score and Data Sync requests', async () => {
+	Jetpack_Boost.site.online = false;
+	renderOverview();
+	expect(
+		screen.getByText( 'Website is not publicly available', { selector: 'span' } )
+	).toBeInTheDocument();
+	expect( screen.queryByRole( 'button', { name: 'Refresh' } ) ).not.toBeInTheDocument();
+	expect( requestSpeedScores ).not.toHaveBeenCalled();
+	expect( apiFetch ).not.toHaveBeenCalled();
+	const { result } = renderHook( () => useSpeedScores() );
+	await act( async () => result.current[ 1 ]( true ) );
+	expect( requestSpeedScores ).not.toHaveBeenCalled();
+} );
+
+test( 'tracks score errors and offers a successful retry', async () => {
+	jest
+		.mocked( requestSpeedScores )
+		.mockRejectedValueOnce( new Error( 'Score service unavailable' ) );
+	renderOverview();
+	await expect( screen.findByText( 'Score service unavailable' ) ).resolves.toBeTruthy();
+	expect( screen.getAllByText( '—' ) ).toHaveLength( 3 );
+	expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	for ( const name of [ 'Overall grade', 'Desktop', 'Mobile' ] ) {
+		expect( screen.getByRole( 'region', { name } ) ).toHaveAttribute( 'aria-busy', 'false' );
+	}
+	expect( screen.getByRole( 'button', { name: 'Refresh' } ) ).toBeEnabled();
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'speed_score_request_error', {
+		error_message: 'Score service unavailable',
+	} );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	expect( screen.queryByText( 'Score service unavailable' ) ).not.toBeInTheDocument();
+} );
+
+test( 'retains loaded scores and Refresh alongside a subsequent score error', async () => {
+	renderOverview();
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	jest.mocked( requestSpeedScores ).mockRejectedValueOnce( new Error( 'Refresh failed' ) );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await expect( screen.findByText( 'Refresh failed' ) ).resolves.toBeTruthy();
+	expect( screen.getByText( '91' ) ).toBeInTheDocument();
+	expect( screen.getByText( '81' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+		'aria-busy',
+		'false'
+	);
+	expect( screen.getByRole( 'button', { name: 'Refresh' } ) ).toBeEnabled();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await waitFor( () => expect( screen.queryByText( 'Refresh failed' ) ).not.toBeInTheDocument() );
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+} );
+
+test( 'does not present initial loading scores as measured scores', () => {
+	jest.mocked( requestSpeedScores ).mockReturnValue( new Promise( () => {} ) );
+	renderOverview();
+	expect( screen.getAllByText( '—' ) ).toHaveLength( 3 );
+	expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+		'aria-busy',
+		'true'
+	);
+	expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+} );
+
+test( 'hides stale and absent baselines while preserving measured scores', () => {
+	const { rerender } = render( <ScoreCards scores={ scores } /> );
+	expect( screen.getByText( /\+10 points/ ) ).toBeInTheDocument();
+	rerender( <ScoreCards scores={ { ...scores, isStale: true } } /> );
+	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+	expect( screen.getByText( '91' ) ).toBeInTheDocument();
+	rerender( <ScoreCards scores={ { ...scores, noBoost: null } } /> );
+	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+} );
+
+test( 'selects the free history upgrade using module availability', async () => {
+	window.jetpack_boost_ds!.modules_state!.value = {
+		performance_history: { available: false, active: false },
+	};
+	renderOverview();
+	await expect( screen.findByRole( 'button', { name: 'Upgrade now' } ) ).resolves.toBeTruthy();
+	expect( screen.queryByText( /Performance history will appear/ ) ).not.toBeInTheDocument();
+} );
+
+test( 'selects the paid empty history state using module availability', async () => {
+	renderOverview();
+	await expect( screen.findByText( /Performance history will appear/ ) ).resolves.toBeTruthy();
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).not.toBeInTheDocument();
+} );
+
+test( 'debounces optimization changes and waits for generation to finish', async () => {
+	jest.useFakeTimers();
+	try {
+		const { result, rerender, unmount } = renderHook( state => useSpeedScores( state ), {
+			initialProps: { config: 'modules-active:1,updated:10', isPending: false },
+		} );
+		await waitFor( () => expect( result.current[ 0 ].status ).toBe( 'loaded' ) );
+		rerender( { config: 'modules-active:1,updated:20', isPending: true } );
+		act( () => jest.advanceTimersByTime( 2000 ) );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+		rerender( { config: 'modules-active:1,updated:20', isPending: false } );
+		act( () => jest.advanceTimersByTime( 1999 ) );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 2 );
+		expect( requestSpeedScores ).toHaveBeenLastCalledWith(
+			true,
+			wpApiSettings.root,
+			Jetpack_Boost.site.url,
+			wpApiSettings.nonce
+		);
+		unmount();
+	} finally {
+		jest.useRealTimers();
+	}
+} );
+
+test( 'passes the history server error message to the notice', async () => {
+	const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
+	jest
+		.mocked( apiFetch )
+		.mockImplementation( options =>
+			options.url?.endsWith( '/performance-history' )
+				? Promise.resolve( { status: 'error', message: 'History service unavailable' } )
+				: fetch( options )
+		);
+	renderOverview();
+	await expect( screen.findByText( 'History service unavailable' ) ).resolves.toBeTruthy();
+	await expect( screen.findByRole( 'button', { name: 'Try again' } ) ).resolves.toBeEnabled();
+} );
+
+const decreasedScores = {
+	current: { desktop: 60, mobile: 60 },
+	noBoost: { desktop: 80, mobile: 80 },
+	isStale: false,
+};
+
+test( 'shows a score decrease with guidance and persists permanent dismissal', async () => {
+	jest.mocked( requestSpeedScores ).mockResolvedValue( decreasedScores );
+	renderOverview();
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).toBeVisible() );
+	expect( screen.getByRole( 'link', { name: /Read the guide/ } ) ).toHaveAttribute(
+		'href',
+		expect.stringContaining( 'boost-improve-site-speed-score' )
+	);
+	fireEvent.click( screen.getByRole( 'button', { name: 'Do not show me again' } ) );
+	await waitFor( () =>
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/set',
+				method: 'POST',
+				data: { JSON: { performance_history_fresh_start: true, score_decrease: true } },
+			} )
+		)
+	);
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).not.toBeVisible() );
+} );
+
+test( 'temporarily closes the score decrease without persisting dismissal', async () => {
+	jest.mocked( requestSpeedScores ).mockResolvedValue( decreasedScores );
+	renderOverview();
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).toBeVisible() );
+	fireEvent.click( screen.getByRole( 'link', { name: 'Dismiss' } ) );
+	expect( screen.getByText( 'Speed score has fallen' ) ).not.toBeVisible();
+	expect( apiFetch ).not.toHaveBeenCalledWith( expect.objectContaining( { method: 'POST' } ) );
+} );
+
+test.each( [
+	{ name: 'dismissed', scoreFixture: decreasedScores, dismissed: true },
+	{
+		name: 'unchanged',
+		scoreFixture: { ...decreasedScores, current: { desktop: 80, mobile: 80 } },
+		dismissed: false,
+	},
+	{ name: 'stale', scoreFixture: { ...decreasedScores, isStale: true }, dismissed: false },
+] )( 'does not show a $name score decrease alert', async ( { scoreFixture, dismissed } ) => {
+	window.jetpack_boost_ds!.dismissed_alerts!.value = {
+		performance_history_fresh_start: true,
+		score_decrease: dismissed,
+	};
+	jest.mocked( requestSpeedScores ).mockResolvedValue( scoreFixture );
+	renderOverview();
+	await waitFor( () =>
+		expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+			'aria-busy',
+			'false'
+		)
+	);
+	expect(
+		screen.queryByRole( 'heading', { name: 'Speed score has fallen' } )
+	).not.toBeInTheDocument();
+	expect( recordBoostEvent ).not.toHaveBeenCalledWith(
+		'speed_score_alert_shown',
+		expect.anything()
+	);
+} );

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -1,0 +1,108 @@
+import { getScoreMovementPercentage } from '@automattic/jetpack-boost-score-api';
+import { useQueryClient } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/ui';
+import { useEffect } from 'react';
+import PopOut from '../../app/assets/src/js/features/speed-score/pop-out/pop-out';
+import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
+import HistoryChartCard from './history-chart-card';
+import { useModulesState, useScoreRefreshState } from './lib/use-modules-state';
+import { useDismissibleAlertState, usePerformanceHistory } from './lib/use-performance-history';
+import { useSpeedScores } from './lib/use-speed-scores';
+import ScoreCards from './score-cards';
+import './overview.scss';
+
+export default function Overview() {
+	const modules = useModulesState();
+	const refreshState = useScoreRefreshState( modules.data );
+	const [ scoreState, refreshScores ] = useSpeedScores( refreshState );
+	const history = usePerformanceHistory();
+	const [ freshStartCompleted, dismissFreshStart ] = useDismissibleAlertState(
+		'performance_history_fresh_start'
+	);
+	const queryClient = useQueryClient();
+	const online = Jetpack_Boost.site.online;
+	const isLoading = scoreState.status === 'loading';
+
+	useEffect( () => {
+		if ( online && scoreState.status === 'loaded' ) {
+			queryClient.invalidateQueries( { queryKey: [ 'performance_history' ] } );
+		}
+	}, [ online, scoreState, queryClient ] );
+
+	const onRefresh = () => {
+		recordBoostEvent( 'speed_score_refresh_clicked', {} );
+		refreshScores( true );
+	};
+
+	if ( ! online ) {
+		return (
+			<div className="jetpack-boost-overview">
+				<Notice.Root
+					intent="info"
+					spokenMessage={ __( 'Website is not publicly available', 'jetpack-boost' ) }
+				>
+					<Notice.Title>
+						{ __( 'Website is not publicly available', 'jetpack-boost' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ __(
+							'Performance score and some other Boost features cannot work because the Boost Cloud cannot reach your website. To fix this, you need to make your website publicly available.',
+							'jetpack-boost'
+						) }
+					</Notice.Description>
+				</Notice.Root>
+			</div>
+		);
+	}
+
+	return (
+		<div className="jetpack-boost-overview">
+			{ scoreState.status === 'error' && (
+				<Notice.Root
+					intent="error"
+					spokenMessage={ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }
+				>
+					<Notice.Title>{ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }</Notice.Title>
+					<Notice.Description>{ scoreState.error?.message }</Notice.Description>
+					<Notice.Actions>
+						<Button onClick={ () => refreshScores( true ) }>
+							{ __( 'Try again', 'jetpack-boost' ) }
+						</Button>
+					</Notice.Actions>
+				</Notice.Root>
+			) }
+			<ScoreCards
+				scores={ scoreState.scores }
+				isLoading={ isLoading }
+				showPlaceholder={ isLoading || ! scoreState.hasScores }
+				headerAction={
+					<Button variant="minimal" size="compact" disabled={ isLoading } onClick={ onRefresh }>
+						{ __( 'Refresh', 'jetpack-boost' ) }
+					</Button>
+				}
+			/>
+			<PopOut
+				scoreChange={
+					scoreState.status === 'loaded' &&
+					! scoreState.scores.isStale &&
+					getScoreMovementPercentage( scoreState.scores )
+				}
+				useAlertState={ useDismissibleAlertState }
+			/>
+			<HistoryChartCard
+				data={ modules.isPending ? undefined : history.data }
+				isLoading={ modules.isPending || ( history.isFetching && ! history.data?.periods.length ) }
+				isError={ modules.isError || ( history.isError && ! history.isFetching ) }
+				error={ history.error }
+				onRetry={ () => {
+					modules.refetch();
+					history.refetch();
+				} }
+				needsUpgrade={ ! modules.isPending && ! modules.data?.performance_history?.available }
+				isFreshStart={ ! freshStartCompleted }
+				onDismissFreshStart={ dismissFreshStart }
+			/>
+		</div>
+	);
+}

--- a/projects/plugins/boost/_inc/overview/score-card.tsx
+++ b/projects/plugins/boost/_inc/overview/score-card.tsx
@@ -1,0 +1,72 @@
+import { __ } from '@wordpress/i18n';
+import { Badge, Stack, Text } from '@wordpress/ui';
+import {
+	formatScoreDelta,
+	getScoreDelta,
+	getScoreTier,
+	getScoreTierLabel,
+	getTrendDirection,
+} from './lib/score-utils';
+import type { ReactNode } from 'react';
+
+type Props = {
+	icon: ReactNode;
+	label: string;
+	value: ReactNode;
+	score?: number;
+	noBoost?: number | null;
+	isLoading?: boolean;
+	showPlaceholder?: boolean;
+};
+
+export default function ScoreCard( {
+	icon,
+	label,
+	value,
+	score,
+	noBoost,
+	isLoading,
+	showPlaceholder = isLoading,
+}: Props ) {
+	const tier = score === undefined ? undefined : getScoreTier( score );
+	const delta = score === undefined ? null : getScoreDelta( score, noBoost );
+	const intent = tier === 'good' ? 'stable' : tier === 'medium' ? 'medium' : 'high';
+	return (
+		<section
+			className="jetpack-boost-overview__score-section"
+			aria-label={ label }
+			aria-busy={ isLoading }
+		>
+			<Stack direction="row" align="center" gap="sm">
+				{ icon }
+				<Text render={ <h3 /> } variant="body-md">
+					{ label }
+				</Text>
+			</Stack>
+			<Stack direction="row" align="center" gap="md">
+				<Text variant="heading-2xl">{ showPlaceholder ? '—' : value }</Text>
+				{ ! showPlaceholder && score !== undefined && (
+					<Badge intent={ intent }>{ getScoreTierLabel( score ) }</Badge>
+				) }
+			</Stack>
+			{ ! showPlaceholder && score !== undefined && (
+				<progress
+					className={ `jetpack-boost-overview__progress jetpack-boost-overview__progress--${ tier }` }
+					value={ score }
+					max={ 100 }
+					aria-label={ label }
+				/>
+			) }
+			{ ! showPlaceholder && delta !== null && (
+				<Text
+					variant="body-sm"
+					className={ `jetpack-boost-overview__delta jetpack-boost-overview__delta--${ getTrendDirection(
+						delta
+					) }` }
+				>
+					{ formatScoreDelta( delta ) } { __( 'compared to without Boost', 'jetpack-boost' ) }
+				</Text>
+			) }
+		</section>
+	);
+}

--- a/projects/plugins/boost/_inc/overview/score-cards.tsx
+++ b/projects/plugins/boost/_inc/overview/score-cards.tsx
@@ -1,0 +1,56 @@
+import { didScoresChange, getScoreLetter } from '@automattic/jetpack-boost-score-api';
+import { __ } from '@wordpress/i18n';
+import { Icon, dashboard, desktop, mobile } from '@wordpress/icons';
+import { Card, Stack } from '@wordpress/ui';
+import ScoreCard from './score-card';
+import type { SpeedScoresSet } from './lib/use-speed-scores';
+import type { ReactNode } from 'react';
+
+type Props = {
+	scores: SpeedScoresSet;
+	isLoading?: boolean;
+	showPlaceholder?: boolean;
+	headerAction?: ReactNode;
+};
+
+export default function ScoreCards( { scores, isLoading, showPlaceholder, headerAction }: Props ) {
+	const { current } = scores;
+	const noBoost = ! scores.isStale && didScoresChange( scores ) ? scores.noBoost : null;
+	return (
+		<Card.Root>
+			<Card.Header>
+				<Stack direction="row" justify="space-between" align="center" gap="md">
+					<Card.Title>{ __( 'Performance scores', 'jetpack-boost' ) }</Card.Title>
+					{ headerAction }
+				</Stack>
+			</Card.Header>
+			<div className="jetpack-boost-overview__score-row">
+				<ScoreCard
+					icon={ <Icon icon={ dashboard } size={ 20 } /> }
+					label={ __( 'Overall grade', 'jetpack-boost' ) }
+					value={ getScoreLetter( current.mobile, current.desktop ) }
+					isLoading={ isLoading }
+					showPlaceholder={ showPlaceholder }
+				/>
+				<ScoreCard
+					icon={ <Icon icon={ desktop } size={ 20 } /> }
+					label={ __( 'Desktop', 'jetpack-boost' ) }
+					value={ current.desktop }
+					score={ current.desktop }
+					noBoost={ noBoost?.desktop }
+					isLoading={ isLoading }
+					showPlaceholder={ showPlaceholder }
+				/>
+				<ScoreCard
+					icon={ <Icon icon={ mobile } size={ 20 } /> }
+					label={ __( 'Mobile', 'jetpack-boost' ) }
+					value={ current.mobile }
+					score={ current.mobile }
+					noBoost={ noBoost?.mobile }
+					isLoading={ isLoading }
+					showPlaceholder={ showPlaceholder }
+				/>
+			</div>
+		</Card.Root>
+	);
+}

--- a/projects/plugins/boost/_inc/overview/upgrade-cta.test.tsx
+++ b/projects/plugins/boost/_inc/overview/upgrade-cta.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import { Notice } from '@wordpress/ui';
+import { OVERVIEW_UPGRADE_EVENT, type UpgradeSlotRequest } from './lib/upgrade-bridge';
+import UpgradeCTA from './upgrade-cta';
+
+test( 'mounts and releases the upgrade UI once when the notice changes to paid', () => {
+	const cleanup = jest.fn();
+	const handleMount = jest.fn( ( event: Event ) => {
+		const request = ( event as CustomEvent< UpgradeSlotRequest > ).detail;
+		request.container.textContent = 'Existing upgrade flow';
+		request.unmount = cleanup;
+	} );
+	window.addEventListener( OVERVIEW_UPGRADE_EVENT, handleMount );
+	try {
+		const { rerender, unmount } = render(
+			<Notice.Root intent="info" spokenMessage="Unlock historical performance">
+				<Notice.Title>Unlock historical performance</Notice.Title>
+				<Notice.Actions>
+					<UpgradeCTA />
+				</Notice.Actions>
+			</Notice.Root>
+		);
+		expect( screen.getByText( 'Existing upgrade flow' ) ).toBeInTheDocument();
+		expect( handleMount ).toHaveBeenCalledTimes( 1 );
+		rerender(
+			<Notice.Root intent="success" spokenMessage="History is ready">
+				<Notice.Title>History is ready</Notice.Title>
+			</Notice.Root>
+		);
+		expect( screen.queryByText( 'Existing upgrade flow' ) ).not.toBeInTheDocument();
+		expect( cleanup ).toHaveBeenCalledTimes( 1 );
+		unmount();
+		expect( handleMount ).toHaveBeenCalledTimes( 1 );
+		expect( cleanup ).toHaveBeenCalledTimes( 1 );
+	} finally {
+		window.removeEventListener( OVERVIEW_UPGRADE_EVENT, handleMount );
+	}
+} );

--- a/projects/plugins/boost/_inc/overview/upgrade-cta.tsx
+++ b/projects/plugins/boost/_inc/overview/upgrade-cta.tsx
@@ -1,0 +1,16 @@
+import { useEffect, useRef } from 'react';
+import { OVERVIEW_UPGRADE_EVENT, type UpgradeSlotRequest } from './lib/upgrade-bridge';
+
+export default function UpgradeCTA() {
+	const container = useRef< HTMLDivElement >( null );
+	useEffect( () => {
+		if ( ! container.current ) {
+			return;
+		}
+		// The prerequisite webpack bundle owns the existing upgrade flow and its providers.
+		const request: UpgradeSlotRequest = { container: container.current };
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: request } ) );
+		return () => request.unmount?.();
+	}, [] );
+	return <div ref={ container } />;
+}

--- a/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/speed-score/pop-out/pop-out.tsx
@@ -1,14 +1,18 @@
 import { animated, useSpring } from '@react-spring/web';
-import CloseButton from '$features/ui/close-button/close-button';
+import CloseButton from '../../ui/close-button/close-button';
 import styles from './pop-out.module.scss';
 import { __ } from '@wordpress/i18n';
 import { ReactNode, useState, useEffect } from 'react';
-import { Button, getRedirectUrl } from '@automattic/jetpack-components';
-import { useDismissibleAlertState } from '$features/performance-history/lib/hooks';
-import { recordBoostEvent } from '$lib/utils/analytics';
+import Button from '@automattic/jetpack-components/button';
+import getRedirectUrl from '@automattic/jetpack-components/tools/jp-redirect';
+import { useDismissibleAlertState } from '../../performance-history/lib/hooks';
+import { recordBoostEvent } from '../../../lib/utils/analytics';
 
 type Props = {
 	scoreChange: number | false; // Speed score shift to show, or false if none.
+	useAlertState?: (
+		alertId: 'score_increase' | 'score_decrease'
+	) => readonly [ boolean, () => void ];
 };
 
 /**
@@ -112,7 +116,7 @@ export const VanillaPopOut = ( { message, onClose, onDismiss, isVisible }: Vanil
 	);
 };
 
-function PopOut( { scoreChange }: Props ) {
+function PopOut( { scoreChange, useAlertState = useDismissibleAlertState }: Props ) {
 	/*
 	 * Determine if the score has changed enough to show the alert.
 	 */
@@ -127,7 +131,7 @@ function PopOut( { scoreChange }: Props ) {
 	 * Use datasync to track which score alerts have been dismissed.
 	 * Dismissed means that the user asked to never show us this alert again.
 	 */
-	const [ isDismissed, dismissAlert ] = useDismissibleAlertState( message.id );
+	const [ isDismissed, dismissAlert ] = useAlertState( message.id );
 	/*
 	 * Hide the alert for now. The alert will show up again if the user refreshes the page.
 	 */

--- a/projects/plugins/boost/app/assets/src/js/features/ui/close-button/close-button.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/close-button/close-button.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
+import type { MouseEvent } from 'react';
 import styles from './close-button.module.scss';
 
-const CloseButton = ( { onClick } ) => {
-	const handleOnClick = event => {
+const CloseButton = ( { onClick }: { onClick: () => void } ) => {
+	const handleOnClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
 		event.preventDefault();
 		onClick();
 	};

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable testing-library/prefer-user-event */
+/* eslint-disable jest-dom/prefer-in-document -- The legacy Boost Jest project does not load jest-dom. */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
+import { recordBoostEvent } from './lib/utils/analytics';
+import './modern-overview-upgrade';
+import type { UpgradeSlotRequest } from '../../../../_inc/overview/lib/upgrade-bridge';
+import type { ReactNode } from 'react';
+
+jest.mock( './features/upgrade-cta/interstitial-modal-cta', () => ( {
+	__esModule: true,
+	default: ( { customModalTrigger }: { customModalTrigger: ReactNode } ) => customModalTrigger,
+} ) );
+jest.mock( './lib/utils/analytics', () => ( { recordBoostEvent: jest.fn() } ) );
+jest.mock( 'jetpackConfig', () => ( { consumer_slug: 'jetpack-boost' } ), { virtual: true } );
+
+test( 'mounts the upgrade action on request and cleans up its root', async () => {
+	render( <div data-testid="upgrade-slot" /> );
+	const request: UpgradeSlotRequest = { container: screen.getByTestId( 'upgrade-slot' ) };
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+	await act( async () => {
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: request } ) );
+	} );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Upgrade now' } ) );
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'performance_history_upgrade_cta_click', {} );
+	await act( async () => request.unmount?.() );
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+} );
+
+test( 'cancels a pending root before a strict-mode remount', async () => {
+	render( <div data-testid="upgrade-slot" /> );
+	const container = screen.getByTestId( 'upgrade-slot' );
+	const first: UpgradeSlotRequest = { container };
+	const second: UpgradeSlotRequest = { container };
+	await act( async () => {
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: first } ) );
+		first.unmount?.();
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: second } ) );
+	} );
+	expect( screen.getAllByRole( 'button', { name: 'Upgrade now' } ) ).toHaveLength( 1 );
+	await act( async () => second.unmount?.() );
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+} );

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@automattic/jetpack-components';
+import { createRoot } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
+import InterstitialModalCTA from './features/upgrade-cta/interstitial-modal-cta';
+import { recordBoostEvent } from './lib/utils/analytics';
+import type { UpgradeSlotRequest } from '../../../../_inc/overview/lib/upgrade-bridge';
+
+function handleUpgrade() {
+	recordBoostEvent( 'performance_history_upgrade_cta_click', {} );
+}
+
+window.addEventListener( OVERVIEW_UPGRADE_EVENT, ( event: Event ) => {
+	const request = ( event as CustomEvent< UpgradeSlotRequest > ).detail;
+	let disposed = false;
+	let root: ReturnType< typeof createRoot > | undefined;
+
+	// The slot mounts inside another React root; defer nested root updates until its commit completes.
+	request.unmount = () => {
+		disposed = true;
+		queueMicrotask( () => root?.unmount() );
+	};
+	queueMicrotask( () => {
+		if ( disposed ) {
+			return;
+		}
+		root = createRoot( request.container );
+		root.render(
+			<InterstitialModalCTA
+				identifier="historical-performance"
+				customModalTrigger={
+					<Button onClick={ handleUpgrade }>{ __( 'Upgrade now', 'jetpack-boost' ) }</Button>
+				}
+			/>
+		);
+	} );
+} );

--- a/projects/plugins/boost/changelog/cycle-one-overview
+++ b/projects/plugins/boost/changelog/cycle-one-overview
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add Overview presentation behind the disabled modern dashboard filter.
+
+

--- a/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
+++ b/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
@@ -28,14 +28,19 @@ If not, you might need as a prerequisite to bypass the Jetpack connection.
 
 ## Build the project
 
-You may also need building the Image CDN Jetpack Package dependency using the following command:
+From the monorepo root, build Boost and its dependencies:
 
-  ```sh
-  jetpack build packages/image_cdn
-  ```
+```sh
+jetpack build plugins/boost --deps
+```
 
-You may need to do this only once.
+Boost builds the webpack assets and the modern dashboard's wp-build assets together. To rebuild both as files change, run from `projects/plugins/boost`:
 
+```sh
+pnpm watch
+```
+
+For development access to the modern dashboard, use the `rsm_jetpack_ui_modernization_boost` filter documented in [the admin loader](../app/admin/class-admin.php). Its default and asset fallback are defined there.
 
 ## PHP unit tests
 
@@ -79,21 +84,13 @@ To check for PHP code compatibility run:
   ```
 
 ## Linting Jetpack Boost JavaScript code
-The following commands need to be run from the `projects/plugins/boost` directory.
+Run the monorepo's ESLint command from the monorepo root, scoped to Boost:
 
-To check syntax and style in the all the TypeScript and Svelte files that Jetpack Boost relies on, you can run:
+```sh
+pnpm run lint-file projects/plugins/boost
+```
 
-  ```sh
-  pnpm lint
-  ``` 
-
-
-To automatically fix some JavaScript related issues, you can run:
-
-  ```sh
-  pnpm lint:fix
-  ``` 
-
+Append `--fix` to apply automatic fixes. See [Monorepo linting](../../../../docs/monorepo.md#linting) for configuration guidance.
 
 # Debugging Concatenate JS/CSS exclusions
 

--- a/projects/plugins/boost/routes/dashboard/stage.test.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.test.tsx
@@ -7,6 +7,11 @@ import type { ReactNode } from 'react';
 
 const mockNavigate = jest.fn();
 
+jest.mock( '../../_inc/overview/overview', () => ( {
+	__esModule: true,
+	default: () => <div>Performance Overview</div>,
+} ) );
+
 jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( { tab: new URLSearchParams( globalThis.location.search ).get( 'tab' ) } ),
 	useNavigate: () => mockNavigate,

--- a/projects/plugins/boost/routes/dashboard/stage.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
 import BoostPage, { type BoostTab } from '../../_inc/components/boost-page';
+import Overview from '../../_inc/overview/overview';
 import './route.scss';
 
 const SUBPAGES = [
@@ -97,7 +98,9 @@ function Stage() {
 			subpage={ <div id="jb-subpage-mount" hidden={ subpage === null } /> }
 		>
 			<Tabs.Panel value="overview">
-				<QueryClientProvider client={ queryClient }>{ null }</QueryClientProvider>
+				<QueryClientProvider client={ queryClient }>
+					{ activeTab === 'overview' && subpage === null ? <Overview /> : null }
+				</QueryClientProvider>
 			</Tabs.Panel>
 			<Tabs.Panel value="settings" keepMounted>
 				<div id="jb-settings-tab-mount" />

--- a/projects/plugins/boost/tests/e2e/README.md
+++ b/projects/plugins/boost/tests/e2e/README.md
@@ -12,7 +12,7 @@ Automated end-to-end acceptance tests for the Jetpack Boost plugin.
 ## Pre-requisites
 
 - This readme assumes that `node`, `pnpm` and `docker` are already installed on your machine.
-- Make sure you built Jetpack Boost first. `pnpm install && pnpm jetpack build plugins/boost` in the monorepo root directory should walk you through it. You can also refer to the Jetpack Boost [documentation](../../docs/DEVELOPMENT_GUIDE.md) in how to build Jetpack Boost.
+- Build Jetpack Boost and its dependencies using [Build the project](../../docs/DEVELOPEMENT_GUIDE.md#build-the-project).
 - Run `pnpm install` from the Jetpack Boost E2E tests directory. This command install all the required dependencies
 
 Jetpack Boost E2E tests also rely on an encrypted configuration file, which is included in the [e2e commons package](../../../../../tools/e2e-commons) config folder as [`encrypted.enc`](../../../../../tools/e2e-commons/config/encrypted.enc). To be able to run tests - that file should be decrypted first.
@@ -32,7 +32,7 @@ From the root of the repo (this has to be done only once or when pulling new cha
 
 1. run `pnpm install` - This command will install the monorepo NPM dependencies.
 2. run `jetpack build plugins/jetpack` - This command will install Jetpack NPM and Composer dependencies as well as building the asset files.
-3. run `jetpack build plugins/boost` - This command will install Jetpack Boost NPM and Composer dependencies as well as building the asset files.
+3. Follow Boost's [build instructions](../../docs/DEVELOPEMENT_GUIDE.md#build-the-project).
 
 From the `projects/plugins/boost/tests/e2e` folder:
 

--- a/projects/plugins/boost/tests/e2e/package.json
+++ b/projects/plugins/boost/tests/e2e/package.json
@@ -3,7 +3,7 @@
 	"type": "module",
 	"scripts": {
 		"allure-report": "allure generate --clean --output ./output/allure-report ./output/allure-results && allure open ./output/allure-report",
-		"build": "pnpm jetpack build plugins/jetpack plugins/boost js-packages/components js-packages/boost-score-api js-packages/number-formatters js-packages/image-guide js-packages/critical-css-gen js-packages/social-logos packages/plugin-deactivation packages/connection packages/jitm packages/my-jetpack packages/assets packages/wp-build-polyfills -v --no-pnpm-install --production",
+		"build": "pnpm jetpack build plugins/jetpack plugins/boost js-packages/components js-packages/charts js-packages/react-data-sync-client js-packages/boost-score-api js-packages/number-formatters js-packages/image-guide js-packages/critical-css-gen js-packages/social-logos packages/plugin-deactivation packages/connection packages/jitm packages/my-jetpack packages/assets packages/wp-build-polyfills -v --no-pnpm-install --production",
 		"clean": "rm -rf output",
 		"config:decrypt": "openssl enc -md sha1 -aes-256-cbc -pbkdf2 -iter 100000 -d -pass env:CONFIG_KEY -in ./node_modules/@automattic/_jetpack-e2e-commons/config/encrypted.enc -out ./config/local.cjs",
 		"distclean": "rm -rf node_modules",

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = [
 	 */
 	{
 		entry: {
-			index: './app/assets/src/js/index.tsx',
+			index: [ './app/assets/src/js/modern-overview-upgrade.tsx', './app/assets/src/js/index.tsx' ],
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,


### PR DESCRIPTION
Superseded by https://github.com/Automattic/jetpack/pull/52080, https://github.com/Automattic/jetpack/pull/52143, https://github.com/Automattic/jetpack/pull/52165, https://github.com/Automattic/jetpack/pull/52168, and https://github.com/Automattic/jetpack/pull/52178.