### PR TITLE
fix(forms): keep editor defaults nonpersistent

### DIFF
--- a/projects/packages/forms/changelog/fix-editor-default-initialization
+++ b/projects/packages/forms/changelog/fix-editor-default-initialization
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: Keep editor-initialized defaults from marking imported forms as changed.

--- a/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
+++ b/projects/packages/forms/src/blocks/contact-form/shared/hooks/use-form-block-defaults.js
@@ -1,4 +1,4 @@
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { INTEGRATIONS_STORE } from '../../../../store/integrations/index.ts';
 
@@ -13,6 +13,7 @@ import { INTEGRATIONS_STORE } from '../../../../store/integrations/index.ts';
  * @param {Function} params.setAttributes - Setter for block attributes
  */
 export default function useFormBlockDefaults( { attributes, setAttributes } ) {
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( 'core/block-editor' );
 	const integrations = useSelect( select => {
 		const store = select( INTEGRATIONS_STORE );
 		return store.getIntegrations() || [];
@@ -31,10 +32,12 @@ export default function useFormBlockDefaults( { attributes, setAttributes } ) {
 		const salesforce = find( 'salesforce' );
 
 		if ( typeof attributes?.jetpackCRM === 'undefined' && crm ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { jetpackCRM: !! crm.enabledByDefault } );
 		}
 
 		if ( typeof attributes?.mailpoet?.enabledForForm === 'undefined' && mailpoet ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				mailpoet: {
 					...attributes.mailpoet,
@@ -44,6 +47,7 @@ export default function useFormBlockDefaults( { attributes, setAttributes } ) {
 		}
 
 		if ( typeof attributes?.salesforceData?.sendToSalesforce === 'undefined' && salesforce ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( {
 				salesforceData: {
 					...attributes.salesforceData,
@@ -58,5 +62,6 @@ export default function useFormBlockDefaults( { attributes, setAttributes } ) {
 		attributes.mailpoet,
 		attributes.salesforceData,
 		setAttributes,
+		__unstableMarkNextChangeAsNotPersistent,
 	] );
 }

--- a/projects/packages/forms/src/blocks/field-telephone/edit.jsx
+++ b/projects/packages/forms/src/blocks/field-telephone/edit.jsx
@@ -11,6 +11,7 @@ import {
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
@@ -44,6 +45,7 @@ export default function PhoneFieldEdit( props ) {
 		requiredIndicator,
 	} = attributes;
 	const [ countryList, setCountryList ] = useState( EMPTY_ARRAY );
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch( 'core/block-editor' );
 
 	const { isInnerBlockSelected, hasPlaceholder } = useFieldSelected( clientId );
 	const { blockStyle } = useJetpackFieldStyles( attributes );
@@ -78,10 +80,17 @@ export default function PhoneFieldEdit( props ) {
 
 	useEffect( () => {
 		if ( showCountrySelector === undefined || showCountrySelector === true ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { showCountrySelector: true, default: defaultCountry || 'US' } );
 			setCountryList( countryPairs );
 		}
-	}, [ showCountrySelector, setAttributes, countryPairs, defaultCountry ] );
+	}, [
+		showCountrySelector,
+		setAttributes,
+		countryPairs,
+		defaultCountry,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
 
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'jetpack-field__control' },

--- a/projects/packages/forms/tests/js/blocks/contact-form/shared/hooks/use-form-block-defaults.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/contact-form/shared/hooks/use-form-block-defaults.test.jsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+
+const markNextChangeAsNotPersistent = jest.fn();
+let integrations = [];
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+	useDispatch: () => ( { __unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent } ),
+	useSelect: selector =>
+		selector( () => ( {
+			getIntegrations: () => integrations,
+			isIntegrationsLoading: () => false,
+		} ) ),
+} ) );
+
+const { default: useFormBlockDefaults } = await import(
+	'../../../../../../src/blocks/contact-form/shared/hooks/use-form-block-defaults.js'
+);
+
+describe( 'useFormBlockDefaults', () => {
+	beforeEach( () => {
+		integrations = [
+			{ id: 'zero-bs-crm', enabledByDefault: false },
+			{ id: 'mailpoet', enabledByDefault: false },
+			{ id: 'salesforce', enabledByDefault: false },
+		];
+		markNextChangeAsNotPersistent.mockReset();
+	} );
+
+	it( 'marks every editor-initialized integration default nonpersistent before setting it', () => {
+		const setAttributes = jest.fn();
+		renderHook( () =>
+			useFormBlockDefaults( {
+				attributes: { mailpoet: { listId: null }, salesforceData: { organizationId: '' } },
+				setAttributes,
+			} )
+		);
+
+		expect( setAttributes ).toHaveBeenCalledWith( { jetpackCRM: false } );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			mailpoet: { listId: null, enabledForForm: false },
+		} );
+		expect( setAttributes ).toHaveBeenCalledWith( {
+			salesforceData: { organizationId: '', sendToSalesforce: false },
+		} );
+		expect( markNextChangeAsNotPersistent ).toHaveBeenCalledTimes( 3 );
+		setAttributes.mock.invocationCallOrder.forEach( ( callOrder, index ) => {
+			expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ index ] ).toBeLessThan(
+				callOrder
+			);
+		} );
+	} );
+} );

--- a/projects/packages/forms/tests/js/field-telephone/edit.test.jsx
+++ b/projects/packages/forms/tests/js/field-telephone/edit.test.jsx
@@ -1,0 +1,61 @@
+import { expect, it, jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+
+const markNextChangeAsNotPersistent = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: () => ( { __unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent } ),
+} ) );
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	useBlockProps: () => ( {} ),
+	useInnerBlocksProps: () => ( {} ),
+	BlockContextProvider: ( { children } ) => children,
+	BlockControls: ( { children } ) => children,
+	RichText: () => null,
+} ) );
+await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	BaseControl: ( { children } ) => children,
+	TextControl: () => null,
+	ToggleControl: () => null,
+	ToolbarButton: () => null,
+	ToolbarGroup: ( { children } ) => children,
+} ) );
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( { __: value => value } ) );
+await jest.unstable_mockModule( '@wordpress/icons', () => ( { globe: {} } ) );
+await jest.unstable_mockModule( 'clsx', () => ( { default: () => '' } ) );
+await jest.unstable_mockModule( '../../../src/blocks/shared/hooks/use-field-selected.js', () => ( {
+	default: () => ( { isInnerBlockSelected: false, hasPlaceholder: false } ),
+} ) );
+await jest.unstable_mockModule( '../../../src/blocks/shared/hooks/use-form-wrapper.js', () => ( {
+	default: () => {},
+} ) );
+await jest.unstable_mockModule(
+	'../../../src/blocks/shared/hooks/use-jetpack-field-styles.js',
+	() => ( {
+		default: () => ( { blockStyle: {} } ),
+	} )
+);
+await jest.unstable_mockModule(
+	'../../../src/blocks/shared/hooks/use-sync-required-indicator.js',
+	() => ( {
+		default: () => {},
+	} )
+);
+await jest.unstable_mockModule(
+	'../../../src/blocks/shared/components/jetpack-field-controls.jsx',
+	() => ( {
+		default: () => null,
+	} )
+);
+
+const { default: PhoneFieldEdit } = await import( '../../../src/blocks/field-telephone/edit.jsx' );
+
+it( 'marks telephone initialization nonpersistent before setting its default country', () => {
+	const setAttributes = jest.fn();
+	render( <PhoneFieldEdit attributes={ {} } clientId="phone" setAttributes={ setAttributes } /> );
+
+	expect( setAttributes ).toHaveBeenCalledWith( { showCountrySelector: true, default: 'US' } );
+	expect( markNextChangeAsNotPersistent.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+		setAttributes.mock.invocationCallOrder[ 0 ]
+	);
+} );


### PR DESCRIPTION
## Proposed Changes

Mark Forms integration and telephone editor-initialization writes as nonpersistent before calling `setAttributes`. This retains initialized values for the next real save without marking a previously clean post dirty solely from initialization.

## Related Investigation

- Automattic/blocks-engine#1586
- Automattic/static-site-importer#1534

The initial serialization diagnosis was disproved. The actual cause was Jetpack editor effects initializing previously undefined attributes. This uses the existing Forms nonpersistent-initialization pattern rather than introducing importer-specific defaults.

## Data And Privacy

No change to collected data or activity tracking.

## Verification

- Forms package tests: 111 suites, 1,488 tests passed on the initial candidate.
- Added focused integration-default and telephone-initialization ordering tests in the final revision.
- Repository CI passed, including JS/PHP tests, lint, builds, coverage, Forms E2E, and WordPress.com checks.
- Independent follow-up verification installed the exact production-mirror artifact `Automattic/jetpack-production@83f1f1e3fefaf7fefc5b40b618f51744b9a5f38f` into a disposable WordPress Studio site, enabled Forms, and confirmed the editor loaded that artifact's Forms scripts. This was not WP Codebox or a WordPress.com sandbox.
- The earlier title-only fixture was insufficient: on independent inspection it rendered missing blocks with Forms inactive. It is superseded by the following registered-block verification.
- Using Playwright and the actual Gutenberg data stores, a valid form was saved with integration initialization attributes omitted. Loading it initialized those attributes without making the post dirty.
- Country selection (`CA`), country-selector off/on, CRM, MailPoet, and Salesforce setting changes were each applied through `core/block-editor.updateBlockAttributes`. Every actual change marked the post dirty, saved successfully, persisted after reload, and returned to clean with zero invalid blocks. These tests exercise real editor state and persistence, not pointer interaction or external integration delivery.

## Reproduction And Regression Checks

1. Use WordPress with Jetpack Forms enabled and a saved form containing telephone and integration attributes that have not yet been initialized by the editor.
2. Open the post and verify initialization alone does not mark it dirty.
3. Edit the title, save, and reload; verify the change persists and the editor is clean.
4. Exercise country selection, selector visibility, and integration settings; each change must mark dirty, persist after save/reload, and return to clean.
5. Complete the normal WordPress.com Sun/Moon sandbox smoke checks before activation; the local checks do not replace that deployment-stage gate.

## AI Assistance

OpenAI GPT-5.6 Terra via direct OpenCode implemented and tested the change. GPT-6 Astra via OpenCode orchestrated the work, reviewed the diff and CI, and merged it. No human GitHub review was recorded before merge.
