### PR TITLE
Enable React 19 on 20% of Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-20pct-atomic
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-react-19-on-20pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable the React 19 experiment on 20% of Atomic sites, and skip more incompatible plugins.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -31,6 +31,8 @@ class Jetpack_Mu_Wpcom {
 		'wp-table-builder/wp-table-builder.php',
 		'ultimate-blocks/ultimate-blocks.php',
 		'beehive-analytics/beehive-analytics.php',
+		'xspeed/xspeed.php',
+		'classified-listing/classified-listing.php',
 	);
 
 	/**
@@ -980,7 +982,7 @@ class Jetpack_Mu_Wpcom {
 			} elseif ( self::has_react_19_incompatible_extension() ) {
 				$is_enabled = false;
 			} else {
-				$current_segment = 10; // Segment of Atomic sites in the experiment, in %.
+				$current_segment = 20; // Segment of Atomic sites in the experiment, in %.
 				$site_segment    = $site_id % 100;
 
 				/*

--- a/projects/plugins/wpcomsh/changelog/update-react-19-on-20pct-atomic
+++ b/projects/plugins/wpcomsh/changelog/update-react-19-on-20pct-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Enable wp-admin JS error reporting on 20% of sites, to keep up with the React 19 experiment rollout.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -222,7 +222,7 @@ function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
 		return false;
 	}
 
-	$current_segment = 10; // Segment of sites that get error reporting, in %.
+	$current_segment = 20; // Segment of sites that get error reporting, in %.
 	$site_segment    = $site_id % 100;
 
 	// Sites whose id ends in digits < $current_segment are in the segment.


### PR DESCRIPTION
Increase the React 19 Atomic percentage from 10% to 20%, and opt out two new plugins that are known to be incompatible: `xspeed` and `classified-listing`.

In #51985 we had to disable the React 19 experiment for Gutenberg 23.9.0, because there was a bug. That disabled React 19 for everyone who upgraded to the latest version. Most people do that apparently, because that briefly compressed the error rate to almost zero. Now when 23.9.1 is out, I'm starting to see errors again.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Install the Jetpack build from this PR on your Atomic site and verify it doesn't crash.
