### PR TITLE
Jetpack: return site verification codes from settings API

### DIFF
--- a/projects/plugins/jetpack/changelog/dsgcom-797-site-verification-settings-response
+++ b/projects/plugins/jetpack/changelog/dsgcom-797-site-verification-settings-response
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: Return saved site verification codes from the site settings API.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -467,6 +467,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'site_icon'                        => $this->get_cast_option_value_or_null( 'site_icon', 'intval' ),
 						Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => get_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION, '' ),
 						Jetpack_SEO_Titles::TITLE_FORMATS_OPTION => get_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION, array() ),
+						'verification_services_codes'      => get_option( 'verification_services_codes', null ),
 						'api_cache'                        => $api_cache,
 						'posts_per_page'                   => (int) get_option( 'posts_per_page' ),
 						'posts_per_rss'                    => (int) get_option( 'posts_per_rss' ),

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -604,6 +604,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 			'woocommerce_default_country'      => array( 'woocommerce_default_country', '' ),
 			'woocommerce_store_postcode'       => array( 'woocommerce_store_postcode', '' ),
 			'woocommerce_onboarding_profile'   => array( 'woocommerce_onboarding_profile', array() ),
+			'verification_services_codes'      => array( 'verification_services_codes', null ),
 			'supports_free_tier_customization' => array( 'supports_free_tier_customization', true ),
 			// With no free tier description set, the rendered value is an empty string.
 			'free_tier_description_rendered'   => array( 'free_tier_description_rendered', '' ),
@@ -645,6 +646,16 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 			'woocommerce_default_country'    => array( 'woocommerce_default_country', 'woocommerce_default_country', 'US:NY' ),
 			'woocommerce_store_postcode'     => array( 'woocommerce_store_postcode', 'woocommerce_store_postcode', '98738' ),
 			'woocommerce_onboarding_profile' => array( 'woocommerce_onboarding_profile', 'woocommerce_onboarding_profile', array( 'test' => 'test value' ) ),
+			'verification_services_codes'    => array(
+				'verification_services_codes',
+				'verification_services_codes',
+				array(
+					'google'    => 'google-test-code',
+					'bing'      => 'bing-test-code',
+					'pinterest' => 'pinterest-test-code',
+					'yandex'    => 'yandex-test-code',
+				),
+			),
 			// Add MCP settings GET test
 			'mcp_abilities'                  => array(
 				'mcp_abilities',        // option name


### PR DESCRIPTION
Fix saved site verification codes being write-only in the site settings API. After this change, clients can read the same verification codes back from `GET /sites/$site/settings` that they saved through the POST endpoint.

## Proposed changes

* Return `verification_services_codes` in the site settings response.
* Cover the unset default and a populated code map in the existing endpoint tests.

## Related product discussion/links

* DSGCOM-797

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp docker phpunit jetpack -- --filter=WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test`.
* Confirm all 52 focused tests pass.
* Optionally save verification codes through `POST /sites/$site/settings`, then confirm `GET /sites/$site/settings` returns them in `settings.verification_services_codes`.
