### PR TITLE
STATS: Support escalating notice dismiss (include_details) in stats-admin

### DIFF
--- a/projects/packages/stats-admin/changelog/stats-473-escalating-notice-dismiss
+++ b/projects/packages/stats-admin/changelog/stats-473-escalating-notice-dismiss
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Notices: Add an `include_details` parameter that returns a detail record per notice, so a dismissal can escalate.
+Notices: Add an `include_details` parameter that returns a detail record per notice, so a dismissal can escalate, and accept a dismissal that omits `postponed_for`.

--- a/projects/packages/stats-admin/changelog/stats-473-escalating-notice-dismiss
+++ b/projects/packages/stats-admin/changelog/stats-473-escalating-notice-dismiss
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Notices: Add an `include_details` parameter that returns a detail record per notice, so a dismissal can escalate.

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -69,7 +69,7 @@ class Notices {
 	}
 
 	/**
-	 * Return an array of notices IDs as keys and their value to flag whther to show them.
+	 * Return an array of notices IDs as keys and their value to flag whether to show them.
 	 *
 	 * @param bool $include_details Return a detail record per notice instead of a bare flag.
 	 * @return array

--- a/projects/packages/stats-admin/src/class-notices.php
+++ b/projects/packages/stats-admin/src/class-notices.php
@@ -17,10 +17,17 @@ use Jetpack_Options;
  */
 class Notices {
 	const STATS_DASHBOARD_NOTICES_CACHE_KEY = 'jetpack_stats_dashboard_notices_cache_key';
-	const OPT_OUT_NEW_STATS_NOTICE_ID       = 'opt_out_new_stats';
-	const NEW_STATS_FEEDBACK_NOTICE_ID      = 'new_stats_feedback';
-	const OPT_IN_NEW_STATS_NOTICE_ID        = 'opt_in_new_stats';
-	const GDPR_COOKIE_CONSENT_NOTICE_ID     = 'gdpr_cookie_consent';
+
+	/**
+	 * The flat map and the detail records are different shapes of the same resource, so they
+	 * cannot share a transient.
+	 */
+	const STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY = self::STATS_DASHBOARD_NOTICES_CACHE_KEY . '_details';
+
+	const OPT_OUT_NEW_STATS_NOTICE_ID   = 'opt_out_new_stats';
+	const NEW_STATS_FEEDBACK_NOTICE_ID  = 'new_stats_feedback';
+	const OPT_IN_NEW_STATS_NOTICE_ID    = 'opt_in_new_stats';
+	const GDPR_COOKIE_CONSENT_NOTICE_ID = 'gdpr_cookie_consent';
 
 	const VIEWS_TO_SHOW_FEEDBACK      = 3;
 	const POSTPONE_OPT_IN_NOTICE_DAYS = 30;
@@ -35,6 +42,7 @@ class Notices {
 	 */
 	public function update_notice( $id, $status, $postponed_for = 0 ) {
 		delete_transient( self::STATS_DASHBOARD_NOTICES_CACHE_KEY );
+		delete_transient( self::STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY );
 		return WPCOM_Client::request_as_blog(
 			sprintf(
 				'/sites/%d/jetpack-stats-dashboard/notices',
@@ -63,10 +71,12 @@ class Notices {
 	/**
 	 * Return an array of notices IDs as keys and their value to flag whther to show them.
 	 *
+	 * @param bool $include_details Return a detail record per notice instead of a bare flag.
 	 * @return array
 	 */
-	public function get_notices_to_show() {
-		$notices_wpcom = $this->get_notices_from_wpcom();
+	public function get_notices_to_show( bool $include_details = false ) {
+		// Reuse the one fetch for every flag below, so details mode doesn't also pull the flat map.
+		$notices_wpcom = $this->get_notices_from_wpcom( $include_details );
 
 		$new_stats_enabled        = Stats_Options::get_option( 'enable_odyssey_stats' );
 		$stats_views              = intval( Stats_Options::get_option( 'views' ) );
@@ -76,40 +86,78 @@ class Notices {
 		$complianz_options_integrations  = get_option( 'complianz_options_integrations' );
 		$is_jetpack_blocked_by_complianz = ! isset( $complianz_options_integrations['jetpack'] ) || $complianz_options_integrations['jetpack'];
 
-		return array_merge(
-			$notices_wpcom,
-			array(
-				// Show Opt-in notice 30 days after the new stats being disabled.
-				self::OPT_IN_NEW_STATS_NOTICE_ID    => ! $new_stats_enabled
-					&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
-					&& ! $this->is_notice_hidden( self::OPT_IN_NEW_STATS_NOTICE_ID ),
+		$local_notices = array(
+			// Show Opt-in notice 30 days after the new stats being disabled.
+			self::OPT_IN_NEW_STATS_NOTICE_ID    => ! $new_stats_enabled
+				&& $odyssey_stats_changed_at < time() - self::POSTPONE_OPT_IN_NOTICE_DAYS * DAY_IN_SECONDS
+				&& ! $this->is_hidden( $notices_wpcom, self::OPT_IN_NEW_STATS_NOTICE_ID ),
 
-				// Show feedback notice after 3 views of the new stats.
-				self::NEW_STATS_FEEDBACK_NOTICE_ID  => $new_stats_enabled
-					&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
-					&& ! $this->is_notice_hidden( self::NEW_STATS_FEEDBACK_NOTICE_ID ),
+			// Show feedback notice after 3 views of the new stats.
+			self::NEW_STATS_FEEDBACK_NOTICE_ID  => $new_stats_enabled
+				&& $stats_views >= self::VIEWS_TO_SHOW_FEEDBACK
+				&& ! $this->is_hidden( $notices_wpcom, self::NEW_STATS_FEEDBACK_NOTICE_ID ),
 
-				// Show opt-out notice before 3 views of the new stats, where 3 is included.
-				self::OPT_OUT_NEW_STATS_NOTICE_ID   => $new_stats_enabled
-					&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
-					&& ! $this->is_notice_hidden( self::OPT_OUT_NEW_STATS_NOTICE_ID ),
+			// Show opt-out notice before 3 views of the new stats, where 3 is included.
+			self::OPT_OUT_NEW_STATS_NOTICE_ID   => $new_stats_enabled
+				&& $stats_views < self::VIEWS_TO_SHOW_FEEDBACK
+				&& ! $this->is_hidden( $notices_wpcom, self::OPT_OUT_NEW_STATS_NOTICE_ID ),
 
-				// GDPR cookie consent notice for Complianz users.
-				self::GDPR_COOKIE_CONSENT_NOTICE_ID => class_exists( 'COMPLIANZ' ) && $is_jetpack_blocked_by_complianz
-					&& ! $this->is_notice_hidden( self::GDPR_COOKIE_CONSENT_NOTICE_ID ),
-			)
+			// GDPR cookie consent notice for Complianz users.
+			self::GDPR_COOKIE_CONSENT_NOTICE_ID => class_exists( 'COMPLIANZ' ) && $is_jetpack_blocked_by_complianz
+				&& ! $this->is_hidden( $notices_wpcom, self::GDPR_COOKIE_CONSENT_NOTICE_ID ),
 		);
+
+		if ( $include_details ) {
+			return $this->to_detail_records( $notices_wpcom, $local_notices );
+		}
+
+		return array_merge( $notices_wpcom, $local_notices );
+	}
+
+	/**
+	 * Normalize every notice to the detail shape, whichever shape WPCOM answered in.
+	 *
+	 * The package ships to self-hosted sites and can run for months against a WPCOM that does not
+	 * serve `include_details` yet, so a passed-through flat value would leave the caller parsing
+	 * two shapes in one response.
+	 *
+	 * @param array $notices_wpcom The WPCOM response, flat map or detail records.
+	 * @param array $local_notices The locally-computed visibility flags.
+	 * @return array
+	 */
+	private function to_detail_records( array $notices_wpcom, array $local_notices ) {
+		$notices = array();
+
+		foreach ( array_keys( array_merge( $notices_wpcom, $local_notices ) ) as $id ) {
+			// A local notice keeps its own visibility; its escalation fields still come from WPCOM.
+			$show = array_key_exists( $id, $local_notices )
+				? (bool) $local_notices[ $id ]
+				: ! $this->is_hidden( $notices_wpcom, $id );
+
+			$notices[ $id ] = $this->to_detail_record( $notices_wpcom[ $id ] ?? null, $show );
+		}
+
+		return $notices;
 	}
 
 	/**
 	 * Get the array of hidden notices from WPCOM.
+	 *
+	 * @param bool $include_details Ask WPCOM for detail records instead of a flat map.
+	 * @return array
 	 */
-	public function get_notices_from_wpcom() {
+	public function get_notices_from_wpcom( bool $include_details = false ) {
+		$path = sprintf(
+			'/sites/%d/jetpack-stats-dashboard/notices',
+			Jetpack_Options::get_option( 'id' )
+		);
+
+		if ( $include_details ) {
+			$path .= '?include_details=true';
+		}
+
 		$notices_wpcom = WPCOM_Client::request_as_blog_cached(
-			sprintf(
-				'/sites/%d/jetpack-stats-dashboard/notices',
-				Jetpack_Options::get_option( 'id' )
-			),
+			$path,
 			'v2',
 			array(
 				'timeout' => 5,
@@ -117,7 +165,9 @@ class Notices {
 			null,
 			'wpcom',
 			true,
-			static::STATS_DASHBOARD_NOTICES_CACHE_KEY
+			$include_details
+				? static::STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY
+				: static::STATS_DASHBOARD_NOTICES_CACHE_KEY
 		);
 
 		if ( is_wp_error( $notices_wpcom ) ) {
@@ -133,7 +183,42 @@ class Notices {
 	 * @return bool
 	 */
 	public function is_notice_hidden( $id ) {
-		$notices_wpcom = $this->get_notices_from_wpcom();
-		return array_key_exists( $id, $notices_wpcom ) && $notices_wpcom[ $id ] === false;
+		return $this->is_hidden( $this->get_notices_from_wpcom(), $id );
+	}
+
+	/**
+	 * Whether a notice is hidden in an already-fetched WPCOM response, in either shape.
+	 *
+	 * @param array $notices_wpcom The WPCOM response, flat map or detail records.
+	 * @param mixed $id            ID of the notice.
+	 * @return bool
+	 */
+	private function is_hidden( array $notices_wpcom, $id ) {
+		if ( ! array_key_exists( $id, $notices_wpcom ) ) {
+			return false;
+		}
+
+		$record = $notices_wpcom[ $id ];
+
+		return is_array( $record ) ? empty( $record['show'] ) : $record === false;
+	}
+
+	/**
+	 * Wrap a locally-computed flag in the detail shape, filling the escalation fields from WPCOM.
+	 *
+	 * @param mixed $wpcom_record The WPCOM detail record for this notice, or null when it has none.
+	 * @param bool  $show         The locally-computed visibility flag.
+	 * @return array
+	 */
+	private function to_detail_record( $wpcom_record, bool $show ) {
+		$record = is_array( $wpcom_record ) ? $wpcom_record : array();
+
+		return array(
+			'show'            => $show,
+			'status'          => $record['status'] ?? null,
+			'postponed_count' => (int) ( $record['postponed_count'] ?? 0 ),
+			// A non-numeric value would cast to 0, which reads as "due now" rather than "not scheduled".
+			'next_show_at'    => is_numeric( $record['next_show_at'] ?? null ) ? (int) $record['next_show_at'] : null,
+		);
 	}
 }

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -221,7 +221,7 @@ class REST_Controller {
 					),
 					'postponed_for' => array(
 						'type'        => 'number',
-						'default'     => null,
+						'default'     => 0,
 						'description' => 'Postponed for (in seconds)',
 						'minimum'     => 0,
 					),
@@ -250,7 +250,8 @@ class REST_Controller {
 					),
 					'postponed_for' => array(
 						'type'        => 'number',
-						'default'     => null,
+						// Forwarded to WPCOM as-is, whose schema rejects the null an omitted param would carry.
+						'default'     => 0,
 						'description' => 'Postponed for (in seconds)',
 						'minimum'     => 0,
 					),

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -266,6 +266,13 @@ class REST_Controller {
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_notice_status' ),
 				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+				'args'                => array(
+					'include_details' => array(
+						'type'        => 'boolean',
+						'default'     => false,
+						'description' => 'Return a detail record per notice instead of a flat boolean map',
+					),
+				),
 			)
 		);
 
@@ -1040,10 +1047,11 @@ class REST_Controller {
 	/**
 	 * Get stats notices.
 	 *
+	 * @param WP_REST_Request $req The request object.
 	 * @return array
 	 */
-	public function get_notice_status() {
-		return ( new Notices() )->get_notices_to_show();
+	public function get_notice_status( $req ) {
+		return ( new Notices() )->get_notices_to_show( (bool) $req->get_param( 'include_details' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Notices_Test.php
+++ b/projects/packages/stats-admin/tests/php/Notices_Test.php
@@ -19,6 +19,13 @@ class Notices_Test extends Stats_TestCase {
 	protected static $notices;
 
 	/**
+	 * The notices response override owned by the current test.
+	 *
+	 * @var \Closure|null
+	 */
+	private $forced_notices_filter;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
@@ -27,6 +34,17 @@ class Notices_Test extends Stats_TestCase {
 		Stats_Options::set_option( 'notices', array() );
 		Stats_Options::set_option( 'views', 0 );
 		self::$notices = new Notices();
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		if ( $this->forced_notices_filter ) {
+			remove_filter( 'pre_http_request', $this->forced_notices_filter, 11 );
+			$this->forced_notices_filter = null;
+		}
+		parent::tearDown();
 	}
 
 	/**
@@ -64,5 +82,200 @@ class Notices_Test extends Stats_TestCase {
 	 */
 	public function test_traffic_page_settings_hidden() {
 		$this->assertFalse( self::$notices->get_notices_to_show()['traffic_page_settings'] );
+	}
+
+	/**
+	 * Test the default response is still a flat map of booleans.
+	 */
+	public function test_plain_get_returns_flat_booleans() {
+		$notices = self::$notices->get_notices_to_show();
+
+		foreach ( array( 'opt_in_new_stats', 'opt_out_new_stats', 'new_stats_feedback', 'gdpr_cookie_consent', 'traffic_page_settings' ) as $id ) {
+			$this->assertIsBool( $notices[ $id ], "$id should be a bare boolean" );
+		}
+	}
+
+	/**
+	 * Test the locally-computed notices are wrapped in the detail shape.
+	 */
+	public function test_details_mode_wraps_local_notices() {
+		$notices = self::$notices->get_notices_to_show( true );
+
+		$this->assertSame(
+			array(
+				'show'            => true,
+				'status'          => null,
+				'postponed_count' => 0,
+				'next_show_at'    => null,
+			),
+			$notices['opt_out_new_stats']
+		);
+	}
+
+	/**
+	 * Test a local notice takes its escalation fields from the matching WPCOM record.
+	 */
+	public function test_details_mode_sources_escalation_fields_from_wpcom() {
+		Stats_Options::set_option( 'views', 3 );
+
+		$record = self::$notices->get_notices_to_show( true )['new_stats_feedback'];
+
+		// The fixture hides this one on WPCOM, so the locally-computed flag has to follow.
+		$this->assertFalse( $record['show'] );
+		$this->assertSame( 'postponed', $record['status'] );
+		$this->assertSame( 1, $record['postponed_count'] );
+		$this->assertSame( 1788000000, $record['next_show_at'] );
+	}
+
+	/**
+	 * Test a notice WPCOM owns outright keeps its own fields.
+	 */
+	public function test_details_mode_keeps_wpcom_only_notice_fields() {
+		$record = self::$notices->get_notices_to_show( true )['traffic_page_settings'];
+
+		$this->assertFalse( $record['show'] );
+		$this->assertSame( 'dismissed', $record['status'] );
+		$this->assertSame( 2, $record['postponed_count'] );
+	}
+
+	/**
+	 * Test a WPCOM that ignores `include_details` still yields one shape, not a mix.
+	 */
+	public function test_details_mode_normalizes_a_flat_wpcom_response() {
+		$this->force_wpcom_notices( '{"traffic_page_settings":false,"legacy_only_notice":true}' );
+
+		$notices = self::$notices->get_notices_to_show( true );
+
+		foreach ( $notices as $id => $record ) {
+			$this->assertIsArray( $record, "$id should be a detail record" );
+			$this->assertArrayHasKey( 'show', $record );
+		}
+
+		// The flat flag has to survive the normalization, in both directions.
+		$this->assertTrue( $notices['legacy_only_notice']['show'] );
+		$this->assertFalse( $notices['traffic_page_settings']['show'] );
+		$this->assertSame( 0, $notices['legacy_only_notice']['postponed_count'] );
+	}
+
+	/**
+	 * Test a local notice keeps its locally-computed visibility when WPCOM answers flat.
+	 */
+	public function test_details_mode_keeps_local_visibility_over_a_flat_response() {
+		$this->force_wpcom_notices( '{"opt_out_new_stats":true}' );
+		Stats_Options::set_option( 'views', 3 );
+
+		// Three views puts this one past its window, whatever WPCOM says about the dismissal.
+		$this->assertFalse( self::$notices->get_notices_to_show( true )['opt_out_new_stats']['show'] );
+	}
+
+	/**
+	 * Test a malformed `next_show_at` is reported as unscheduled rather than as 1970.
+	 */
+	public function test_details_mode_rejects_a_non_numeric_next_show_at() {
+		$this->force_wpcom_notices( '{"new_stats_feedback":{"show":false,"status":"postponed","postponed_count":1,"next_show_at":"soon"}}' );
+
+		$this->assertNull( self::$notices->get_notices_to_show( true )['new_stats_feedback']['next_show_at'] );
+	}
+
+	/**
+	 * Test a failed WPCOM fetch drops the notices WPCOM owns instead of inventing records.
+	 */
+	public function test_details_mode_drops_wpcom_notices_when_the_fetch_fails() {
+		$this->fail_wpcom_notices();
+
+		$notices = self::$notices->get_notices_to_show( true );
+
+		// Every escalating notice is WPCOM's, so dropping them leaves the client with no record
+		// rather than a fabricated postponed_count 0 it would read as a first dismissal.
+		$this->assertArrayNotHasKey( 'traffic_page_settings', $notices );
+		$this->assertCount( 4, $notices );
+		$this->assertSame(
+			array( 'show', 'status', 'postponed_count', 'next_show_at' ),
+			array_keys( $notices['opt_out_new_stats'] )
+		);
+	}
+
+	/**
+	 * Answer the notices endpoint with a given body. Runs after the shared fixture, which
+	 * replaces whatever it was handed rather than passing it along.
+	 *
+	 * @param string $body The JSON body WPCOM should appear to return.
+	 */
+	private function force_wpcom_notices( string $body ) {
+		$this->intercept_wpcom_notices(
+			array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'ok',
+				),
+				'body'     => $body,
+			)
+		);
+	}
+
+	/**
+	 * Make the notices request fail at the transport layer.
+	 */
+	private function fail_wpcom_notices() {
+		$this->intercept_wpcom_notices( new \WP_Error( 'http_request_failed', 'timeout' ) );
+	}
+
+	/**
+	 * Answer the notices request with a fixed result.
+	 *
+	 * @param array|\WP_Error $result What the notices request should return.
+	 */
+	private function intercept_wpcom_notices( $result ) {
+		$this->forced_notices_filter = static function ( $response, $args, $url ) use ( $result ) {
+			return strpos( $url, '/jetpack-stats-dashboard/notices' ) === false ? $response : $result;
+		};
+
+		add_filter( 'pre_http_request', $this->forced_notices_filter, 11, 3 );
+	}
+
+	/**
+	 * Test a notice with no WPCOM record at all still gets the default escalation fields.
+	 */
+	public function test_details_mode_defaults_when_wpcom_has_no_record() {
+		$this->assertSame(
+			array(
+				'show'            => false,
+				'status'          => null,
+				'postponed_count' => 0,
+				'next_show_at'    => null,
+			),
+			self::$notices->get_notices_to_show( true )['gdpr_cookie_consent']
+		);
+	}
+
+	/**
+	 * Test the two response shapes are cached apart, so neither can be served for the other.
+	 */
+	public function test_flat_and_details_responses_use_separate_caches() {
+		self::$notices->get_notices_to_show();
+		self::$notices->get_notices_to_show( true );
+
+		$flat    = (array) json_decode( (string) get_transient( Notices::STATS_DASHBOARD_NOTICES_CACHE_KEY ), true );
+		$details = (array) json_decode( (string) get_transient( Notices::STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY ), true );
+
+		$this->assertArrayHasKey( 'traffic_page_settings', $flat );
+		$this->assertArrayHasKey( 'traffic_page_settings', $details );
+		$this->assertIsBool( $flat['traffic_page_settings'] );
+		$this->assertIsArray( $details['traffic_page_settings'] );
+	}
+
+	/**
+	 * Test a dismissal clears both cached shapes, not just the flat one.
+	 */
+	public function test_update_notice_clears_both_caches() {
+		self::$notices->get_notices_to_show();
+		self::$notices->get_notices_to_show( true );
+		$this->assertNotFalse( get_transient( Notices::STATS_DASHBOARD_NOTICES_CACHE_KEY ) );
+		$this->assertNotFalse( get_transient( Notices::STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY ) );
+
+		self::$notices->update_notice( 'new_stats_feedback', 'postponed', 2592000 );
+
+		$this->assertFalse( get_transient( Notices::STATS_DASHBOARD_NOTICES_CACHE_KEY ) );
+		$this->assertFalse( get_transient( Notices::STATS_DASHBOARD_NOTICES_DETAILS_CACHE_KEY ) );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -197,10 +197,10 @@ class REST_Controller_Test extends Stats_TestCase {
 	 */
 	public function test_stats_notices_omitted_postponed_for_forwards_zero() {
 		wp_set_current_user( $this->admin_id );
-		$forwarded = null;
-		$capture   = function ( $response, $parsed_args, $url ) use ( &$forwarded ) {
+		$body    = '';
+		$capture = function ( $response, $parsed_args, $url ) use ( &$body ) {
 			if ( strpos( $url, '/jetpack-stats-dashboard/notices' ) !== false ) {
-				$forwarded = json_decode( $parsed_args['body'], true );
+				$body = $parsed_args['body'];
 			}
 			return $response;
 		};
@@ -220,6 +220,7 @@ class REST_Controller_Test extends Stats_TestCase {
 		$response = $this->server->dispatch( $request );
 		remove_filter( 'pre_http_request', $capture, 9 );
 
+		$forwarded = (array) json_decode( (string) $body, true );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertSame( 0, $forwarded['postponed_for'] );
 	}

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -193,6 +193,38 @@ class REST_Controller_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * Test the notices POST forwards `postponed_for` as 0 when omitted.
+	 */
+	public function test_stats_notices_omitted_postponed_for_forwards_zero() {
+		wp_set_current_user( $this->admin_id );
+		$forwarded = null;
+		$capture   = function ( $response, $parsed_args, $url ) use ( &$forwarded ) {
+			if ( strpos( $url, '/jetpack-stats-dashboard/notices' ) !== false ) {
+				$forwarded = json_decode( $parsed_args['body'], true );
+			}
+			return $response;
+		};
+		add_filter( 'pre_http_request', $capture, 9, 3 );
+
+		$request = new WP_REST_Request( 'POST', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'id'     => 'new_stats_feedback',
+					'status' => 'dismissed',
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		remove_filter( 'pre_http_request', $capture, 9 );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 0, $forwarded['postponed_for'] );
+	}
+
+	/**
 	 * Test '/jetpack/v4/stats-app/stats/notices' failed
 	 */
 	public function test_stats_notices_illegal_params() {

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -209,6 +209,43 @@ class REST_Controller_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * Test the notices GET defaults to the flat boolean map.
+	 */
+	public function test_stats_notices_get_defaults_to_flat_map() {
+		wp_set_current_user( $this->admin_id );
+		$request  = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertIsBool( $response->get_data()['traffic_page_settings'] );
+	}
+
+	/**
+	 * Test the notices GET forwards `include_details` through to the detail records.
+	 */
+	public function test_stats_notices_get_include_details() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
+		$request->set_query_params( array( 'include_details' => 'true' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'postponed_count', $response->get_data()['traffic_page_settings'] );
+	}
+
+	/**
+	 * Test a falsy `include_details` still gets the flat map, rather than being read as opt-in.
+	 */
+	public function test_stats_notices_get_include_details_false() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/jetpack-stats-dashboard/notices' );
+		$request->set_query_params( array( 'include_details' => 'false' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertIsBool( $response->get_data()['traffic_page_settings'] );
+	}
+
+	/**
 	 * Test filter_and_build_query_string.
 	 */
 	public function test_filter_and_build_query_string() {

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -189,6 +189,16 @@ abstract class TestCase extends PHPUnit_TestCase {
 			);
 		}
 
+		if ( strpos( $url, '/jetpack-stats-dashboard/notices' ) !== false && strpos( $url, 'include_details=true' ) !== false ) {
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'ok',
+				),
+				'body'     => '{"opt_in_new_stats":{"show":true,"status":null,"postponed_count":0,"next_show_at":null},"opt_out_new_stats":{"show":true,"status":null,"postponed_count":0,"next_show_at":null},"new_stats_feedback":{"show":false,"status":"postponed","postponed_count":1,"next_show_at":1788000000},"traffic_page_settings":{"show":false,"status":"dismissed","postponed_count":2,"next_show_at":null}}',
+			);
+		}
+
 		if ( strpos( $url, '/jetpack-stats-dashboard/notices' ) !== false ) {
 			return array(
 				'response' => array(


### PR DESCRIPTION
## Proposed changes

Enable the Stats client on Jetpack and Atomic sites to read notice dismissal history through the site-local REST API. This supports the planned dismissal flow: the first dismissal postpones a notice for 30 days, and the second dismisses it permanently. The current API returns only whether to show each notice, so the client cannot tell whether it has already been postponed.

This PR adds an optional `include_details=true` parameter to `GET /jetpack/v4/stats-app/sites/<id>/jetpack-stats-dashboard/notices` and forwards it to WordPress.com. With this parameter, each notice returns `show`, `status`, `postponed_count`, and `next_show_at`. For example, a postponed notice returns:

```json
{
  "new_stats_feedback": {
    "show": false,
    "status": "postponed",
    "postponed_count": 1,
    "next_show_at": 1788000000
  }
}
```

Requests without the parameter (or with `include_details=false`) keep the existing `{ "notice_id": true/false }` response. This PR exposes the data needed by the upcoming client change; it does not implement the client’s dismissal decision or change the dismissal UI.

The implementation preserves existing notice visibility rules while making the new response consistent:

* **Keep local visibility checks.** The four package-local notices (`opt_in_new_stats`, `opt_out_new_stats`, `new_stats_feedback`, and `gdpr_cookie_consent`) still use the existing site settings, view counts, plugin checks, and WordPress.com dismissal state to determine `show`. Their dismissal metadata comes from WordPress.com. The same fetched response is reused across these checks.
* **Return one shape for every notice.** Details mode normalizes both local and WordPress.com-owned notices, even if WordPress.com returns legacy booleans. Otherwise, a client reading `notice.show` could interpret a bare `true` as hidden. Missing metadata defaults to `status: null`, `postponed_count: 0`, and `next_show_at: null`; non-numeric timestamps also become `null`. If the WordPress.com request fails, only the local notices are returned.
* **Keep cached responses consistent.** Boolean and detailed responses use separate transients so one format cannot be served in place of the other. Updating a notice clears both caches so the next request fetches its updated dismissal state.

Tests cover the REST parameter and default response, metadata and visibility handling, legacy responses and request failures, and cache separation and invalidation.

## Related product discussion/links

* STATS-473. Server side is STATS-472, client side is STATS-474.

## Does this pull request change what data or activity we track or use?

No. It exposes fields the notices endpoint already returns, and adds no new tracking.

## Testing instructions

Needs a Jetpack-connected site (self-hosted or Atomic). Substitute the site's blog ID for `<id>`.

* `GET /jetpack/v4/stats-app/sites/<id>/jetpack-stats-dashboard/notices` returns a flat map whose every value is a bare boolean, exactly as before.
* `GET` the same path with `?include_details=true`. Every value is an object with `show`, `status`, `postponed_count` and `next_show_at`, with no bare booleans mixed in. The four package-local notices (`opt_in_new_stats`, `opt_out_new_stats`, `new_stats_feedback`, `gdpr_cookie_consent`) are in there too.
* `POST` `{"id":"new_stats_feedback","status":"postponed","postponed_for":2592000}` to that path, then immediately `GET` with `?include_details=true`. The dismissal is reflected right away rather than after the 5 minute cache expires.
* `POST` again with `{"id":"new_stats_feedback","status":"dismissed"}` and confirm the record shows the permanent dismissal.
* `jp test php packages/stats-admin` passes.



