### PR TITLE
VideoPress: Preserve unknown plans when site features fail

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-unknown-entitlement
+++ b/projects/packages/videopress/changelog/fix-videopress-unknown-entitlement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid free-plan limits and upgrade prompts when site features cannot be loaded.

--- a/projects/packages/videopress/global.d.ts
+++ b/projects/packages/videopress/global.d.ts
@@ -21,9 +21,9 @@ export declare global {
 					gmtOffset: number;
 					timezoneString: string;
 					locale: string;
-					hasVideoPressAccess: boolean;
-					isVideoPress1TB?: boolean;
-					isVideoPressUnlimited?: boolean;
+					hasVideoPressAccess: boolean | null;
+					isVideoPress1TB?: boolean | null;
+					isVideoPressUnlimited?: boolean | null;
 				};
 				assets: {
 					buildUrl: string;

--- a/projects/packages/videopress/routes/overview/stage.tsx
+++ b/projects/packages/videopress/routes/overview/stage.tsx
@@ -42,7 +42,7 @@ const StageInner = () => {
 	} = useStats();
 	const { isFree, isAtomic, isUnlimited, videoCount } = useFreeTier();
 
-	const showStorageMeter = ! isFree && videoCount > 0 && ! isUnlimited && ! isAtomic;
+	const showStorageMeter = isFree === false && videoCount > 0 && ! isUnlimited && ! isAtomic;
 	// A failed stats request would otherwise render as all-zero KPI cards —
 	// indistinguishable from a genuine zero-activity site. Only when there's
 	// no (cached) data behind it, though: a failed *background* refetch keeps

--- a/projects/packages/videopress/src/class-initial-state.php
+++ b/projects/packages/videopress/src/class-initial-state.php
@@ -189,26 +189,29 @@ class Initial_State {
 	 * counts as paid access. On WPCOM the legacy `videopress` slug also
 	 * grants access.
 	 *
-	 * @return bool
+	 * @return bool|null Null when site features could not be retrieved.
 	 */
 	public static function has_videopress_access() {
-		// Any paid storage tier grants access; on the WPCOM platform (Simple or
-		// Atomic) the legacy `videopress` slug does too. No Simple special-case is
-		// needed here: each has_videopress_feature() call already routes through the
-		// Simple-local wpcom_site_has_feature() check under IS_WPCOM, and
-		// is_wpcom_platform() is true on Simple, so the third term reduces to
-		// wpcom_site_has_feature( 'videopress' ) there — the check the old early
-		// return performed, minus the redundancy.
-		return self::has_videopress_feature( 'videopress-1tb-storage' )
-			|| self::has_videopress_feature( 'videopress-unlimited-storage' )
-			|| ( ( new Host() )->is_wpcom_platform() && self::has_videopress_feature( 'videopress' ) );
+		$feature_slugs = array( 'videopress-1tb-storage', 'videopress-unlimited-storage' );
+		if ( ( new Host() )->is_wpcom_platform() ) {
+			$feature_slugs[] = 'videopress';
+		}
+
+		foreach ( $feature_slugs as $feature_slug ) {
+			$has_feature = self::has_videopress_feature( $feature_slug );
+			if ( null === $has_feature || $has_feature ) {
+				return $has_feature;
+			}
+		}
+
+		return false;
 	}
 
 	/**
 	 * Whether the named feature appears in the WPCOM active-features list.
 	 *
 	 * @param string $feature_slug Feature slug as returned by WPCOM (e.g. `videopress-1tb-storage`).
-	 * @return bool
+	 * @return bool|null Null when site features could not be retrieved.
 	 */
 	private static function has_videopress_feature( $feature_slug ) {
 		if ( ( new Host() )->is_wpcom_simple() ) {
@@ -218,7 +221,7 @@ class Initial_State {
 		$features = Product::get_site_features_from_wpcom();
 
 		if ( is_wp_error( $features ) ) {
-			return false;
+			return null;
 		}
 
 		$active = $features['active'] ?? array();

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-free-tier.test.ts
@@ -46,6 +46,31 @@ describe( 'useFreeTier', () => {
 		expect( result.current.isAtLimit ).toBe( true );
 	} );
 
+	it.each( [ null, undefined ] )(
+		'keeps unavailable access (%s) unknown with four videos',
+		async access => {
+			const win = window as unknown as { JPVIDEOPRESS_INITIAL_STATE: { siteData: unknown } };
+			const previousSiteData = win.JPVIDEOPRESS_INITIAL_STATE.siteData;
+			win.JPVIDEOPRESS_INITIAL_STATE.siteData = {
+				hasVideoPressAccess: access,
+				isVideoPressUnlimited: null,
+			};
+			mockApiFetch( async () => ( {
+				headers: { get: ( key: string ) => ( key === 'X-WP-Total' ? '3' : '1' ) },
+				json: async () => [],
+			} ) );
+
+			try {
+				const { result } = renderHook( () => useFreeTier(), { wrapper: createTestWrapper() } );
+				await waitFor( () => expect( result.current.videoCount ).toBe( 4 ) );
+				expect( result.current.isFree ).toBeNull();
+				expect( result.current.isAtLimit ).toBe( false );
+			} finally {
+				win.JPVIDEOPRESS_INITIAL_STATE.siteData = previousSiteData;
+			}
+		}
+	);
+
 	// Regression: an unlimited (grandfathered) plan must never be reported as
 	// at the limit, even when the counted videos reach the free-tier cap.
 	// `isFree` and `isUnlimited` come from independent signals, so `isAtLimit`

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-intake.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-intake.test.ts
@@ -55,6 +55,16 @@ describe( 'useUploadIntake', () => {
 		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 
+	it( 'leaves unknown-plan uploads to the server without a quota upsell', () => {
+		mockFreeTier = { ...mockFreeTier, isFree: null, videoCount: 4 };
+		const files = [ video( 'a.mp4' ), video( 'b.mp4' ) ];
+
+		expect( intake()( files ) ).toBe( 2 );
+		expect( mockStartUpload ).toHaveBeenCalledTimes( 2 );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+		expect( mockRunUpgrade ).not.toHaveBeenCalled();
+	} );
+
 	it( 'refuses a selection with no videos in it', () => {
 		const files = [ new File( [ 'x' ], 'doc.pdf', { type: 'application/pdf' } ) ];
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-free-tier.ts
@@ -5,7 +5,8 @@ import { useUpload } from './use-upload';
 import type { View } from '@wordpress/dataviews';
 
 export type FreeTierState = {
-	isFree: boolean;
+	// Null means the site features are unavailable, not a free or paid plan.
+	isFree: boolean | null;
 	isAtomic: boolean;
 	isUnlimited: boolean;
 	videoCount: number;
@@ -46,7 +47,8 @@ export function useFreeTier(): FreeTierState {
 			? JPVIDEOPRESS_INITIAL_STATE?.siteData
 			: undefined;
 
-	const isFree = ! siteData?.hasVideoPressAccess;
+	const access = siteData?.hasVideoPressAccess;
+	const isFree = typeof access === 'boolean' ? ! access : null;
 
 	const completed = paginationInfo?.totalItems ?? 0;
 	const inFlight = uploadQueue.filter(
@@ -61,7 +63,7 @@ export function useFreeTier(): FreeTierState {
 	// 2TB plans) and paid access come from signals independent of `isFree`, so
 	// guard against an "unlimited yet free-flagged" combination wrongly gating
 	// uploads.
-	const isAtLimit = isFree && ! isUnlimited && videoCount >= FREE_TIER_UPLOAD_LIMIT;
+	const isAtLimit = isFree === true && ! isUnlimited && videoCount >= FREE_TIER_UPLOAD_LIMIT;
 
 	return {
 		isFree,

--- a/projects/packages/videopress/tests/php/Initial_State_Test.php
+++ b/projects/packages/videopress/tests/php/Initial_State_Test.php
@@ -9,12 +9,19 @@ namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\My_Jetpack\Product;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use WorDBless\BaseTestCase;
 use WP_Error;
 
 /**
  * Tests for dashboard entitlement state.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
  */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
 class Initial_State_Test extends BaseTestCase {
 
 	/**

--- a/projects/packages/videopress/tests/php/Initial_State_Test.php
+++ b/projects/packages/videopress/tests/php/Initial_State_Test.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for VideoPress dashboard entitlement state.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use Automattic\Jetpack\My_Jetpack\Product;
+use PHPUnit\Framework\Attributes\DataProvider;
+use WorDBless\BaseTestCase;
+use WP_Error;
+
+/**
+ * Tests for dashboard entitlement state.
+ */
+class Initial_State_Test extends BaseTestCase {
+
+	/**
+	 * Clean up the site-features cache.
+	 */
+	public function tearDown(): void {
+		delete_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY );
+		parent::tearDown();
+	}
+
+	/**
+	 * Check that failed feature requests cannot classify a site as free.
+	 */
+	public function test_failed_features_remain_unknown() {
+		set_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, new WP_Error( 'site_features_fetch_failed' ), 15 );
+
+		$this->assertNull( Initial_State::has_videopress_access() );
+	}
+
+	/**
+	 * Check known free and paid feature lists.
+	 *
+	 * @dataProvider known_features_provider
+	 * @param array $active Active site features.
+	 * @param bool  $expected Expected paid entitlement.
+	 */
+	#[DataProvider( 'known_features_provider' )]
+	public function test_known_features( $active, $expected ) {
+		set_transient( Product::MY_JETPACK_SITE_FEATURES_TRANSIENT_KEY, array( 'active' => $active ), 15 );
+
+		$this->assertSame( $expected, Initial_State::has_videopress_access() );
+	}
+
+	/**
+	 * Known site-feature combinations.
+	 *
+	 * @return array Test cases.
+	 */
+	public static function known_features_provider() {
+		return array(
+			'free'      => array( array(), false ),
+			'paid'      => array( array( 'videopress-1tb-storage' ), true ),
+			'unlimited' => array( array( 'videopress-unlimited-storage' ), true ),
+		);
+	}
+}

--- a/projects/plugins/jetpack/changelog/fix-videopress-unknown-entitlement
+++ b/projects/plugins/jetpack/changelog/fix-videopress-unknown-entitlement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Avoid free-plan limits and upgrade prompts when site features cannot be loaded.

--- a/projects/plugins/videopress/changelog/fix-videopress-unknown-entitlement
+++ b/projects/plugins/videopress/changelog/fix-videopress-unknown-entitlement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Avoid free-plan limits and upgrade prompts when site features cannot be loaded.


### PR DESCRIPTION
Fixes [JETPACK-2525](https://linear.app/a8c/issue/JETPACK-2525).

## Proposed changes

When the site-features request fails, VideoPress treats paid sites as free and incorrectly shows upload limits and upgrade prompts. Preserve an unknown plan instead: apply free-plan limits only to confirmed free plans, and show the storage meter only for confirmed paid plans. Uploads continue through the existing server-side authorization and error handling.

## Related product discussion/links

* Related connection-error handling: #51541.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a disposable Jetpack-connected site with a Complete or VideoPress paid plan, activate this PR through Jetpack Beta (or install the corresponding standalone VideoPress build). Upload at least two videos.
2. Open VideoPress and confirm the normal paid-plan dashboard appears.
3. To simulate an unavailable plan lookup while keeping the site's connection intact, create `wp-content/mu-plugins/videopress-plan-lookup-test.php` (create the directory if necessary) containing:

   ```php
   <?php
   add_filter( 'pre_transient_my-jetpack-site-features', function () {
       return new WP_Error( 'site_features_fetch_failed', 'Simulated plan lookup failure.' );
   } );
   ```

4. Reload VideoPress. Visit Library, Stats, and Settings. Confirm no free-plan quota or plan-upgrade prompt appears, and Stats does not show a plan storage meter while the plan is unknown.
5. From Library, select multiple videos and upload them. Confirm the UI does not block them with a free-plan limit; uploads should proceed normally while the connection is healthy.
6. Delete the temporary MU-plugin and reload. Confirm normal paid-plan information returns.
7. On a connected Free test site with one uploaded video, activate the same build and attempt another upload. Confirm the free-plan limit and upgrade prompt still appear. Do not install the failure-simulation MU-plugin for this check.
