### PR TITLE
Premium Analytics: explain the Visitors per-period sum with an info popover

### DIFF
--- a/projects/packages/premium-analytics/changelog/uni-752-visitors-per-period-sum-note
+++ b/projects/packages/premium-analytics/changelog/uni-752-visitors-per-period-sum-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Traffic: Note in the widget help that the Visitors total is a per-period sum.

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
@@ -3,7 +3,7 @@
 	"title": "Traffic summary",
 	"description": "Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.",
 	"help": {
-		"content": "A summary of your site's views, visitors, likes, and comments."
+		"content": "A summary of your site's views, visitors, likes, and comments. The Visitors total is a per-period sum, not a unique count."
 	},
 	"category": "traffic",
 	"presentation": "framed"

--- a/projects/plugins/jetpack/changelog/uni-752-visitors-per-period-sum-note
+++ b/projects/plugins/jetpack/changelog/uni-752-visitors-per-period-sum-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Note in the Traffic summary help that the Visitors total is a per-period sum.

--- a/projects/plugins/premium-analytics/changelog/uni-752-visitors-per-period-sum-note
+++ b/projects/plugins/premium-analytics/changelog/uni-752-visitors-per-period-sum-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Traffic: Note in the widget help that the Visitors total is a per-period sum.

--- a/projects/plugins/wpcomsh/changelog/uni-752-visitors-per-period-sum-note
+++ b/projects/plugins/wpcomsh/changelog/uni-752-visitors-per-period-sum-note
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: Note in the Traffic summary help that the Visitors total is a per-period sum.


### PR DESCRIPTION
Fixes #

## Proposed changes

The Traffic chart's **Visitors** headline changes when you switch the chart interval between "By days" and "By weeks" over the same range — 87K vs 81K over the last 30 days on the reported site. This PR explains that number rather than changing it.

**It is not a date-range bug.** Views (127K), Comments (7) and Likes (33) are identical at both intervals; only Visitors moves. Verified against the live `stats/visits` endpoint: both requests send the same `start_date`/`date`, and the API returns 30 daily buckets (Aug 10 → Sep 8) or the 5 weekly buckets covering them — identical coverage.

The cause is that `stats/visits` returns no total, only buckets, so we compute the headline by summing them ([`time-series.ts`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts#L286-L297) → [`build-metric-tab.ts`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts#L46-L48)). Summing is right for views, likes and comments, which are additive. It is wrong for visitors, which is **de-duplicated within each bucket**: 30 daily uniques count a repeat visitor once per day; 5 weekly uniques count them once per week.

Existing Jetpack Stats computes the total the same way and labels it, so this is not a regression — we were just missing the disclosure. This PR adds the same note, in Calypso's wording, appended to the Traffic summary widget's existing help text:

> A summary of your site's views, visitors, likes, and comments. **The Visitors total is a per-period sum, not a unique count.**

That is the whole change: one string in `widgets/traffic-chart/widget.json`, plus changelog entries. It reuses the widget frame's existing help affordance, so there is no new component, no new markup in the metric tab strip, and no change to the tabs' ARIA or keyboard behaviour.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/uni-752-mismatch-in-data-when-selecting-days-vs-weeks/before.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/uni-752-mismatch-in-data-when-selecting-days-vs-weeks/after.png) |

## Related product discussion/links

* UNI-752

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open **Stats v2 → Traffic** (`admin.php?page=jetpack-premium-analytics-wp-admin`) on a site with Premium Analytics enabled.
* Click the ⓘ next to the **Traffic summary** heading.
* The popover reads "A summary of your site's views, visitors, likes, and comments. The Visitors total is a per-period sum, not a unique count."
* Confirm the metric tabs themselves are unchanged — no tooltip on hover, no extra icon.

On a site with real traffic, the underlying numbers still differ between "By days" and "By weeks" — that is the documented behaviour this note explains, and it matches existing Jetpack Stats.

## Considered and rejected

Attaching the note to the Visitors tab itself. `Tabs.Tab` renders a `<button role="tab">`, so a `Popover.Trigger` cannot go inside it (invalid nesting), and making the tab *be* the trigger cost it its `aria-controls`, pulled focus into the popup on activation, and seeded the tablist with the trigger's `aria-hidden` focus guards — all verified in Chrome. Anchoring a popover to the tab avoided those, but the design system reserves that shape for a trigger whose purpose is to open the popup ([Tooltip usage guidelines](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-tooltip-usage-guidelines--docs)). Calypso attaches its own tooltip to the metric item, but its tabs are `<li>` elements with the a11y lint rules disabled and no tab ARIA at all, so the constraint never arises there.

## Also not fixed here

The weekly grid snaps outward to whole ISO weeks and nothing trims the overhang, so a range starting on any day but Monday pulls in up to 6 days of out-of-range traffic (`start_date=2026-08-16` returns a first bucket of `2026W08W10`). A bucket-window filter exists in [`bucket-window.ts`](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/premium-analytics/packages/data/src/processing/stats/bucket-window.ts#L88) but is wired only to the email time series. That one *would* move Views, which is why it is not the bug in this report. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E89vsMKvxTSye7n5ExC7my
