### PR TITLE
Tiled Gallery: fix mosaic layout collapse on direct image uploads

### DIFF
--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.jsx
@@ -1,6 +1,8 @@
 import { getBlockIconComponent } from '@automattic/jetpack-shared-extension-utils';
+import { isBlobURL } from '@wordpress/blob';
 import { MediaPlaceholder, useBlockProps } from '@wordpress/block-editor';
 import { DropZone, FormFileUpload, withNotices } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { mediaUpload } from '@wordpress/editor';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -21,9 +23,18 @@ export function defaultColumnsNumber( attributes ) {
 }
 
 export const pickRelevantMediaFiles = image => {
-	const imageProps = pick( image, [ [ 'alt' ], [ 'id' ], [ 'link' ] ] );
-	imageProps.url =
-		image?.sizes?.large?.url || image?.media_details?.sizes?.large?.source_url || image.url;
+	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const chosenSize =
+		image?.sizes?.large ||
+		image?.media_details?.sizes?.large ||
+		image?.sizes?.full ||
+		image?.media_details?.sizes?.full ||
+		image;
+
+	imageProps.url = chosenSize?.url || chosenSize?.source_url || image?.url;
+	imageProps.width = chosenSize?.width || image?.media_details?.width || image?.width || null;
+	imageProps.height = chosenSize?.height || image?.media_details?.height || image?.height || null;
+
 	return imageProps;
 };
 
@@ -46,6 +57,7 @@ const TiledGalleryEdit = ( {
 	const layoutStyle = getActiveStyleName( LAYOUT_STYLES, attributes.className );
 
 	const blockProps = useBlockProps();
+	const { lockPostSaving, unlockPostSaving } = useDispatch( 'core/editor' ) || {};
 	const [ selectedImage, setSelectedImage ] = useState( null );
 	const [ changed, setChanged ] = useState(
 		'undefined' === typeof columnWidths || columnWidths?.length === 0 ? true : false
@@ -54,17 +66,38 @@ const TiledGalleryEdit = ( {
 	const setImages = imgs => {
 		setAttributes( {
 			images: imgs,
-			ids: imgs.map( ( { id } ) => parseInt( id, 10 ) ),
+			ids: imgs.map( ( { id } ) => parseInt( id, 10 ) ).filter( Boolean ),
 		} );
 	};
 
 	const addFiles = files => {
+		const currentImages = images || [];
+		const lockName = 'tiledGalleryLock';
+
+		lockPostSaving?.( lockName );
+
 		mediaUpload( {
 			allowedTypes: ALLOWED_MEDIA_TYPES,
 			filesList: files,
-			onFileChange: value =>
-				setImages( ( images || [] ).concat( value.map( pickRelevantMediaFiles ) ) ),
-			onError: noticeOperations.createErrorNotice,
+			onFileChange: value => {
+				const newImages = value.map( pickRelevantMediaFiles );
+				const combined = [ ...currentImages, ...newImages ];
+
+				setImages( combined );
+				setAttributes( {
+					columns: columns
+						? Math.min( combined.length, columns )
+						: defaultColumnsNumber( { images: combined } ),
+				} );
+
+				if ( ! newImages.some( img => isBlobURL( img.url ) ) ) {
+					unlockPostSaving?.( lockName );
+				}
+			},
+			onError: message => {
+				noticeOperations.createErrorNotice( message );
+				unlockPostSaving?.( lockName );
+			},
 		} );
 
 		setChanged( true );
@@ -87,6 +120,19 @@ const TiledGalleryEdit = ( {
 	};
 
 	const onSelectImages = files => {
+		const isUpload =
+			( typeof FileList !== 'undefined' && files instanceof FileList ) ||
+			( Array.isArray( files ) &&
+				files.length > 0 &&
+				( files[ 0 ] instanceof File ||
+					files[ 0 ] instanceof Blob ||
+					( files[ 0 ].name && ! files[ 0 ].id ) ) );
+
+		if ( isUpload ) {
+			addFiles( files );
+			return;
+		}
+
 		const newImages = files.map( file => {
 			const existingImage = images.find(
 				img => parseInt( img.id, 10 ) === parseInt( file.id, 10 )
@@ -178,6 +224,7 @@ const TiledGalleryEdit = ( {
 	if ( images.length === 0 ) {
 		content = (
 			<MediaPlaceholder
+				handleUpload={ false }
 				icon={ getBlockIconComponent( metadata ) }
 				labels={ {
 					title: __( 'Tiled Gallery', 'jetpack' ),

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/test/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/test/edit.jsx
@@ -1,5 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import Edit from '../edit';
+import { mediaUpload } from '@wordpress/editor';
+import Edit, { pickRelevantMediaFiles } from '../edit';
+
+jest.mock( '@wordpress/editor', () => ( {
+	mediaUpload: jest.fn(),
+} ) );
 
 const defaultAttributes = {
 	images: [],
@@ -11,12 +16,16 @@ const images = [
 		caption: 'A caption',
 		id: '1',
 		url: 'http://localhost:4759/wp-content/uploads/2021/03/tree1.jpeg',
+		width: 1024,
+		height: 768,
 	},
 	{
 		alt: 'Gallery Image 2',
 		caption: '',
 		id: '2',
 		url: 'http://localhost:4759/wp-content/uploads/2021/03/tree2.jpeg',
+		width: 800,
+		height: 600,
 	},
 ];
 
@@ -34,4 +43,60 @@ test( 'renders images if present', () => {
 	render( <Edit { ...propsWithImages } /> );
 	expect( screen.getByAltText( 'Gallery Image 1' ) ).toBeInTheDocument();
 	expect( screen.getByAltText( 'Gallery Image 2' ) ).toBeInTheDocument();
+} );
+
+describe( 'pickRelevantMediaFiles', () => {
+	test( 'extracts width, height, and url from large size', () => {
+		const media = {
+			id: 123,
+			alt: 'Test Alt',
+			link: 'http://example.com/item',
+			sizes: {
+				large: {
+					url: 'http://example.com/large.jpg',
+					width: 1024,
+					height: 768,
+				},
+				full: {
+					url: 'http://example.com/full.jpg',
+					width: 2048,
+					height: 1536,
+				},
+			},
+		};
+
+		const result = pickRelevantMediaFiles( media );
+		expect( result ).toEqual( {
+			alt: 'Test Alt',
+			id: 123,
+			link: 'http://example.com/item',
+			url: 'http://example.com/large.jpg',
+			width: 1024,
+			height: 768,
+		} );
+	} );
+
+	test( 'extracts width and height from media_details fallback', () => {
+		const media = {
+			id: 456,
+			alt_text: 'Fallback Alt',
+			source_url: 'http://example.com/original.jpg',
+			media_details: {
+				width: 1600,
+				height: 1200,
+				sizes: {
+					large: {
+						source_url: 'http://example.com/large.jpg',
+						width: 1024,
+						height: 768,
+					},
+				},
+			},
+		};
+
+		const result = pickRelevantMediaFiles( media );
+		expect( result.width ).toBe( 1024 );
+		expect( result.height ).toBe( 768 );
+		expect( result.url ).toBe( 'http://example.com/large.jpg' );
+	} );
 } );


### PR DESCRIPTION
## Description

Fixes #51871

### Problem
When uploading multiple images directly to a fresh Tiled Gallery block via `MediaPlaceholder` (either by clicking the "Upload" button and choosing multiple files or dragging and dropping files onto the placeholder):
1. `MediaPlaceholder` by default had `handleUpload={true}`. In modern Gutenberg/WordPress core, `MediaPlaceholder` begins uploading and fires `onSelect` after the first file completes or as raw files.
2. `TiledGalleryEdit` conditionally renders `<MediaPlaceholder>` when `images.length === 0`, and `<Layout>` when `images.length > 0`. As soon as the first image is processed and set in state, `images.length` becomes non-zero, unmounting `MediaPlaceholder` mid-upload. This drops subsequent upload callbacks from the queue and leaves the gallery with only 1 image.
3. `columns` was also calculated using the single initial image, collapsing the mosaic layout to a single column/tile.
4. `pickRelevantMediaFiles` previously picked `[ [ 'alt' ], [ 'id' ], [ 'link' ] ]` and did not extract `width` or `height`. Without dimensions:
   - Photon / Jetpack CDN responsive resizing in `photonizedImgProps` bails out (`if ( ! img.height || ! img.width ) return { src: img.url };`), rendering poor-quality or improperly scaled images.
   - The mosaic ratio computation defaults to square (1:1), distorting original image aspect ratios.
   - Saved block markup lacks `data-width` and `data-height`, breaking PHP backend rendering.

### Solution
1. **Prevent premature unmount during upload:** Passed `handleUpload={ false }` to `<MediaPlaceholder>` (matching core Gutenberg Gallery block behavior).
2. **Handle raw FileList / File array in `onSelectImages`:** Route files directly to `addFiles` if raw files or a `FileList` are passed by the placeholder or drop events.
3. **Prevent batch duplication and update column count:** In `addFiles`, snapshot `currentImages = images || []` so iterative `onFileChange` calls replace the newly uploading batch rather than repeatedly concatenating. Set `columns` to match the combined count.
4. **Lock post saving during blob uploads:** Lock saving while blob URLs are present and release when uploads complete.
5. **Extract dimensions in `pickRelevantMediaFiles`:** Read `width` and `height` from `large`, `media_details`, `full`, or base image attributes so Photon, aspect ratios, and backend layout calculations work properly.
6. **Unit tests:** Added unit tests verifying `pickRelevantMediaFiles` dimension and URL extraction.

## Testing Instructions
1. In the Block Editor, insert a **Tiled Gallery** block into a new post.
2. Ensure the layout is set to "Tiled Mosaic" (default).
3. Click the **Upload** button in the placeholder (or drag and drop multiple image files onto the placeholder).
4. Select 3 or more images simultaneously.
5. Verify that all selected images upload and appear in the block as a multi-tile mosaic layout (not collapsed into a single tile).
6. Verify that post saving is prevented while images are uploading, and succeeds once completed.
7. Save the post and check the frontend to ensure all images render with correct aspect ratios and Photon sizes.
