### PR TITLE
Premium Analytics: match the Stats header logo to 20px

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-stats-header-logo-20px
+++ b/projects/packages/premium-analytics/changelog/add-stats-header-logo-20px
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Match the Jetpack logo in the Stats header to the 20px size used by the other Jetpack admin pages.

--- a/projects/packages/premium-analytics/packages/ui/src/stats-page-icon/stats-page-icon.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/stats-page-icon/stats-page-icon.tsx
@@ -5,5 +5,5 @@ import { Icon } from '@jetpack-premium-analytics/externals';
 import { jetpack } from '@jetpack-premium-analytics/icons';
 
 export function StatsPageIcon() {
-	return <Icon icon={ jetpack } size={ 24 } />;
+	return <Icon icon={ jetpack } size={ 20 } />;
 }

--- a/projects/plugins/jetpack/changelog/add-stats-header-logo-20px
+++ b/projects/plugins/jetpack/changelog/add-stats-header-logo-20px
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Match the Jetpack logo in the Stats header to the 20px size used by the other Jetpack admin pages.

--- a/projects/plugins/premium-analytics/changelog/add-stats-header-logo-20px
+++ b/projects/plugins/premium-analytics/changelog/add-stats-header-logo-20px
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Match the Jetpack logo in the Stats header to the 20px size used by the other Jetpack admin pages.


### PR DESCRIPTION
Fixes N/A

## Proposed changes
* The Jetpack logo in the Stats header rendered at 24px, while every other Jetpack admin page renders it at 20px — `AdminPage` passes `height={ 20 }` into the same admin-ui header `visual` slot. `StatsPageIcon` hardcoded `size={ 24 }`, so the Stats header sat a few pixels off from the rest of the Jetpack menu. The design mock uses 20px too, so this drops ours to match. It is one shared component, so every page built on the Stats shell — dashboard, report pages, post and video detail — picks it up.

## Related product discussion/links
* p1788763926271309-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build and activate Premium Analytics: `jp build plugins/premium-analytics --deps`.
* Open Jetpack → My Jetpack and look at the logo left of the "Jetpack" title. That is the 20px size this matches.
* Open Stats v2 → Traffic. The logo left of the "Stats" title is the same size now, and the title, tab strip and header height do not move.
* Check a report page (Traffic → Top posts & pages → View all) and a post detail page — they share the same header icon.

| State | Stats header |
|---|---|
| Before | ![before](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/stats-header-logo-20px/before-header.png) |
| After | ![after](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/stats-header-logo-20px/after-header.png) |
| My Jetpack, for reference | ![reference](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/stats-header-logo-20px/reference-header.png) |
