### PR TITLE
Premium Analytics: offer the whole period menu on the post and video detail pages

### DIFF
--- a/projects/packages/premium-analytics/changelog/uni-754-detail-date-presets
+++ b/projects/packages/premium-analytics/changelog/uni-754-detail-date-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post, page and video detail pages: offer every period the dashboard's date picker does, plus a custom range.

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/menu-surface-presets.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/menu-surface-presets.test.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { getMenuSurfacePresetGroups } from '../presets';
-import { PRESET_ALL_TIME, MENU_SURFACE_PRESETS } from '../presets/types';
+import { DETAIL_SURFACE_PRESETS, MENU_SURFACE_PRESETS } from '../presets/types';
 
 const TIME_ZONE = 'America/New_York';
 
@@ -28,11 +28,16 @@ describe( 'getMenuSurfacePresetGroups', () => {
 
 	// Only a surface with a start date to anchor it can offer one.
 	it( 'leaves all time out unless the surface asks for it', () => {
+		expect( idsOf( getMenuSurfacePresetGroups( TIME_ZONE ) ).flat() ).not.toContain( 'all-time' );
+	} );
+
+	it( 'offers a detail surface every period the menu lists, all time last', () => {
 		const groups = getMenuSurfacePresetGroups( TIME_ZONE, {
-			presetIds: [ ...MENU_SURFACE_PRESETS, PRESET_ALL_TIME ],
+			presetIds: DETAIL_SURFACE_PRESETS,
 			startDate: new Date( '2024-03-01T00:00:00.000Z' ),
 		} );
 
+		expect( idsOf( groups ).flat() ).toEqual( [ ...MENU_SURFACE_PRESETS, 'all-time' ] );
 		expect( idsOf( groups ).at( -1 ) ).toEqual( [ 'all-time' ] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/quick-surface-presets.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/quick-surface-presets.test.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { computePrimaryRange, getQuickSurfacePresets } from '../presets';
-import { DETAIL_SURFACE_PRESETS, PRESET_ALL_TIME, QUICK_SURFACE_PRESETS } from '../presets/types';
+import { PRESET_ALL_TIME, QUICK_SURFACE_PRESETS } from '../presets/types';
 import { dateToISOStringWithTZ } from '../tz';
 
 // A zone ahead of UTC, so a naive (UTC) day boundary would land on the wrong
@@ -36,19 +36,9 @@ describe( 'quick surface presets', () => {
 		] );
 	} );
 
-	it( 'leads the detail surface with all time, in the designed order', () => {
-		expect( DETAIL_SURFACE_PRESETS ).toEqual( [ PRESET_ALL_TIME, ...QUICK_SURFACE_PRESETS ] );
-
-		expect(
-			getQuickSurfacePresets( TIME_ZONE, { presetIds: DETAIL_SURFACE_PRESETS } ).map(
-				preset => preset.label
-			)
-		).toEqual( [ 'All time', 'Last 24 hours', 'Last 7 days', 'Last 30 days', 'Last 12 months' ] );
-	} );
-
 	it( 'anchors all time on the site-local start of the given day, through the end of today', () => {
 		const [ allTime ] = getQuickSurfacePresets( TIME_ZONE, {
-			presetIds: DETAIL_SURFACE_PRESETS,
+			presetIds: [ PRESET_ALL_TIME ],
 			startDate: PUBLISHED,
 		} );
 
@@ -69,7 +59,7 @@ describe( 'quick surface presets', () => {
 	} );
 
 	it( 'falls back to the year surface span without an anchor', () => {
-		const [ allTime ] = getQuickSurfacePresets( TIME_ZONE, { presetIds: DETAIL_SURFACE_PRESETS } );
+		const [ allTime ] = getQuickSurfacePresets( TIME_ZONE, { presetIds: [ PRESET_ALL_TIME ] } );
 
 		expect( allTime.range ).toEqual( computePrimaryRange( PRESET_ALL_TIME, TIME_ZONE ) );
 		// Years back, not the day the test pinned.

--- a/projects/packages/premium-analytics/packages/datetime/src/presets/types.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/presets/types.ts
@@ -48,12 +48,6 @@ export const QUICK_SURFACE_PRESETS = [
 ] as const;
 
 /**
- * Quick presets of a resource detail page (post, video): the rolling windows
- * led by all time, per the detail-page design.
- */
-export const DETAIL_SURFACE_PRESETS = [ PRESET_ALL_TIME, ...QUICK_SURFACE_PRESETS ] as const;
-
-/**
  * Every preset a quick surface can render as a pill: the rolling windows, plus
  * all time where the surface opts into it.
  */
@@ -86,6 +80,12 @@ export const MENU_SURFACE_PRESET_GROUPS = [
  * out: only a surface with a start date to anchor it can offer one.
  */
 export const MENU_SURFACE_PRESETS = SELECTABLE_PRESETS;
+
+/**
+ * What a resource detail page (post, video) offers: the whole menu, plus all
+ * time, which such a page anchors on the resource's own publish date.
+ */
+export const DETAIL_SURFACE_PRESETS = [ ...MENU_SURFACE_PRESETS, PRESET_ALL_TIME ] as const;
 
 /**
  * Prefix of the per-year preset IDs, e.g. `year-2024`.

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/__tests__/date-filters-panel.test.tsx
@@ -116,11 +116,10 @@ describe( 'DateFiltersPanel', () => {
 		expect( screen.getByRole( 'button', { name: 'Last 30 days' } ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the detail surface: all time offered, no custom range', async () => {
+	it( 'renders the detail surface: every period, plus all time and a custom range', async () => {
 		const user = userEvent.setup();
 		renderPanel( {
 			presetIds: DETAIL_SURFACE_PRESETS,
-			withCustomRange: false,
 			appliedPresetId: 'all-time',
 		} );
 
@@ -131,7 +130,20 @@ describe( 'DateFiltersPanel', () => {
 			within( menu )
 				.getAllByRole( 'menuitemradio' )
 				.map( item => item.textContent )
-		).toEqual( [ 'Last 24 hours', 'Last 7 days', 'Last 30 days', 'Last 12 months', 'All time' ] );
+		).toEqual( [
+			'Today',
+			'Yesterday',
+			'Last 24 hours',
+			'Last 7 days',
+			'Last 30 days',
+			'Last 90 days',
+			'Last 365 days',
+			'Last month',
+			'Last 12 months',
+			'Last year',
+			'All time',
+			'Custom range',
+		] );
 		expect( screen.getByRole( 'menuitemradio', { name: 'All time' } ) ).toBeChecked();
 	} );
 

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/date-filters-panel.tsx
@@ -65,8 +65,8 @@ export type DateFiltersPanelProps = {
 	allTimeStart?: Date;
 
 	/**
-	 * Whether to offer Custom range at the end of the menu. On by default; the
-	 * detail pages' design has common periods only.
+	 * Whether to offer Custom range at the end of the menu. On by default; a
+	 * surface whose design lists common periods only turns it off.
 	 */
 	withCustomRange?: boolean;
 

--- a/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-filters-panel/stories/date-filters-panel.stories.tsx
@@ -205,7 +205,6 @@ function DateFiltersPanelStory( {
 					? {
 							presetIds: DETAIL_SURFACE_PRESETS,
 							allTimeStart: STORY_PUBLISHED_DATE,
-							withCustomRange: false,
 					  }
 					: {} ) }
 				withIntervalControl

--- a/projects/packages/premium-analytics/packages/ui/src/date-period-dropdown/date-period-dropdown.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-period-dropdown/date-period-dropdown.tsx
@@ -95,8 +95,8 @@ type DatePeriodDropdownProps = {
 	canApply: boolean;
 
 	/**
-	 * Whether to offer Custom range. On by default; the detail pages' design has
-	 * common periods only.
+	 * Whether to offer Custom range. On by default; a surface whose design lists
+	 * common periods only turns it off.
 	 */
 	withCustomRange?: boolean;
 

--- a/projects/packages/premium-analytics/packages/ui/src/date-period-dropdown/stories/date-period-dropdown.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-period-dropdown/stories/date-period-dropdown.stories.tsx
@@ -108,7 +108,7 @@ export const CustomRange: Story = {
 };
 
 /**
- * A resource detail page, which offers all time and only the rolling windows.
+ * A resource detail page, which offers all time on top of the menu's periods.
  */
 export const DetailSurface: Story = {
 	render: () => (

--- a/projects/packages/premium-analytics/routes/use-detail-date-controls.test.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-date-controls.test.ts
@@ -42,14 +42,13 @@ function filters( overrides: Partial< Parameters< typeof useDetailDateControls >
 }
 
 describe( 'useDetailDateControls', () => {
-	it( 'offers the preset pills alone, anchored on the site-local publish instant', () => {
+	it( 'offers the period menu alone, anchored on the site-local publish instant', () => {
 		const { result } = renderHook( () =>
 			useDetailDateControls( '2026-07-08 00:29:35', filters() )
 		);
 
 		expect( result.current ).toMatchObject( {
 			presetIds: DETAIL_SURFACE_PRESETS,
-			withCustomRange: false,
 			withIntervalControl: false,
 			onStep: undefined,
 		} );

--- a/projects/packages/premium-analytics/routes/use-detail-date-controls.test.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-date-controls.test.ts
@@ -52,6 +52,8 @@ describe( 'useDetailDateControls', () => {
 			withIntervalControl: false,
 			onStep: undefined,
 		} );
+		// Unset, not false: the panel's own default is what offers Custom range.
+		expect( result.current ).not.toHaveProperty( 'withCustomRange' );
 		// Half past midnight in Taipei, not in the runner's zone.
 		expect( result.current.allTimeStart?.toISOString() ).toBe( '2026-07-07T16:29:35.000Z' );
 	} );

--- a/projects/packages/premium-analytics/routes/use-detail-date-controls.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-date-controls.ts
@@ -14,7 +14,6 @@ import {
 type DetailDateControls = {
 	presetIds: typeof DETAIL_SURFACE_PRESETS;
 	allTimeStart: Date | undefined;
-	withCustomRange: false;
 	withIntervalControl: false;
 	onStep: undefined;
 };
@@ -31,10 +30,10 @@ type DetailDateFilters = {
 };
 
 /**
- * The date controls a resource detail page (post, video) offers: preset pills
- * alone, with all time anchored to the resource's publish date. The controls
- * render before the summary loads, so an all-time range applied against an
- * unknown or stale start is re-anchored in place once it resolves.
+ * The date controls a resource detail page (post, video) offers: the period
+ * menu alone, with all time anchored to the resource's publish date. The
+ * controls render before the summary loads, so an all-time range applied
+ * against an unknown or stale start is re-anchored in place once it resolves.
  *
  * Spread after the date-filter controller's props — `onStep` and the interval
  * props it hands out are what this unsets.
@@ -78,7 +77,6 @@ export function useDetailDateControls(
 		() => ( {
 			presetIds: DETAIL_SURFACE_PRESETS,
 			allTimeStart,
-			withCustomRange: false,
 			withIntervalControl: false,
 			onStep: undefined,
 		} ),

--- a/projects/plugins/jetpack/changelog/uni-754-detail-date-presets
+++ b/projects/plugins/jetpack/changelog/uni-754-detail-date-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: on the post, page and video detail pages, offer every period the dashboard's date picker does, plus a custom range.

--- a/projects/plugins/premium-analytics/changelog/uni-754-detail-date-presets
+++ b/projects/plugins/premium-analytics/changelog/uni-754-detail-date-presets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post, page and video detail pages: offer every period the dashboard's date picker does, plus a custom range.


### PR DESCRIPTION
Fixes [UNI-754](https://linear.app/a8c/issue/UNI-754/date-picker-limitation-on-the-postpagevideo-details-page)

## Proposed changes

The post and video detail pages offered five periods where the dashboard offered eleven. This gives them the same menu.

* **The detail pages take the whole period menu.** `DETAIL_SURFACE_PRESETS` is now the menu's own list plus all time, which a detail page can still anchor on the resource's publish date. The narrow list was drawn for the segmented pill row that #51835 / #51842 replaced with a dropdown, where the row's width bounded what could fit; a menu has no such bound, and the list was never revisited. Today and Yesterday have been on the dashboard menu since it landed.
* **Custom range comes back.** #51533 dropped it because the pill row's mock had no room for it, and logged the removal as "easy to revisit — one-line flip". The dropdown's own design lists it, so `withCustomRange: false` goes.

A deep link naming a period the page did not offer, e.g. `&preset=last-90-days`, also stops falling back to a bare date range on the trigger — the period now names itself.

### Screenshots

Post detail, period menu open:

| Before | After |
|---|---|
| <img width="300" src="https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/uni-754-detail-date-presets/before-detail-menu.png" /> | <img width="300" src="https://raw.githubusercontent.com/Automattic/jetpack/screenshots/add/uni-754-detail-date-presets/after-detail-menu.png" /> |

## Related product discussion/links

* Linear: [UNI-754](https://linear.app/a8c/issue/UNI-754/date-picker-limitation-on-the-postpagevideo-details-page)
* The five-item list came from [WOOA7S-1785](https://linear.app/a8c/issue/WOOA7S-1785) (#51533); the dropdown that replaced the pill row came from [WOOA7S-2025](https://linear.app/a8c/issue/WOOA7S-2025) (#51835, #51842).
* [WOOA7S-1915](https://linear.app/a8c/issue/WOOA7S-1915) asked for Today and Yesterday from a customer interview and was closed as superseded by the WOOA7S-2025 design, not rejected.
* **Month to date and Year to date**, which the UNI-754 prototype also shows, are not here — they are not presets we ship on any surface yet. They are in #52088, stacked on this branch, so this one stays scoped to the detail pages.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Build the dashboard: `jetpack build --deps packages/premium-analytics`, then open Premium Analytics (`wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`).

On a post's detail page (from Top posts) and a video's (from the VideoPress widget):

* Open the period dropdown. It lists **Today · Yesterday · Last 24 hours · Last 7 days · Last 30 days · Last 90 days · Last 365 days · Last month · Last 12 months · Last year · All time · Custom range** — the dashboard's own menu, with All time last and Custom range under it.
* **Today** and **Yesterday** resolve to that single day; the header reads "Performance from … to …" accordingly.
* Pick **Custom range**: the calendar opens beside the list, and Apply commits it.
* **All time** still starts on the post's publish / video's upload day, and still survives a reload.
* Load the page with `&preset=last-90-days` in the `p` param: the trigger reads "Last 90 days" rather than a date range.
* The dashboard is unchanged.

`pnpm run test` in `projects/packages/premium-analytics` passes (3175 tests), as does `pnpm run test-tz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015eDqAWndvFNBrBRdKcsYus
