### PR TITLE
Backup: add a REST endpoint that flushes the object cache

### DIFF
--- a/projects/packages/backup/changelog/jetpack-2546-backup-object-cache-flush
+++ b/projects/packages/backup/changelog/jetpack-2546-backup-object-cache-flush
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add an endpoint that lets WordPress.com flush the object cache after a database restore.

--- a/projects/packages/backup/changelog/jetpack-2546-backup-object-cache-flush
+++ b/projects/packages/backup/changelog/jetpack-2546-backup-object-cache-flush
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add an endpoint that lets WordPress.com flush the object cache after a database restore.
+Add an endpoint for flushing the object cache, which a database restore leaves stale.

--- a/projects/packages/backup/src/class-rest-controller.php
+++ b/projects/packages/backup/src/class-rest-controller.php
@@ -784,7 +784,7 @@ class REST_Controller {
 	 * @access public
 	 * @static
 	 *
-	 * @return \WP_REST_Response Whether the cache was flushed, and why it was not when it was skipped.
+	 * @return \WP_REST_Response Whether the cache was flushed, carrying a `reason` whenever it was not.
 	 */
 	public static function flush_object_cache() {
 		if ( ! wp_using_ext_object_cache() ) {
@@ -796,7 +796,18 @@ class REST_Controller {
 			);
 		}
 
-		return rest_ensure_response( array( 'flushed' => (bool) wp_cache_flush() ) );
+		// Core documents false as the only failure signal, so a drop-in whose
+		// flush() returns nothing must not be reported as a failed flush.
+		if ( false === wp_cache_flush() ) {
+			return rest_ensure_response(
+				array(
+					'flushed' => false,
+					'reason'  => 'flush_failed',
+				)
+			);
+		}
+
+		return rest_ensure_response( array( 'flushed' => true ) );
 	}
 
 	/**

--- a/projects/packages/backup/src/class-rest-controller.php
+++ b/projects/packages/backup/src/class-rest-controller.php
@@ -34,7 +34,9 @@ use function is_wp_error;
 use function register_rest_route;
 use function rest_authorization_required_code;
 use function rest_ensure_response;
+use function wp_cache_flush;
 use function wp_remote_retrieve_response_code;
+use function wp_using_ext_object_cache;
 
 /**
  * Registers the REST routes for Backup.
@@ -229,6 +231,17 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => __CLASS__ . '::get_site_backup_preflight',
 				'permission_callback' => __NAMESPACE__ . '\Jetpack_Backup::backups_permissions_callback',
+			)
+		);
+
+		// Flush the object cache, which a database restore leaves stale.
+		register_rest_route(
+			'jetpack/v4',
+			'/site/cache/flush',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => __CLASS__ . '::flush_object_cache',
+				'permission_callback' => __CLASS__ . '::backup_permissions_callback',
 			)
 		);
 	}
@@ -759,6 +772,31 @@ class REST_Controller {
 
 		$body = json_decode( $response['body'], true );
 		return rest_ensure_response( $body );
+	}
+
+	/**
+	 * Flush the object cache.
+	 *
+	 * A database restore writes MySQL directly and never tells WordPress, so
+	 * a site with a persistent cache keeps serving pre-restore rows until
+	 * something busts it.
+	 *
+	 * @access public
+	 * @static
+	 *
+	 * @return \WP_REST_Response Whether the cache was flushed, and why it was not when it was skipped.
+	 */
+	public static function flush_object_cache() {
+		if ( ! wp_using_ext_object_cache() ) {
+			return rest_ensure_response(
+				array(
+					'flushed' => false,
+					'reason'  => 'no_ext_object_cache',
+				)
+			);
+		}
+
+		return rest_ensure_response( array( 'flushed' => (bool) wp_cache_flush() ) );
 	}
 
 	/**

--- a/projects/packages/backup/tests/php/REST_Controller_Test.php
+++ b/projects/packages/backup/tests/php/REST_Controller_Test.php
@@ -27,11 +27,14 @@ use function add_action;
 use function add_filter;
 use function do_action;
 use function remove_filter;
+use function wp_cache_get;
+use function wp_cache_set;
 use function wp_delete_file;
 use function wp_insert_post;
 use function wp_insert_user;
 use function wp_json_encode;
 use function wp_set_current_user;
+use function wp_using_ext_object_cache;
 
 require_once __DIR__ . '/trait-wpcom-request-mock.php';
 
@@ -54,6 +57,20 @@ class REST_Controller_Test extends TestCase {
 	private $admin_id;
 
 	/**
+	 * The object cache in place before a test swapped in a stub drop-in.
+	 *
+	 * @var \WP_Object_Cache
+	 */
+	private $real_object_cache;
+
+	/**
+	 * Whether the site reported a persistent object cache before a test flipped it.
+	 *
+	 * @var bool|null
+	 */
+	private $was_using_ext_object_cache;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
@@ -70,6 +87,9 @@ class REST_Controller_Test extends TestCase {
 			)
 		);
 		wp_set_current_user( 0 );
+
+		$this->real_object_cache          = $GLOBALS['wp_object_cache'];
+		$this->was_using_ext_object_cache = wp_using_ext_object_cache();
 
 		// Register REST routes.
 		add_action( 'rest_api_init', array( 'Automattic\\Jetpack\\Backup\\V0005\\REST_Controller', 'register_rest_routes' ) );
@@ -94,6 +114,11 @@ class REST_Controller_Test extends TestCase {
 			$_GET['signature'],
 			$_SERVER['REQUEST_METHOD']
 		);
+
+		$GLOBALS['wp_object_cache'] = $this->real_object_cache;
+
+		// Cast: passing null would read the flag rather than restore it.
+		wp_using_ext_object_cache( (bool) $this->was_using_ext_object_cache );
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();
@@ -690,14 +715,13 @@ class REST_Controller_Test extends TestCase {
 
 	/**
 	 * Without a persistent cache there is nothing stale to bust, so the route
-	 * says so rather than reporting a flush it never performed.
+	 * skips the flush and says why.
 	 */
 	public function test_flush_object_cache_skips_a_site_without_a_persistent_cache() {
-		$was_using = wp_using_ext_object_cache( false );
+		wp_using_ext_object_cache( false );
+		wp_cache_set( 'jetpack_2546', 'survives' );
 
-		$response = $this->dispatch_request_signed_with_blog_token( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
-
-		wp_using_ext_object_cache( $was_using );
+		$response = $this->dispatch_flush();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame(
@@ -707,22 +731,103 @@ class REST_Controller_Test extends TestCase {
 			),
 			$response->get_data()
 		);
+		$this->assertSame( 'survives', wp_cache_get( 'jetpack_2546' ), 'The cache should have been left alone.' );
 	}
 
 	/**
-	 * With a persistent cache the route flushes and reports what it got back.
+	 * With a persistent cache the route empties it, rather than merely saying so.
 	 *
-	 * The absent `reason` is the assertion that matters: it separates a real
-	 * flush from the skip above, which also reports `flushed` as false.
+	 * The witness key is the point: without it this passes just as happily
+	 * against a route that reports success and flushes nothing.
 	 */
-	public function test_flush_object_cache_flushes_a_persistent_cache() {
-		$was_using = wp_using_ext_object_cache( true );
+	public function test_flush_object_cache_empties_a_persistent_cache() {
+		wp_using_ext_object_cache( true );
+		wp_cache_set( 'jetpack_2546', 'stale' );
 
-		$response = $this->dispatch_request_signed_with_blog_token( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
-
-		wp_using_ext_object_cache( $was_using );
+		$response = $this->dispatch_flush();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame( array( 'flushed' => true ), $response->get_data() );
+		$this->assertFalse( wp_cache_get( 'jetpack_2546' ), 'The cache should have been emptied.' );
+	}
+
+	/**
+	 * A drop-in that declines to flush is reported as a failure, with a reason.
+	 *
+	 * Shared Memcached setups sometimes disable flushing so one site cannot
+	 * empty its neighbours', and that refusal is invisible to WordPress.com
+	 * unless the route forwards it.
+	 */
+	public function test_flush_object_cache_reports_a_drop_in_that_declines() {
+		wp_using_ext_object_cache( true );
+		$this->arrange_object_cache_drop_in( false );
+
+		$response = $this->dispatch_flush();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'flushed' => false,
+				'reason'  => 'flush_failed',
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * A drop-in whose flush() returns nothing counts as a success.
+	 *
+	 * Core documents false as the only failure signal, so casting the return
+	 * to bool would report a working flush as a failed one.
+	 */
+	public function test_flush_object_cache_treats_a_void_drop_in_return_as_success() {
+		wp_using_ext_object_cache( true );
+		$this->arrange_object_cache_drop_in( null );
+
+		$response = $this->dispatch_flush();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( array( 'flushed' => true ), $response->get_data() );
+	}
+
+	/**
+	 * Dispatch a flush request signed with the blog token.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function dispatch_flush() {
+		return $this->dispatch_request_signed_with_blog_token( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
+	}
+
+	/**
+	 * Stand a drop-in in for the object cache, so its flush() answer can be chosen.
+	 *
+	 * Subclassed rather than faked outright: the signed dispatch reads and
+	 * writes the cache on its way to the callback.
+	 *
+	 * @param mixed $result What the drop-in's flush() hands back.
+	 */
+	private function arrange_object_cache_drop_in( $result ) {
+		$cache = new class() extends \WP_Object_Cache {
+			/**
+			 * What flush() hands back.
+			 *
+			 * @var mixed
+			 */
+			public $flush_result;
+
+			/**
+			 * Stand in for a drop-in's flush().
+			 *
+			 * @return mixed
+			 */
+			public function flush() {
+				return $this->flush_result;
+			}
+		};
+
+		$cache->flush_result = $result;
+
+		$GLOBALS['wp_object_cache'] = $cache;
 	}
 }

--- a/projects/packages/backup/tests/php/REST_Controller_Test.php
+++ b/projects/packages/backup/tests/php/REST_Controller_Test.php
@@ -672,4 +672,57 @@ class REST_Controller_Test extends TestCase {
 		$this->assertSame( 'plugin__updated', $data['last_rewindable_event']['name'] );
 		$this->assertSame( '1786600000.11', $data['undo_backup_id'] );
 	}
+
+	/**
+	 * The flush route is site-level only, like the rest of this controller.
+	 *
+	 * An administrator's own session is not a blog token, so widening the
+	 * callback to reach it would hand every admin a site-wide cache flush.
+	 */
+	public function test_flush_object_cache_rejects_an_administrator() {
+		wp_set_current_user( $this->admin_id );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
+
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'You are not allowed to perform this action.', $response->get_data()['message'] );
+	}
+
+	/**
+	 * Without a persistent cache there is nothing stale to bust, so the route
+	 * says so rather than reporting a flush it never performed.
+	 */
+	public function test_flush_object_cache_skips_a_site_without_a_persistent_cache() {
+		$was_using = wp_using_ext_object_cache( false );
+
+		$response = $this->dispatch_request_signed_with_blog_token( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
+
+		wp_using_ext_object_cache( $was_using );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame(
+			array(
+				'flushed' => false,
+				'reason'  => 'no_ext_object_cache',
+			),
+			$response->get_data()
+		);
+	}
+
+	/**
+	 * With a persistent cache the route flushes and reports what it got back.
+	 *
+	 * The absent `reason` is the assertion that matters: it separates a real
+	 * flush from the skip above, which also reports `flushed` as false.
+	 */
+	public function test_flush_object_cache_flushes_a_persistent_cache() {
+		$was_using = wp_using_ext_object_cache( true );
+
+		$response = $this->dispatch_request_signed_with_blog_token( new WP_REST_Request( 'POST', '/jetpack/v4/site/cache/flush' ) );
+
+		wp_using_ext_object_cache( $was_using );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( array( 'flushed' => true ), $response->get_data() );
+	}
 }


### PR DESCRIPTION
Part of JETPACK-2546 — deliberately not `Fixes`, because the change is only complete once the WordPress.com side lands too.

## Proposed changes
* Adds `POST jetpack/v4/site/cache/flush` to the Backup package's always-on REST controller (`src/class-rest-controller.php`, not the modernization-gated `src/rest/` one).
* Blog-token only, via the existing `backup_permissions_callback` — WordPress.com can call it, an administrator's own browser session cannot.
* Skips the flush and says why when `wp_using_ext_object_cache()` is false, since a non-persistent cache dies with the request anyway and there is nothing stale to bust.

### Why

A VaultPress restore writes MySQL directly and never tells WordPress, so it does not invalidate the object cache. On a host with a persistent object cache the site keeps serving pre-restore rows: the dashboard, the Pages list and the REST API all still show the *old* content while the database underneath has already been reverted.

That makes a **successful restore indistinguishable from one that silently did nothing** — the worst possible impression of the product's most consequential feature, at the moment the user is already anxious. It is not limited to posts either: a database restore reverts `wp_options` including `alloptions`, and different cache keys expire at different times, so the site can sit in a partially restored state.

This is the Jetpack half of the handshake. WordPress.com already knows when a restore reaches `finished` and already holds the Jetpack connection, so it is the natural place to trigger from; the endpoint to trigger simply did not exist yet. **Until the WordPress.com side lands, this route is inert** — nothing in Jetpack calls it.

### Response shape

| Situation | Response |
| --- | --- |
| No persistent object cache | `{ "flushed": false, "reason": "no_ext_object_cache" }` |
| Flushed | `{ "flushed": true }` |
| Drop-in declined to flush | `{ "flushed": false, "reason": "flush_failed" }` |

Every `flushed: false` carries a `reason`, so the caller never has to infer one from a missing key. `wp_cache_flush()` is not universally effective — some drop-ins make it a no-op, and on shared Memcached it is sometimes disabled so one site cannot flush its neighbours — and `flush_failed` is how that surfaces instead of passing silently. That distinction is the point of the endpoint's logging value: it answers "does flushing actually work on this host" from real traffic.

**Two caveats for whoever writes the WordPress.com side:**

* `flushed: true` means the drop-in reported success, not that the persistent store is provably empty — some drop-ins clear only the runtime cache.
* A site running an older bundled copy of `jetpack-backup` will not have this route at all and answers **404**. Treat that as "skip", not "error".

## Related product discussion/links
* JETPACK-2546

## Does this pull request change what data or activity we track or use?

No. The endpoint reads no data, stores nothing, and sends nothing anywhere; it only discards a local cache.

## Testing instructions

**Automated**

* `jp test php packages/backup` — 424 tests pass, including five new ones: the 403 for a logged-in admin, the skip when there is no persistent cache, the flush when there is (asserted via a witness key that must vanish), a drop-in that declines to flush, and a drop-in whose `flush()` returns nothing.

**Registration and auth**, on any Jetpack-connected site with this branch:

1. As an administrator in `wp-admin`, open the browser console and run:
   ```js
   wp.apiFetch( { path: '/jetpack/v4/site/cache/flush', method: 'POST' } )
   ```
2. It should **reject** with a 403 and `You are not allowed to perform this action.` That is the expected, correct result — the route is site-level only, so a browser session must not reach it.

**Behaviour**, exercising the callback directly (bypasses auth, which is what makes it testable without WordPress.com):

3. On a site with no persistent object cache:
   ```bash
   wp eval 'var_dump( \Automattic\Jetpack\Backup\V0005\REST_Controller::flush_object_cache()->get_data() );'
   ```
   Expect `['flushed' => false, 'reason' => 'no_ext_object_cache']`.
4. Activate an object-cache drop-in (Redis Object Cache or Memcached both work) so `wp_using_ext_object_cache()` returns true, then re-run the same command. Expect `['flushed' => true]`.

<sup>The `V0005` segment is the package's current namespace version; if this branch is rebased past a bump, adjust it.</sup>

**End to end** — not yet possible from this PR alone, and worth stating plainly: it needs the WordPress.com change that calls this route. Once that exists, the check is to edit a post on a site with a persistent object cache, restore to a backup from before the edit, and confirm the site shows the reverted content without anyone manually flushing anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rfhDyjzLPxbhsch9YibKP
