### PR TITLE
Premium Analytics: converge both date pickers onto one range-bounds helper

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2079-range-patch
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2079-range-patch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report date filters: measure a widget-configured comparison against the selected period, not the rest of the day.

--- a/projects/packages/premium-analytics/changelog/wooa7s-2079-range-patch
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2079-range-patch
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: changed
 
-Report date filters: measure a widget-configured comparison against the selected period, not the rest of the day.
+Report date filters: stage a date range through one shared bounds helper in both pickers.

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -346,20 +346,30 @@ describe( 'report params field', () => {
 	 * `to`, while passing the comparison it spawned through untouched.
 	 */
 	it( 'measures a comparison against the preset window, not the rest of the day', async () => {
-		const user = userEvent.setup();
+		/*
+		 * Pinned away from the day's last hour: "Last 24 hours" ends at
+		 * `endOfHour( now )`, which already *is* end of day from 23:00, so the
+		 * stretch this guards against would be a no-op and the test would pass
+		 * on the unfixed code.
+		 */
+		jest.useFakeTimers().setSystemTime( new Date( '2026-06-15T12:00:00.000Z' ) );
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		const { latest } = renderField();
 
 		await user.click( screen.getByRole( 'button', { name: /compare/i } ) );
 		await user.click( await screen.findByRole( 'menuitemradio', { name: /^previous /i } ) );
 		await pickPeriod( user, 'Last 24 hours' );
 
+		// The preset's own end, not the end of the day it falls in.
+		expect( latest()?.to ).toBe( '2026-06-15T12:59:59.999+00:00' );
+
 		const params = normalizeReportParams( latest() );
 		const span = ( from?: string, to?: string ) =>
 			new Date( String( to ) ).getTime() - new Date( String( from ) ).getTime();
 
-		expect( span( params.compare_from, params.compare_to ) ).toBe(
-			span( params.from, params.to )
-		);
+		expect( span( params.compare_from, params.compare_to ) ).toBe( span( params.from, params.to ) );
+
+		jest.useRealTimers();
 	} );
 
 	// A widget can carry a preset with no window behind it, and it compares

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -120,6 +120,10 @@ describe( 'reportParamsAttributeField', () => {
 } );
 
 describe( 'report params field', () => {
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
 	it( 'offers no bucket control by default', () => {
 		renderField();
 
@@ -368,8 +372,6 @@ describe( 'report params field', () => {
 			new Date( String( to ) ).getTime() - new Date( String( from ) ).getTime();
 
 		expect( span( params.compare_from, params.compare_to ) ).toBe( span( params.from, params.to ) );
-
-		jest.useRealTimers();
 	} );
 
 	// A widget can carry a preset with no window behind it, and it compares

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
@@ -336,6 +337,28 @@ describe( 'report params field', () => {
 				compare_from: expect.any( String ),
 				compare_to: expect.any( String ),
 			} )
+		);
+	} );
+
+	/*
+	 * Read back through `normalizeReportParams`, the way a widget reads it: that
+	 * recomputes the primary window from the preset and so repairs a stretched
+	 * `to`, while passing the comparison it spawned through untouched.
+	 */
+	it( 'measures a comparison against the preset window, not the rest of the day', async () => {
+		const user = userEvent.setup();
+		const { latest } = renderField();
+
+		await user.click( screen.getByRole( 'button', { name: /compare/i } ) );
+		await user.click( await screen.findByRole( 'menuitemradio', { name: /^previous /i } ) );
+		await pickPeriod( user, 'Last 24 hours' );
+
+		const params = normalizeReportParams( latest() );
+		const span = ( from?: string, to?: string ) =>
+			new Date( String( to ) ).getTime() - new Date( String( from ) ).getTime();
+
+		expect( span( params.compare_from, params.compare_to ) ).toBe(
+			span( params.from, params.to )
 		);
 	} );
 

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -13,7 +13,6 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	type ComparisonPresetId,
-	endOfDayTZ,
 	type IntervalType,
 	isPrimaryPreset,
 	QUICK_SURFACE_PRESETS,
@@ -26,6 +25,7 @@ import {
 	decodeDateSearchParam,
 	deriveComparisonRange,
 	encodeDateToSearchParam,
+	encodeRangeToSearchParams,
 	hasPrimaryDateDraft,
 	useStagedValue,
 } from '@jetpack-premium-analytics/routing';
@@ -202,11 +202,12 @@ function ReportParamsControl( {
 			const patch: Partial< ReportParams > = {};
 
 			if ( nextRange?.from && nextRange?.to ) {
-				patch.from = encodeDateToSearchParam( nextRange.from );
-				patch.to = encodeDateToSearchParam(
-					// The site's day boundary, not the visitor's (see build-range-patch).
-					endOfDayTZ( nextRange.to, reportingTimeZone() )
+				const { from, to } = encodeRangeToSearchParams(
+					{ from: nextRange.from, to: nextRange.to },
+					{ presetId: nextPresetId }
 				);
+				patch.from = from;
+				patch.to = to;
 			}
 
 			if ( nextPresetId ) {

--- a/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/report-params-field/report-params-field.tsx
@@ -14,11 +14,11 @@ import {
 import {
 	type ComparisonPresetId,
 	type IntervalType,
-	isPrimaryPreset,
 	QUICK_SURFACE_PRESETS,
 	type QuickSurfacePresetId,
 	reportingTimeZone,
 	type DateRange,
+	type PrimaryPresetId,
 } from '@jetpack-premium-analytics/datetime';
 import { Stack } from '@jetpack-premium-analytics/externals';
 import {
@@ -198,20 +198,21 @@ function ReportParamsControl( {
 	}, [ isUnofferedPreset, fallbackPreset ] );
 
 	const stageDateRange = useCallback(
-		( nextRange?: DateRange, nextPresetId?: string ) => {
+		( nextRange?: DateRange, nextPresetId?: PrimaryPresetId ) => {
 			const patch: Partial< ReportParams > = {};
 
 			if ( nextRange?.from && nextRange?.to ) {
-				const { from, to } = encodeRangeToSearchParams(
-					{ from: nextRange.from, to: nextRange.to },
-					{ presetId: nextPresetId }
+				Object.assign(
+					patch,
+					encodeRangeToSearchParams(
+						{ from: nextRange.from, to: nextRange.to },
+						{ presetId: nextPresetId }
+					)
 				);
-				patch.from = from;
-				patch.to = to;
 			}
 
 			if ( nextPresetId ) {
-				patch.preset = isPrimaryPreset( nextPresetId ) ? nextPresetId : undefined;
+				patch.preset = nextPresetId;
 			}
 
 			if ( reportParams.comp === '1' ) {

--- a/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/hooks/use-report-date-filters/build-range-patch.ts
@@ -3,9 +3,6 @@
  */
 import { resolveIntervalForRange, type ReportQueryParams } from '@jetpack-premium-analytics/data';
 import {
-	endOfDayTZ,
-	isSelectablePreset,
-	reportingTimeZone,
 	type ComparisonPresetId,
 	type DateRange,
 	type PrimaryPresetId,
@@ -14,7 +11,7 @@ import {
  * Internal dependencies
  */
 import { deriveComparisonRange } from '../../search/comparison';
-import { encodeDateToSearchParam } from '../../search/date-range';
+import { encodeRangeToSearchParams } from '../../search/date-range';
 
 /**
  * The report search params the date filters read and stage.
@@ -67,16 +64,9 @@ export function buildRangePatch( {
 	const patch: ReportQuerySearchParams = {};
 
 	if ( nextRange?.from && nextRange.to ) {
-		/*
-		 * Preset/exact ranges are authoritative and skip end-of-day adjustment;
-		 * calendar edits stage midnight `to`, adjusted to the *site's* end of day —
-		 * date-fns' bare `endOfDay` would use the browser's and stretch the range.
-		 */
-		const rangeFrom = encodeDateToSearchParam( nextRange.from );
-		const rangeTo = encodeDateToSearchParam(
-			exactRange || isSelectablePreset( nextPresetId )
-				? nextRange.to
-				: endOfDayTZ( nextRange.to, reportingTimeZone() )
+		const { from: rangeFrom, to: rangeTo } = encodeRangeToSearchParams(
+			{ from: nextRange.from, to: nextRange.to },
+			{ presetId: nextPresetId, exactRange }
 		);
 		patch.from = rangeFrom;
 		patch.to = rangeTo;

--- a/projects/packages/premium-analytics/packages/routing/src/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/index.ts
@@ -1,4 +1,8 @@
-export { decodeDateSearchParam, encodeDateToSearchParam } from './search/date-range';
+export {
+	decodeDateSearchParam,
+	encodeDateToSearchParam,
+	encodeRangeToSearchParams,
+} from './search/date-range';
 
 export { deriveComparisonRange } from './search/comparison';
 export {

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
@@ -118,6 +118,16 @@ describe( 'encodeRangeToSearchParams', () => {
 		);
 	} );
 
+	// The year surface computes its own bounds too, so they are stored as given.
+	it( 'stores a year-surface range as given', () => {
+		expect( encodeRangeToSearchParams( { from, to }, { presetId: 'year-2025' } ).to ).toBe(
+			'2026-07-09T00:00:00.000-04:00'
+		);
+		expect( encodeRangeToSearchParams( { from, to }, { presetId: 'all-time' } ).to ).toBe(
+			'2026-07-09T00:00:00.000-04:00'
+		);
+	} );
+
 	// 'custom' marks a manual edit, so it takes the calendar rule, not the preset one.
 	it( 'extends a custom range', () => {
 		expect( encodeRangeToSearchParams( { from, to }, { presetId: 'custom' } ).to ).toBe(

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.test.ts
@@ -5,7 +5,11 @@ import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import { decodeDateSearchParam, encodeDateToSearchParam } from './date-range';
+import {
+	decodeDateSearchParam,
+	encodeDateToSearchParam,
+	encodeRangeToSearchParams,
+} from './date-range';
 
 const DEFAULTS = getSettings();
 
@@ -75,5 +79,49 @@ describe( 'encodeDateToSearchParam', () => {
 		const encoded = encodeDateToSearchParam( new Date( '2026-06-29T04:00:00.000Z' ) );
 
 		expect( decodeDateSearchParam( encoded )?.toISOString() ).toBe( '2026-06-29T04:00:00.000Z' );
+	} );
+} );
+
+describe( 'encodeRangeToSearchParams', () => {
+	beforeEach( () => {
+		setSettings( {
+			...DEFAULTS,
+			timezone: {
+				offset: -4,
+				offsetFormatted: '-4',
+				string: 'America/New_York',
+				abbr: 'EDT',
+			},
+		} );
+	} );
+
+	// Midnight in the site zone, the shape the calendar inputs stage.
+	const from = new Date( '2026-06-29T04:00:00.000Z' );
+	const to = new Date( '2026-07-09T04:00:00.000Z' );
+
+	it( 'extends a calendar edit to the end of the site day', () => {
+		expect( encodeRangeToSearchParams( { from, to } ) ).toEqual( {
+			from: '2026-06-29T00:00:00.000-04:00',
+			to: '2026-07-09T23:59:59.999-04:00',
+		} );
+	} );
+
+	it( 'stores a selectable preset range as given', () => {
+		expect( encodeRangeToSearchParams( { from, to }, { presetId: 'last-24-hours' } ).to ).toBe(
+			'2026-07-09T00:00:00.000-04:00'
+		);
+	} );
+
+	it( 'stores an exact range as given', () => {
+		expect( encodeRangeToSearchParams( { from, to }, { exactRange: true } ).to ).toBe(
+			'2026-07-09T00:00:00.000-04:00'
+		);
+	} );
+
+	// 'custom' marks a manual edit, so it takes the calendar rule, not the preset one.
+	it( 'extends a custom range', () => {
+		expect( encodeRangeToSearchParams( { from, to }, { presetId: 'custom' } ).to ).toBe(
+			'2026-07-09T23:59:59.999-04:00'
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
@@ -5,9 +5,11 @@ import {
 	dateToISOStringWithLocalTZ,
 	endOfDayTZ,
 	isSelectablePreset,
+	isYearSurfacePresetId,
 	localTZDate,
 	reportingTimeZone,
 	type DateRange,
+	type PrimaryPresetId,
 } from '@jetpack-premium-analytics/datetime';
 import { isValid } from 'date-fns';
 
@@ -50,7 +52,7 @@ export function encodeDateToSearchParam( date?: Date ): string | undefined {
  */
 export function encodeRangeToSearchParams(
 	range: Required< DateRange >,
-	{ presetId, exactRange }: { presetId?: string; exactRange?: boolean } = {}
+	{ presetId, exactRange }: { presetId?: PrimaryPresetId; exactRange?: boolean } = {}
 ): { from: string; to: string } {
 	return {
 		from: dateToISOStringWithLocalTZ( range.from ),
@@ -60,7 +62,7 @@ export function encodeRangeToSearchParams(
 		 * day because date-fns' bare `endOfDay` would use the visitor's.
 		 */
 		to: dateToISOStringWithLocalTZ(
-			exactRange || isSelectablePreset( presetId )
+			exactRange || isSelectablePreset( presetId ) || isYearSurfacePresetId( presetId )
 				? range.to
 				: endOfDayTZ( range.to, reportingTimeZone() )
 		),

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/date-range.ts
@@ -1,7 +1,14 @@
 /**
  * External dependencies
  */
-import { dateToISOStringWithLocalTZ, localTZDate } from '@jetpack-premium-analytics/datetime';
+import {
+	dateToISOStringWithLocalTZ,
+	endOfDayTZ,
+	isSelectablePreset,
+	localTZDate,
+	reportingTimeZone,
+	type DateRange,
+} from '@jetpack-premium-analytics/datetime';
 import { isValid } from 'date-fns';
 
 /**
@@ -30,4 +37,32 @@ export function decodeDateSearchParam( value?: string, timezone?: string ): Date
  */
 export function encodeDateToSearchParam( date?: Date ): string | undefined {
 	return date ? dateToISOStringWithLocalTZ( date ) : undefined;
+}
+
+/**
+ * Serialize a picker range into the `from`/`to` report params.
+ *
+ * @param range              - The range to serialize.
+ * @param options            - How the range was produced.
+ * @param options.presetId   - The preset that produced the range, if any.
+ * @param options.exactRange - Store both bounds as given.
+ * @return The serialized bounds.
+ */
+export function encodeRangeToSearchParams(
+	range: Required< DateRange >,
+	{ presetId, exactRange }: { presetId?: string; exactRange?: boolean } = {}
+): { from: string; to: string } {
+	return {
+		from: dateToISOStringWithLocalTZ( range.from ),
+		/*
+		 * Preset and already-normalized ranges carry their own `to` and are stored
+		 * verbatim; a calendar edit stages midnight, moved to the *site's* end of
+		 * day because date-fns' bare `endOfDay` would use the visitor's.
+		 */
+		to: dateToISOStringWithLocalTZ(
+			exactRange || isSelectablePreset( presetId )
+				? range.to
+				: endOfDayTZ( range.to, reportingTimeZone() )
+		),
+	};
 }

--- a/projects/packages/premium-analytics/packages/routing/src/search/date-range/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/date-range/index.ts
@@ -1,1 +1,5 @@
-export { decodeDateSearchParam, encodeDateToSearchParam } from './date-range';
+export {
+	decodeDateSearchParam,
+	encodeDateToSearchParam,
+	encodeRangeToSearchParams,
+} from './date-range';


### PR DESCRIPTION
Fixes WOOA7S-2079 (item 1 of 8; the rest follow in a separate PR)

## Proposed changes

* Export one `encodeRangeToSearchParams` helper that owns where a staged date range's `to` bound lands, and have both date pickers call it.
* `buildRangePatch` (the URL picker) keeps a preset or already-normalized range verbatim and moves only a calendar edit's midnight `to` to the site's end of day. `stageDateRange` (a widget's own date field) applied that move unconditionally, while its comment pointed at `build-range-patch` as though it followed the same rule.
* Add tests for the shared helper, and one at the field level asserting a preset's `to` survives staging.

The divergence is currently unreachable. `reportParamsAttributeField` has one production consumer, `wordads-chart-tabs`, whose grain offers only `last-7-days`, `last-30-days` and `last-12-months`, and `presetIds` filters the period menu as well as the pills. Every one of those ends at end of day, so the extra move was a no-op. `last-24-hours` (`to: endOfHour( now )`) is the only selectable preset it would change, and nothing offers it through this field today. What this removes is a trap in a documented extension point, not a live bug.

The shared helper also skips the move for the year surface (`all-time` and `year-YYYY`), which `buildRangePatch` did not. That is behavior-neutral: every year-surface range already ends at the site's end of day, so the move was a no-op there too. A test in `date-range.test.ts` pins it.

Worth knowing for the review: the unconditional `endOfDayTZ` came from #51419, where the concern was that a bare `endOfDay` used the visitor's timezone rather than the site's. That fix is preserved. A calendar edit still goes through `endOfDayTZ( ..., reportingTimeZone() )`; only presets stop being extended.

## Related product discussion/links

* WOOA7S-2079

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The bug this closes cannot be reached from any shipping surface, so these steps check that the one live consumer did not regress.

* Open a dashboard section that renders the **WordAds metric tabs** widget, and open the widget's own date control.
* Pick each of Last 7 days, Last 30 days and Last 12 months. Each should apply as before, with the chart and the bucket menu reshaping to the range.
* Pick Custom range, set a range by hand, Apply. The stored `to` should still be the site's end of day, not the visitor's.
* Turn on a comparison and re-pick a period. The comparison window should stay the same length as the primary window.

To see the behavior the change actually fixes, drive the field's API directly rather than the UI: staging `last-24-hours` through `stageDateRange` previously stored `to` at end of day, and the comparison derived from it kept that stretch even after `normalizeReportParams` recomputed the primary window from the preset. `packages/fields/src/report-params-field/__tests__/report-params-field.test.tsx` pins the clock and asserts both halves.

## Testing

Tested on a local site with its timezone set to Europe/Amsterdam (+02:00), serving this branch. The discriminator is `last-24-hours` at 09:59 site time: it is the only selectable preset whose `to` is not end of day, so a regression in the shared bounds helper would show `to` at `23:59:59.999+02:00` and a ~38h primary window instead of 24h.

| Checked | What happened | Status |
| --- | --- | --- |
| Last 30 days through the header picker | `from 2026-08-10T00:00:00.000+02:00`, `to 2026-09-08T23:59:59.999+02:00`, primary window 720h | ✅ |
| Previous period comparison on that range | Comparison window 720h, equal to the primary, both ending at the site's end of day | ✅ |
| Last 24 hours with comparison on (the discriminator) | `to 2026-09-08T09:59:59.999+02:00`, not stretched. Primary 24.000h, comparison 24.000h, interval coerced to `hour` | ✅ |
| Custom range Sep 1 to Sep 8, applied by hand | `to 2026-09-08T23:59:59.999+02:00`, extended to the site's end of day rather than the browser's. Primary 192h, comparison 192h | ✅ |
| Browser console across the pass, including a reload | No errors or exceptions | ✅ |



