### PR TITLE
fix(boost): preserve script loading strategies during concatenation

### DIFF
--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -153,6 +153,10 @@ class Concatenate_JS extends WP_Scripts {
 				}
 			}
 
+			if ( $do_concat && in_array( $this->get_data( $handle, 'strategy' ), array( 'defer', 'async' ), true ) ) {
+				$do_concat = false;
+			}
+
 			if ( $do_concat && $this->has_inline_content( $handle ) ) {
 				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 					printf( "\n<!-- No Concat JS %s => Has Inline Content -->\n", esc_html( $handle ) );

--- a/projects/plugins/boost/changelog/fix-concat-js-loading-strategy
+++ b/projects/plugins/boost/changelog/fix-concat-js-loading-strategy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS: Preserve deferred and asynchronous script loading.

--- a/projects/plugins/boost/phpunit.11.xml.dist
+++ b/projects/plugins/boost/phpunit.11.xml.dist
@@ -26,6 +26,7 @@
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
+			<exclude>tests/php/lib/minify/Concatenate_JS_Strategy_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -36,6 +37,7 @@
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</file>
+			<file>tests/php/lib/minify/Concatenate_JS_Strategy_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>

--- a/projects/plugins/boost/phpunit.9.xml.dist
+++ b/projects/plugins/boost/phpunit.9.xml.dist
@@ -17,6 +17,7 @@
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
 			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
+			<exclude>tests/php/lib/minify/Concatenate_JS_Strategy_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
@@ -27,6 +28,7 @@
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
 			<file>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</file>
+			<file>tests/php/lib/minify/Concatenate_JS_Strategy_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_JS_Strategy_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_JS_Strategy_Test.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
+
+use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
+use WorDBless\BaseTestCase;
+use WP_HTML_Tag_Processor;
+use WP_Scripts;
+
+if ( ! defined( 'JETPACK_BOOST_DIR_PATH' ) ) {
+	define( 'JETPACK_BOOST_DIR_PATH', dirname( __DIR__, 4 ) );
+}
+require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/loader.php';
+
+if ( ! function_exists( 'jetpack_boost_ds_get' ) ) {
+	require_once JETPACK_BOOST_DIR_PATH . '/wp-js-data-sync.php';
+}
+
+class Concatenate_JS_Strategy_Test extends BaseTestCase {
+	/**
+	 * @var string
+	 */
+	private $asset_dir;
+
+	public function set_up() {
+		parent::set_up();
+
+		// Local files are required for the scripts to be concatenation candidates.
+		$this->asset_dir = WP_CONTENT_DIR . '/boost-strategy-test-' . getmypid();
+		mkdir( $this->asset_dir, 0755, true );
+		foreach ( array( 'dependency', 'consumer', 'other', 'last' ) as $name ) {
+			file_put_contents( $this->asset_dir . '/' . $name . '.js', 'var boostStrategyTest = 1;' );
+		}
+		add_filter( 'js_do_concat', array( $this, 'exclude_dependency' ), 10, 2 );
+	}
+
+	public function tear_down() {
+		remove_filter( 'js_do_concat', array( $this, 'exclude_dependency' ), 10 );
+		foreach ( array( 'dependency', 'consumer', 'other', 'last' ) as $name ) {
+			unlink( $this->asset_dir . '/' . $name . '.js' );
+		}
+		rmdir( $this->asset_dir );
+
+		parent::tear_down();
+	}
+
+	public function exclude_dependency( $do_concat, $handle ) {
+		return 'boost-strategy-dependency' === $handle ? false : $do_concat;
+	}
+
+	private function register( WP_Scripts $scripts, $name, $dependencies = array(), $strategy = '' ) {
+		$handle = 'boost-strategy-' . $name;
+		$scripts->add( $handle, '/wp-content/' . basename( $this->asset_dir ) . '/' . $name . '.js', $dependencies, null );
+		if ( $strategy ) {
+			$scripts->add_data( $handle, 'strategy', $strategy );
+		}
+		return $handle;
+	}
+
+	private function render( WP_Scripts $scripts ) {
+		ob_start();
+		try {
+			$scripts->do_items();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		$processor = new WP_HTML_Tag_Processor( $output );
+		$tags      = array();
+		while ( $processor->next_tag( 'SCRIPT' ) ) {
+			$tags[] = array(
+				'id'           => $processor->get_attribute( 'id' ),
+				'src'          => $processor->get_attribute( 'src' ),
+				'defer'        => $processor->get_attribute( 'defer' ),
+				'async'        => $processor->get_attribute( 'async' ),
+				'data-handles' => $processor->get_attribute( 'data-handles' ),
+			);
+		}
+		return $tags;
+	}
+
+	public function test_deferred_consumer_stays_out_of_a_singleton_group() {
+		$this->assert_deferred_dependency_and_consumer( false );
+	}
+
+	public function test_deferred_consumer_stays_out_of_a_multi_handle_group() {
+		$this->assert_deferred_dependency_and_consumer( true );
+	}
+
+	private function assert_deferred_dependency_and_consumer( $with_other_scripts ) {
+		$scripts    = new Concatenate_JS( new WP_Scripts() );
+		$dependency = $this->register( $scripts, 'dependency', array(), 'defer' );
+		$consumer   = $this->register( $scripts, 'consumer', array( $dependency ), 'defer' );
+		$scripts->enqueue( $consumer );
+		if ( $with_other_scripts ) {
+			$scripts->enqueue( $this->register( $scripts, 'other' ) );
+			$scripts->enqueue( $this->register( $scripts, 'last' ) );
+		}
+
+		$tags = $this->render( $scripts );
+
+		$this->assertCount( $with_other_scripts ? 3 : 2, $tags );
+		$this->assertSame( $dependency . '-js', $tags[0]['id'] );
+		$this->assertSame( $consumer . '-js', $tags[1]['id'] );
+		foreach ( array( 'dependency', 'consumer' ) as $index => $name ) {
+			$this->assertNotNull( $tags[ $index ]['defer'] );
+			$this->assertNull( $tags[ $index ]['async'] );
+			$this->assertStringContainsString( '/' . $name . '.js', $tags[ $index ]['src'] );
+		}
+		foreach ( $tags as $tag ) {
+			$this->assertStringNotContainsString( $consumer, (string) $tag['data-handles'] );
+		}
+		if ( $with_other_scripts ) {
+			if ( WP_DEBUG ) {
+				$this->assertSame( 'boost-strategy-other,boost-strategy-last', $tags[2]['data-handles'] );
+			}
+			$this->assertNull( $tags[2]['id'] );
+			$this->assertMatchesRegularExpression( '~/(?:_jb_static/\?\?|boost-cache/static/)~', $tags[2]['src'] );
+			$this->assertStringNotContainsString( '/consumer.js', $tags[2]['src'] );
+		}
+	}
+
+	public function test_async_registration_is_preserved() {
+		$scripts = new Concatenate_JS( new WP_Scripts() );
+		$handle  = $this->register( $scripts, 'consumer', array(), 'async' );
+		$scripts->enqueue( $handle );
+
+		$tags = $this->render( $scripts );
+
+		$this->assertCount( 1, $tags );
+		$this->assertSame( $handle . '-js', $tags[0]['id'] );
+		$this->assertNotNull( $tags[0]['async'] );
+		$this->assertNull( $tags[0]['defer'] );
+		$this->assertNull( $tags[0]['data-handles'] );
+	}
+
+	public function test_blocking_dependent_removes_defer_as_in_core() {
+		$core  = new WP_Scripts();
+		$boost = new Concatenate_JS( new WP_Scripts() );
+		foreach ( array( $core, $boost ) as $scripts ) {
+			$consumer = $this->register( $scripts, 'consumer', array(), 'defer' );
+			$other    = $this->register( $scripts, 'other', array( $consumer ) );
+			$scripts->enqueue( array( $consumer, $other ) );
+		}
+
+		$core_tags  = $this->render( $core );
+		$boost_tags = $this->render( $boost );
+
+		$this->assertCount( 2, $boost_tags );
+		$this->assertSame( $core_tags[0], $boost_tags[0] );
+		$this->assertSame( 'boost-strategy-consumer-js', $boost_tags[0]['id'] );
+		$this->assertNull( $boost_tags[0]['defer'] );
+		$this->assertNull( $boost_tags[0]['async'] );
+		$this->assertStringContainsString( '/other.js', $boost_tags[1]['src'] );
+	}
+
+	public function test_scripts_without_a_strategy_still_bundle() {
+		$scripts = new Concatenate_JS( new WP_Scripts() );
+		$scripts->enqueue( $this->register( $scripts, 'consumer' ) );
+		$scripts->enqueue( $this->register( $scripts, 'other' ) );
+
+		$tags = $this->render( $scripts );
+
+		$this->assertCount( 1, $tags );
+		$this->assertNull( $tags[0]['id'] );
+		$this->assertMatchesRegularExpression( '~/(?:_jb_static/\?\?|boost-cache/static/)~', $tags[0]['src'] );
+		$this->assertNull( $tags[0]['defer'] );
+		$this->assertNull( $tags[0]['async'] );
+	}
+}


### PR DESCRIPTION
Fixes [BOOST-690](https://linear.app/a8c/issue/BOOST-690)

Boost currently drops registered `defer` and `async` loading strategies when concatenating JavaScript. Keep these scripts out of bundles so WordPress prints them individually and computes the appropriate loading strategy. This addresses a Subscribe form startup failure when its dependency is deferred separately but its consumer runs immediately.

## Proposed changes

- Exclude scripts registered with `defer` or `async` from concatenation using the existing individual-script path.
- Leave strategy downgrades and dependency ordering to WordPress. Scripts without a strategy continue to bundle.
- Add five rendered-output PHP regression tests covering singleton and multi-handle groups, deferred dependency order, async preservation, blocking dependents, and ordinary bundling.
- Add a Boost changelog entry.

## Related product discussion/links

The reported Subscribe form submitted natively because its JavaScript handler did not attach. The loading-order defect is reproduced with a separately deferred dependency; email delivery itself has not been verified.

Separate follow-up: singleton URL generation in `app/lib/minify/functions-helpers.php` drops explicit ports. That existing issue is outside this change.

## Does this pull request change what data or activity we track or use?

No. This change preserves script loading behavior and does not change data collection or tracking.

## Testing instructions

1. Run `pnpm jetpack install plugins/boost`, then `pnpm jetpack test php plugins/boost`.
2. Run `composer phpcs:lint -- projects/plugins/boost/`, `composer phpcs:compatibility`, and `pnpm jetpack phan plugins/boost`.
3. Inspect the new `Concatenate_JS_Strategy_Test` coverage: a local deferred dependency excluded from concatenation and its deferred consumer render separately in dependency order, including when ordinary scripts follow. Async remains async, and an enqueued blocking dependent makes the deferred script blocking as WordPress computes it.

Validation completed:

- Full Boost PHP suite: 373 tests, 1,270 assertions passed.
- Plugin-wide PHPCS passed; Phan reported zero issues. PHP compatibility and syntax checks passed.
- Focused debug-output verification: five tests, 43 assertions passed, including bundle `data-handles` checks.
- Replacing the fix with the original implementation produced four expected regression failures; strategy-free bundling still passed.
- A local browser fixture using the actual Subscribe handler confirmed handler attachment, prevented native submission, and modal invocation with the fixed tags. The original tags reproduced the startup failure. Modal transport was stubbed; no email delivery or live customer site was tested.

`pnpm-lock.yaml` is unchanged.
