### PR TITLE
VideoPress: refine the welcome modal type scale and match the dropzone text to the design system empty state

### DIFF
--- a/projects/packages/videopress/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/packages/videopress/changelog/update-vp-welcome-modal-type-scale
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Welcome modal: body copy stepped up to the design system's lg size with the lede in the same colour as the value cards, and the dialog now sits at true center; upload dropzone text now matches the design system's empty state.
+Welcome modal: body copy stepped up to the design system's lg size with the lede in the same colour as the value cards, and the dialog now sits at true center. Library: the upload dropzone text matches the design system's empty state, and the header's Upload button steps aside while that dropzone is the only thing to upload into.

--- a/projects/packages/videopress/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/packages/videopress/changelog/update-vp-welcome-modal-type-scale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Welcome modal: body copy stepped up to the design system's lg size with the lede in the same colour as the value cards, and the dialog now sits at true center; upload dropzone text now matches the design system's empty state.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -404,6 +404,20 @@ const StageInner = () => {
 		/>
 	);
 
+	// The empty-library verdict, in the same order the viewport decides it
+	// below: a failed listing wins, then anything listable (fetched rows or
+	// in-flight uploads), then the undecided wait, and only then does a
+	// settled count of zero mean "empty". Shared with the header, which
+	// drops its Upload button while the dropzone owns that affordance —
+	// "Upload video" beside "Select a video to upload" was two buttons for
+	// one action.
+	const showsEmptyDropzone =
+		! isError &&
+		items.length === 0 &&
+		uploadQueue.length === 0 &&
+		totalPagination !== undefined &&
+		totalPagination.totalItems === 0;
+
 	// The viewport's four mutually exclusive surfaces, flattened out of
 	// nested ternaries so each branch can say why it exists. Order matters:
 	// error first, then anything already listable, then the undecided wait,
@@ -454,10 +468,11 @@ const StageInner = () => {
 		// An empty library gets an upload dropzone instead of DataViews'
 		// "No results" — a first-video invitation rather than a failed
 		// search. Dropping or picking files lands in the same
-		// `handleFilesSelected` pipeline as the page-wide DropZone and the
-		// header button, so the listing (with its spliced in-flight rows)
-		// takes over the moment anything enters the queue.
-		if ( totalPagination.totalItems === 0 ) {
+		// `handleFilesSelected` pipeline as the page-wide DropZone (and the
+		// header's Upload button, once the listing shows), so the listing
+		// (with its spliced in-flight rows) takes over the moment anything
+		// enters the queue.
+		if ( showsEmptyDropzone ) {
 			return (
 				<div className="vp-library__empty-state">
 					<Card.Root className="vp-library__empty-card">
@@ -492,35 +507,37 @@ const StageInner = () => {
 			activeTab="library"
 			hideFooter
 			actions={
-				<>
-					<input
-						ref={ filePickerRef }
-						type="file"
-						accept="video/*"
-						// The capped free tier can only ever host `limit` videos, so
-						// multi-select there would only produce skipped-file notices;
-						// paid and grandfathered-unlimited plans get bulk selection.
-						multiple={ ! isFree || isUnlimited }
-						style={ { display: 'none' } }
-						onChange={ onFilePicked }
-					/>
-					<Tooltip
-						text={
-							isAtLimit
-								? FREE_TIER_AT_LIMIT_MESSAGE
-								: __( 'Upload a new video', 'jetpack-videopress-pkg' )
-						}
-					>
-						<Button
-							className="vp-library__upload-button"
-							size="compact"
-							onClick={ onClickHeaderUpload }
-							aria-disabled={ isAtLimit }
+				showsEmptyDropzone ? undefined : (
+					<>
+						<input
+							ref={ filePickerRef }
+							type="file"
+							accept="video/*"
+							// The capped free tier can only ever host `limit` videos, so
+							// multi-select there would only produce skipped-file notices;
+							// paid and grandfathered-unlimited plans get bulk selection.
+							multiple={ ! isFree || isUnlimited }
+							style={ { display: 'none' } }
+							onChange={ onFilePicked }
+						/>
+						<Tooltip
+							text={
+								isAtLimit
+									? FREE_TIER_AT_LIMIT_MESSAGE
+									: __( 'Upload a new video', 'jetpack-videopress-pkg' )
+							}
 						>
-							{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
-						</Button>
-					</Tooltip>
-				</>
+							<Button
+								className="vp-library__upload-button"
+								size="compact"
+								onClick={ onClickHeaderUpload }
+								aria-disabled={ isAtLimit }
+							>
+								{ __( 'Upload video', 'jetpack-videopress-pkg' ) }
+							</Button>
+						</Tooltip>
+					</>
+				)
 			}
 		>
 			{ isAtLimit && (

--- a/projects/packages/videopress/routes/library/test/stage.test.tsx
+++ b/projects/packages/videopress/routes/library/test/stage.test.tsx
@@ -135,6 +135,9 @@ describe( 'library stage empty state', () => {
 		expect( screen.getByText( 'Upload your first video' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Drag and drop your videos here' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'dataviews' ) ).not.toBeInTheDocument();
+		// The dropzone is the upload affordance here; the header must not
+		// offer a second button for the same action.
+		expect( screen.queryByRole( 'button', { name: 'Upload video' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps the listing while videos exist', () => {
@@ -142,6 +145,7 @@ describe( 'library stage empty state', () => {
 
 		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
 		expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Upload video' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'hands the surface to the listing the moment an upload is queued', () => {
@@ -157,6 +161,7 @@ describe( 'library stage empty state', () => {
 
 		expect( screen.queryByText( 'Upload your first video' ) ).not.toBeInTheDocument();
 		expect( screen.getByTestId( 'dataviews' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Upload video' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'never masks a failed listing request with the empty state', () => {

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/index.tsx
@@ -421,12 +421,10 @@ export default function OnboardingModal(): ReactElement | null {
 
 				<Dialog.Content className="vp-onboarding-modal__body">
 					{ /*
-					 * Title and lede render at the design system's own dialog
-					 * type scale. The Figma spec drew them larger (32px/15px),
-					 * but Dialog.Title/Description expose no size variant, and
-					 * overriding their internals is not a stable API — if the
-					 * larger scale is wanted back, the ask is a variant prop on
-					 * the components, not a local override.
+					 * The title renders at Dialog.Title's own heading-xl. The
+					 * lede carries a class name because Dialog.Description pins
+					 * body-md and exposes no variant; the stylesheet lifts it to
+					 * body-lg from design-system tokens to match the card bodies.
 					 */ }
 					<Dialog.Title>
 						{ __( 'Your Video. Your Player.', 'jetpack-videopress-pkg' ) }
@@ -454,7 +452,7 @@ export default function OnboardingModal(): ReactElement | null {
 									{ card.title }
 								</Text>
 								<Text
-									variant="body-md"
+									variant="body-lg"
 									render={ <span /> }
 									className="vp-onboarding-modal__card-body"
 								>

--- a/projects/packages/videopress/src/dashboard/components/onboarding-modal/style.scss
+++ b/projects/packages/videopress/src/dashboard/components/onboarding-modal/style.scss
@@ -20,10 +20,6 @@
 		border: var(--wpds-border-width-xs) solid CanvasText;
 	}
 
-	// A touch above true center: dialog convention weights the empty space
-	// toward the bottom, and the band-heavy layout reads better lifted.
-	inset-block-start: 42%;
-
 	// The video sits flush to the popup's top corners, above the padded body.
 	// `Dialog.Popup` is `overflow: hidden`, so the band inherits its radius.
 	&__media {
@@ -104,13 +100,29 @@
 		container-type: inline-size;
 	}
 
-	// Title and lede type comes from Dialog.Title/Description's own variants —
-	// no size overrides (the design system's internals are not a stable API to
-	// override; if the Figma spec's larger scale returns, the ask is a variant
-	// prop on the components). The lede runs the full modal width;
-	// `text-wrap: pretty` keeps its second line from breaking mid-phrase.
-	&__lede {
+	// Dialog.Description exposes no size variant (it pins body-md), so the lede
+	// takes its scale from the design system's tokens here. The selector names
+	// the element and sits under `__body` on purpose: the design system ships
+	// an unlayered, element-scoped guard rule (`p.…`, specificity 0,1,1) that
+	// sets font-size and line-height on paragraphs, and a lone class loses to
+	// it. `__body p.__lede` is 0,2,1 and wins. The title stays at
+	// Dialog.Title's own heading-xl.
+
+	// The lede matches the card bodies' `body-lg` variant: lg size on the md
+	// line-height (15px/24px). `text-wrap: pretty` keeps its last line from
+	// breaking mid-phrase.
+	&__body p.vp-onboarding-modal__lede {
+		font-size: var(--wpds-typography-font-size-lg);
+		line-height: var(--wpds-typography-line-height-md);
 		text-wrap: pretty;
+	}
+
+	// Both paragraphs on the weak foreground: Dialog.Description otherwise
+	// inherits the popup's strong content colour, and the lede and the card
+	// bodies read as different voices.
+	&__lede,
+	&__card-body {
+		color: var(--wpds-color-foreground-content-neutral-weak);
 	}
 
 	// Three equal columns; the hairlines between them are drawn as centered
@@ -171,10 +183,6 @@
 	&__card-title {
 		margin-block-end: var(--wpds-dimension-gap-xs);
 		color: var(--wpds-color-foreground-content-neutral);
-	}
-
-	&__card-body {
-		color: var(--wpds-color-foreground-content-neutral-weak);
 	}
 
 	&__footer {

--- a/projects/packages/videopress/src/dashboard/components/upload-dropzone/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/upload-dropzone/index.tsx
@@ -193,12 +193,17 @@ const UploadDropzone = ( {
 				 * top of the one this surface already has.
 				 */ }
 				<EmptyState.Icon icon={ upload } className="vp-upload-dropzone__icon" />
-				<Text variant="body-lg" className="vp-upload-dropzone__hint">
+				{ /*
+				 * Same type as the design system's own empty state (the
+				 * treatment Jetpack Social's "Auto-sharing is turned off" uses):
+				 * heading-lg for the hint, body-md for the sub copy.
+				 */ }
+				<Text variant="heading-lg" className="vp-upload-dropzone__hint">
 					{ plural
 						? __( 'Drag and drop your videos here', 'jetpack-videopress-pkg' )
 						: __( 'Drag and drop your video here', 'jetpack-videopress-pkg' ) }
 				</Text>
-				<Text variant="body-sm" className="vp-upload-dropzone__sub">
+				<Text variant="body-md" className="vp-upload-dropzone__sub">
 					{ subCopy ??
 						( plural
 							? __(

--- a/projects/plugins/jetpack/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/plugins/jetpack/changelog/update-vp-welcome-modal-type-scale
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-VideoPress: refine the welcome modal type scale and match the upload dropzone text to the design system's empty state.
+VideoPress: refine the welcome modal type scale, match the upload dropzone text to the design system's empty state, and drop the duplicate header Upload button while the empty-library dropzone is showing.

--- a/projects/plugins/jetpack/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/plugins/jetpack/changelog/update-vp-welcome-modal-type-scale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+VideoPress: refine the welcome modal type scale and match the upload dropzone text to the design system's empty state.

--- a/projects/plugins/videopress/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/plugins/videopress/changelog/update-vp-welcome-modal-type-scale
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-VideoPress: refine the welcome modal type scale and match the upload dropzone text to the design system's empty state.
+VideoPress: refine the welcome modal type scale, match the upload dropzone text to the design system's empty state, and drop the duplicate header Upload button while the empty-library dropzone is showing.

--- a/projects/plugins/videopress/changelog/update-vp-welcome-modal-type-scale
+++ b/projects/plugins/videopress/changelog/update-vp-welcome-modal-type-scale
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+VideoPress: refine the welcome modal type scale and match the upload dropzone text to the design system's empty state.


### PR DESCRIPTION
## Proposed changes

Small design polish on the VideoPress welcome modal and the empty Library. Everything uses sizes and colours the design system already has, nothing new.

* **Body copy** in the modal is now one size and one grey. The line under the headline and the three card blurbs all use `body-lg`. Before, the lede was smaller and darker than the cards, so it read like two different voices.
* **Centered modal.** The dialog used to sit a bit high. Now it sits at true center like every other dialog.
* **One upload button** on the empty Library, not two. With the "Upload your first video" box on screen, the header's "Upload video" button steps aside. It comes back as soon as there is a list.
* **Dropzone text** now matches the design system's empty state, same as Social's "Auto-sharing is turned off" screen.

One thing worth knowing: the lede rule in `style.scss` names the element on purpose (`.vp-onboarding-modal__body p.vp-onboarding-modal__lede`). The design system's own paragraph rule beats a plain class, so a simpler selector quietly loses the size. The comment in the file explains why.

The headline stays at the dialog's default 20px. I tried it bigger, but the next step in the scale is 32px and that was too much.

## Related product discussion/links

* Follows #51520 and #51567.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Go to Jetpack → VideoPress. Add `&welcome=1` to the URL if the modal doesn't show.
2. The modal should be centered. The line under the headline and the three card blurbs should be the same size and the same grey.
3. Close it. With no videos, there should be no "Upload video" button in the header, just the upload box.
4. Upload a video, or drop one in. The header button should come back with the list.

Tests: `jetpack test js packages/videopress`.
