### PR TITLE
Newsletter: add the email design screen

### DIFF
--- a/projects/plugins/jetpack/changelog/add-nl-839-email-design-screen
+++ b/projects/plugins/jetpack/changelog/add-nl-839-email-design-screen
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: add the email design screen behind a feature flag.

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1125,7 +1125,7 @@ require __DIR__ . '/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.
 require __DIR__ . '/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php';
 require __DIR__ . '/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php';
 require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php';
-require __DIR__ . '/subscriptions/email-design-editor/class-jetpack-email-design-editor.php';
+require_once __DIR__ . '/subscriptions/email-design-editor/class-jetpack-email-design-editor.php';
 
 require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
 \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions.php
+++ b/projects/plugins/jetpack/modules/subscriptions.php
@@ -1125,6 +1125,7 @@ require __DIR__ . '/subscriptions/subscribe-modal/class-jetpack-subscribe-modal.
 require __DIR__ . '/subscriptions/subscribe-overlay/class-jetpack-subscribe-overlay.php';
 require __DIR__ . '/subscriptions/subscribe-floating-button/class-jetpack-subscribe-floating-button.php';
 require __DIR__ . '/subscriptions/newsletter-widget/class-jetpack-newsletter-dashboard-widget.php';
+require __DIR__ . '/subscriptions/email-design-editor/class-jetpack-email-design-editor.php';
 
 require_once __DIR__ . '/subscriptions/abilities/class-newsletter-abilities.php';
 \Automattic\Jetpack\Plugin\Abilities\Newsletter_Abilities::init();

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -180,6 +180,10 @@ class Jetpack_Email_Design_Editor {
 			#wpfooter { display: none; }
 			#' . self::HANDLE . ' {
 				position: fixed;
+				/* Above #adminmenuwrap (9990) and below #wpadminbar (100000): the editor paints
+				   notices and popovers against the viewport, so without this they land behind
+				   the admin menu. */
+				z-index: 9991;
 				inset-block: var(--wp-admin--admin-bar--height, 32px) 0;
 				inset-inline: 160px 0;
 			}

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -167,6 +167,10 @@ class Jetpack_Email_Design_Editor {
 	 *       here the way `Jetpack_Scan::load_wp_build()` does, or gate the page on 7.1. NL-839 (j).
 	 */
 	private static function enqueue_block_editor_assets() {
+		// Named rather than built from a post: there is no post here, and `get_block_categories()`
+		// hands whatever it gets to filters that type-hint the context.
+		$context = new WP_Block_Editor_Context( array( 'name' => 'jetpack/email-design' ) );
+
 		wp_enqueue_media();
 
 		do_action( 'enqueue_block_assets' );
@@ -177,7 +181,7 @@ class Jetpack_Email_Design_Editor {
 
 		wp_add_inline_script(
 			'wp-blocks',
-			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( get_post() ), self::JSON_FLAGS ) ),
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $context ), self::JSON_FLAGS ) ),
 			'after'
 		);
 		wp_add_inline_script(
@@ -220,22 +224,76 @@ class Jetpack_Email_Design_Editor {
 	 * WordPress.com strips both from the bootstrap bundle, because there they would name
 	 * WordPress.com's own asset URLs and push them into the site's canvas.
 	 *
-	 * @todo `allowedIframeStyleHandles` is what keeps the site's own CSS out of the canvas;
-	 *       without it the canvas paints the site's styles, not the email's. Mirror the
-	 *       package's `Settings_Controller::get_allowed_iframe_style_handles()`. NL-839 (b).
-	 *
 	 * @return array
 	 */
 	private static function get_iframe_asset_settings() {
-		$settings = array();
-
-		// Private, but it is what core's own block editors call to resolve the assets an
-		// iframed canvas needs. Absent before WP 6.3.
-		if ( function_exists( '_wp_get_iframed_editor_assets' ) ) {
-			$settings['__unstableResolvedAssets'] = _wp_get_iframed_editor_assets();
+		// Absent before WP 6.3, and private, but it is what core's own block editors call to
+		// resolve the assets an iframed canvas needs.
+		if ( ! function_exists( '_wp_get_iframed_editor_assets' ) ) {
+			return array();
 		}
 
-		return $settings;
+		$handles = self::get_allowed_iframe_style_handles();
+
+		return array(
+			'__unstableResolvedAssets'  => self::get_resolved_assets( $handles ),
+			'allowedIframeStyleHandles' => $handles,
+		);
+	}
+
+	/**
+	 * The stylesheet handles the canvas is allowed to keep.
+	 *
+	 * Mirrors the package's `Settings_Controller::get_allowed_iframe_style_handles()`. An empty
+	 * list is not a no-op: the client strips every stylesheet not named here, so omitting this
+	 * leaves the canvas painted in the site's own styles rather than the email's.
+	 *
+	 * @return string[]
+	 */
+	private static function get_allowed_iframe_style_handles() {
+		$handles = array(
+			'wp-components-css',
+			'wp-reset-editor-styles-css',
+			'wp-block-library-css',
+			'wp-block-editor-content-css',
+			'wp-edit-blocks-css',
+		);
+
+		foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $block ) {
+			if ( empty( $block->supports['email'] ) ) {
+				continue;
+			}
+
+			foreach ( array_merge( $block->style_handles, $block->editor_style_handles ) as $handle ) {
+				$handles[] = $handle . '-css';
+			}
+		}
+
+		return $handles;
+	}
+
+	/**
+	 * The iframe assets, trimmed to the allowed handles.
+	 *
+	 * @param string[] $allowed Handles to keep.
+	 * @return array The `_wp_get_iframed_editor_assets()` shape, with `styles` filtered.
+	 */
+	private static function get_resolved_assets( array $allowed ) {
+		$assets = _wp_get_iframed_editor_assets();
+		$kept   = array();
+
+		foreach ( explode( "\n", (string) $assets['styles'] ) as $asset ) {
+			foreach ( $allowed as $handle ) {
+				if ( str_contains( $asset, $handle ) ) {
+					$kept[] = $asset;
+					break;
+				}
+			}
+		}
+
+		$assets['styles'] = implode( "\n", $kept );
+
+		return $assets;
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -138,19 +138,56 @@ class Jetpack_Email_Design_Editor {
 		);
 		wp_set_script_translations( self::HANDLE, 'jetpack' );
 
+		// `wp-editor`, `wp-block-editor` and `wp-preferences` are what lay the editor's frame
+		// out; without them every region stacks into one narrow column. Keep the list to
+		// handles WordPress registers — an unregistered one drops this stylesheet silently,
+		// which is `wp-interface`'s trap.
 		wp_enqueue_style(
 			self::HANDLE,
 			plugins_url( '_inc/build/email-design-editor.css', JETPACK__PLUGIN_FILE ),
-			array( 'wp-edit-blocks' ),
+			array(
+				'wp-components',
+				'wp-block-editor',
+				'wp-editor',
+				'wp-edit-blocks',
+				'wp-preferences',
+				'wp-format-library',
+			),
 			$asset['version']
 		);
 		wp_style_add_data( self::HANDLE, 'rtl', 'replace' );
+		wp_add_inline_style( self::HANDLE, self::get_layout_css() );
 
 		wp_add_inline_script(
 			self::HANDLE,
 			'window.JetpackEmailDesignEditor = ' . wp_json_encode( self::get_screen_data(), self::JSON_FLAGS ) . ';',
 			'before'
 		);
+	}
+
+	/**
+	 * Fill the screen with the editor.
+	 *
+	 * The editor's frame expects a viewport, not the flow of an admin page: inside the usual
+	 * wp-admin content column it collapses to a fraction of the height and scrolls its own
+	 * regions. Woo avoids this by running on `post.php`, which is already fullscreen.
+	 *
+	 * @return string
+	 */
+	private static function get_layout_css() {
+		return '
+			#wpcontent { padding-inline-start: 0; }
+			#wpfooter { display: none; }
+			#' . self::HANDLE . ' {
+				position: fixed;
+				inset-block: var(--wp-admin--admin-bar--height, 32px) 0;
+				inset-inline: 160px 0;
+			}
+			body.folded #' . self::HANDLE . ' { inset-inline-start: 36px; }
+			@media screen and (max-width: 782px) {
+				#' . self::HANDLE . ' { inset-inline-start: 0; }
+			}
+		';
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * The newsletter email design screen.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Feature_Flags\Feature_Flags;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Registers an Appearance page that mounts the WooCommerce email editor against the
+ * newsletter template, so a creator sets their email design once for the whole site.
+ *
+ * The design itself lives on the WordPress.com shadow blog: the browser fetches it from
+ * `/wpcom/v2/email-editor-bootstrap` and this page supplies only what describes *this*
+ * installation. See NL-839.
+ */
+class Jetpack_Email_Design_Editor {
+
+	/**
+	 * The `page` query arg the screen answers to.
+	 */
+	const PAGE_SLUG = 'jetpack-email-design';
+
+	/**
+	 * The feature flag gating the screen. Registered off, forced on for testing with
+	 * `wp companion feature-flag enable jetpack-email-design`.
+	 */
+	const FEATURE_FLAG = 'jetpack-email-design';
+
+	/**
+	 * The script handle, and the id of the element the editor mounts into.
+	 */
+	const HANDLE = 'jetpack-email-design-editor';
+
+	/**
+	 * Flags for JSON handed to a `<script>` tag.
+	 */
+	const JSON_FLAGS = JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP;
+
+	/**
+	 * The hook suffix `add_theme_page()` returned, or null when the page is not registered.
+	 *
+	 * @var string|null
+	 */
+	private static $hook_suffix = null;
+
+	/**
+	 * Wire the screen up.
+	 */
+	public static function init() {
+		// Registered here rather than on `admin_menu` so the flag exists under WP-CLI, REST
+		// and cron too — `wp companion feature-flag list` reads it from one of those.
+		self::register_feature_flags();
+
+		add_action( 'admin_menu', array( __CLASS__, 'add_admin_page' ) );
+	}
+
+	/**
+	 * Declare the screen's feature flag.
+	 */
+	public static function register_feature_flags() {
+		Feature_Flags::register(
+			self::FEATURE_FLAG,
+			array(
+				'default'     => false,
+				'description' => 'Edit the newsletter email design in wp-admin, under Appearance.',
+				'owner'       => 'jetpack-newsletter',
+			)
+		);
+	}
+
+	/**
+	 * Whether the screen should exist on this site.
+	 *
+	 * The WordPress.com `email-design-editor` sticker gates the bootstrap endpoint, not this
+	 * page: a Jetpack site cannot read stickers without an API call, so the screen carries
+	 * its own gate.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		return Feature_Flags::is_enabled( self::FEATURE_FLAG );
+	}
+
+	/**
+	 * Add the screen under Appearance.
+	 */
+	public static function add_admin_page() {
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		self::$hook_suffix = add_theme_page(
+			__( 'Email Design', 'jetpack' ),
+			__( 'Email Design', 'jetpack' ),
+			'edit_theme_options',
+			self::PAGE_SLUG,
+			array( __CLASS__, 'render' )
+		);
+
+		if ( self::$hook_suffix ) {
+			add_action( 'load-' . self::$hook_suffix, array( __CLASS__, 'on_load' ) );
+		}
+	}
+
+	/**
+	 * Scope everything else to this one screen.
+	 */
+	public static function on_load() {
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Enqueue the editor bundle and the block-editor assets it expects to find.
+	 */
+	public static function enqueue_assets() {
+		$asset_path = JETPACK__PLUGIN_DIR . '_inc/build/email-design-editor.asset.php';
+
+		if ( ! file_exists( $asset_path ) ) {
+			return;
+		}
+
+		$asset = include $asset_path;
+
+		self::enqueue_block_editor_assets();
+
+		wp_enqueue_script(
+			self::HANDLE,
+			plugins_url( '_inc/build/email-design-editor.js', JETPACK__PLUGIN_FILE ),
+			$asset['dependencies'],
+			$asset['version'],
+			true
+		);
+		wp_set_script_translations( self::HANDLE, 'jetpack' );
+
+		wp_enqueue_style(
+			self::HANDLE,
+			plugins_url( '_inc/build/email-design-editor.css', JETPACK__PLUGIN_FILE ),
+			array( 'wp-edit-blocks' ),
+			$asset['version']
+		);
+		wp_style_add_data( self::HANDLE, 'rtl', 'replace' );
+
+		wp_add_inline_script(
+			self::HANDLE,
+			'window.JetpackEmailDesignEditor = ' . wp_json_encode( self::get_screen_data(), self::JSON_FLAGS ) . ';',
+			'before'
+		);
+	}
+
+	/**
+	 * Reproduce what the package's `Assets_Manager` does on WooCommerce's own screen.
+	 *
+	 * None of this happens automatically on a custom admin page: without it the editor
+	 * mounts against no block library, no block categories and no server-side block
+	 * definitions. See NL-839 (a).
+	 *
+	 * @todo Firing `enqueue_block_editor_assets` wholesale is the leading suspect for the
+	 *       second Styles button — it pulls in core's site-editing global styles UI. NL-839 (e).
+	 * @todo `@wordpress/global-styles-engine` opts into private APIs under a name core only
+	 *       allowlisted in WP 7.1, so the bundle throws on 7.0 — polyfill `wp-private-apis`
+	 *       here the way `Jetpack_Scan::load_wp_build()` does, or gate the page on 7.1. NL-839 (j).
+	 */
+	private static function enqueue_block_editor_assets() {
+		wp_enqueue_media();
+
+		do_action( 'enqueue_block_assets' );
+		do_action( 'enqueue_block_editor_assets' );
+
+		wp_enqueue_style( 'wp-edit-blocks' );
+		wp_enqueue_style( 'wp-format-library' );
+
+		wp_add_inline_script(
+			'wp-blocks',
+			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( get_post() ), self::JSON_FLAGS ) ),
+			'after'
+		);
+		wp_add_inline_script(
+			'wp-blocks',
+			sprintf(
+				'wp.blocks.unstable__bootstrapServerSideBlockDefinitions( %s );',
+				wp_json_encode( get_block_editor_server_block_settings(), self::JSON_FLAGS )
+			),
+			'after'
+		);
+	}
+
+	/**
+	 * What the page hands the bundle, as `window.JetpackEmailDesignEditor`.
+	 *
+	 * Every WordPress.com id — the template's, the global-styles record's — comes from the
+	 * bootstrap response instead, because they are namespaced to the shadow blog's theme and
+	 * a locally computed one is right on Simple and wrong everywhere else. See NL-839 (c).
+	 *
+	 * @return array
+	 */
+	private static function get_screen_data() {
+		return array(
+			'elementId'      => self::HANDLE,
+			'editorSettings' => self::get_iframe_asset_settings(),
+
+			// The editor assigns these to `window.location.href` from its header buttons.
+			// Both point at Appearance until the screen has a real entry point (NL-844).
+			'urls'           => array(
+				'back'     => admin_url( 'themes.php' ),
+				'listings' => admin_url( 'themes.php' ),
+			),
+			'userEmail'      => wp_get_current_user()->user_email,
+		);
+	}
+
+	/**
+	 * The two editor settings that describe this installation rather than the design.
+	 *
+	 * WordPress.com strips both from the bootstrap bundle, because there they would name
+	 * WordPress.com's own asset URLs and push them into the site's canvas.
+	 *
+	 * @todo `allowedIframeStyleHandles` is what keeps the site's own CSS out of the canvas;
+	 *       without it the canvas paints the site's styles, not the email's. Mirror the
+	 *       package's `Settings_Controller::get_allowed_iframe_style_handles()`. NL-839 (b).
+	 *
+	 * @return array
+	 */
+	private static function get_iframe_asset_settings() {
+		$settings = array();
+
+		// Private, but it is what core's own block editors call to resolve the assets an
+		// iframed canvas needs. Absent before WP 6.3.
+		if ( function_exists( '_wp_get_iframed_editor_assets' ) ) {
+			$settings['__unstableResolvedAssets'] = _wp_get_iframed_editor_assets();
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Render the container the editor mounts into.
+	 */
+	public static function render() {
+		printf( '<div id="%s" class="jetpack-email-design-editor"></div>', esc_attr( self::HANDLE ) );
+	}
+}
+
+Jetpack_Email_Design_Editor::init();

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -299,13 +299,18 @@ class Jetpack_Email_Design_Editor {
 			'wp-edit-blocks-css',
 		);
 
+		// Registration args reach the block type verbatim — `WP_Block_Type::set_props()` normalizes
+		// only `attributes`, and `register_block_type_args` can rewrite the rest — so a block
+		// declaring a bare string here would otherwise fatal the screen inside `array_merge()`.
 		foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $block ) {
-			if ( empty( $block->supports['email'] ) ) {
+			if ( ! is_array( $block->supports ) || empty( $block->supports['email'] ) ) {
 				continue;
 			}
 
-			foreach ( array_merge( $block->style_handles, $block->editor_style_handles ) as $handle ) {
-				$handles[] = $handle . '-css';
+			foreach ( array_merge( (array) $block->style_handles, (array) $block->editor_style_handles ) as $handle ) {
+				if ( is_string( $handle ) ) {
+					$handles[] = $handle . '-css';
+				}
 			}
 		}
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -129,6 +129,8 @@ class Jetpack_Email_Design_Editor {
 
 		self::enqueue_block_editor_assets();
 
+		// `@woocommerce/email-editor` opts into core's private APIs as `@wordpress/edit-site`,
+		// resolved against the site's `wp-private-apis`. Re-check on a package bump. NL-839 (j).
 		wp_enqueue_script(
 			self::HANDLE,
 			plugins_url( '_inc/build/email-design-editor.js', JETPACK__PLUGIN_FILE ),
@@ -203,9 +205,6 @@ class Jetpack_Email_Design_Editor {
 	 *
 	 * @todo Firing `enqueue_block_editor_assets` wholesale is the leading suspect for the
 	 *       second Styles button — it pulls in core's site-editing global styles UI. NL-839 (e).
-	 * @todo `@wordpress/global-styles-engine` opts into private APIs under a name core only
-	 *       allowlisted in WP 7.1, so the bundle throws on 7.0 — polyfill `wp-private-apis`
-	 *       here the way `Jetpack_Scan::load_wp_build()` does, or gate the page on 7.1. NL-839 (j).
 	 */
 	private static function enqueue_block_editor_assets() {
 		// Named rather than built from a post: there is no post here, and `get_block_categories()`

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Tests for the newsletter email design screen (NL-839).
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Feature_Flags\Feature_Flags;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php';
+
+/**
+ * @covers Jetpack_Email_Design_Editor
+ */
+#[CoversClass( Jetpack_Email_Design_Editor::class )]
+class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The asset file the screen looks for, which decides whether it enqueues anything.
+	 *
+	 * @var string
+	 */
+	private $asset_path;
+
+	/**
+	 * Where a real build's asset file was moved for the duration of a test, if there was one.
+	 *
+	 * @var string|null
+	 */
+	private $asset_backup = null;
+
+	/**
+	 * The build directory, when this test created it.
+	 *
+	 * @var string|null
+	 */
+	private $created_build_dir = null;
+
+	/**
+	 * Whether this test wrote the asset file.
+	 *
+	 * @var bool
+	 */
+	private $wrote_asset = false;
+
+	/**
+	 * A snapshot of the admin menu globals, which add_theme_page() appends to.
+	 *
+	 * @var array
+	 */
+	private $menu_snapshot = array();
+
+	/**
+	 * A snapshot of the script and style registries, which this test replaces.
+	 *
+	 * @var array
+	 */
+	private $asset_registries = array();
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->asset_path    = JETPACK__PLUGIN_DIR . '_inc/build/email-design-editor.asset.php';
+		$this->menu_snapshot = array( $GLOBALS['menu'] ?? array(), $GLOBALS['submenu'] ?? array() );
+
+		// A development environment may force the flag on for the whole site, which would make
+		// the tests below assert the environment's answer rather than the registered default.
+		remove_all_filters( 'jetpack_feature_flag_enabled' );
+		remove_all_filters( 'jetpack_feature_flag_enabled_' . Jetpack_Email_Design_Editor::FEATURE_FLAG );
+
+		// Other tests leave bare stdClass entries in the script registry, which the iframed-asset
+		// helper copies wholesale and then trips over. Rebuilt rather than cleared: the helper
+		// reads these globals before anything initializes them, and would copy nothing at all.
+		$this->asset_registries = array( $GLOBALS['wp_scripts'] ?? null, $GLOBALS['wp_styles'] ?? null );
+		$GLOBALS['wp_scripts']  = null;
+		$GLOBALS['wp_styles']   = null;
+		wp_scripts();
+		wp_styles();
+
+		// What the screen owes the bundle is that these fire, not what anything else hangs on
+		// them — and on the wpcomsh run their callbacks warn on build files that job never built.
+		remove_all_actions( 'enqueue_block_assets' );
+		remove_all_actions( 'enqueue_block_editor_assets' );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		if ( $this->wrote_asset && file_exists( $this->asset_path ) ) {
+			unlink( $this->asset_path );
+		}
+
+		if ( null !== $this->asset_backup ) {
+			rename( $this->asset_backup, $this->asset_path );
+		}
+
+		if ( null !== $this->created_build_dir ) {
+			rmdir( $this->created_build_dir );
+		}
+
+		list( $GLOBALS['menu'], $GLOBALS['submenu'] )         = $this->menu_snapshot;
+		list( $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] ) = $this->asset_registries;
+
+		$this->wrote_asset       = false;
+		$this->asset_backup      = null;
+		$this->created_build_dir = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Decide what the screen finds where its build should be.
+	 *
+	 * A real build is moved aside rather than deleted, so running the suite in a checkout that
+	 * has been built does not destroy it.
+	 *
+	 * @param array|null $asset The asset file's return value, or null for no build at all.
+	 * @return void
+	 */
+	private function set_build( ?array $asset ) {
+		$build_dir = dirname( $this->asset_path );
+
+		if ( file_exists( $this->asset_path ) ) {
+			$this->asset_backup = $this->asset_path . '.test-backup';
+			rename( $this->asset_path, $this->asset_backup );
+		}
+
+		if ( null === $asset ) {
+			return;
+		}
+
+		if ( ! is_dir( $build_dir ) ) {
+			mkdir( $build_dir, 0777, true );
+			$this->created_build_dir = $build_dir;
+		}
+
+		file_put_contents( $this->asset_path, '<?php return ' . var_export( $asset, true ) . ';' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+		$this->wrote_asset = true;
+	}
+
+	/**
+	 * Call one of the screen's private helpers.
+	 *
+	 * @param string $method Method name.
+	 * @param array  $args   Arguments.
+	 * @return mixed
+	 */
+	private function call_private( $method, array $args = array() ) {
+		$reflected = new ReflectionMethod( Jetpack_Email_Design_Editor::class, $method );
+
+		// Required on the 7.4 run, a no-op since 8.1, and deprecated as of 8.5.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflected->setAccessible( true );
+		}
+
+		return $reflected->invokeArgs( null, $args );
+	}
+
+	/**
+	 * The submenu entries registered under Appearance for the screen's slug.
+	 *
+	 * @return array
+	 */
+	private function appearance_entries_for_screen() {
+		$entries = $GLOBALS['submenu']['themes.php'] ?? array();
+
+		return array_values(
+			array_filter(
+				$entries,
+				function ( $entry ) {
+					return Jetpack_Email_Design_Editor::PAGE_SLUG === $entry[2];
+				}
+			)
+		);
+	}
+
+	public function test_the_flag_is_registered_and_defaults_to_off() {
+		$this->assertNotNull( Feature_Flags::get( Jetpack_Email_Design_Editor::FEATURE_FLAG ) );
+		$this->assertFalse( Jetpack_Email_Design_Editor::is_enabled() );
+	}
+
+	public function test_the_flag_can_be_turned_on_by_filter() {
+		add_filter( 'jetpack_feature_flag_enabled_' . Jetpack_Email_Design_Editor::FEATURE_FLAG, '__return_true' );
+
+		$this->assertTrue( Jetpack_Email_Design_Editor::is_enabled() );
+	}
+
+	public function test_no_appearance_page_while_the_flag_is_off() {
+		Jetpack_Email_Design_Editor::add_admin_page();
+
+		$this->assertSame( array(), $this->appearance_entries_for_screen() );
+	}
+
+	public function test_the_appearance_page_is_gated_on_edit_theme_options() {
+		add_filter( 'jetpack_feature_flag_enabled_' . Jetpack_Email_Design_Editor::FEATURE_FLAG, '__return_true' );
+
+		Jetpack_Email_Design_Editor::add_admin_page();
+		$entries = $this->appearance_entries_for_screen();
+
+		$this->assertCount( 1, $entries );
+		$this->assertSame( 'edit_theme_options', $entries[0][1] );
+	}
+
+	public function test_render_prints_the_element_the_bundle_mounts_into() {
+		ob_start();
+		Jetpack_Email_Design_Editor::render();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="' . Jetpack_Email_Design_Editor::HANDLE . '"', $html );
+	}
+
+	/**
+	 * The element id is the contract between the page and the bundle: the bundle mounts into
+	 * whatever `elementId` names, so the two must not drift apart.
+	 */
+	public function test_the_rendered_element_is_the_one_the_screen_data_names() {
+		$data = $this->call_private( 'get_screen_data' );
+
+		ob_start();
+		Jetpack_Email_Design_Editor::render();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="' . $data['elementId'] . '"', $html );
+	}
+
+	/**
+	 * Every WordPress.com id comes from the bootstrap response instead, because a locally
+	 * computed one is right on Simple and wrong on Atomic and self-hosted.
+	 */
+	public function test_the_screen_data_carries_no_wordpress_com_ids() {
+		$data = $this->call_private( 'get_screen_data' );
+
+		$this->assertSame(
+			array( 'elementId', 'editorSettings', 'urls', 'userEmail' ),
+			array_keys( $data )
+		);
+	}
+
+	public function test_the_screen_data_describes_this_installation() {
+		$user = wp_get_current_user();
+		$data = $this->call_private( 'get_screen_data' );
+
+		$this->assertSame( admin_url( 'themes.php' ), $data['urls']['back'] );
+		$this->assertSame( admin_url( 'themes.php' ), $data['urls']['listings'] );
+		$this->assertSame( $user->user_email, $data['userEmail'] );
+	}
+
+	public function test_the_allowed_iframe_handles_start_from_the_editor_stylesheets() {
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertContains( 'wp-components-css', $handles );
+		$this->assertContains( 'wp-block-library-css', $handles );
+		$this->assertContains( 'wp-block-editor-content-css', $handles );
+		$this->assertContains( 'wp-edit-blocks-css', $handles );
+	}
+
+	public function test_a_block_declaring_email_support_keeps_its_stylesheet() {
+		register_block_type(
+			'jetpack-test/email-block',
+			array(
+				'supports'             => array( 'email' => true ),
+				'style_handles'        => array( 'jetpack-test-email-style' ),
+				'editor_style_handles' => array( 'jetpack-test-email-editor-style' ),
+			)
+		);
+
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertContains( 'jetpack-test-email-style-css', $handles );
+		$this->assertContains( 'jetpack-test-email-editor-style-css', $handles );
+
+		unregister_block_type( 'jetpack-test/email-block' );
+	}
+
+	public function test_a_block_without_email_support_does_not() {
+		register_block_type(
+			'jetpack-test/ordinary-block',
+			array(
+				'supports'      => array( 'align' => true ),
+				'style_handles' => array( 'jetpack-test-ordinary-style' ),
+			)
+		);
+
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertNotContains( 'jetpack-test-ordinary-style-css', $handles );
+
+		unregister_block_type( 'jetpack-test/ordinary-block' );
+	}
+
+	/**
+	 * An unfiltered list would leave the canvas painted in the site's own styles rather than
+	 * the email's, and it would look plausible while doing it.
+	 */
+	public function test_the_resolved_assets_keep_only_allowed_stylesheets() {
+		$assets = $this->call_private( 'get_resolved_assets', array( array( 'wp-block-library-css' ) ) );
+		$tags   = array_filter( explode( "\n", $assets['styles'] ) );
+
+		$this->assertArrayHasKey( 'scripts', $assets );
+		$this->assertNotEmpty( $tags, 'Nothing was kept, so the filter below asserts nothing.' );
+
+		foreach ( $tags as $tag ) {
+			$this->assertStringContainsString( 'wp-block-library-css', $tag );
+		}
+	}
+
+	public function test_the_iframe_settings_name_the_handles_they_were_filtered_against() {
+		$settings = $this->call_private( 'get_iframe_asset_settings' );
+
+		$this->assertSame(
+			$this->call_private( 'get_allowed_iframe_style_handles' ),
+			$settings['allowedIframeStyleHandles']
+		);
+		$this->assertArrayHasKey( '__unstableResolvedAssets', $settings );
+	}
+
+	/**
+	 * The editor paints notices and popovers against the viewport, so below #adminmenuwrap
+	 * (9990) they land behind the admin menu, and above #wpadminbar (100000) they cover it.
+	 */
+	public function test_the_layout_lifts_the_editor_between_the_admin_menu_and_the_admin_bar() {
+		$css = $this->call_private( 'get_layout_css' );
+
+		preg_match( '/z-index:\s*(\d+)/', $css, $matches );
+
+		$this->assertNotEmpty( $matches );
+		$this->assertGreaterThan( 9990, (int) $matches[1] );
+		$this->assertLessThan( 100000, (int) $matches[1] );
+	}
+
+	public function test_the_layout_is_rtl_aware() {
+		$css = $this->call_private( 'get_layout_css' );
+
+		$this->assertStringContainsString( 'inset-inline', $css );
+		$this->assertDoesNotMatchRegularExpression( '/(?<!-)\b(left|right):/', $css );
+	}
+
+	public function test_nothing_is_enqueued_without_a_build() {
+		$this->set_build( null );
+
+		Jetpack_Email_Design_Editor::enqueue_assets();
+
+		$this->assertFalse( wp_script_is( Jetpack_Email_Design_Editor::HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( Jetpack_Email_Design_Editor::HANDLE, 'enqueued' ) );
+	}
+
+	public function test_the_bundle_and_its_screen_data_are_enqueued_from_a_build() {
+		$this->set_build(
+			array(
+				'dependencies' => array( 'wp-blocks' ),
+				'version'      => 'test-version',
+			)
+		);
+
+		Jetpack_Email_Design_Editor::enqueue_assets();
+
+		$this->assertTrue( wp_script_is( Jetpack_Email_Design_Editor::HANDLE, 'enqueued' ) );
+		$this->assertTrue( wp_style_is( Jetpack_Email_Design_Editor::HANDLE, 'enqueued' ) );
+
+		$before = wp_scripts()->get_data( Jetpack_Email_Design_Editor::HANDLE, 'before' );
+
+		$this->assertStringContainsString( 'window.JetpackEmailDesignEditor = {', implode( "\n", (array) $before ) );
+	}
+
+	/**
+	 * The stylesheet's dependencies are what lay the editor's frame out, and naming one
+	 * WordPress does not register drops the whole stylesheet silently.
+	 */
+	public function test_every_style_dependency_is_a_handle_wordpress_registers() {
+		$this->set_build(
+			array(
+				'dependencies' => array(),
+				'version'      => 'test-version',
+			)
+		);
+
+		Jetpack_Email_Design_Editor::enqueue_assets();
+
+		$deps = wp_styles()->registered[ Jetpack_Email_Design_Editor::HANDLE ]->deps;
+
+		$this->assertNotEmpty( $deps, 'No dependencies, so the check below asserts nothing.' );
+
+		foreach ( $deps as $handle ) {
+			$this->assertTrue( wp_style_is( $handle, 'registered' ), "$handle is not a registered style handle." );
+		}
+	}
+
+	public function test_the_stylesheet_is_flipped_rather_than_supplemented_for_rtl() {
+		$this->set_build(
+			array(
+				'dependencies' => array(),
+				'version'      => 'test-version',
+			)
+		);
+
+		Jetpack_Email_Design_Editor::enqueue_assets();
+
+		$this->assertSame( 'replace', wp_styles()->get_data( Jetpack_Email_Design_Editor::HANDLE, 'rtl' ) );
+	}
+
+	public function test_the_block_editor_globals_the_bundle_expects_are_bootstrapped() {
+		$this->set_build(
+			array(
+				'dependencies' => array(),
+				'version'      => 'test-version',
+			)
+		);
+
+		Jetpack_Email_Design_Editor::enqueue_assets();
+
+		$after = implode( "\n", (array) wp_scripts()->get_data( 'wp-blocks', 'after' ) );
+
+		$this->assertStringContainsString( 'wp.blocks.setCategories(', $after );
+		$this->assertStringContainsString( 'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(', $after );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
@@ -60,6 +60,13 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 	private $asset_registries = array();
 
 	/**
+	 * Block types registered by a test, unregistered again however the test ends.
+	 *
+	 * @var string[]
+	 */
+	private $registered_blocks = array();
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {
@@ -105,6 +112,11 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 		if ( null !== $this->created_build_dir ) {
 			rmdir( $this->created_build_dir );
 		}
+
+		foreach ( $this->registered_blocks as $name ) {
+			unregister_block_type( $name );
+		}
+		$this->registered_blocks = array();
 
 		list( $GLOBALS['menu'], $GLOBALS['submenu'] )         = $this->menu_snapshot;
 		list( $GLOBALS['wp_scripts'], $GLOBALS['wp_styles'] ) = $this->asset_registries;
@@ -162,6 +174,22 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 		}
 
 		return $reflected->invokeArgs( null, $args );
+	}
+
+	/**
+	 * Register a block type for the duration of one test.
+	 *
+	 * Returned so a test can write shapes past `register_block_type()` that a caller could still
+	 * reach through `register_block_type_args`.
+	 *
+	 * @param string $name Block name.
+	 * @param array  $args Registration args.
+	 * @return WP_Block_Type
+	 */
+	private function register_test_block( $name, array $args = array() ) {
+		$this->registered_blocks[] = $name;
+
+		return register_block_type( $name, $args );
 	}
 
 	/**
@@ -263,7 +291,7 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 	}
 
 	public function test_a_block_declaring_email_support_keeps_its_stylesheet() {
-		register_block_type(
+		$this->register_test_block(
 			'jetpack-test/email-block',
 			array(
 				'supports'             => array( 'email' => true ),
@@ -276,12 +304,10 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 
 		$this->assertContains( 'jetpack-test-email-style-css', $handles );
 		$this->assertContains( 'jetpack-test-email-editor-style-css', $handles );
-
-		unregister_block_type( 'jetpack-test/email-block' );
 	}
 
 	public function test_a_block_without_email_support_does_not() {
-		register_block_type(
+		$this->register_test_block(
 			'jetpack-test/ordinary-block',
 			array(
 				'supports'      => array( 'align' => true ),
@@ -292,8 +318,38 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
 
 		$this->assertNotContains( 'jetpack-test-ordinary-style-css', $handles );
+	}
 
-		unregister_block_type( 'jetpack-test/ordinary-block' );
+	/**
+	 * `WP_Block_Type::set_props()` normalizes only `attributes`, so a handle list arrives however
+	 * it was registered — and `register_block_type_args` can rewrite it after that.
+	 */
+	public function test_a_block_declaring_its_handles_as_a_string_does_not_break_the_list() {
+		$block                = $this->register_test_block( 'jetpack-test/string-handles', array( 'supports' => array( 'email' => true ) ) );
+		$block->style_handles = 'jetpack-test-string-style';
+
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertContains( 'jetpack-test-string-style-css', $handles );
+	}
+
+	public function test_a_block_whose_supports_is_not_an_array_is_skipped() {
+		$block           = $this->register_test_block( 'jetpack-test/object-supports', array( 'style_handles' => array( 'jetpack-test-object-style' ) ) );
+		$block->supports = new stdClass();
+
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertNotContains( 'jetpack-test-object-style-css', $handles );
+	}
+
+	public function test_a_handle_that_is_not_a_string_is_left_out_rather_than_concatenated() {
+		$block                = $this->register_test_block( 'jetpack-test/nested-handle', array( 'supports' => array( 'email' => true ) ) );
+		$block->style_handles = array( array( 'nested' ), 'jetpack-test-nested-sibling' );
+
+		$handles = $this->call_private( 'get_allowed_iframe_style_handles' );
+
+		$this->assertContains( 'jetpack-test-nested-sibling-css', $handles );
+		$this->assertNotContains( 'Array-css', $handles );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

Adds the wp-admin screen that mounts the email design editor bundle, behind a feature flag so it ships off and nothing is user-visible yet.

This is the first of several chunks split out of #51846. It is the PHP screen only — registration, the flag, and everything needed to get the bundle from #51577 to mount and paint correctly. The save path, the client-side block registration, and the rest of the editor's behaviour follow in their own PRs.

* **The page.** An `edit_theme_options` page under Appearance — the same capability the bootstrap endpoint already enforces. Everything beyond registration is scoped to `load-{$hook_suffix}`.
* **The flag.** `Feature_Flags::register( 'jetpack-email-design', … )`, default `false`, checked through one `is_enabled()` predicate. Registered at module load rather than on `admin_menu`, so the flag is visible under WP-CLI, REST and cron rather than only in wp-admin. `automattic/jetpack-feature-flags` was already a dependency of this plugin, so there is no lock-file churn.
* **What the page hands the bundle.** `window.JetpackEmailDesignEditor` carries only what describes *this* installation. No WordPress.com ids: the template id and the global-styles id come from the bootstrap response, because they are namespaced to the shadow blog's theme, and a locally computed one is right on Simple and wrong on Atomic and self-hosted.
* **The two iframe-asset settings.** `allowedIframeStyleHandles` plus an `__unstableResolvedAssets` trimmed to those handles, mirroring the package's `Settings_Controller`. WordPress.com strips both from the bundle because they describe the server that computed them; without the first, the canvas paints in the site's own CSS instead of the email's.
* **Block-editor parity.** A custom admin page gets none of this automatically, so the page reproduces what the package's `Assets_Manager` does on WooCommerce's own screen: both `enqueue_block_*_assets` actions, editor styles, block categories, and the server-side block definitions.
* **Layout.** The editor's frame needs a viewport-sized container — inside the normal admin content column every region stacks into one narrow scrolling strip. WooCommerce avoids this by running on `post.php`, which is already fullscreen.

<img width="1284" height="705" alt="Screenshot 2026-09-08 at 3 54 01 PM" src="https://github.com/user-attachments/assets/d781d185-87f9-4f85-8ded-69bac548c06f" />


## Related product discussion/links

* NL-839

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Prerequisite on every host:** the WordPress.com blog the site is connected to needs the `email-design-editor` sticker. It gates the bootstrap endpoint that supplies the design, so without it the editor mounts against a 501 and the canvas stays empty.

1. **With the flag off (the default):** there should be no **Email Design** item under Appearance, and `/wp-admin/themes.php?page=jetpack-email-design` should return "Sorry, you are not allowed to access this page."
2. Turn the flag on. How differs by host:
   * **Jurassic Ninja:** `wp companion feature-flag enable jetpack-email-design`, then confirm `wp companion feature-flag list` shows `effective` as `1`. That command comes from JN's companion plugin and exists nowhere else.
   * **Atomic and self-hosted:** add an mu-plugin carrying the per-flag filter:
     ```php
     add_filter( 'jetpack_feature_flag_enabled_jetpack-email-design', '__return_true' );
     ```
3. **Appearance → Email Design** should now exist and open the editor: header across the top, canvas in the middle, settings sidebar on the right, filling the screen below the admin bar. The admin menu stays visible.
4. The canvas should show the newsletter template, and the title in the header should name it.
5. Check the canvas is not wearing the site's theme CSS — in the console:
   ```js
   [ ...document.querySelector( 'iframe[name="editor-canvas"]' ).contentDocument
       .querySelectorAll( 'link[rel=stylesheet]' ) ].map( l => l.id )
   ```
   Expect only `wp-components-css`, `wp-block-library-css`, `wp-block-editor-content-css` and `wp-edit-blocks-css`, plus any handle from a block that declares email support. The theme's stylesheet should not be among them.
6. There should be **no Styles item** in the header's More menu — see above.
