### PR TITLE
Jetpack AI: say in the hub when custom code holds the AI module off

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/components/ai-unavailable-notice/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/components/ai-unavailable-notice/index.jsx
@@ -1,0 +1,55 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { ExternalLink } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
+
+/**
+ * Jetpack redirect slug for each reason's support doc.
+ */
+const LEARN_MORE_SLUGS = {
+	host: 'jetpack-ai-hub-docs-wp-supports-ai',
+	forced_off: 'jetpack-ai-hub-docs-module-forced-off',
+};
+
+/**
+ * One message per reason, as separate `__()` calls in a lookup so the
+ * minifier cannot fold them into one call with a non-literal message.
+ *
+ * @param {string} reason - 'host' or 'forced_off'.
+ * @return {string} The message to show.
+ */
+const getMessage = reason => {
+	const messages = {
+		forced_off: __(
+			'Jetpack AI is turned off by custom code running on this site, so it can’t be turned on here.',
+			'jetpack'
+		),
+		host: __( 'Jetpack AI is not available for this site.', 'jetpack' ),
+	};
+
+	return messages[ reason === 'forced_off' ? 'forced_off' : 'host' ];
+};
+
+/**
+ * Notice shown in place of the AI settings when nothing on this page can turn
+ * Jetpack AI on: the host has switched AI off in WordPress, or a filter such
+ * as a module allowlist keeps the `ai` module off.
+ *
+ * @param {object} props        - Component props.
+ * @param {string} props.reason - 'host' or 'forced_off'.
+ * @return {object} Component markup.
+ */
+export default function AiUnavailableNotice( { reason } ) {
+	const slug = LEARN_MORE_SLUGS[ reason ] ?? LEARN_MORE_SLUGS.host;
+
+	return (
+		<Notice.Root intent="warning">
+			<Notice.Description>
+				{ getMessage( reason ) }{ ' ' }
+				<ExternalLink href={ getRedirectUrl( slug ) }>
+					{ __( 'Learn more', 'jetpack' ) }
+				</ExternalLink>
+			</Notice.Description>
+		</Notice.Root>
+	);
+}

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -13,17 +13,13 @@
  * MCP hub as the landing view and no tab bar.
  */
 
-import {
-	AdminPage,
-	GlobalNotices,
-	useGlobalNotices,
-	getRedirectUrl,
-} from '@automattic/jetpack-components';
-import { Spinner, ExternalLink } from '@wordpress/components';
+import { AdminPage, GlobalNotices, useGlobalNotices } from '@automattic/jetpack-components';
+import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
+import AiUnavailableNotice from './components/ai-unavailable-notice';
 import MasterOffNotice from './components/master-off-notice';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
@@ -415,7 +411,8 @@ export default function App() {
 				{ ! masterEnabled &&
 					MASTER_SWITCH_VIEWS.includes( view ) &&
 					aiSettings?.is_connected !== false &&
-					aiSettings?.host_allows_ai !== false && <MasterOffNotice /> }
+					aiSettings?.host_allows_ai !== false &&
+					aiSettings?.master_forced_off !== true && <MasterOffNotice /> }
 
 				{ isMcpContext && (
 					<>
@@ -490,6 +487,7 @@ export default function App() {
 						planName={ planName }
 						isUserConnected={ isUserConnected }
 						hostAllowsAi={ aiSettings?.host_allows_ai }
+						masterForcedOff={ aiSettings?.master_forced_off }
 						// Same preconditions the MCP hub applies to its copy of the
 						// row: the copy promises AI-agent actions, which need MCP.
 						showActivityLog={
@@ -512,15 +510,10 @@ export default function App() {
 
 						{ ! isAiSettingsLoading &&
 							! aiSettingsError &&
-							( aiSettings?.host_allows_ai === false ? (
-								<Notice.Root intent="warning">
-									<Notice.Description>
-										{ __( 'Jetpack AI is not available for this site.', 'jetpack' ) }{ ' ' }
-										<ExternalLink href={ getRedirectUrl( 'jetpack-ai-hub-docs-wp-supports-ai' ) }>
-											{ __( 'Learn more', 'jetpack' ) }
-										</ExternalLink>
-									</Notice.Description>
-								</Notice.Root>
+							( aiSettings?.host_allows_ai === false || aiSettings?.master_forced_off === true ? (
+								<AiUnavailableNotice
+									reason={ aiSettings?.host_allows_ai === false ? 'host' : 'forced_off' }
+								/>
 							) : (
 								<AiFeatures
 									settings={ aiSettings }

--- a/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/index.jsx
@@ -11,6 +11,7 @@ import { useEffect } from '@wordpress/element';
 import { sprintf, __ } from '@wordpress/i18n';
 import { list } from '@wordpress/icons';
 import { Card, Link, LinkButton, Notice, Skeleton, Stack, Text } from '@wordpress/ui';
+import AiUnavailableNotice from '../components/ai-unavailable-notice';
 import NavRow from '../components/nav-row';
 import { EVENTS, recordAiHubEvent, useRecordOnce } from '../tracks';
 import AssistantBanner from './assistant-banner';
@@ -344,6 +345,9 @@ function UsageCard( { upgradeUrl, planName } ) {
  *                                          copy promises AI-agent actions, which need MCP.
  * @param {boolean} [props.hostAllowsAi]    - The host's AI switch; when explicitly false, no
  *                                          usage is shown and no upgrade is ever offered.
+ * @param {boolean} [props.masterForcedOff] - Whether a filter, such as a module allowlist,
+ *                                          keeps the `ai` module off; treated like the host
+ *                                          switch, since nothing here can turn it on.
  * @param {boolean} [props.isUserConnected] - Whether the current user's own WordPress.com
  *                                          account is linked; the usage fetch needs it.
  * @return {object} Component markup.
@@ -355,9 +359,10 @@ export default function AiOverview( {
 	planName,
 	showActivityLog,
 	hostAllowsAi,
+	masterForcedOff,
 	isUserConnected,
 } ) {
-	const hostBlocked = hostAllowsAi === false;
+	const hostBlocked = hostAllowsAi === false || masterForcedOff === true;
 	const userUnlinked = isUserConnected === false;
 	useRecordOnce( EVENTS.VIEWED, { tab: 'overview' } );
 	const recordLinkClick = ( linkType, slug ) => () =>
@@ -371,14 +376,7 @@ export default function AiOverview( {
 			     the wrapper so the outer 3xl gap doesn't double. */ }
 			<Stack direction="column" gap="xl" className="jetpack-ai-overview__intro">
 				{ !! blogId && hostBlocked && (
-					<Notice.Root intent="warning">
-						<Notice.Description>
-							{ __( 'Jetpack AI is not available for this site.', 'jetpack' ) }{ ' ' }
-							<ExternalLink href={ getRedirectUrl( 'jetpack-ai-hub-docs-wp-supports-ai' ) }>
-								{ __( 'Learn more', 'jetpack' ) }
-							</ExternalLink>
-						</Notice.Description>
-					</Notice.Root>
+					<AiUnavailableNotice reason={ hostAllowsAi === false ? 'host' : 'forced_off' } />
 				) }
 				{ !! blogId && ! hostBlocked && userUnlinked && (
 					// The usage endpoint proxies as the current user, so without a

--- a/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/overview/test/component.jsx
@@ -315,6 +315,24 @@ describe( 'AiOverview', () => {
 		expect( screen.getByText( 'Documentation' ) ).toBeInTheDocument();
 	} );
 
+	test( 'module forced off by a filter: its own notice and doc link, no usage fetch', () => {
+		render( <AiOverview { ...PROPS } masterForcedOff={ true } /> );
+
+		expect(
+			screen.getByText(
+				'Jetpack AI is turned off by custom code running on this site, so it can’t be turned on here.',
+				IGNORE_A11Y
+			)
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Available requests' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: /Learn more/ } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'jetpack-ai-hub-docs-module-forced-off' )
+		);
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
 	test( 'host AI off: the notice renders above the assistant banner', () => {
 		dispatch( preferencesStore ).set( 'jetpack/ai', 'assistantBannerDismissed', false );
 		render( <AiOverview { ...PROPS } hostAllowsAi={ false } /> );

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -230,6 +230,23 @@ describe( 'AI admin page (main.jsx)', () => {
 			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
 		} );
 
+		test( 'forced off by a filter: its own notice shows, the My Jetpack link does not', async () => {
+			mockApiFetch( { featureGet: { ...masterOffSettings(), master_forced_off: true } } );
+
+			render( <App /> );
+
+			await expect(
+				screen.findByText(
+					'Jetpack AI is turned off by custom code running on this site, so it can’t be turned on here.',
+					IGNORE_A11Y
+				)
+			).resolves.toBeInTheDocument();
+			expect( screen.queryByText( MASTER_OFF_TITLE, IGNORE_A11Y ) ).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'link', { name: 'Manage in My Jetpack' } )
+			).not.toBeInTheDocument();
+		} );
+
 		test( 'not connected: the connect ask wins over the master-off notice', async () => {
 			mockApiFetch( { featureGet: { ...masterOffSettings(), is_connected: false } } );
 

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -288,6 +288,32 @@ class Jetpack_AI_Settings {
 	}
 
 	/**
+	 * Whether a filter, such as a module allowlist, keeps the `ai` module off,
+	 * so no switch on this site can turn it on. Always false on WordPress.com
+	 * Simple, which runs no modules.
+	 *
+	 * @return bool
+	 */
+	public static function is_master_forced_off() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return false;
+		}
+
+		if ( self::is_master_enabled() ) {
+			return false;
+		}
+
+		// Removed from the available list by `jetpack_get_available_modules`.
+		if ( ! in_array( self::AI_MODULE, ( new Modules() )->get_available(), true ) ) {
+			return true;
+		}
+
+		// Forced off through `option_jetpack_active_modules` or `jetpack_active_modules`.
+		return class_exists( 'Jetpack_Modules_Overrides' )
+			&& 'inactive' === Jetpack_Modules_Overrides::instance()->get_module_override( self::AI_MODULE );
+	}
+
+	/**
 	 * Set the site-wide AI master switch, writing to whichever store backs it on
 	 * this platform (see {@see self::is_master_enabled()}).
 	 *

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -261,6 +261,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 				'is_free_search_plan' => $supports_search && $search_plan->is_free_plan(),
 			),
 			'master_enabled'    => Jetpack_AI_Settings::is_master_enabled(),
+			'master_forced_off' => Jetpack_AI_Settings::is_master_forced_off(),
 			'features'          => array(
 				'writing_assistant' => array( 'enabled' => $stored['writing_assistant'] ),
 				'image_editor'      => array( 'enabled' => $stored['image_editor'] ),

--- a/projects/plugins/jetpack/changelog/add-ai-module-forced-off-notice
+++ b/projects/plugins/jetpack/changelog/add-ai-module-forced-off-notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: compat
+
+Jetpack AI: when a filter such as a module allowlist keeps the AI module off, say so in the AI hub instead of offering a switch that cannot stick.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -94,6 +94,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 
 		remove_filter( 'jetpack_offline_mode', '__return_true' );
 		StatusCache::clear();
+		// Module overrides are cached per request, which spans the whole test run.
+		Jetpack_Modules_Overrides::instance()->clear_cache();
 		\Jetpack_Options::delete_option( array( 'master_user', 'user_tokens' ) );
 		( new Connection_Manager( 'jetpack' ) )->reset_connection_status();
 
@@ -421,6 +423,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertTrue( $data['host_allows_ai'] );
 		$this->assertTrue( $data['master_enabled'] );
+		$this->assertFalse( $data['master_forced_off'] );
 		$this->assertArrayHasKey( 'is_connected', $data );
 		$this->assertArrayHasKey( 'is_user_connected', $data );
 		$this->assertArrayHasKey( 'supports_ai', $data['plan'] );
@@ -625,6 +628,21 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		$this->assertFalse( $data['master_enabled'] );
 		$this->assertFalse( ( new Modules() )->is_active( 'ai' ), 'The setter routed the write to the ai module.' );
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
+	}
+
+	/**
+	 * A filter that holds the `ai` module off is reported separately from the host gate.
+	 */
+	public function test_master_forced_off_when_a_filter_holds_the_module_off() {
+		wp_set_current_user( self::$admin_id );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		self::set_ai_module_active( false );
+
+		$data = $this->dispatch( 'GET' )->get_data();
+
+		$this->assertFalse( $data['master_enabled'] );
+		$this->assertTrue( $data['master_forced_off'] );
+		$this->assertTrue( $data['host_allows_ai'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -58,6 +58,23 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Filter that keeps `ai` out of the active list, as an allowlist would.
+	 *
+	 * @var callable|null
+	 */
+	private $force_ai_inactive_filter = null;
+
+	/**
+	 * Filter `ai` out of the active module list.
+	 */
+	private function force_ai_module_inactive() {
+		$this->force_ai_inactive_filter = static function ( $modules ) {
+			return array_values( array_diff( (array) $modules, array( 'ai' ) ) );
+		};
+		add_filter( 'jetpack_active_modules', $this->force_ai_inactive_filter );
+	}
+
+	/**
 	 * Make the current request look like WordPress.com Atomic.
 	 */
 	private function force_atomic_site() {
@@ -87,6 +104,11 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		remove_filter( 'jetpack_ai_enabled', '__return_true', 11 );
 		remove_filter( 'jetpack_is_connection_ready', '__return_true' );
 
+		if ( $this->force_ai_inactive_filter !== null ) {
+			remove_filter( 'jetpack_active_modules', $this->force_ai_inactive_filter );
+			$this->force_ai_inactive_filter = null;
+		}
+		Jetpack_Modules_Overrides::instance()->clear_cache();
 		if ( $this->force_ai_active_filter !== null ) {
 			remove_filter( 'jetpack_active_modules', $this->force_ai_active_filter );
 			$this->force_ai_active_filter = null;
@@ -256,6 +278,80 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
 		$this->force_ai_module_active();
 		$this->assertTrue( Jetpack_AI_Settings::is_master_enabled(), 'An active module means master on even with the option off.' );
+	}
+
+	/**
+	 * A filter that strips `ai` from the active list forces it off.
+	 */
+	public function test_master_forced_off_when_a_filter_removes_the_module() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		$this->force_ai_module_inactive();
+
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'Precondition: the filter reports the master off.' );
+		$this->assertTrue( Jetpack_AI_Settings::is_master_forced_off() );
+	}
+
+	/**
+	 * The filter is caught even when the stored list never had `ai`.
+	 */
+	public function test_master_forced_off_when_a_filter_removes_the_module_never_stored() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+		$this->force_ai_module_inactive();
+
+		$this->assertTrue( Jetpack_AI_Settings::is_master_forced_off() );
+	}
+
+	/**
+	 * A filter that removes `ai` from the available list forces it off.
+	 */
+	public function test_master_forced_off_when_a_filter_removes_the_module_from_available() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		$remove = static function ( $modules ) {
+			unset( $modules['ai'] );
+			return $modules;
+		};
+		add_filter( 'jetpack_get_available_modules', $remove );
+
+		$forced_off = Jetpack_AI_Settings::is_master_forced_off();
+
+		remove_filter( 'jetpack_get_available_modules', $remove );
+		$this->assertTrue( $forced_off );
+	}
+
+	/**
+	 * A module that is simply deactivated is an ordinary opt-out, not forced off.
+	 */
+	public function test_master_not_forced_off_when_module_is_plainly_inactive() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'Precondition: the module reads off.' );
+		$this->assertFalse( Jetpack_AI_Settings::is_master_forced_off() );
+	}
+
+	/**
+	 * An active master is never forced off.
+	 */
+	public function test_master_not_forced_off_when_module_active() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		$this->force_ai_module_active();
+
+		$this->assertFalse( Jetpack_AI_Settings::is_master_forced_off() );
+	}
+
+	/**
+	 * Never forced off on WordPress.com Simple.
+	 */
+	public function test_master_never_forced_off_on_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+
+		$this->assertFalse( Jetpack_AI_Settings::is_master_forced_off() );
 	}
 
 	/**


### PR DESCRIPTION
Relates to FORNO-521

## Proposed changes
* A filter that pins Jetpack's module list, such as a host allowlist written before the `ai` module existed, keeps `ai` off no matter what the site stores. My Jetpack then offers a switch that cannot stick, and the AI hub says AI is merely off.
* `Jetpack_AI_Settings::is_master_forced_off()` asks the module filters directly, via `Jetpack_Modules_Overrides`, and the feature-settings read reports it as `master_forced_off`.
* The hub shows a notice for that state, "Jetpack AI is turned off by custom code running on this site, so it can’t be turned on here", with a Learn more link to `jetpack-ai-hub-docs-module-forced-off`. The "Manage in My Jetpack" notice is hidden, since it cannot help. Reads only; feature toggles still save.

The redirect slug `jetpack-ai-hub-docs-module-forced-off` needs to exist in the registry before this merges.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a connected site with AI on, add an mu-plugin that filters `jetpack_active_modules` to a list without `ai`.
* Open Jetpack → AI. Expect the custom-code notice on the Overview and AI Features tabs, no toggles, and no "Manage in My Jetpack" notice.
* Remove the mu-plugin. Expect the toggles back.