### PR TITLE
AI Assistant: return default feature data on unconnected sites

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php
@@ -471,7 +471,12 @@ class Jetpack_AI_Helper {
 		}
 
 		// Outside of WPCOM, we need to fetch the data from the site.
-		$blog_id = Jetpack_Options::get_option( 'id' );
+		$connection = new Manager();
+		$blog_id    = Jetpack_Options::get_option( 'id' );
+
+		if ( ! $connection->is_connected() || empty( $blog_id ) ) {
+			return self::get_default_ai_assistance_feature();
+		}
 
 		// Try to pick the AI Assistant feature from cache.
 		$transient_name = self::transient_name_for_ai_assistance_feature( $blog_id );
@@ -513,7 +518,7 @@ class Jetpack_AI_Helper {
 				'failed_to_fetch_data',
 				esc_html__( 'Unable to fetch the requested data.', 'jetpack' ),
 				array(
-					'status' => $response_code,
+					'status' => ! empty( $response_code ) ? (int) $response_code : 500,
 					'ts'     => time(),
 				)
 			);
@@ -525,5 +530,37 @@ class Jetpack_AI_Helper {
 
 			return $error;
 		}
+	}
+
+	/**
+	 * Get default AI assistance feature data for unconnected or unprovisioned sites.
+	 *
+	 * @return array
+	 */
+	public static function get_default_ai_assistance_feature() {
+		return array(
+			'has-feature'          => false,
+			'is-over-limit'        => false,
+			'requests-count'       => 0,
+			'requests-limit'       => 20,
+			'usage-period'         => array(
+				'current-start'  => '',
+				'next-start'     => '',
+				'requests-count' => 0,
+			),
+			'site-require-upgrade' => false,
+			'upgrade-type'         => 'default',
+			'upgrade-url'          => '',
+			'current-tier'         => array(
+				'slug'  => 'ai-assistant-tier-free',
+				'value' => 0,
+				'limit' => 20,
+			),
+			'next-tier'            => null,
+			'tier-plans'           => array(),
+			'tier-plans-enabled'   => false,
+			'costs'                => array(),
+			'features-control'     => array(),
+		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
@@ -195,4 +195,17 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 			'The AI Chat rank route must not register when AI Chat is disabled.'
 		);
 	}
+
+	public function test_ai_assistant_feature_returns_default_when_unconnected() {
+		$this->register_routes_on_fresh_server();
+
+		$data = Jetpack_AI_Helper::get_ai_assistance_feature();
+
+		$this->assertIsArray( $data );
+		$this->assertFalse( $data['has-feature'] );
+		$this->assertFalse( $data['is-over-limit'] );
+		$this->assertSame( 0, $data['requests-count'] );
+		$this->assertSame( 20, $data['requests-limit'] );
+		$this->assertSame( 'ai-assistant-tier-free', $data['current-tier']['slug'] );
+	}
 }


### PR DESCRIPTION
Fixes #52066

## Proposed changes

* In `Jetpack_AI_Helper::get_ai_assistance_feature()`, verify that the site is connected via `( new Manager() )->is_connected()` and has a valid `blog_id`. If unconnected or missing `blog_id`, return a default feature data structure via `get_default_ai_assistance_feature()` instead of attempting a remote request to `/sites/0/jetpack-ai/ai-assistant-feature`.
* Ensure the fallback `WP_Error` status integer defaults to `500` instead of an empty status code string if a remote failure occurs.
* Add unit test `test_ai_assistant_feature_returns_default_when_unconnected` in `WPCOM_REST_API_V2_Endpoint_AI_Test`.

## Related product discussion/links

* Closes #52066

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Set up a fresh WordPress site with Jetpack activated, but do **not** connect it to WordPress.com.
2. Log in as an administrator and open the block editor (e.g. create or edit a post/page).
3. Open browser Developer Tools Network and Console tabs.
4. Verify that `GET /wp-json/wpcom/v2/jetpack-ai/ai-assistant-feature` returns HTTP 200 with default feature state (`has-feature: false`), with no REST 500 error or console errors.