### PR TITLE
Subscriptions: Restore token-only subscriber login state

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-jetpack-2522-subscriber-session
+++ b/projects/plugins/jetpack/changelog/fix-jetpack-2522-subscriber-session
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Recognize subscriber sessions in the Subscriber Login and Premium Content blocks.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -80,21 +80,15 @@ function get_subscriber_login_url( $redirect ) {
 }
 
 /**
- * Determines whether the current visitor is a confirmed subscriber -- someone who
- * actually holds a premium-content session token, not merely someone with a
- * WordPress session on this site.
+ * Determines whether the visitor has a subscriber session for the login UI.
  *
- * A bare WordPress session is not proof of a subscription (see NL-787): the
- * previous is_user_logged_in() || has_token_from_cookie() check hid this block's
- * only "Log in" link -- the sole way to mint a fresh token via the
- * subscribe.wordpress.com magic-link round trip -- for anyone the site owner
- * simply added as a WP user (or anyone else with an ordinary session and no
- * token), leaving them with no way to recover.
+ * WordPress sessions count on Simple; other hosts require the subscriber cookie.
+ * Content access validates the token separately.
  *
  * @return bool
  */
 function is_subscriber_logged_in() {
-	return is_user_logged_in() && Abstract_Token_Subscription_Service::has_token_from_cookie();
+	return ( ( new Host() )->is_wpcom_simple() && is_user_logged_in() ) || Abstract_Token_Subscription_Service::has_token_from_cookie();
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -113,21 +113,15 @@ function get_subscriber_login_url( $redirect ) {
 }
 
 /**
- * Determines whether the current visitor is a confirmed subscriber -- someone who
- * actually holds a premium-content session token, not merely someone with a
- * WordPress session on this site.
+ * Determines whether the visitor has a subscriber session for the login UI.
  *
- * A bare WordPress session is not proof of a subscription (see NL-787): the
- * previous is_user_logged_in() || has_token_from_cookie() check hid this block's
- * only "Log in" link -- the sole way to mint a fresh token via the
- * subscribe.wordpress.com magic-link round trip -- for anyone the site owner
- * simply added as a WP user (or anyone else with an ordinary session and no
- * token), leaving them with no way to recover.
+ * WordPress sessions count on Simple; other hosts require the subscriber cookie.
+ * Content access validates the token separately.
  *
  * @return bool
  */
 function is_subscriber_logged_in() {
-	return is_user_logged_in() && Abstract_Token_Subscription_Service::has_token_from_cookie();
+	return ( ( new Host() )->is_wpcom_simple() && is_user_logged_in() ) || Abstract_Token_Subscription_Service::has_token_from_cookie();
 }
 
 /**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
@@ -74,19 +74,19 @@ class Subscriber_Session_Test extends WP_UnitTestCase {
 			);
 			try {
 				$subscriber = render_block( array( 'blockName' => 'jetpack/test-subscriber-session' ) );
+
+				if ( $expected ) {
+					$this->assertSame( '', $premium_content );
+					$this->assertStringContainsString( '>Log out</a>', $subscriber );
+					$this->assertStringNotContainsString( '>Log in</a>', $subscriber );
+				} else {
+					$this->assertStringContainsString( '>Log in</a>', $premium_content );
+					$this->assertStringContainsString( '>Log in</a>', $subscriber );
+					$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $premium_content );
+					$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $subscriber );
+				}
 			} finally {
 				unregister_block_type( 'jetpack/test-subscriber-session' );
-			}
-
-			if ( $expected ) {
-				$this->assertSame( '', $premium_content );
-				$this->assertStringContainsString( '>Log out</a>', $subscriber );
-				$this->assertStringNotContainsString( '>Log in</a>', $subscriber );
-			} else {
-				$this->assertStringContainsString( '>Log in</a>', $premium_content );
-				$this->assertStringContainsString( '>Log in</a>', $subscriber );
-				$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $premium_content );
-				$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $subscriber );
 			}
 		} finally {
 			wp_set_current_user( $original_user );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Subscriber session detection for both login blocks.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Extensions\Premium_Content\Subscription_Service\Abstract_Token_Subscription_Service;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
+use function Automattic\Jetpack\Extensions\Premium_Content\is_subscriber_logged_in as premium_content_is_logged_in;
+use function Automattic\Jetpack\Extensions\Premium_Content\render_login_button_block;
+use function Automattic\Jetpack\Extensions\Subscriber_Login\is_subscriber_logged_in as subscriber_is_logged_in;
+use function Automattic\Jetpack\Extensions\Subscriber_Login\render_block;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/access-check.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/login-button/login-button.php';
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/subscriber-login/subscriber-login.php';
+
+/**
+ * @covers ::Automattic\Jetpack\Extensions\Premium_Content\is_subscriber_logged_in
+ * @covers ::Automattic\Jetpack\Extensions\Premium_Content\render_login_button_block
+ * @covers ::Automattic\Jetpack\Extensions\Subscriber_Login\is_subscriber_logged_in
+ * @covers ::Automattic\Jetpack\Extensions\Subscriber_Login\render_block
+ */
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Premium_Content\is_subscriber_logged_in' )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Premium_Content\render_login_button_block' )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Subscriber_Login\is_subscriber_logged_in' )]
+#[CoversFunction( 'Automattic\Jetpack\Extensions\Subscriber_Login\render_block' )]
+class Subscriber_Session_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Test both login surfaces across host, WordPress session, and cookie states.
+	 *
+	 * @dataProvider subscriber_session_provider
+	 * @param bool        $simple   Whether the site runs on WordPress.com Simple.
+	 * @param bool        $wp_login Whether the visitor has a WordPress session.
+	 * @param string|null $cookie   Subscriber cookie, or null when absent.
+	 * @param bool        $expected Whether the login UI considers the visitor logged in.
+	 */
+	#[DataProvider( 'subscriber_session_provider' )]
+	public function test_subscriber_session( $simple, $wp_login, $cookie, $expected ) {
+		$cookie_name        = Abstract_Token_Subscription_Service::JWT_AUTH_TOKEN_COOKIE_NAME;
+		$original_cookie    = $_COOKIE[ $cookie_name ] ?? null;
+		$had_cookie         = array_key_exists( $cookie_name, $_COOKIE );
+		$original_user      = get_current_user_id();
+		$had_wpcom_override = array_key_exists( 'IS_WPCOM', Constants::$set_constants );
+		$wpcom_override     = Constants::$set_constants['IS_WPCOM'] ?? null;
+
+		try {
+			Constants::set_constant( 'IS_WPCOM', $simple );
+			wp_set_current_user( $wp_login ? self::factory()->user->create( array( 'role' => 'subscriber' ) ) : 0 );
+			if ( null === $cookie ) {
+				unset( $_COOKIE[ $cookie_name ] );
+			} else {
+				$_COOKIE[ $cookie_name ] = $cookie;
+			}
+
+			$this->assertSame( $expected, premium_content_is_logged_in() );
+			$this->assertSame( $expected, subscriber_is_logged_in() );
+
+			// Logged-out Simple rendering calls wpcom_logmein_redirect_url(), which is provided by wpcom.
+			if ( $simple && ! $expected ) {
+				return;
+			}
+
+			update_option( Jetpack_Memberships::$has_connected_account_option_name, 1 );
+			$premium_content = render_login_button_block( array(), '<a>Log in</a>' );
+			$subscriber      = render_block( array() );
+
+			if ( $expected ) {
+				$this->assertSame( '', $premium_content );
+				$this->assertStringContainsString( '>Log out</a>', $subscriber );
+				$this->assertStringNotContainsString( '>Log in</a>', $subscriber );
+			} else {
+				$this->assertStringContainsString( '>Log in</a>', $premium_content );
+				$this->assertStringContainsString( '>Log in</a>', $subscriber );
+				$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $premium_content );
+				$this->assertStringContainsString( 'subscribe.wordpress.com/memberships/jwt/', $subscriber );
+			}
+		} finally {
+			wp_set_current_user( $original_user );
+			if ( $had_cookie ) {
+				$_COOKIE[ $cookie_name ] = $original_cookie;
+			} else {
+				unset( $_COOKIE[ $cookie_name ] );
+			}
+			if ( $had_wpcom_override ) {
+				Constants::set_constant( 'IS_WPCOM', $wpcom_override );
+			} else {
+				Constants::clear_single_constant( 'IS_WPCOM' );
+			}
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public static function subscriber_session_provider() {
+		// Session detection checks cookie presence; content access validates the actual JWT separately.
+		return array(
+			'self-hosted anonymous'       => array( false, false, null, false ),
+			'self-hosted token only'      => array( false, false, 'subscriber-token', true ),
+			'self-hosted WP session only' => array( false, true, null, false ),
+			'self-hosted WP and token'    => array( false, true, 'subscriber-token', true ),
+			'self-hosted empty cookie'    => array( false, false, '', false ),
+			'self-hosted WP empty cookie' => array( false, true, '', false ),
+			'Simple anonymous'            => array( true, false, null, false ),
+			'Simple token only'           => array( true, false, 'subscriber-token', true ),
+			'Simple WP session only'      => array( true, true, null, true ),
+			'Simple WP and token'         => array( true, true, 'subscriber-token', true ),
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Subscriber_Session_Test.php
@@ -12,7 +12,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use function Automattic\Jetpack\Extensions\Premium_Content\is_subscriber_logged_in as premium_content_is_logged_in;
 use function Automattic\Jetpack\Extensions\Premium_Content\render_login_button_block;
 use function Automattic\Jetpack\Extensions\Subscriber_Login\is_subscriber_logged_in as subscriber_is_logged_in;
-use function Automattic\Jetpack\Extensions\Subscriber_Login\render_block;
 
 require_once JETPACK__PLUGIN_DIR . 'modules/memberships/class-jetpack-memberships.php';
 require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/premium-content/_inc/access-check.php';
@@ -69,7 +68,15 @@ class Subscriber_Session_Test extends WP_UnitTestCase {
 
 			update_option( Jetpack_Memberships::$has_connected_account_option_name, 1 );
 			$premium_content = render_login_button_block( array(), '<a>Log in</a>' );
-			$subscriber      = render_block( array() );
+			register_block_type(
+				'jetpack/test-subscriber-session',
+				array( 'render_callback' => 'Automattic\Jetpack\Extensions\Subscriber_Login\render_block' )
+			);
+			try {
+				$subscriber = render_block( array( 'blockName' => 'jetpack/test-subscriber-session' ) );
+			} finally {
+				unregister_block_type( 'jetpack/test-subscriber-session' );
+			}
 
 			if ( $expected ) {
 				$this->assertSame( '', $premium_content );


### PR DESCRIPTION
## Proposed changes

Subscribers who return from the magic-link flow with a subscriber session cookie but no local WordPress session currently see “Log in” again. Restore the Subscriber Login and Premium Content login-button state so a subscriber cookie is sufficient, while an ordinary WordPress session counts only on WordPress.com Simple. This preserves the recovery link for self-hosted WordPress users without a subscriber cookie.

- Match the existing hosting-aware session check in the subscriptions module.
- Verify both files already import `Automattic\Jetpack\Status\Host`; no additional import is needed.
- Add regression coverage for both predicates and rendered login surfaces, including absent/empty cookies, token-only visitors, WordPress-only sessions, and Simple.
- Add the Jetpack changelog entry. Token validation and premium-content access checks are unchanged.

## Related product discussion/links

Regression introduced by #50984.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a connected self-hosted site with subscriptions and payments enabled, add Subscriber Login and Premium Content blocks to a page.
2. Visit logged out without a subscriber cookie: both login surfaces should offer “Log in”. Repeat with an ordinary local WordPress subscriber account and no cookie; the login route should remain available.
3. Sign in through the subscriber magic-link flow, without logging into WordPress locally. Subscriber Login should show “Log out” (or “Manage subscription” when enabled for a subscribed visitor), and the Premium Content login button should disappear.
4. Remove or empty the `wp-jp-premium-content-session` cookie: the login route should return. Confirm actual premium-content access still requires a valid token/subscription.
5. On WordPress.com Simple, verify a WordPress session without a subscriber cookie still counts as logged in.

Automated validation completed locally with a real WordPress test bootstrap and a dedicated disposable MariaDB database:

- Both affected block directories: **72 tests, 172 assertions passed**, including randomized execution (seed 2522).
- New regression class alone: **10 tests, 51 assertions passed** (PHPUnit 12.5.33, PHP 8.5.4).
- Negative control using the old predicate failed the token-only and Simple WordPress-only cases; the fix was restored and the suite passed again.
- Changed-file PHPCS, PHPCompatibilityWP, and `git diff --check` passed.
- Full Jetpack Phan analysis now passes locally using the repository Docker image and native PHP parser (exit 0). The test assertions remain inside the render try scope so Phan can track the assigned markup.
- Fixed the initial PHP 8.4 / WordPress previous CI warning by rendering the test fixture through the core block lifecycle. The affected block directories now pass locally on **WordPress 7.0 / PHP 8.4.25: 72 tests, 172 assertions**, with warnings treated as failures.

Run the targeted suite with `jp docker phpunit jetpack -- --filter=Subscriber_Session_Test`, or run both `tests/php/extensions/blocks/premium-content` and `tests/php/extensions/blocks/subscriber-login` with the Jetpack PHPUnit bootstrap.

Browser smoke passed on a local WordPress 7.0 site using the PR callbacks through core block rendering and real WordPress session cookies: anonymous and WordPress-only visitors see both login links; token-only and combined sessions show “Log out” and hide the Premium Content login button; removing the sessions restores both login links. This used a placeholder subscriber cookie to exercise UI state. Connected magic-link flow, validated premium access, and WordPress.com Simple browser checks remain pending. The previous CI run passed the PHP 7.4–8.5 latest-version matrix and the formerly failing PHP 8.4 / WordPress previous job. The latest test-scope correction passed local PHPUnit and full Phan; its refreshed CI matrix is running. This PR remains a draft.

