### PR TITLE
Jetpack: run the component tests in CI

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
@@ -83,15 +83,14 @@ describe( 'JetpackConnectionErrors', () => {
 			},
 		];
 
-		render( <JetpackConnectionErrors errors={ errors } /> );
+		render( <JetpackConnectionErrors errors={ errors } />, { initialState } );
 
 		expect(
 			screen.getByText( 'The connection owner needs to reconnect their account.' )
 		).toBeInTheDocument();
-		// No reconnect/restore CTA should be rendered for an informational notice.
-		// Matched exactly: the notice's own message contains the word "reconnect".
-		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
-		expect( screen.queryByRole( 'link', { name: 'Restore Connection' } ) ).not.toBeInTheDocument();
+		// Matched by label, not by role: NoticeAction renders an <a> with no href, which
+		// has no implicit link role, so queryByRole( 'link' ) can never fail here.
+		expect( screen.queryByText( 'Restore Connection' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should handle multiple errors correctly', () => {

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
@@ -116,5 +116,7 @@ describe( 'JetpackConnectionErrors', () => {
 		expect( screen.getByText( 'First error' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Second error' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Fix Issue' ) ).toBeInTheDocument();
+		// Positive control for the 'none' case above: proves this query can see the CTA.
+		expect( screen.getByText( 'Restore Connection' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx
@@ -1,5 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen } from 'test/test-utils';
 import JetpackConnectionErrors from '../jetpack-connection-errors';
+
+// The 'reconnect' action reaches a connected NoticeActionReconnect, which reads
+// the site reconnection request state.
+const initialState = {
+	jetpack: { connection: { requests: { reconnectingSite: false } } },
+};
 
 describe( 'JetpackConnectionErrors', () => {
 	it( 'should render error with URL action', () => {
@@ -83,8 +89,9 @@ describe( 'JetpackConnectionErrors', () => {
 			screen.getByText( 'The connection owner needs to reconnect their account.' )
 		).toBeInTheDocument();
 		// No reconnect/restore CTA should be rendered for an informational notice.
+		// Matched exactly: the notice's own message contains the word "reconnect".
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Reconnect', { exact: false } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Restore Connection' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should handle multiple errors correctly', () => {
@@ -105,7 +112,7 @@ describe( 'JetpackConnectionErrors', () => {
 			},
 		];
 
-		render( <JetpackConnectionErrors errors={ errors } /> );
+		render( <JetpackConnectionErrors errors={ errors } />, { initialState } );
 
 		expect( screen.getByText( 'First error' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Second error' ) ).toBeInTheDocument();

--- a/projects/plugins/jetpack/changelog/jetpack-2543-component-tests-in-ci
+++ b/projects/plugins/jetpack/changelog/jetpack-2543-component-tests-in-ci
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Test configuration only; no user-facing change.
+
+

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -9,6 +9,8 @@ module.exports = {
 	testMatch: [
 		'<rootDir>/_inc/client/test/main.js',
 		'<rootDir>/_inc/client/**/test/component.js',
+		'<rootDir>/_inc/client/**/test/component.jsx',
+		'<rootDir>/_inc/client/components/**/test/*.test.jsx',
 		'<rootDir>/_inc/client/ai/test/ai-admin.jsx',
 		'<rootDir>/_inc/client/ai/features/test/component.jsx',
 		'<rootDir>/_inc/client/ai/mcp/test/allowlist-updated.jsx',

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -3,28 +3,21 @@ const baseConfig = require( './jest.config.base.js' );
 module.exports = {
 	...baseConfig,
 	roots: [ '<rootDir>/_inc/client/' ],
-	// Curated rather than a glob: `**/test/*.js` would also pick up the many
-	// `test/fixtures.js` files (which contain no tests) and re-run the
+	// Matched by filename rather than a bare `**/test/*`: that would also pick up the
+	// many `test/fixtures.js` files (which contain no tests) and re-run the
 	// `_inc/client/state/` suites that jest.config.client.js already owns.
 	testMatch: [
 		'<rootDir>/_inc/client/test/main.js',
 		'<rootDir>/_inc/client/**/test/component.js',
 		'<rootDir>/_inc/client/**/test/component.jsx',
-		'<rootDir>/_inc/client/components/**/test/*.test.jsx',
+		'<rootDir>/_inc/client/**/test/*.test.{js,jsx}',
 		'<rootDir>/_inc/client/ai/test/ai-admin.jsx',
-		'<rootDir>/_inc/client/ai/features/test/component.jsx',
 		'<rootDir>/_inc/client/ai/mcp/test/allowlist-updated.jsx',
 		'<rootDir>/_inc/client/ai/mcp/test/use-mcp-settings.jsx',
-		'<rootDir>/_inc/client/ai/overview/assistant-banner/test/component.jsx',
-		'<rootDir>/_inc/client/ai/overview/test/component.jsx',
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/index.jsx',
 		'<rootDir>/_inc/client/ai/scheduled-tasks/test/use-scheduled-tasks.js',
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/ai/test/tracks.js',
-		'<rootDir>/_inc/client/at-a-glance/boost/test/component.jsx',
-		'<rootDir>/_inc/client/components/jetpack-notices/test/state-notices.test.jsx',
-		'<rootDir>/_inc/client/sharing/test/component.jsx',
-		'<rootDir>/_inc/client/traffic/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',
 	],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest-globals.gui.js' ],

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -8,8 +8,7 @@ module.exports = {
 	// `_inc/client/state/` suites that jest.config.client.js already owns.
 	testMatch: [
 		'<rootDir>/_inc/client/test/main.js',
-		'<rootDir>/_inc/client/**/test/component.js',
-		'<rootDir>/_inc/client/**/test/component.jsx',
+		'<rootDir>/_inc/client/**/test/component.{js,jsx}',
 		'<rootDir>/_inc/client/**/test/*.test.{js,jsx}',
 		'<rootDir>/_inc/client/ai/test/ai-admin.jsx',
 		'<rootDir>/_inc/client/ai/mcp/test/allowlist-updated.jsx',


### PR DESCRIPTION
Fixes JETPACK-2543

## Proposed changes

`projects/plugins/jetpack/tests/jest.config.gui.js` matched `_inc/client/**/test/component.js`. Every component test under `_inc/client/components/` is named `component.jsx`, and `jest.config.client.js` excludes `components/` from its `roots`, so **20 files ran in neither suite**.

PR #52015 broke seven of them and CI stayed green through six commits. They were only found by running the files by hand.

`**/test/component.js` is broadened to `**/test/component.{js,jsx}` — four `component.js` files still exist, so both extensions are needed — and `**/test/*.test.{js,jsx}` is added for the two files following the other naming convention. Together they take the GUI suite from 19 files and 203 tests to **54 files and 487 tests**. Both are anchored at `_inc/client/**`, so a test added under `traffic/` or `at-a-glance/` cannot fall in the same gap. Seven explicit entries the new patterns already match are removed; `jest --listTests` selects the same 54 files with and without them.

### When this broke

#50418 ("Clean up JSX-in-`.js`", merged 2026-07-10) renamed 768 files from `.js` to `.jsx` and did not update this `testMatch`. These suites have been dead since that date.

**No other project is affected.** Most use `tools/js-tools/jest/config.base.js`, which sets no `testMatch` at all, so jest's defaults apply and those cover `.jsx` — which is why, for example, `js-packages/api/test/rest-api.jsx` still runs. Four configs do use `.js`-only patterns (`js-packages/config`, `packages/menu-badges`, `js-packages/critical-css-gen`, `wpcomsh/tests/e2e`); each was checked for stranded `.jsx` tests and none have any. `js-packages/config` documents why it deviates.

The list still matches by filename rather than by a bare `**/test/*`, for the reason the comment above it gives: the bare pattern also picks up the many `test/fixtures.js` files, which contain no tests, and re-runs the `_inc/client/state/` suites that `jest.config.client.js` already owns.

### Two pre-existing failures

Both fail identically at `a67f5be8ec6~1`, so neither comes from #52015. They only had to be fixed here because the config change makes them visible.

`_inc/client/components/jetpack-notices/test/jetpack-connection-errors.test.jsx`

* **`should handle multiple errors correctly`** rendered through `@testing-library/react` directly, so there was no `<Provider>`. One of its errors carries `action: 'reconnect'`, which reaches the connected `NoticeActionReconnect` and threw `Could not find "store" in the context of…`. It now uses the shared `test/test-utils` helper and supplies the slice `isReconnectingSite` reads.
* **`should render an informational notice with no action for the 'none' action`** asserted `queryByText( 'Reconnect', { exact: false } )` was absent. `exact: false` is a case-insensitive substring match, and the notice's own message is "The connection owner needs to reconnect their account.", so the assertion could never pass. It now matches the CTA by its label, `Restore Connection`. Matching it by role would be no better than the substring: `NoticeAction` renders an `<a>` with no `href` when given an `onClick`, and an anchor without `href` has no implicit link role. The test also supplies the store state now, so making the `'none'` case render the reconnect CTA fails the assertion instead of crashing the render.

The `'none'` assertion now has a positive control: `should handle multiple errors correctly` already renders a `reconnect` action, so it asserts the CTA **is** visible. That proves the query used in the negative test can see the thing whose absence it asserts, so it cannot quietly become a no-op again.

## Related product discussion/links

* JETPACK-2543
* #52015 is the PR whose breakage surfaced this. The seven failures it caused are already fixed there; this PR only makes that class of breakage visible in future.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From `projects/plugins/jetpack`, run `pnpm run test-gui`.
* On trunk: 19 suites, 203 tests.
* On this branch: 54 suites, 487 tests, 2 skipped, all passing.
* `pnpm run test-client` is unchanged at 47 suites and 442 tests — this touches only the GUI config.

To confirm the `'none'` assertion guards something, edit the `case 'none':` arm of `_inc/client/components/jetpack-notices/jetpack-connection-errors.jsx` to return `ErrorNoticeCycleConnection` with `action={ 'reconnect' }`, as the `default` arm does. `pnpm run test-gui` then fails with `expected document not to contain element, found <span>Restore Connection</span> instead`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfGbCrDbhYmgwY5hW68VLA

