### PR TITLE
Jetpack: remove the unreachable "manage" branch from DashItem

### DIFF
--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -1,5 +1,4 @@
-import { getRedirectUrl } from '@automattic/jetpack-components';
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -8,7 +7,6 @@ import Button from 'components/button';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
-import SimpleNotice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import SupportInfo from 'components/support-info';
 import analytics from 'lib/analytics';
@@ -79,9 +77,7 @@ export class DashItem extends Component {
 					'videopress',
 				].includes( this.props.module ) &&
 					this.props.isOfflineMode ) ||
-				this.props.noToggle ||
-				// Avoid toggle for manage as it's no longer a module
-				'manage' === this.props.module ? (
+				this.props.noToggle ? (
 					''
 				) : (
 					<ModuleToggle
@@ -92,29 +88,6 @@ export class DashItem extends Component {
 						compact={ true }
 					/>
 				);
-
-			if ( 'manage' === this.props.module ) {
-				if ( 'is-warning' === this.props.status ) {
-					toggle = (
-						<a
-							href={
-								this.props.isOfflineMode
-									? this.props.siteAdminUrl + 'update-core.php'
-									: getRedirectUrl( 'calypso-plugins-manage', { site: this.props.siteRawUrl } )
-							}
-						>
-							<SimpleNotice showDismiss={ false } status={ this.props.status } isCompact={ true }>
-								{ _x( 'Updates needed', 'Short warning message', 'jetpack' ) }
-							</SimpleNotice>
-						</a>
-					);
-				}
-				if ( 'is-working' === this.props.status ) {
-					toggle = (
-						<span className="jp-dash-item__active-label">{ __( 'Active', 'jetpack' ) }</span>
-					);
-				}
-			}
 
 			if ( 'rewind' === this.props.module ) {
 				toggle = null;

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/index.jsx
@@ -12,7 +12,7 @@ import SupportInfo from 'components/support-info';
 import analytics from 'lib/analytics';
 import ProStatus from 'pro-status';
 import { isOfflineMode } from 'state/connection';
-import { getSiteRawUrl, getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
+import { getSiteAdminUrl, userCanManageModules } from 'state/initial-state';
 import { getModule as _getModule } from 'state/modules';
 
 export class DashItem extends Component {
@@ -143,7 +143,6 @@ export default connect( state => {
 		getModule: module_name => _getModule( state, module_name ),
 		isOfflineMode: isOfflineMode( state ),
 		userCanToggle: userCanManageModules( state ),
-		siteRawUrl: getSiteRawUrl( state ),
 		siteAdminUrl: getSiteAdminUrl( state ),
 	};
 } )( withModuleSettingsFormHelpers( DashItem ) );

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -1,4 +1,3 @@
-@use "sass:color";
 @use "../../scss/functions/rem";
 @use "../../scss/calypso-colors";
 @use "../../scss/mixins/ui";
@@ -134,15 +133,6 @@
 			color: colors.$gray-text-min;
 		}
 	}
-}
-
-.jp-dash-item__active-label {
-	display: inline-block;
-	color: color.adjust(colors.$gray, $lightness: -10%);
-	color: colors.$gray;
-	font-size: rem.convert(12px);
-	font-weight: 400;
-	text-transform: uppercase;
 }
 
 // conditional styles for content when items are inactive

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/test/component.jsx
@@ -171,50 +171,6 @@ describe( 'DashItem', () => {
 		} );
 	} );
 
-	describe( 'if this is the DashItem for Manage module', () => {
-		const manageProps = {
-			label: 'Manage',
-			module: 'manage',
-			status: 'is-warning',
-			pro: false,
-			isOfflineMode: false,
-			userCanToggle: true,
-			siteAdminUrl: 'https://example.org/wp-admin/',
-			siteRawUrl: 'example.org',
-			getOptionValue: () => true,
-			isUpdating: () => false,
-		};
-
-		it( "shows a warning badge when status is 'is-warning'", () => {
-			const { container } = render( <DashItem { ...manageProps } />, {
-				initialState: buildInitialState(),
-			} );
-			// eslint-disable-next-line testing-library/no-container
-			expect( container.querySelector( '.dops-notice.is-warning' ) ).toBeInTheDocument();
-		} );
-
-		it( 'when it is activated, the warning badge is linked to Plugins screen in WordPress.com', () => {
-			const { container } = render( <DashItem { ...manageProps } />, {
-				initialState: buildInitialState(),
-			} );
-			// eslint-disable-next-line testing-library/no-container
-			const node = container.querySelector( '.dops-notice.is-warning' ).closest( 'a' );
-			expect( node ).toBeInTheDocument();
-			expect( node ).toHaveAttribute(
-				'href',
-				getRedirectUrl( 'calypso-plugins-manage', { site: manageProps.siteRawUrl } )
-			);
-		} );
-
-		it( "when status is 'is-working', the warning badge has an 'active' label", () => {
-			const { container } = render( <DashItem { ...manageProps } status="is-working" />, {
-				initialState: buildInitialState(),
-			} );
-			// eslint-disable-next-line testing-library/no-container
-			expect( container.querySelector( '.jp-dash-item__active-label' ) ).toBeInTheDocument();
-		} );
-	} );
-
 	describe( 'if this is the DashItem for Monitor module', () => {
 		const monitorProps = {
 			module: 'monitor',

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/test/component.jsx
@@ -49,7 +49,6 @@ describe( 'DashItem', () => {
 		href: getRedirectUrl( 'jetpack' ),
 		userCanToggle: true,
 		siteAdminUrl: 'https://example.org/wp-admin/',
-		siteRawUrl: 'example.org',
 		getOptionValue: () => true,
 		isUpdating: () => false,
 	};
@@ -180,7 +179,6 @@ describe( 'DashItem', () => {
 			isOfflineMode: false,
 			userCanToggle: true,
 			siteAdminUrl: 'https://example.org/wp-admin/',
-			siteRawUrl: 'example.org',
 			getOptionValue: () => true,
 			isUpdating: () => false,
 		};

--- a/projects/plugins/jetpack/changelog/remove-dash-item-manage-branch
+++ b/projects/plugins/jetpack/changelog/remove-dash-item-manage-branch
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Removes unreachable code; no user-facing change.
+
+


### PR DESCRIPTION
## Proposed changes

`DashItem` carries a branch for `module="manage"` that replaces the module toggle with either an "Updates needed" badge or an "Active" label. It is unreachable.

* Nothing in the plugin passes `module="manage"`. The only occurrence outside the component is the test fixture.
* The two dynamic call sites, `at-a-glance/backups.jsx` and `at-a-glance/scan.jsx`, take `props.feature`, and the only `feature=` passed anywhere in At a Glance is `jetpack_videopress`.
* `PluginDashItem` shares part of the name but renders a different component.
* The file already documents why: `// Avoid toggle for manage as it's no longer a module`. Manage was retired as a module and this branch outlived it.

Removing it also retires `DashItem`'s `SimpleNotice`, `getRedirectUrl` and `__` imports, so the component is no longer a notice consumer at all.

A second commit clears what the deletion orphaned, all of it confirmed unreferenced rather than assumed:

* `.jp-dash-item__active-label` in `dash-item/style.scss` — the removed span was its only consumer. That rule was also the file's only `color.adjust` call, so `@use "sass:color"` goes with it.
* `siteRawUrl` in `mapStateToProps`, and `getSiteRawUrl` from the import. `siteAdminUrl` stays — `ProStatus` still uses it.
* The two matching `siteRawUrl` keys in the test fixtures, so they agree with the component.

## Related product discussion/links

* Found while reviewing #52015, which migrates every Jetpack admin notice to the `@wordpress/ui` `Notice`. This branch was the sole call site of `SimpleNotice`'s `isCompact` prop, which the design system has no equivalent for — so it was listed there as an open design decision. It is not one; there is nothing to look at.
* Deliberately kept out of #52015 to avoid holding that PR up. **Landing this one first is the tidier order** — both touch `dash-item/test/component.jsx`, and if this merges first, the assertions #52015 had to update disappear with the tests.
* #52056 makes these component tests run in CI. They currently run in neither suite.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

There is no user-facing change to verify, because the code never ran. What is worth checking is that nothing else did reach it:

* `git grep -n "manage" projects/plugins/jetpack/_inc/client --include=*.jsx | grep -E "module\s*[:=]"` returns only the deleted test fixture.
* From `projects/plugins/jetpack`, `pnpm run test-gui` passes — 20 suites, 215 tests.
* `NODE_PATH=tests:_inc/client pnpm exec jest --config=tests/jest.config.gui.js --testMatch='<rootDir>/_inc/client/components/dash-item/test/component.jsx'` passes — 16 tests, 2 skipped. That file does not run in CI today; see #52056.
* Sanity check in a browser: **Jetpack → Dashboard**, confirm the At a Glance cards still render their toggles and status labels as before.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfGbCrDbhYmgwY5hW68VLA

