### PR TITLE
Backup: recognise the restore statuses WordPress.com actually returns

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-restore-finished-status
+++ b/projects/packages/backup/changelog/fix-backup-restore-finished-status
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the flag: the restore screen now reports a completed restore as complete instead of losing track of it, keeps watching a restore WordPress.com is holding in its queue, and refuses to start a second restore of a site that already has one queued. The bridge recognises the statuses the v2 route actually returns, and tells "upstream has no record of this restore" apart from "upstream has it queued".
+Comment: Modernized dashboard only, behind the flag: the restore screen reports a completed restore as complete instead of losing track of it, keeps watching one WordPress.com is holding in its queue or reporting under a status we do not recognise, refuses to start a second restore of a site that already has one queued, reports the outcome of a restore whose reply was lost instead of claiming it never ran, and retires the "already running" notice when it finishes.

--- a/projects/packages/backup/changelog/fix-backup-restore-finished-status
+++ b/projects/packages/backup/changelog/fix-backup-restore-finished-status
@@ -1,3 +1,3 @@
 Significance: patch
 Type: fixed
-Comment: Modernized dashboard only, behind the flag: the restore screen now reports a completed restore as complete instead of losing track of it, and stops declaring a restore lost while WordPress.com is still reporting it as queued. The bridge recognises the statuses the v2 route actually returns, and tells "upstream has no record of this restore" apart from "upstream has it queued".
+Comment: Modernized dashboard only, behind the flag: the restore screen now reports a completed restore as complete instead of losing track of it, keeps watching a restore WordPress.com is holding in its queue, and refuses to start a second restore of a site that already has one queued. The bridge recognises the statuses the v2 route actually returns, and tells "upstream has no record of this restore" apart from "upstream has it queued".

--- a/projects/packages/backup/changelog/fix-backup-restore-finished-status
+++ b/projects/packages/backup/changelog/fix-backup-restore-finished-status
@@ -1,0 +1,3 @@
+Significance: patch
+Type: fixed
+Comment: Modernized dashboard only, behind the flag: the restore screen now reports a completed restore as complete instead of losing track of it, and stops declaring a restore lost while WordPress.com is still reporting it as queued. The bridge recognises the statuses the v2 route actually returns, and tells "upstream has no record of this restore" apart from "upstream has it queued".

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -7,15 +7,20 @@ import type { RestoreItems } from '../../types/restore';
  * Deliberately not WPCOM's own vocabulary. Upstream says
  * `queued | running | finished | fail` for a Rewind restore and
  * `success | success-with-errors | aborted` for a legacy one; the bridge
- * maps both to these, reports a not-yet-visible restore as `queued`, and
- * anything it does not recognise as `unknown` rather than guessing. See
- * `Restore_Bridge::STATUS_MAP`.
+ * maps both to these, reports a restore upstream cannot find as
+ * `not-found`, and anything it does not recognise as `unknown` rather
+ * than guessing. See `Restore_Bridge::STATUS_MAP`.
+ *
+ * `not-found` and `queued` render the same and mean opposite things:
+ * upstream has no record of the restore, versus upstream is holding a
+ * real one in its queue. Only the second is a sign of life.
  *
  * `unknown` exists so a status WPCOM adds later degrades into "keep
  * asking for a while" instead of a progress bar frozen at whatever
  * percentage happened to arrive first.
  */
 export type RestoreStatus =
+	| 'not-found'
 	| 'queued'
 	| 'running'
 	| 'finished'
@@ -139,7 +144,7 @@ export function parseRestoreWhen( when: string ): number | null {
 }
 
 /** Statuses that mean the restore is still going, or might be. */
-const LIVE_STATUSES: RestoreStatus[] = [ 'queued', 'running', 'unknown' ];
+const LIVE_STATUSES: RestoreStatus[] = [ 'not-found', 'queued', 'running', 'unknown' ];
 
 /**
  * Whether a status reading ends the poll.

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -150,17 +150,31 @@ export function isTerminal( status: RestoreStatus | undefined ): boolean {
 }
 
 /**
- * Whether WordPress.com is holding a real restore under this id.
+ * Whether WordPress.com answered about this restore at all.
  *
- * Narrower than `! isTerminal(…)`, which also passes `not-found` and
- * `unknown` — absence of evidence, not evidence. Three callers have to
- * agree on this line: the silence deadline, adoption at mount, and the
- * refusal to start one on a destructive click.
+ * `unknown` counts: the bridge mints it only for a status string upstream
+ * did send and we do not map, where `not-found` is a 404 and proof of
+ * nothing. Excluding it put a live restore under a spelling WPCOM added
+ * on a five-minute fuse.
  *
  * @param status - The status the bridge reported, if any.
- * @return True when upstream has a live record of the restore.
+ * @return True when the reading is evidence rather than silence.
  */
-export function isUpstreamTracking( status: RestoreStatus | undefined ): boolean {
+export function isSignOfLife( status: RestoreStatus | undefined ): boolean {
+	return status === 'running' || status === 'queued' || status === 'unknown';
+}
+
+/**
+ * Whether a restore is actually under way.
+ *
+ * Stricter than `isSignOfLife`: an `unknown` reading proves upstream has
+ * a record but not that it is still running, and adopting a finished
+ * restore withholds the form with nothing left to give it back.
+ *
+ * @param status - The status the bridge reported, if any.
+ * @return True when upstream is holding a live restore.
+ */
+export function isRestoreInFlight( status: RestoreStatus | undefined ): boolean {
 	return status === 'running' || status === 'queued';
 }
 
@@ -183,7 +197,7 @@ export function isUpstreamTracking( status: RestoreStatus | undefined ): boolean
  * @param target    - The rewind id this screen submitted.
  * @return True when both name the same backup.
  */
-function sameRewindId( candidate: string, target: string ): boolean {
+export function sameRewindId( candidate: string, target: string ): boolean {
 	if ( ! candidate || ! target ) {
 		return false;
 	}
@@ -347,5 +361,5 @@ export async function fetchRunningRestore(): Promise< RecentRestore | null > {
 		return null;
 	}
 	const status = await fetchRestoreStatus( candidate.restore_id );
-	return isUpstreamTracking( status.status ) ? candidate : null;
+	return isRestoreInFlight( status.status ) ? candidate : null;
 }

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -5,8 +5,9 @@ import type { RestoreItems } from '../../types/restore';
  * Lifecycle of a restore, as the bridge reports it.
  *
  * Deliberately not WPCOM's own vocabulary. Upstream says
- * `running | success | fail | aborted | success-with-errors`; the bridge
- * maps those to these, reports a not-yet-visible restore as `queued`, and
+ * `queued | running | finished | fail` for a Rewind restore and
+ * `success | success-with-errors | aborted` for a legacy one; the bridge
+ * maps both to these, reports a not-yet-visible restore as `queued`, and
  * anything it does not recognise as `unknown` rather than guessing. See
  * `Restore_Bridge::STATUS_MAP`.
  *

--- a/projects/packages/backup/src/dashboard/data/api/restore.ts
+++ b/projects/packages/backup/src/dashboard/data/api/restore.ts
@@ -4,20 +4,13 @@ import type { RestoreItems } from '../../types/restore';
 /**
  * Lifecycle of a restore, as the bridge reports it.
  *
- * Deliberately not WPCOM's own vocabulary. Upstream says
- * `queued | running | finished | fail` for a Rewind restore and
- * `success | success-with-errors | aborted` for a legacy one; the bridge
- * maps both to these, reports a restore upstream cannot find as
- * `not-found`, and anything it does not recognise as `unknown` rather
- * than guessing. See `Restore_Bridge::STATUS_MAP`.
+ * Deliberately not WPCOM's own vocabulary, which the bridge owns the
+ * translation of — see `Restore_Bridge::STATUS_MAP`.
  *
  * `not-found` and `queued` render the same and mean opposite things:
- * upstream has no record of the restore, versus upstream is holding a
- * real one in its queue. Only the second is a sign of life.
- *
- * `unknown` exists so a status WPCOM adds later degrades into "keep
- * asking for a while" instead of a progress bar frozen at whatever
- * percentage happened to arrive first.
+ * upstream has no record of the restore, versus upstream is holding one.
+ * `unknown` is a spelling WPCOM added that we do not know yet, kept live
+ * so it degrades into "keep asking" rather than a frozen progress bar.
  */
 export type RestoreStatus =
 	| 'not-found'
@@ -154,6 +147,21 @@ const LIVE_STATUSES: RestoreStatus[] = [ 'not-found', 'queued', 'running', 'unkn
  */
 export function isTerminal( status: RestoreStatus | undefined ): boolean {
 	return status !== undefined && ! LIVE_STATUSES.includes( status );
+}
+
+/**
+ * Whether WordPress.com is holding a real restore under this id.
+ *
+ * Narrower than `! isTerminal(…)`, which also passes `not-found` and
+ * `unknown` — absence of evidence, not evidence. Three callers have to
+ * agree on this line: the silence deadline, adoption at mount, and the
+ * refusal to start one on a destructive click.
+ *
+ * @param status - The status the bridge reported, if any.
+ * @return True when upstream has a live record of the restore.
+ */
+export function isUpstreamTracking( status: RestoreStatus | undefined ): boolean {
+	return status === 'running' || status === 'queued';
 }
 
 /**
@@ -323,7 +331,7 @@ export async function fetchRecentRestores(): Promise< RecentRestore[] | null > {
  * Two reads, because the collection alone cannot answer it: its rows
  * carry a status in a vocabulary that is not ours, so a row is only a
  * candidate until the status route — which speaks the vocabulary the
- * bridge maps — confirms it is `running`.
+ * bridge maps — confirms upstream is holding it.
  *
  * Deliberately separate from `useAdoptedRestore`, which asks the same
  * question at mount through two cached queries so its confirmation
@@ -339,5 +347,5 @@ export async function fetchRunningRestore(): Promise< RecentRestore | null > {
 		return null;
 	}
 	const status = await fetchRestoreStatus( candidate.restore_id );
-	return 'running' === status.status ? candidate : null;
+	return isUpstreamTracking( status.status ) ? candidate : null;
 }

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -1,7 +1,7 @@
 // The restore state machine — the only place in this dashboard where a
 // bug costs someone their site rather than their patience.
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider, focusManager } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 import { createElement, type ReactNode } from 'react';
@@ -378,6 +378,10 @@ describe( 'useRestore — the silence deadline', () => {
 
 	afterEach( () => {
 		jest.useRealTimers();
+		// Focus is global to the query client. A test that fails between
+		// hiding and restoring it would silently stop every later suite
+		// from polling.
+		focusManager.setFocused( true );
 	} );
 
 	// The case with no safety net before: the status query is disabled
@@ -440,9 +444,90 @@ describe( 'useRestore — the silence deadline', () => {
 		expect( result.current.state.phase ).toBe( 'queued' );
 
 		// Saying "queued" while no longer asking would be the same lie in
-		// a quieter voice. A hidden tab gets no polls and no catch-up
-		// fetch on return, so the deadline can pass under a restore that
-		// is fine — the poll has to survive it.
+		// a quieter voice.
+		const before = callsFor( '/status' );
+		await advance( 60_000 );
+		expect( callsFor( '/status' ) ).toBeGreaterThan( before );
+	} );
+
+	// The three pieces below each need `lostTrack` to be *true* while a
+	// sign of life is arriving, which a steady poll never produces — every
+	// reading pushes the deadline back. Hiding the tab is what creates it:
+	// query-core ticks the interval but gates the fetch on
+	// `focusManager.isFocused()`, and this dashboard sets
+	// `refetchOnWindowFocus: false`, so a hidden tab is polled neither on
+	// its interval nor on return.
+	/**
+	 * Let the deadline expire with no polls arriving, then restore focus.
+	 *
+	 * @param result - The rendered hook result.
+	 */
+	async function hideTabPastTheDeadline( result: PhaseResult ) {
+		focusManager.setFocused( false );
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'queued' );
+		focusManager.setFocused( true );
+	}
+
+	it( 'resumes polling after the deadline passes under a hidden tab', async () => {
+		respondWith( { status: statusPayload( { status: 'queued' } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+		await settleAt( result, 'queued' );
+
+		await hideTabPastTheDeadline( result );
+
+		const before = callsFor( '/status' );
+		await advance( 60_000 );
+		expect( callsFor( '/status' ) ).toBeGreaterThan( before );
+	} );
+
+	// `lostTrack` has to mean "nothing heard lately", not "there was once
+	// a gap". Latched, the next silent reading is judged against a
+	// deadline that expired while the tab was hidden.
+	it( 'gives a restore a fresh deadline once it is heard from again', async () => {
+		let status: unknown = statusPayload( { status: 'queued' } );
+		mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+			if ( options?.method === 'POST' ) {
+				return Promise.resolve( { id: 912682, rewind_id: REWIND_ID } );
+			}
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				return Promise.resolve( [] );
+			}
+			return Promise.resolve( status );
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+		await settleAt( result, 'queued' );
+
+		await hideTabPastTheDeadline( result );
+		await advance( 30_000 );
+
+		// Upstream loses sight of it *after* the latch should have been
+		// cleared, so this reading starts its own five minutes.
+		status = statusPayload( { status: 'not-found' } );
+		await advance( 60_000 );
+		expect( result.current.state.phase ).toBe( 'queued' );
+	} );
+
+	// `unknown` is minted only for a status string upstream *did* send.
+	// Timing it out puts a live restore under a spelling WPCOM adds on a
+	// five-minute fuse — the bug this flow exists to prevent.
+	it( 'keeps watching a restore reported under a spelling it does not know', async () => {
+		respondWith( { status: statusPayload( { status: 'unknown', progress: 50 } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+		await settleAt( result, 'queued' );
+
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'queued' );
+
 		const before = callsFor( '/status' );
 		await advance( 60_000 );
 		expect( callsFor( '/status' ) ).toBeGreaterThan( before );
@@ -937,6 +1022,37 @@ describe( 'useRestore — a submission we never got an answer to', () => {
 		await settleAt( result, 'unconfirmed' );
 		// The point of the phase: no control at all until we know.
 		expect( result.current.state ).not.toMatchObject( { phase: 'error' } );
+	} );
+
+	// "Nothing on your site has changed" is the one claim here that must
+	// never be guessed at. The recovery poll only looks for a *live*
+	// restore, so a submission whose reply was lost and whose restore then
+	// finished leaves no live row — and reporting that as "didn't start"
+	// asserts the site is untouched next to a Try again button.
+	it.each( [
+		[ 'finished', 'success' ],
+		[ 'fail', 'error' ],
+	] )( 'reports a %s restore it recovers rather than denying it ran', async ( row, phase ) => {
+		respondWith( {
+			initiateError: TIMEOUT,
+			restores: [
+				{
+					restore_id: 912682,
+					rewind_id: REWIND_ID,
+					when: '2026-08-20T10:00:00+00:00',
+					status: row,
+				},
+			],
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, phase );
+		expect( result.current.state ).not.toMatchObject( {
+			message: "Your restore didn't start, so nothing on your site has changed.",
+		} );
 	} );
 
 	it( 'adopts the restore when it turns out to have started', async () => {

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -1,11 +1,5 @@
 // The restore state machine — the only place in this dashboard where a
 // bug costs someone their site rather than their patience.
-//
-// It had no test at all, and was dead on arrival: the client tested for
-// `in-progress`, `queued`, `finished` and `failed`, and WordPress.com has
-// never returned any of those. Nothing noticed because the v1 route it
-// called answered 401 before a status could come back, so the whole
-// machine was unreachable rather than merely wrong.
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -409,8 +409,8 @@ describe( 'useRestore — the silence deadline', () => {
 		expect( result.current.state ).toMatchObject( { detail: null } );
 	} );
 
-	it( 'gives up on a restore whose status never leaves queued', async () => {
-		respondWith( { status: statusPayload( { status: 'queued' } ) } );
+	it( 'gives up on a restore WordPress.com never finds', async () => {
+		respondWith( { status: statusPayload( { status: 'not-found' } ) } );
 		const { wrapper } = makeWrapper();
 
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
@@ -421,6 +421,23 @@ describe( 'useRestore — the silence deadline', () => {
 		await advance( 5 * 60_000 + 1000 );
 		expect( result.current.state.phase ).toBe( 'lost-track' );
 		expect( result.current.state ).toMatchObject( { detail: null } );
+	} );
+
+	// The other half of the same distinction. `not-found` is upstream
+	// having no record; `queued` is upstream tracking a real restore that
+	// has not started. Declaring the second one lost is the bug this
+	// deadline was written to avoid, pointed the other way.
+	it( 'keeps waiting while WordPress.com reports the restore as queued', async () => {
+		respondWith( { status: statusPayload( { status: 'queued' } ) } );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		submitAll( result );
+
+		await settleAt( result, 'queued' );
+
+		await advance( 5 * 60_000 + 1000 );
+		expect( result.current.state.phase ).toBe( 'queued' );
 	} );
 
 	// The half that matters as much as firing: a long restore that keeps
@@ -546,14 +563,36 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 	} );
 
 	it( 'refuses to adopt on a status that only means "not visible"', async () => {
-		// `queued` is what the bridge mints for a **404** — "that restore
-		// is not visible to this route" — so reading it as a sign of life
-		// turns absence of evidence into evidence of life. Paired with a
-		// collection spelling we do not recognise as settled (`started` is
-		// the one WordPress.com's own docblock claims), a restore from
-		// January locks the screen out of restoring permanently: the form
-		// never returns, and the stale adoption is what withholds the
-		// button that would have replaced it.
+		// `not-found` is what the bridge mints for a **404** — "that
+		// restore is not visible to this route" — so reading it as a sign
+		// of life turns absence of evidence into evidence of life. Paired
+		// with a collection spelling we do not recognise as settled
+		// (`started` is the one WordPress.com's own docblock claims), a
+		// restore from January locks the screen out of restoring
+		// permanently: the form never returns, and the stale adoption is
+		// what withholds the button that would have replaced it.
+		respondWith( {
+			restores: [
+				{
+					restore_id: 111,
+					rewind_id: '1700000000.1',
+					when: '2026-01-01T00:00:00+00:00',
+					status: 'started',
+				},
+			],
+			status: statusPayload( { id: 111, status: 'not-found', rewind_id: '1700000000.1' } ),
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+		expect( result.current.adopted ).toBeNull();
+	} );
+
+	// Withholding the form is the point: a restore upstream is holding in
+	// its queue is one the reader must not be able to start again.
+	it( 'adopts a restore WordPress.com reports as queued', async () => {
 		respondWith( {
 			restores: [
 				{
@@ -569,8 +608,7 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 
 		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
 
-		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
-		expect( result.current.adopted ).toBeNull();
+		await waitFor( () => expect( result.current.adopted ).toEqual( { rewindId: '1700000000.1' } ) );
 	} );
 
 	it( 'withholds the form until it knows whether anything is running', async () => {

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -438,6 +438,14 @@ describe( 'useRestore — the silence deadline', () => {
 
 		await advance( 5 * 60_000 + 1000 );
 		expect( result.current.state.phase ).toBe( 'queued' );
+
+		// Saying "queued" while no longer asking would be the same lie in
+		// a quieter voice. A hidden tab gets no polls and no catch-up
+		// fetch on return, so the deadline can pass under a restore that
+		// is fine — the poll has to survive it.
+		const before = callsFor( '/status' );
+		await advance( 60_000 );
+		expect( callsFor( '/status' ) ).toBeGreaterThan( before );
 	} );
 
 	// The half that matters as much as firing: a long restore that keeps
@@ -1089,6 +1097,42 @@ describe( 'useRestore — a restore that starts after the screen loaded', () => 
 		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
 		expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } );
 		// The whole point: no restore was started.
+		expect( initiateCall() ).toBeUndefined();
+	}, 15000 );
+
+	// The same guard, on the status the queue reports before it starts.
+	// A restore WordPress.com is holding is one the reader must not be
+	// able to duplicate.
+	it( 'adopts instead of starting a second restore when the other one is queued', async () => {
+		let rows: unknown[] = [];
+		mockedApiFetch.mockImplementation( ( options: { path?: string; method?: string } ) => {
+			if ( options?.method === 'POST' ) {
+				return Promise.resolve( { id: 5, rewind_id: REWIND_ID } );
+			}
+			if ( ( options?.path ?? '' ).includes( '/restores' ) ) {
+				return Promise.resolve( rows );
+			}
+			return Promise.resolve(
+				statusPayload( { id: 912682, status: 'queued', progress: 0, rewind_id: OTHER_ID } )
+			);
+		} );
+		const { wrapper } = makeWrapper();
+
+		const { result } = renderHook( () => useRestore( REWIND_ID ), { wrapper } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'idle' ) );
+
+		rows = [
+			{
+				restore_id: 912682,
+				rewind_id: OTHER_ID,
+				when: '2026-08-20T10:00:00+00:00',
+				status: 'started',
+			},
+		];
+
+		submitAll( result );
+
+		await waitFor( () => expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } ) );
 		expect( initiateCall() ).toBeUndefined();
 	}, 15000 );
 

--- a/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from '@wordpress/element';
-import { fetchRestoreStatus, pickLiveRestore } from '../data/api/restore';
+import { fetchRestoreStatus, isUpstreamTracking, pickLiveRestore } from '../data/api/restore';
 import { keys } from '../data/query-client';
 import { useRecentRestores } from './use-recent-restores';
 
@@ -77,24 +77,11 @@ export function useAdoptedRestore( enabled: boolean ): Result {
 	const isChecking =
 		enabled && ( collection.isPending || ( candidate !== null && confirmation.isPending ) );
 
-	// Positive evidence only, and deliberately stricter than the poll's
-	// own `! isTerminal(…)`, which also counts `not-found` and `unknown`.
-	//
-	// `not-found` is a **404** — "that restore is not visible to this
-	// route" — so counting it would read absence of evidence as evidence
-	// of life. For a restore we are *watching*, erring that way is right:
-	// keep polling. For one we are deciding whether to adopt, it is
-	// backwards. A collection row spelled in a way we do not recognise as
-	// settled, pointing at a restore upstream cannot find, would take the
-	// form away and never give it back — and the adoption is what
-	// withholds the button that would have replaced it, so it cannot
-	// self-correct.
-	//
-	// `queued` is on the other side of that line: upstream is holding a
-	// real restore, and letting the reader start a second one is the
-	// outcome adoption exists to prevent.
-	const status = confirmation.data?.status;
-	const isLive = status === 'running' || status === 'queued';
+	// Positive evidence only. A row we cannot read as settled, pointing at
+	// a restore upstream cannot find, would take the form away and never
+	// give it back — the adoption is what withholds the button that would
+	// have replaced it, so it cannot self-correct.
+	const isLive = isUpstreamTracking( confirmation.data?.status );
 
 	return {
 		adopted:

--- a/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
@@ -78,21 +78,23 @@ export function useAdoptedRestore( enabled: boolean ): Result {
 		enabled && ( collection.isPending || ( candidate !== null && confirmation.isPending ) );
 
 	// Positive evidence only, and deliberately stricter than the poll's
-	// own `! isTerminal(…)`.
+	// own `! isTerminal(…)`, which also counts `not-found` and `unknown`.
 	//
-	// That test counts `queued` as live, and `queued` is exactly what the
-	// bridge mints for a **404** — "that restore is not visible to this
-	// route" — so it reads absence of evidence as evidence of life. For a
-	// restore we are *watching*, erring that way is right: keep polling.
-	// For one we are deciding whether to adopt, it is backwards. A
-	// collection row spelled in a way we do not recognise as settled,
-	// pointing at a restore upstream cannot find, would take the form
-	// away and never give it back — and the adoption is what withholds
-	// the button that would have replaced it, so it cannot self-correct.
+	// `not-found` is a **404** — "that restore is not visible to this
+	// route" — so counting it would read absence of evidence as evidence
+	// of life. For a restore we are *watching*, erring that way is right:
+	// keep polling. For one we are deciding whether to adopt, it is
+	// backwards. A collection row spelled in a way we do not recognise as
+	// settled, pointing at a restore upstream cannot find, would take the
+	// form away and never give it back — and the adoption is what
+	// withholds the button that would have replaced it, so it cannot
+	// self-correct.
 	//
-	// The cost of being strict is a missed adoption, which is what this
-	// hook already accepts for a confirmation that fails to arrive.
-	const isLive = confirmation.data?.status === 'running';
+	// `queued` is on the other side of that line: upstream is holding a
+	// real restore, and letting the reader start a second one is the
+	// outcome adoption exists to prevent.
+	const status = confirmation.data?.status;
+	const isLive = status === 'running' || status === 'queued';
 
 	return {
 		adopted:

--- a/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-adopted-restore.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from '@wordpress/element';
-import { fetchRestoreStatus, isUpstreamTracking, pickLiveRestore } from '../data/api/restore';
+import { fetchRestoreStatus, isRestoreInFlight, pickLiveRestore } from '../data/api/restore';
 import { keys } from '../data/query-client';
 import { useRecentRestores } from './use-recent-restores';
 
@@ -24,7 +24,9 @@ type Result = {
  * second tab, or arriving after a restore started from Calypso all left
  * an armed **Confirm restore** button on screen. Following the only
  * control there would have started a second concurrent whole-site
- * restore, and nothing upstream is known to refuse that.
+ * restore. Upstream does guard against that — `endpoint-site-queue-rewind.php`
+ * calls `is_any_restore_running()` — but it answers as a bare failure the
+ * reader has to decode, which is a worse screen than not offering the button.
  *
  * Two reads, in order, because they answer different questions.
  *
@@ -77,11 +79,11 @@ export function useAdoptedRestore( enabled: boolean ): Result {
 	const isChecking =
 		enabled && ( collection.isPending || ( candidate !== null && confirmation.isPending ) );
 
-	// Positive evidence only. A row we cannot read as settled, pointing at
-	// a restore upstream cannot find, would take the form away and never
-	// give it back — the adoption is what withholds the button that would
-	// have replaced it, so it cannot self-correct.
-	const isLive = isUpstreamTracking( confirmation.data?.status );
+	// Positive evidence only, which is why `not-found` and `unknown` are
+	// both excluded: a row we cannot read as settled, pointing at a
+	// restore upstream cannot find or cannot describe, would take the form
+	// away and never give it back.
+	const isLive = isRestoreInFlight( confirmation.data?.status );
 
 	return {
 		adopted:

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -7,9 +7,10 @@ import {
 	fetchRestoreStatus,
 	fetchRunningRestore,
 	initiateRestore,
+	isSignOfLife,
 	isTerminal,
-	isUpstreamTracking,
 	pickLiveRestore,
+	sameRewindId,
 } from '../data/api/restore';
 import { keys } from '../data/query-client';
 import { useAdoptedRestore } from './use-adopted-restore';
@@ -64,6 +65,8 @@ type DeriveInput = {
 	unconfirmed: string | null;
 	startedRewindId: string | null;
 	restoreId: number | null;
+	/** Our restore, found already over in the collection; null when no row matches. */
+	settledOutcome: 'succeeded' | 'failed' | null;
 	statusError: Error | null;
 	data: RestoreStatusResponse | undefined;
 	lostTrack: boolean;
@@ -89,6 +92,7 @@ function deriveState( input: DeriveInput ): RestoreState {
 		unconfirmed,
 		startedRewindId,
 		restoreId,
+		settledOutcome,
 		statusError,
 		data,
 		lostTrack,
@@ -115,6 +119,15 @@ function deriveState( input: DeriveInput ): RestoreState {
 	// looking and finding nothing is that knowledge — before it, offering
 	// one would risk a second concurrent restore.
 	if ( unconfirmed !== null && restoreId === null ) {
+		// It did run, and it is already over — the recovery poll looks
+		// only for a *live* restore, so this is the case it cannot see.
+		// Answered as soon as it is found rather than after the deadline,
+		// whose message would deny the restore ever ran.
+		if ( settledOutcome !== null ) {
+			return settledOutcome === 'succeeded'
+				? { phase: 'success' }
+				: { phase: 'error', message: __( 'Restore failed.', 'jetpack-backup-pkg' ) };
+		}
 		if ( lostTrack ) {
 			return {
 				phase: 'error',
@@ -131,8 +144,8 @@ function deriveState( input: DeriveInput ): RestoreState {
 	//
 	// `lost-track` and not `error`: the restore was accepted and is very
 	// likely still running — we just cannot watch it any more. Reporting
-	// that as an error offers a retry, and the retry starts a second
-	// concurrent restore of the same site.
+	// that as an error offers a retry, which upstream refuses as a bare
+	// failure rather than as anything the reader can act on.
 	if ( restoreId !== null && statusError ) {
 		return { phase: 'lost-track', detail: statusError.message || null };
 	}
@@ -157,21 +170,16 @@ function deriveState( input: DeriveInput ): RestoreState {
 				percent: Math.round( data.progress ?? 0 ),
 				message: data.message,
 			};
-		case 'queued':
-			// Exempt from `lostTrack` for the same reason `running` is:
-			// WordPress.com is answering about this restore, so there is
-			// no silence to time out. A slow queue is not a lost restore,
-			// and saying so would invite a second concurrent one.
-			return { phase: 'queued' };
 		default:
-			// `not-found`, `unknown`, or nothing yet. All the same to the
-			// reader: accepted, nothing to show. Unless it has been that
-			// way long enough that we should stop implying something is
-			// about to happen.
+			// `queued`, `not-found`, `unknown`, or nothing yet. All the
+			// same to the reader: accepted, nothing to show.
 			//
-			// The copy for that lives on the screen, like every other
-			// phase's: this one is entirely ours, with no upstream part.
-			if ( lostTrack ) {
+			// The deadline only settles the readings that are silence —
+			// upstream still answering is not something to time out, and
+			// declaring a restore lost that it can see invites a second
+			// concurrent one. The copy lives on the screen, like every
+			// other phase's.
+			if ( lostTrack && ! isSignOfLife( data?.status ) ) {
 				return { phase: 'lost-track', detail: null };
 			}
 			return { phase: 'queued' };
@@ -372,6 +380,22 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 		}
 	}, [ recoveredId, submittedId ] );
 
+	// The same rows, read for the case `pickLiveRestore` filters out: our
+	// restore, already settled. Without it the five-minute verdict cannot
+	// tell "never started" from "started and finished".
+	const settledOutcome = useMemo( () => {
+		if ( ! needsId || startedRewindId === null ) {
+			return null;
+		}
+		const row = ( restoresQuery.data ?? [] ).find(
+			candidate => candidate.settled && sameRewindId( candidate.rewind_id, startedRewindId )
+		);
+		if ( ! row ) {
+			return null;
+		}
+		return row.succeeded ? ( 'succeeded' as const ) : ( 'failed' as const );
+	}, [ needsId, restoresQuery.data, startedRewindId ] );
+
 	// An adoption stands in for a submission on both counts: it names the
 	// restore to poll, and it is what the screen renders instead of the
 	// form.
@@ -387,16 +411,12 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 		enabled: restoreId !== null && enabled,
 		refetchInterval: query => {
 			// Keep asking through anything unrecognised — stopping there
-			// is what froze this before — but not past the deadline.
-			//
-			// The deadline does not apply while upstream is still
-			// answering, which mirrors `deriveState`. A hidden tab is
-			// polled neither on its interval nor on refocus, so the
-			// deadline can pass under a healthy restore; stopping there
-			// would strand the screen on the queued message with
-			// nothing left to correct it.
+			// is what froze this before — and past the deadline too while
+			// upstream is still answering, mirroring `deriveState`. A
+			// hidden tab is polled neither on its interval nor on refocus,
+			// so the deadline can pass under a healthy restore.
 			const status = query.state.data?.status;
-			if ( isTerminal( status ) || ( lostTrack && ! isUpstreamTracking( status ) ) ) {
+			if ( isTerminal( status ) || ( lostTrack && ! isSignOfLife( status ) ) ) {
 				return false;
 			}
 			return POLL_INTERVAL_MS;
@@ -413,7 +433,7 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 	const observedStatus = statusQuery.data?.status;
 	const statusUpdatedAt = statusQuery.dataUpdatedAt;
 	useEffect( () => {
-		if ( isUpstreamTracking( observedStatus ) && statusUpdatedAt > lastSeenUpdateAt.current ) {
+		if ( isSignOfLife( observedStatus ) && statusUpdatedAt > lastSeenUpdateAt.current ) {
 			lastSeenUpdateAt.current = statusUpdatedAt;
 			setAliveAt( Date.now() );
 			setLostTrack( false );
@@ -455,6 +475,7 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 		unconfirmed,
 		startedRewindId: activeRewindId,
 		restoreId,
+		settledOutcome,
 		statusError: statusQuery.error,
 		data: statusQuery.data,
 		lostTrack,

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -61,14 +61,16 @@ const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
  * silence deadline.
  *
  * Only `running` does, and deliberately not `queued` — which looks like
- * positive information and is not. WordPress.com's status enum is exactly
- * `running | success | fail | aborted | success-with-errors`; there is no
- * `queued` in it. Every `queued` the client sees is minted by our own
- * bridge, and overwhelmingly means *404 — that restore is not visible to
- * this route*. Treating it as a sign of life would mean a restore that
- * never materialises upstream answers 404 forever, resets the deadline
- * every time it does, and polls until the tab closes. That is precisely
- * the frozen-forever failure this hook exists to end.
+ * positive information and is not. The bridge mints `queued` for a 404,
+ * meaning *that restore is not visible to this route*, and cannot tell
+ * that apart from WordPress.com's own `queued`. Treating the pair as a
+ * sign of life would mean a restore that never materialises upstream
+ * answers 404 forever, resets the deadline every time it does, and polls
+ * until the tab closes. That is precisely the frozen-forever failure this
+ * hook exists to end.
+ *
+ * The cost of not separating them: a restore genuinely queued upstream
+ * for longer than `QUIET_TIMEOUT_MS` is reported as lost.
  *
  * @param status - The status the bridge reported, if any.
  * @return True when the restore has demonstrably moved.

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -8,12 +8,13 @@ import {
 	fetchRunningRestore,
 	initiateRestore,
 	isTerminal,
+	isUpstreamTracking,
 	pickLiveRestore,
 } from '../data/api/restore';
 import { keys } from '../data/query-client';
 import { useAdoptedRestore } from './use-adopted-restore';
 import type { AdoptedRestore } from './use-adopted-restore';
-import type { RestoreStatus, RestoreStatusResponse } from '../data/api/restore';
+import type { RestoreStatusResponse } from '../data/api/restore';
 import type { RestoreItems, RestoreState } from '../types/restore';
 
 type Result = {
@@ -55,25 +56,6 @@ const POLL_INTERVAL_MS = 5000;
  * timeout and no way out.
  */
 const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
-
-/**
- * Whether a status reading counts as a sign of life, restarting the
- * silence deadline.
- *
- * The line is whether WordPress.com said anything about *this restore*,
- * not whether it has started moving. `queued` and `running` are upstream
- * tracking a real record; `not-found` is a 404, which is absence of
- * evidence. Reading that as life would mean a restore that never
- * materialises answers 404 forever, resets the deadline every time it
- * does, and polls until the tab closes — precisely the frozen-forever
- * failure this hook exists to end.
- *
- * @param status - The status the bridge reported, if any.
- * @return True when WordPress.com still knows about the restore.
- */
-function isSignOfLife( status: RestoreStatus | undefined ): boolean {
-	return status === 'running' || status === 'queued';
-}
 
 type DeriveInput = {
 	errorMessage: string | null;
@@ -257,7 +239,7 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 	// list is structurally shared into the same array — so React Query's
 	// observer never notifies, no render happens, and any deadline
 	// evaluated during render is never reached. The screen would sit on
-	// "queued and will begin shortly…" for as long as the tab stayed
+	// "queued and will begin automatically." for as long as the tab stayed
 	// open, which is the one scenario this recovery path exists for.
 	const [ aliveAt, setAliveAt ] = useState< number | null >( null );
 	const [ lostTrack, setLostTrack ] = useState( false );
@@ -406,21 +388,35 @@ export function useRestore( rewindId: string, enabled = true ): Result {
 		refetchInterval: query => {
 			// Keep asking through anything unrecognised — stopping there
 			// is what froze this before — but not past the deadline.
-			if ( isTerminal( query.state.data?.status ) || lostTrack ) {
+			//
+			// The deadline does not apply while upstream is still
+			// answering, which mirrors `deriveState`. A hidden tab is
+			// polled neither on its interval nor on refocus, so the
+			// deadline can pass under a healthy restore; stopping there
+			// would strand the screen on the queued message with
+			// nothing left to correct it.
+			const status = query.state.data?.status;
+			if ( isTerminal( status ) || ( lostTrack && ! isUpstreamTracking( status ) ) ) {
 				return false;
 			}
 			return POLL_INTERVAL_MS;
 		},
 	} );
 
-	// A running restore is the only unambiguous sign of life. Recorded in
-	// an effect rather than during render so the render stays pure.
+	// Upstream still answering about this restore is the sign of life.
+	// Recorded in an effect rather than during render so the render stays
+	// pure.
+	//
+	// Clearing `lostTrack` is what makes it mean "nothing heard lately"
+	// rather than "there was once a five-minute gap". Without it the flag
+	// latches on the first gap and no later evidence can undo it.
 	const observedStatus = statusQuery.data?.status;
 	const statusUpdatedAt = statusQuery.dataUpdatedAt;
 	useEffect( () => {
-		if ( isSignOfLife( observedStatus ) && statusUpdatedAt > lastSeenUpdateAt.current ) {
+		if ( isUpstreamTracking( observedStatus ) && statusUpdatedAt > lastSeenUpdateAt.current ) {
 			lastSeenUpdateAt.current = statusUpdatedAt;
 			setAliveAt( Date.now() );
+			setLostTrack( false );
 		}
 	}, [ observedStatus, statusUpdatedAt ] );
 

--- a/projects/packages/backup/src/dashboard/hooks/use-restore.ts
+++ b/projects/packages/backup/src/dashboard/hooks/use-restore.ts
@@ -60,23 +60,19 @@ const QUIET_TIMEOUT_MS = 5 * 60 * 1000;
  * Whether a status reading counts as a sign of life, restarting the
  * silence deadline.
  *
- * Only `running` does, and deliberately not `queued` — which looks like
- * positive information and is not. The bridge mints `queued` for a 404,
- * meaning *that restore is not visible to this route*, and cannot tell
- * that apart from WordPress.com's own `queued`. Treating the pair as a
- * sign of life would mean a restore that never materialises upstream
- * answers 404 forever, resets the deadline every time it does, and polls
- * until the tab closes. That is precisely the frozen-forever failure this
- * hook exists to end.
- *
- * The cost of not separating them: a restore genuinely queued upstream
- * for longer than `QUIET_TIMEOUT_MS` is reported as lost.
+ * The line is whether WordPress.com said anything about *this restore*,
+ * not whether it has started moving. `queued` and `running` are upstream
+ * tracking a real record; `not-found` is a 404, which is absence of
+ * evidence. Reading that as life would mean a restore that never
+ * materialises answers 404 forever, resets the deadline every time it
+ * does, and polls until the tab closes — precisely the frozen-forever
+ * failure this hook exists to end.
  *
  * @param status - The status the bridge reported, if any.
- * @return True when the restore has demonstrably moved.
+ * @return True when WordPress.com still knows about the restore.
  */
 function isSignOfLife( status: RestoreStatus | undefined ): boolean {
-	return status === 'running';
+	return status === 'running' || status === 'queued';
 }
 
 type DeriveInput = {
@@ -179,8 +175,14 @@ function deriveState( input: DeriveInput ): RestoreState {
 				percent: Math.round( data.progress ?? 0 ),
 				message: data.message,
 			};
+		case 'queued':
+			// Exempt from `lostTrack` for the same reason `running` is:
+			// WordPress.com is answering about this restore, so there is
+			// no silence to time out. A slow queue is not a lost restore,
+			// and saying so would invite a second concurrent one.
+			return { phase: 'queued' };
 		default:
-			// `queued`, `unknown`, or nothing yet. All the same to the
+			// `not-found`, `unknown`, or nothing yet. All the same to the
 			// reader: accepted, nothing to show. Unless it has been that
 			// way long enough that we should stop implying something is
 			// about to happen.

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -18,6 +18,12 @@ import { isValidRewindId, rewindIdToIso } from '../types/rewind-id';
 // because only one of these renders per page.
 const SELECTION_HINT_ID = 'jpb-restore__selection-hint';
 
+// `adopted` is latched for the life of the screen, so the "already
+// running" notice needs its own end. An allowlist rather than excluding
+// the terminal phases: a phase added later should not silently start
+// announcing a finished restore as still running.
+const STILL_RUNNING_PHASES = new Set( [ 'checking', 'queued', 'progress' ] );
+
 /**
  * Restore screen — narrow centered layout with the warning notice, the
  * shared item checklist, and a Confirm button. Submit drives a real
@@ -114,11 +120,11 @@ export default function RestoreScreen() {
 					 * running and we can no longer see it — promising an end state
 					 * the notice beneath has just disowned.
 					 *
-					 * "from here" because the constraint is this screen's, not the
-					 * product's: nothing upstream refuses a second restore, and the
+					 * "from here" because the constraint is this screen's: upstream
+					 * refuses a concurrent restore only as a bare failure, and the
 					 * reader can still start one from WordPress.com.
 					 */ }
-					{ adopted && state.phase !== 'lost-track' && (
+					{ adopted && STILL_RUNNING_PHASES.has( state.phase ) && (
 						<Notice status="info" isDismissible={ false }>
 							{ restorePoint
 								? sprintf(
@@ -299,10 +305,9 @@ export default function RestoreScreen() {
 					 * Accepted, and then out of sight — the silence deadline passed, or
 					 * the status poll stopped answering. Deliberately not the error
 					 * branch below, which offers "Try again": that resets to an armed
-					 * Confirm button, so the only control on screen would start a second
-					 * concurrent restore of the same site directly beneath a notice
-					 * saying the first may still be running. Nothing upstream is known
-					 * to refuse that.
+					 * Confirm button directly beneath a notice saying the first restore
+					 * may still be running. Upstream refuses the second one as a bare
+					 * failure — a worse answer than not offering the button.
 					 *
 					 * Warning rather than error for the same reason the copy says "may":
 					 * we have no evidence the restore failed, only that we cannot see

--- a/projects/packages/backup/src/dashboard/screens/restore.tsx
+++ b/projects/packages/backup/src/dashboard/screens/restore.tsx
@@ -198,7 +198,10 @@ export default function RestoreScreen() {
 					{ state.phase === 'queued' && (
 						<Stack direction="column" gap="sm">
 							<Text>
-								{ __( 'Your restore is queued and will begin shortly…', 'jetpack-backup-pkg' ) }
+								{ __(
+									'Your restore is queued and will begin automatically.',
+									'jetpack-backup-pkg'
+								) }
 							</Text>
 							<ProgressBar
 								aria-label={ __( 'Waiting for your restore to begin', 'jetpack-backup-pkg' ) }

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -346,11 +346,12 @@ class Restore_Bridge {
 			$mapped = $force;
 		} elseif ( '' === $raw ) {
 			// A record that arrived without a status is queued and has not
-			// started reporting. A payload naming no restore at all is not
-			// a record, and reporting it as `queued` would claim upstream
-			// is holding a restore it never mentioned — which is enough to
-			// refuse the reader a new one.
-			$mapped = isset( $status['restore_id'] ) ? 'queued' : 'not-found';
+			// started reporting. An empty payload is not a record, and
+			// calling it `queued` would claim upstream is holding a
+			// restore it never mentioned — enough to refuse the reader a
+			// new one. Tested on emptiness rather than on one key, so a
+			// record spelled with fields we do not read still counts.
+			$mapped = empty( $status ) ? 'not-found' : 'queued';
 		} else {
 			// Anything unrecognised is reported as such rather than
 			// guessed at. The client keeps polling through `unknown` under

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -345,9 +345,12 @@ class Restore_Bridge {
 		if ( null !== $force ) {
 			$mapped = $force;
 		} elseif ( '' === $raw ) {
-			// Present but silent about status: the restore exists and has
-			// not started reporting yet.
-			$mapped = 'queued';
+			// A record that arrived without a status is queued and has not
+			// started reporting. A payload naming no restore at all is not
+			// a record, and reporting it as `queued` would claim upstream
+			// is holding a restore it never mentioned — which is enough to
+			// refuse the reader a new one.
+			$mapped = isset( $status['restore_id'] ) ? 'queued' : 'not-found';
 		} else {
 			// Anything unrecognised is reported as such rather than
 			// guessed at. The client keeps polling through `unknown` under

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -301,11 +301,15 @@ class Restore_Bridge {
 		// would turn the ordinary opening seconds of every restore into a
 		// user-visible failure.
 		//
+		// Reported as `not-found` and never as `queued`, which upstream
+		// also returns: the client reads the two the same way on screen
+		// but must not treat "no record of it" as a sign of life.
+		//
 		// Safe to treat softly only because the upstream route now
 		// answers 502 for an unparseable VaultPress reply — before that, a
 		// 404 could quietly have meant "upstream is down".
 		if ( 404 === $status_code ) {
-			return rest_ensure_response( self::project_status( array(), $restore_id, 'queued' ) );
+			return rest_ensure_response( self::project_status( array(), $restore_id, 'not-found' ) );
 		}
 
 		if ( 200 !== $status_code ) {

--- a/projects/packages/backup/src/rest/class-restore-bridge.php
+++ b/projects/packages/backup/src/rest/class-restore-bridge.php
@@ -221,11 +221,14 @@ class Restore_Bridge {
 	/**
 	 * WPCOM's restore statuses, mapped to the vocabulary the client uses.
 	 *
-	 * The client used to test for `in-progress`, `queued`, `finished` and
-	 * `failed`, none of which WPCOM has ever returned — so the poll never
-	 * recognised a live restore and no terminal state was reachable. That
-	 * went unnoticed because the v1 call this bridge used to make answered
-	 * 401 before any status could come back.
+	 * Two engines write this field and the v2 route serves whichever ran:
+	 * a Rewind restore — which is every restore this package starts —
+	 * reports `queued | running | finished | fail`, a legacy VaultPress one
+	 * `success | success-with-errors | aborted`.
+	 *
+	 * The Rewind half comes from Calypso's typed contract for this same
+	 * endpoint, not from the v1 endpoint's docblock: that list omits
+	 * `finished`, so every successful restore once reported `unknown`.
 	 *
 	 * Mapped here rather than in the client for the same reason the
 	 * download bridge derives its own status: the wire vocabulary is
@@ -240,10 +243,12 @@ class Restore_Bridge {
 	 * @var array<string, string>
 	 */
 	private const STATUS_MAP = array(
+		'queued'              => 'queued',
 		'running'             => 'running',
+		'finished'            => 'finished',
+		'fail'                => 'failed',
 		'success'             => 'finished',
 		'success-with-errors' => 'finished-with-errors',
-		'fail'                => 'failed',
 		'aborted'             => 'aborted',
 	);
 

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -335,7 +335,7 @@ describe( 'The Restore screen across a gate flip', () => {
 		render( <RestoreStage /> );
 		await user.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
 		await expect(
-			screen.findByText( /queued and will begin shortly/, undefined, SETTLE )
+			screen.findByText( /queued and will begin automatically/, undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 		const posts = () => mockApiFetch.mock.calls.filter( ( [ o ] ) => o?.method === 'POST' ).length;
 		expect( posts() ).toBe( 1 );
@@ -352,7 +352,7 @@ describe( 'The Restore screen across a gate flip', () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
 		await expect(
-			screen.findByText( /queued and will begin shortly/, undefined, SETTLE )
+			screen.findByText( /queued and will begin automatically/, undefined, SETTLE )
 		).resolves.toBeInTheDocument();
 
 		expect( screen.queryByRole( 'button', { name: /Confirm restore/ } ) ).not.toBeInTheDocument();

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -500,8 +500,12 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A 404 means "queued, not visible yet" — the normal first answer for
-	 * a restore that has only just been accepted.
+	 * A 404 means "not visible to this route yet" — the normal first
+	 * answer for a restore that has only just been accepted.
+	 *
+	 * Reported as `not-found` rather than `queued` so the client can tell
+	 * it from WordPress.com's own `queued`: one is upstream tracking a
+	 * real restore, the other is upstream having no record of it.
 	 *
 	 * Mapping every non-200 to a hard error, as the v1 code did, turns the
 	 * opening seconds of every restore into a user-visible failure. Safe
@@ -509,7 +513,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 * VaultPress returns nothing parseable, so a 404 can no longer
 	 * secretly mean "upstream is down".
 	 */
-	public function test_status_treats_404_as_queued() {
+	public function test_status_treats_404_as_not_found() {
 		$this->arrange_wpcom( array( 'error' => 'not_found' ), 404 );
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
@@ -517,7 +521,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$response = Restore_Bridge::get_restore_status( $request );
 
 		$this->assertNotInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 'queued', $response->get_data()['status'] );
+		$this->assertSame( 'not-found', $response->get_data()['status'] );
 		$this->assertSame( 7, $response->get_data()['id'] );
 	}
 
@@ -570,7 +574,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A 404 reported as a string is still the queued carve-out.
+	 * A 404 reported as a string is still the not-found carve-out.
 	 *
 	 * Both branches of this callback read the same variable, so the cast
 	 * buys more here than the success test above shows: uncast, `'404'`
@@ -578,7 +582,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 * opening seconds of every restore — before the id is visible to this
 	 * route — surfaced as a failure.
 	 */
-	public function test_status_treats_a_string_404_as_queued() {
+	public function test_status_treats_a_string_404_as_not_found() {
 		$this->arrange_wpcom_raw( '{"error":"not_found"}', '404' );
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
@@ -586,7 +590,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$response = Restore_Bridge::get_restore_status( $request );
 
 		$this->assertNotInstanceOf( WP_Error::class, $response );
-		$this->assertSame( 'queued', $response->get_data()['status'] );
+		$this->assertSame( 'not-found', $response->get_data()['status'] );
 		$this->assertSame( 7, $response->get_data()['id'] );
 	}
 

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -423,7 +423,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 * @dataProvider provide_upstream_statuses
 	 */
 	#[DataProvider( 'provide_upstream_statuses' )]
-	public function test_no_upstream_status_reports_as_unknown( $upstream ) {
+	public function test_every_upstream_status_maps_into_the_client_vocabulary( $upstream ) {
 		$this->arrange_wpcom(
 			array(
 				'restore_id' => 1,
@@ -436,7 +436,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$data = Restore_Bridge::get_restore_status( $request )->get_data();
 
 		// `RestoreStatus` in `dashboard/data/api/restore.ts`, less the two
-		// the client mints for itself.
+		// this bridge mints when upstream names no status.
 		$this->assertContains(
 			$data['status'],
 			array( 'queued', 'running', 'finished', 'finished-with-errors', 'failed', 'aborted' ),
@@ -471,7 +471,7 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 *
 	 * Mirrors `STATUS_MAP`, so it can only confirm that each key maps
 	 * where it says — never that the map covers what arrives. That is what
-	 * `test_no_upstream_status_reports_as_unknown` above is for.
+	 * `test_every_upstream_status_maps_into_the_client_vocabulary` is for.
 	 *
 	 * @param string $upstream WPCOM's status value.
 	 * @param string $expected What the bridge should report.
@@ -541,15 +541,24 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
-	 * A 200 carrying no restore record is `not-found`, not `queued`.
+	 * A record that names no `restore_id` is still a record.
 	 *
-	 * `queued` now means *upstream is holding this restore*: it holds the
-	 * silence deadline back, adopts at mount, and refuses a new restore on
-	 * the click. Minting it from a body that named no restore would block
-	 * the reader from restoring with nothing on screen to explain why.
-	 *
-	 * An empty `status` on a record that did arrive stays `queued` — see
-	 * the `absent` row in `provide_statuses`.
+	 * `queued` now means *upstream is holding this restore*, which is
+	 * enough to refuse the reader a new one — so the two must be told
+	 * apart on whether a record arrived, not on one key.
+	 */
+	public function test_status_keeps_a_record_that_names_no_restore_id() {
+		$this->arrange_wpcom_raw( '{"rewind_id":"1786663613.9425","percent":0,"status":""}', 200 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$data = Restore_Bridge::get_restore_status( $request )->get_data();
+
+		$this->assertSame( 'queued', $data['status'] );
+	}
+
+	/**
+	 * A 200 carrying nothing at all is `not-found`.
 	 */
 	public function test_status_treats_a_recordless_200_as_not_found() {
 		$this->arrange_wpcom_raw( '{}', 200 );

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -414,10 +414,10 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	/**
 	 * Every status the v2 route actually returns is recognised.
 	 *
-	 * Sourced from Calypso's typed contract for this same endpoint
-	 * (`packages/api-core/src/site-backup-restore/types.ts`), never from
-	 * `STATUS_MAP` — a provider mirroring the map cannot catch a key the
-	 * map is missing, which is how `finished` went unmapped.
+	 * Sourced from upstream, never from `STATUS_MAP` — a provider
+	 * mirroring the map cannot catch a key the map is missing, which is
+	 * how `finished` went unmapped. Asserting membership rather than
+	 * `!== 'unknown'` so a typo'd map value fails too.
 	 *
 	 * @param string $upstream A status the v2 route returns.
 	 * @dataProvider provide_upstream_statuses
@@ -435,19 +435,34 @@ class Rest_Restore_Bridge_Test extends TestCase {
 		$request->set_param( 'restore_id', 1 );
 		$data = Restore_Bridge::get_restore_status( $request )->get_data();
 
-		$this->assertNotSame( 'unknown', $data['status'], "upstream: $upstream" );
+		// `RestoreStatus` in `dashboard/data/api/restore.ts`, less the two
+		// the client mints for itself.
+		$this->assertContains(
+			$data['status'],
+			array( 'queued', 'running', 'finished', 'finished-with-errors', 'failed', 'aborted' ),
+			"upstream: $upstream"
+		);
 	}
 
 	/**
+	 * Both vocabularies, because the v2 route serves whichever engine ran.
+	 *
+	 * Rewind is Calypso's typed contract for this same endpoint
+	 * (`packages/api-core/src/site-backup-restore/types.ts`); legacy is
+	 * what `BackupRestore.php` assigns when it finishes a restore.
+	 *
 	 * @return array<string, array{0: string}>
 	 */
 	public static function provide_upstream_statuses() {
 		return array(
-			'queued'   => array( 'queued' ),
-			'running'  => array( 'running' ),
-			'finished' => array( 'finished' ),
-			'fail'     => array( 'fail' ),
-			'empty'    => array( '' ),
+			'queued'              => array( 'queued' ),
+			'running'             => array( 'running' ),
+			'finished'            => array( 'finished' ),
+			'fail'                => array( 'fail' ),
+			'empty'               => array( '' ),
+			'success'             => array( 'success' ),
+			'success-with-errors' => array( 'success-with-errors' ),
+			'aborted'             => array( 'aborted' ),
 		);
 	}
 
@@ -515,6 +530,29 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 */
 	public function test_status_treats_404_as_not_found() {
 		$this->arrange_wpcom( array( 'error' => 'not_found' ), 404 );
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
+		$request->set_param( 'restore_id', 7 );
+		$response = Restore_Bridge::get_restore_status( $request );
+
+		$this->assertNotInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'not-found', $response->get_data()['status'] );
+		$this->assertSame( 7, $response->get_data()['id'] );
+	}
+
+	/**
+	 * A 200 carrying no restore record is `not-found`, not `queued`.
+	 *
+	 * `queued` now means *upstream is holding this restore*: it holds the
+	 * silence deadline back, adopts at mount, and refuses a new restore on
+	 * the click. Minting it from a body that named no restore would block
+	 * the reader from restoring with nothing on screen to explain why.
+	 *
+	 * An empty `status` on a record that did arrive stays `queued` — see
+	 * the `absent` row in `provide_statuses`.
+	 */
+	public function test_status_treats_a_recordless_200_as_not_found() {
+		$this->arrange_wpcom_raw( '{}', 200 );
 
 		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/7/status' );
 		$request->set_param( 'restore_id', 7 );

--- a/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
+++ b/projects/packages/backup/tests/php/Rest_Restore_Bridge_Test.php
@@ -412,11 +412,51 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	}
 
 	/**
+	 * Every status the v2 route actually returns is recognised.
+	 *
+	 * Sourced from Calypso's typed contract for this same endpoint
+	 * (`packages/api-core/src/site-backup-restore/types.ts`), never from
+	 * `STATUS_MAP` — a provider mirroring the map cannot catch a key the
+	 * map is missing, which is how `finished` went unmapped.
+	 *
+	 * @param string $upstream A status the v2 route returns.
+	 * @dataProvider provide_upstream_statuses
+	 */
+	#[DataProvider( 'provide_upstream_statuses' )]
+	public function test_no_upstream_status_reports_as_unknown( $upstream ) {
+		$this->arrange_wpcom(
+			array(
+				'restore_id' => 1,
+				'status'     => $upstream,
+			)
+		);
+
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/rewind/restore/1/status' );
+		$request->set_param( 'restore_id', 1 );
+		$data = Restore_Bridge::get_restore_status( $request )->get_data();
+
+		$this->assertNotSame( 'unknown', $data['status'], "upstream: $upstream" );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public static function provide_upstream_statuses() {
+		return array(
+			'queued'   => array( 'queued' ),
+			'running'  => array( 'running' ),
+			'finished' => array( 'finished' ),
+			'fail'     => array( 'fail' ),
+			'empty'    => array( '' ),
+		);
+	}
+
+	/**
 	 * WPCOM's status vocabulary is mapped to the client's.
 	 *
-	 * The client used to test for `in-progress`, `queued`, `finished` and
-	 * `failed` — none of which WPCOM returns — so no terminal state was
-	 * ever reachable and the poll stopped after one response.
+	 * Mirrors `STATUS_MAP`, so it can only confirm that each key maps
+	 * where it says — never that the map covers what arrives. That is what
+	 * `test_no_upstream_status_reports_as_unknown` above is for.
 	 *
 	 * @param string $upstream WPCOM's status value.
 	 * @param string $expected What the bridge should report.
@@ -443,7 +483,9 @@ class Rest_Restore_Bridge_Test extends TestCase {
 	 */
 	public static function provide_statuses() {
 		return array(
+			'queued'                  => array( 'queued', 'queued' ),
 			'running'                 => array( 'running', 'running' ),
+			'finished'                => array( 'finished', 'finished' ),
 			'success'                 => array( 'success', 'finished' ),
 			// Kept distinct rather than folded into either neighbour: a
 			// restore that completed but not cleanly is neither.

--- a/projects/packages/backup/tests/restore-lost-track.test.tsx
+++ b/projects/packages/backup/tests/restore-lost-track.test.tsx
@@ -9,9 +9,9 @@
 // "Try again" button that resets the screen to an armed "Confirm
 // restore". So the only control beneath *"It may still be running —
 // you'll get an email when it finishes"* was one that starts a second
-// concurrent restore of the same site. Nothing upstream is known to
-// refuse that: `queue_restore()` calls `site_queue_rewind()` directly and
-// no in-flight check is visible from either repo.
+// concurrent restore of the same site. Upstream does refuse that —
+// `endpoint-site-queue-rewind.php` calls `is_any_restore_running()` —
+// but only as a bare failure, which is a worse screen than no button.
 //
 // The rule these tests pin: a retry is offered only when we know nothing
 // is running.

--- a/projects/packages/backup/tests/restore-session-recovery.test.tsx
+++ b/projects/packages/backup/tests/restore-session-recovery.test.tsx
@@ -185,6 +185,35 @@ describe( 'Restore screen — a restore already running', () => {
 		expect( view.queryByText( ALREADY_RUNNING ) ).not.toBeInTheDocument();
 	} );
 
+	// The same notice, outliving the restore the other way. `adopted` is
+	// latched for the life of the screen, so nothing retires it when the
+	// restore it describes ends.
+	it.each( [
+		[ 'finished', /Restore complete/ ],
+		[ 'failed', /Restore failed/ ],
+	] )( 'retires the notice once the adopted restore is %s', async ( status, outcome ) => {
+		let calls = 0;
+		mockApiFetch.mockImplementation( ( options: { path?: string } ) => {
+			const path = options?.path ?? '';
+			if ( path.includes( '/restores' ) ) {
+				return Promise.resolve( [ restoreRow() ] );
+			}
+			if ( path.includes( '/rewind/restore/' ) ) {
+				calls += 1;
+				// Adopt on the first read, then let it end.
+				return Promise.resolve(
+					calls === 1 ? statusPayload() : statusPayload( { status, progress: 100 } )
+				);
+			}
+			return Promise.resolve( CAPABILITIES );
+		} );
+
+		const view = within( renderScreen() );
+
+		await expect( view.findByText( outcome ) ).resolves.toBeInTheDocument();
+		expect( view.queryByText( ALREADY_RUNNING ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'stops promising an end state once it has lost track of the restore', async () => {
 		// "You can't start another until it finishes" sat directly above
 		// "We've lost track of this restore. It may still be running" —


### PR DESCRIPTION
Fixes JETPACK-2545

## Proposed changes

Found by running the first real end-to-end restore on the modernized Backup dashboard. The restore worked; the screen that reports it said **"Your restore is queued and will begin shortly…"** throughout, then **"We've lost track of this restore."** The Overview's activity list correctly showed *Restore complete*, because it reads a different endpoint.

### The bridge was translating the wrong endpoint's vocabulary

`Restore_Bridge::STATUS_MAP`'s keys (`running`/`success`/`success-with-errors`/`fail`/`aborted`) come from the **v1** restore endpoint's docblock. The bridge calls **v2**.

Two engines write that column, and the v2 route serves whichever ran:

| Engine | `rewind_id` | Statuses |
| -- | -- | -- |
| Rewind — every restore this package starts | set | `queued \| running \| finished \| fail` |
| Legacy VaultPress | `''` | `success \| success-with-errors \| aborted` |

Sources: Calypso's typed contract for this same endpoint (`packages/api-core/src/site-backup-restore/types.ts`), its two consumers (`client/dashboard/sites/backup-restore/progress.tsx`, `client/state/selectors/get-is-restore-in-progress.ts`), wpcom's Site Studio import manager, and VaultPress's own analytics, which split the two vocabularies on `rewind_id` exactly as above.

So the map recognised **two of the five** statuses that can arrive. `finished` and `queued` both fell through to `unknown`, which the screen renders identically to "queued" and which the silence deadline eventually converts into "lost track".

### One `queued` meant two opposite things

The bridge minted `queued` both for a 404 ("upstream has no record") and for upstream's own `queued` ("upstream is holding a real one"), so the poll could only treat both as the pessimistic case.

* The 404 carve-out reports `not-found`. So does a 200 carrying nothing — but a 200 that carries a record without a `restore_id` stays `queued`, since that is still a record.

### Two questions, not one predicate

Adoption and the click-time guard ask *"is a restore in flight?"*. The silence deadline asks *"did upstream answer at all?"*. `unknown` separates them: the bridge mints it only for a status string upstream **did** send, so it is proof of a record but not proof it is still running.

* `isSignOfLife` (`running`/`queued`/`unknown`) drives the deadline and the poll. Excluding `unknown` had put a live restore under any spelling WPCOM adds on a five-minute fuse and then killed the poll — the frozen-progress failure this flow exists to prevent, with a delay.
* `isRestoreInFlight` (`running`/`queued`) drives adoption and `fetchRunningRestore`, which is the guard at the moment of a destructive click.
* `lostTrack` is cleared on a sign of life, so it means "nothing heard lately" rather than latching on the first gap, and `refetchInterval` no longer stops the poll while upstream is still answering. A hidden tab is polled neither on its interval nor on refocus (`refetchOnWindowFocus: false`), so the deadline can otherwise pass under a perfectly healthy restore.

### Wrong things it said to the reader

* A submission whose reply was lost, whose restore then ran and settled, was reported as **"Your restore didn't start, so nothing on your site has changed."** — a claim about a live site, above a **Try again** button. The recovery poll only looks for a *live* restore, so a settled one was invisible to it. The collection already carries `settled` and `succeeded` per row; the outcome is reported now, as soon as it is found.
* The "A restore … is already running. You can't start another from here until it finishes." notice outlived the restore, rendering directly above **"Restore complete."**
* `queued` is no longer time-bounded, so the copy no longer promises "shortly": **"Your restore is queued and will begin automatically."** This is a user-visible string change, and the only one here.
* Three comments asserted that nothing upstream refuses a concurrent restore. `vp-private-api/endpoint-site-queue-rewind.php` calls `is_any_restore_running()` — it does refuse, just as a bare failure.

### Testing

`provide_statuses` enumerated `STATUS_MAP`'s own keys, so it could only confirm the map does what it says — never that it covers what arrives. `test_every_upstream_status_maps_into_the_client_vocabulary` is sourced from upstream instead, covers both engines, and asserts membership in the client's union so a typo'd map value fails too.

On the JS side, an earlier revision of this PR claimed guards it did not have: three behavioural changes could each be reverted with all tests still green, because the one test covering them was satisfied by any one of the three. Every behaviour below now reddens exactly one test when reverted, verified by mutation:

| Reverting | Reddens |
| -- | -- |
| `refetchInterval` deadline exemption | `resumes polling after the deadline passes under a hidden tab` |
| `setLostTrack( false )` | `gives a restore a fresh deadline once it is heard from again` |
| `unknown` in `isSignOfLife` | `keeps watching a restore reported under a spelling it does not know` |
| `fetchRunningRestore` widening | `adopts instead of starting a second restore when the other one is queued` |
| `useAdoptedRestore` widening | `adopts a restore WordPress.com reports as queued` |
| `not-found` in `LIVE_STATUSES` | `gives up on a restore WordPress.com never finds` |
| the notice's phase allowlist | `retires the notice once the adopted restore is finished` |

The three deadline cases need `lostTrack` true *while* a sign of life arrives, which a steady poll never produces — every reading pushes the deadline back. Hiding the tab is what creates it.

### Known and deliberately not fixed here

Pre-existing, bounded by upstream's own `is_any_restore_running()` guard, and better as their own PR:

* During the opening seconds of any restore the status route 404s, so a fresh collection row plus `not-found` reads as "nothing running" at both the mount adoption and the click guard. The row's `when` is parsed already and would tell a fresh row from a stale one.
* `fetchRunningRestore().catch( () => null )` fails open on both of its two reads; only the collection read should.
* A refusal from upstream never re-reads the collection, so "Try again" re-arms the form.
* `empty( $decoded['ok'] )` is the sole success signal on initiate, so a 200 naming a `restore_id` without `ok` is reported as a failure.
* A permanently-`queued` restore now polls for the life of the tab with no outer cap.

## Related product discussion/links

* JETPACK-2545 — recommended as a gate on JETPACK-2319.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Behind the `rsm_jetpack_ui_modernization_backup` filter; the whole surface is off by default.

**Automated**

* `jp test php packages/backup` — 419 pass.
* `jp test js packages/backup` — 872 pass across 84 suites.
* `jp phan packages/backup` — 0 issues. Typecheck, PHPCS and ESLint clean.

**On a site with Backup and the modernization filter on**

1. Run a real restore (database only is quickest) from the modernized Backup dashboard.
2. The screen should go *queued* → *Restoring…* → **"Restore complete."** It must never reach "We've lost track of this restore."
3. Cross-check `GET /jetpack/v4/restores` against `GET /jetpack/v4/rewind/restore/<id>/status` once it finishes — both should agree the restore is over.
4. While one is queued or running, open the Restore screen in a second tab: it should adopt the running restore rather than offering the form, and the "already running" notice should disappear when the restore ends.
5. Switch away from the tab for more than five minutes mid-restore and come back: the screen should still be watching, not stuck.

**If you use the local `?jpb_sim=` state simulator**, any scenario standing in for the 404 path must now emit `not-found` rather than `queued`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PsbpJFt2cuDfQtcdscVY1c
