### PR TITLE
Premium Analytics: build the custom date range calendar on the design system `RangeCalendar`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4022,9 +4022,6 @@ importers:
       '@automattic/number-formatters':
         specifier: workspace:*
         version: link:../../js-packages/number-formatters
-      '@automattic/ui':
-        specifier: 1.0.2
-        version: 1.0.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@date-fns/tz':
         specifier: 1.4.1
         version: 1.4.1

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -220,12 +220,12 @@ See Automattic/jetpack#50266 for the PR that established this contract.
 - Don't edit dashboard React in Calypso — it lives here now.
 - Internal package names use `@jetpack-premium-analytics/*` aliases throughout the package —
   never `@automattic/jetpack-premium-analytics-*`.
-- Never import `@automattic/ui`, `@wordpress/ui`, or `@wordpress/dataviews` directly from
-  anything under `packages/`, `widgets/`, or `routes/` — go through
-  `@jetpack-premium-analytics/externals`. A direct import compiles the whole library into that
-  bundle again; ESLint enforces this. `@automattic/charts` follows the same rule under
-  `packages/`, but under `widgets/` and `routes/` it must come from
-  `@jetpack-premium-analytics/widgets-toolkit` instead. See `packages/externals/README.md`.
+- Never import `@wordpress/ui` or `@wordpress/dataviews` directly from anything under
+  `packages/`, `widgets/`, or `routes/` — go through `@jetpack-premium-analytics/externals`. A
+  direct import compiles the whole library into that bundle again; ESLint enforces this.
+  `@automattic/charts` follows the same rule under `packages/`, but under `widgets/` and
+  `routes/` it must come from `@jetpack-premium-analytics/widgets-toolkit` instead. See
+  `packages/externals/README.md`.
 
 ## Comments and documentation
 

--- a/projects/packages/premium-analytics/changelog/update-pa-ds-range-calendar
+++ b/projects/packages/premium-analytics/changelog/update-pa-ds-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build the custom date range calendar on the WordPress design system calendar.

--- a/projects/packages/premium-analytics/eslint.config.mjs
+++ b/projects/packages/premium-analytics/eslint.config.mjs
@@ -171,8 +171,7 @@ export default defineConfig(
 							// stylesheet side-effect imports: those are plain
 							// CSS, not the library, so they carry none of the
 							// bundling cost.
-							regex:
-								'^(@automattic/charts|@automattic/ui|@wordpress/ui|@wordpress/dataviews)(/(?!.*\\.css$).*)?$',
+							regex: '^(@automattic/charts|@wordpress/ui|@wordpress/dataviews)(/(?!.*\\.css$).*)?$',
 							message:
 								'Import these from @jetpack-premium-analytics/externals instead: it compiles them once into a shared script module rather than into every module that imports them. Missing an export? Add it to packages/externals/src/index.ts.',
 						},
@@ -212,7 +211,7 @@ export default defineConfig(
 								'Import chart components from @jetpack-premium-analytics/widgets-toolkit instead: it is a shared script module, so charts is bundled once for the whole dashboard. Missing a component? Re-export it from the toolkit "Charts passthrough" section.',
 						},
 						{
-							regex: '^(@automattic/ui|@wordpress/ui|@wordpress/dataviews)(/(?!.*\\.css$).*)?$',
+							regex: '^(@wordpress/ui|@wordpress/dataviews)(/(?!.*\\.css$).*)?$',
 							message:
 								'Import these from @jetpack-premium-analytics/externals instead: it compiles them once into a shared script module rather than into every bundle that imports them. Missing an export? Add it to packages/externals/src/index.ts.',
 						},

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -44,7 +44,6 @@
 		"@automattic/jetpack-connection": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@automattic/number-formatters": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@date-fns/tz": "1.4.1",
 		"@jetpack-premium-analytics/data": "link:packages/data",
 		"@jetpack-premium-analytics/datetime": "link:packages/datetime",

--- a/projects/packages/premium-analytics/packages/externals/README.md
+++ b/projects/packages/premium-analytics/packages/externals/README.md
@@ -1,7 +1,7 @@
 # `@jetpack-premium-analytics/externals`
 
 A passthrough script module for the heavy third-party libraries the dashboard shares:
-`@automattic/charts`, `@automattic/ui`, `@wordpress/ui`, and `@wordpress/dataviews`.
+`@automattic/charts`, `@wordpress/ui`, and `@wordpress/dataviews`.
 
 ## Why this exists
 
@@ -38,9 +38,9 @@ change when the libraries themselves are upgraded. Feature work no longer rewrit
   `no-restricted-imports` again would *replace* the rule for those paths rather than add to it.
 - **Adding an export is cheap; adding a library is not.** A new library only belongs here if more
   than one module needs it, or if it is large enough that re-emitting it per module hurts.
-  `@automattic/ui` qualifies on the second count alone: `DateRangeCalendar` is its only consumer
-  in the package, but it reaches `react-day-picker` behind it, so leaving it in `packages/ui`
-  re-emitted ~55 KB of vendor code on every edit to that module.
+  `@wordpress/ui` qualifies on both: every module renders something from it, and its calendar
+  alone reaches `@daypicker/react` and `date-fns` behind it, so leaving it in `packages/ui`
+  would re-emit that vendor code on every edit to the module.
 
   `date-fns` deliberately stays out. It is imported directly by ~30 files across `data`,
   `datetime`, `routing`, `widgets/`, and `routes/`, and it is tree-shaken per function — routing it
@@ -83,5 +83,5 @@ done
 Today both report *still compiled in* (`@wordpress/ui` declares `wpScript: false`,
 `@wordpress/dataviews` declares nothing).
 
-`@automattic/charts` and `@automattic/ui` are third-party to WordPress and will never gain those
-fields, so they stay here regardless.
+`@automattic/charts` is third-party to WordPress and will never gain those fields, so it stays
+here regardless.

--- a/projects/packages/premium-analytics/packages/externals/package.json
+++ b/projects/packages/premium-analytics/packages/externals/package.json
@@ -14,7 +14,6 @@
 	],
 	"dependencies": {
 		"@automattic/charts": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@wordpress/dataviews": "19.0.1-next.v.202609031004.0",
 		"@wordpress/ui": "0.21.0",
 		"react": "18.3.1"

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -9,7 +9,6 @@
  * External dependencies
  */
 import '@automattic/charts/style.css';
-import '@automattic/ui/style.css';
 
 /**
  * Charts
@@ -52,15 +51,6 @@ export {
 export { LineShape, RectShape } from '@automattic/charts/visx/legend';
 
 /**
- * Calendar
- *
- * `DateRangeCalendar` is the package's only `@automattic/ui` consumer, but
- * pulls in `react-day-picker` + `date-fns` behind it — ~55 KB that would
- * otherwise re-emit on every edit to the importing module.
- */
-export { DateRangeCalendar } from '@automattic/ui';
-
-/**
  * WordPress design system
  *
  * `Field` is exported as `FormField`: `@wordpress/ui`'s form-field namespace
@@ -81,6 +71,7 @@ export {
 	Menu,
 	Notice,
 	Popover,
+	RangeCalendar,
 	SelectControl,
 	Skeleton,
 	Stack,

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/date-range-filter.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/__tests__/date-range-filter.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { DateRangePopoverContent, type DateRange } from '../date-range-filter';
+
+const JULY_2026: DateRange = {
+	from: new Date( 2026, 6, 1, 0, 0, 0, 0 ),
+	to: new Date( 2026, 6, 31, 23, 59, 59, 999 ),
+};
+
+type Props = Parameters< typeof DateRangePopoverContent >[ 0 ];
+
+// Mirrors the dropdown: a reported range comes back as the next `range` prop.
+function Harness( { onChange, ...props }: Props ) {
+	const [ range, setRange ] = useState( props.range );
+
+	return (
+		<DateRangePopoverContent
+			{ ...props }
+			range={ range }
+			onChange={ ( nextRange, presetId ) => {
+				if ( nextRange ) {
+					setRange( nextRange );
+				}
+				onChange( nextRange, presetId );
+			} }
+		/>
+	);
+}
+
+function renderContent( overrides: Partial< Props > = {} ) {
+	const props: Props = {
+		range: JULY_2026,
+		onChange: jest.fn(),
+		onApply: jest.fn(),
+		onCancel: jest.fn(),
+		canApply: true,
+		timeZone: 'UTC',
+		...overrides,
+	};
+
+	render( <Harness { ...props } /> );
+
+	return props;
+}
+
+const day = ( dayOfMonth: number ) =>
+	within( screen.getByRole( 'grid' ) ).getByRole( 'button', {
+		name: new RegExp( `July ${ dayOfMonth }, 2026` ),
+	} );
+
+const isSelected = ( dayOfMonth: number ) => /selected/.test( day( dayOfMonth ).ariaLabel ?? '' );
+
+describe( 'DateRangePopoverContent selection', () => {
+	it( 'stages the first click without reporting a range', async () => {
+		const user = userEvent.setup();
+		const { onChange } = renderContent();
+
+		await user.click( day( 10 ) );
+
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( isSelected( 10 ) ).toBe( true );
+		expect( isSelected( 1 ) ).toBe( false );
+		expect( screen.getByRole( 'button', { name: 'Apply' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'reports the range on the second click, earlier day first', async () => {
+		const user = userEvent.setup();
+		const { onChange } = renderContent();
+
+		await user.click( day( 10 ) );
+		await user.click( day( 5 ) );
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith(
+			{ from: new Date( 2026, 6, 5 ), to: new Date( 2026, 6, 10 ) },
+			'custom'
+		);
+		expect( isSelected( 5 ) && isSelected( 7 ) && isSelected( 10 ) ).toBe( true );
+		expect( screen.getByRole( 'button', { name: 'Apply' } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	// The calendar's own behaviour would move the nearest end of the range.
+	it( 'starts a new range on the third click', async () => {
+		const user = userEvent.setup();
+		const { onChange } = renderContent();
+
+		await user.click( day( 10 ) );
+		await user.click( day( 20 ) );
+		await user.click( day( 25 ) );
+
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( isSelected( 25 ) ).toBe( true );
+		expect( isSelected( 10 ) || isSelected( 20 ) ).toBe( false );
+	} );
+
+	// The calendar previews moving the nearest end of a complete range on hover,
+	// which is not what a click does here, so that preview is hidden until a draft opens.
+	it( 'only keeps the hover preview while a draft is open', async () => {
+		const user = userEvent.setup();
+		renderContent();
+		const isRangeComplete = () =>
+			screen.getByRole( 'application' ).classList.contains( 'date-range-calendar--range-complete' );
+
+		expect( isRangeComplete() ).toBe( true );
+
+		await user.click( day( 10 ) );
+		expect( isRangeComplete() ).toBe( false );
+
+		await user.click( day( 20 ) );
+		expect( isRangeComplete() ).toBe( true );
+	} );
+
+	it( 'reports a single day when the same day is clicked twice', async () => {
+		const user = userEvent.setup();
+		const { onChange } = renderContent();
+
+		await user.click( day( 10 ) );
+		await user.click( day( 10 ) );
+
+		expect( onChange ).toHaveBeenCalledWith(
+			{ from: new Date( 2026, 6, 10 ), to: new Date( 2026, 6, 10 ) },
+			'custom'
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
@@ -20,25 +20,31 @@
 }
 
 .date-range-calendar-wrapper {
-	--wca-calendar-button-width: 32px;
-	--wca-calendar-button-height: 32px;
-	--wca-calendar-button-gap: 1rem; // consistent with automattic/ui style
+	--wca-calendar-cell-size: var(--wpds-dimension-size-md);
+	// The gap the calendar leaves between two month grids.
+	--wca-calendar-months-gap: var(--wpds-dimension-gap-lg);
 	--wca-calendar-padding: var(--wca-popover-padding);
-	--wca-calendar-width: calc(var(--wca-calendar-button-width) * 7 + var(--wca-calendar-padding) * 2);
-	--wca-calendar-width-wide: calc(var(--wca-calendar-button-width) * 14 + var(--wca-calendar-padding) * 2 + var(--wca-calendar-button-gap));
+	--wca-calendar-width: calc(var(--wca-calendar-cell-size) * 7 + var(--wca-calendar-padding) * 2);
+	--wca-calendar-width-wide: calc(var(--wca-calendar-cell-size) * 14 + var(--wca-calendar-padding) * 2 + var(--wca-calendar-months-gap));
 
 	padding: var(--wca-calendar-padding);
 	width: var(--wca-calendar-width);
 	background-color: #fff;
 
 	.date-range-calendar {
-		--a8c-calendar-button-width: var(--wca-calendar-button-width);
-		--a8c-calendar-button-height: var(--wca-calendar-button-height);
+		--wp-ui-calendar-cell-size: var(--wca-calendar-cell-size);
 	}
 
 	&__wide {
 		width: var(--wca-calendar-width-wide);
 	}
+}
+
+// The calendar previews moving the nearest end of a complete range on
+// hover, but a click starts a new range here, so its dashed SVG only stays
+// for the half-open draft.
+.date-range-calendar--range-complete td > svg {
+	display: none;
 }
 
 .date-range-popover-actions {

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.scss
@@ -42,7 +42,8 @@
 
 // The calendar previews moving the nearest end of a complete range on
 // hover, but a click starts a new range here, so its dashed SVG only stays
-// for the half-open draft.
+// for the half-open draft. Drop this once the calendar can restart itself:
+// https://github.com/WordPress/gutenberg/issues/82609
 .date-range-calendar--range-complete td > svg {
 	display: none;
 }

--- a/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/date-range-popover/date-range-filter.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { PRESET_CUSTOM, type PrimaryPresetId } from '@jetpack-premium-analytics/datetime';
-import { Button, DateRangeCalendar, Stack } from '@jetpack-premium-analytics/externals';
+import { Button, RangeCalendar, Stack } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
@@ -13,9 +13,9 @@ import { DateRangeInput } from '../date-range-input';
 import './date-range-filter.scss';
 
 /**
- * The calendar's own range type, from `@automattic/ui`.
+ * The calendar's own range type, from `@wordpress/ui`.
  */
-export type DateRange = NonNullable< Parameters< typeof DateRangeCalendar >[ 0 ][ 'selected' ] >;
+export type DateRange = NonNullable< Parameters< typeof RangeCalendar >[ 0 ][ 'value' ] >;
 
 type DateRangePopoverContentProps = {
 	range: DateRange;
@@ -103,10 +103,10 @@ export function DateRangePopoverContent( {
 
 	/*
 	 * First click starts a new range, second completes it. Uses the clicked day,
-	 * not `onSelect`'s computed range: react-day-picker never restarts a
+	 * not the calendar's computed range: `RangeCalendar` never restarts a
 	 * complete range on click, it only moves the nearest endpoint.
 	 */
-	const handleCalendarSelect = ( _nextRange: DateRange | undefined, triggerDate: Date ) => {
+	const handleCalendarChange = ( _nextRange: DateRange | null, triggerDate: Date ) => {
 		if ( draftRange?.from && ! draftRange.to ) {
 			const [ from, to ] =
 				triggerDate < draftRange.from
@@ -137,10 +137,12 @@ export function DateRangePopoverContent( {
 			>
 				<DateRangeInput range={ range } onChange={ handleChange } timeZone={ timeZone } />
 
-				<DateRangeCalendar
-					className="date-range-calendar"
-					selected={ calendarRange }
-					onSelect={ handleCalendarSelect }
+				<RangeCalendar
+					className={ clsx( 'date-range-calendar', {
+						'date-range-calendar--range-complete': ! draftRange,
+					} ) }
+					value={ calendarRange }
+					onValueChange={ handleCalendarChange }
 					numberOfMonths={ isWideScreen ? 2 : 1 }
 					month={ displayedMonth }
 					onMonthChange={ setDisplayedMonth }

--- a/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part2.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/ui-no-mocks-part2.test.tsx
@@ -1,6 +1,7 @@
 // See README.md before adding a suite to this group.
 
 import '../../packages/ui/src/date-range-input/__tests__/date-range-input.test';
+import '../../packages/ui/src/date-range-popover/__tests__/date-range-filter.test';
 import '../../packages/ui/src/date-year-filter/__tests__/date-year-filter.test';
 import '../../packages/ui/src/section-header/__tests__/section-header.test';
 import '../../packages/ui/src/spotlight-step/__tests__/spotlight-step.test';

--- a/projects/packages/premium-analytics/tests/jest.config.cjs
+++ b/projects/packages/premium-analytics/tests/jest.config.cjs
@@ -39,8 +39,8 @@ module.exports = {
 	testPathIgnorePatterns: [ ...baseConfig.testPathIgnorePatterns, ...groupingIgnorePatterns ],
 	moduleNameMapper: {
 		...baseConfig.moduleNameMapper,
-		// Stub CSS imports (e.g. `@automattic/ui/style.css` pulled in via
-		// widgets-toolkit, or local `*.module.css`). jest's transformIgnorePatterns
+		// Stub CSS imports (e.g. `@automattic/charts/style.css` pulled in via
+		// externals, or local `*.module.css`). jest's transformIgnorePatterns
 		// skips nested node_modules CSS, so it would otherwise be parsed as JS.
 		'\\.s?css$': path.join( __dirname, 'style-stub.cjs' ),
 		// Resolve internal `packages/*` imports to their TypeScript source.

--- a/projects/packages/premium-analytics/tests/style-stub.cjs
+++ b/projects/packages/premium-analytics/tests/style-stub.cjs
@@ -1,5 +1,5 @@
-// Empty stand-in for CSS imports (e.g. `@automattic/ui/style.css` pulled in via
-// widgets-toolkit, or local `*.module.css`). jest's transformIgnorePatterns
+// Empty stand-in for CSS imports (e.g. `@automattic/charts/style.css` pulled in via
+// externals, or local `*.module.css`). jest's transformIgnorePatterns
 // skips nested node_modules CSS, so without this stub it would be parsed as
 // JavaScript and throw.
 module.exports = {};

--- a/projects/plugins/jetpack/changelog/update-pa-ds-range-calendar
+++ b/projects/plugins/jetpack/changelog/update-pa-ds-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Build the custom date range calendar on the WordPress design system calendar.

--- a/projects/plugins/premium-analytics/changelog/update-pa-ds-range-calendar
+++ b/projects/plugins/premium-analytics/changelog/update-pa-ds-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build the custom date range calendar on the WordPress design system calendar.

--- a/projects/plugins/wpcomsh/changelog/update-pa-ds-range-calendar
+++ b/projects/plugins/wpcomsh/changelog/update-pa-ds-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Build the custom date range calendar on the WordPress design system calendar.


### PR DESCRIPTION
## Proposed changes

The custom date range popover in Premium Analytics rendered `DateRangeCalendar` from `@automattic/ui`, the package's only use of that library. It now renders `RangeCalendar` from `@wordpress/ui`, already bundled through the externals module, and `@automattic/ui` leaves the package.

The way a range is picked does not change. The first click stages the start day, the second click reports the range with the earlier day first, and the next click starts a new range instead of moving the nearest end, which is what the calendar would do on its own. A new test covers those steps.

[Placeholder: video of the first, second and third click]

The calendar previews a move of the nearest range end while you hover, which is not what a click does here. That dashed preview is now hidden while the range is complete and only shows for the half-open draft, where it matches the second click. The component has no prop for this, so it is a modifier class on the calendar root and one CSS rule, linked to the upstream proposal below.

[Placeholder: hover on a complete range, before and after]

The calendar takes the design system look: neutral selection colours, dashed hover preview, tooltips on the month navigation. The wrapper width derives from the same tokens the calendar reads instead of hard-coded pixels.

[Placeholder: one month, and two months side by side]

## Related product discussion/links

p1787736910039939-slack-C06FSDTSN82

WOOPRD-3717

Same replacement in Podcast: #51902

Upstream proposal for the selection mode: https://github.com/WordPress/gutenberg/issues/82609

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Build the package first, since Storybook serves the built artifact of `ui` and `externals`:

```bash
jetpack build packages/premium-analytics
```

In Storybook, open `Packages/Premium Analytics/UI/DateRangePopoverContent`. Hover the applied range: no dashed preview, only the hovered day highlights.

https://github.com/user-attachments/assets/2783515a-a92f-4f85-8f48-4696f0d31efc


Click a day: only that day is selected, Apply is disabled, and hovering now draws the dashed preview from that day to the pointer. Click a second day, before or after the first: the range between both is selected and Apply is enabled. Click a third day: the previous range clears and only the new day is selected. Clicking the same day twice gives a one-day range.

The wide story shows two months side by side, at the same width as before.

In the dashboard, open the period dropdown on the Traffic tab and pick `Custom range`. Repeat the clicks above and click Apply: the widgets follow the range, and the `From` / `To` inputs above the calendar still update it.

https://github.com/user-attachments/assets/2ba277bc-a53d-4e8b-b01b-7b9c01423320


## Follow-ups

- [ ] Pass the site language and start of week to the calendar (`locale`, `weekStartsOn`). It renders `en-US` names and a Sunday week start today, as the previous calendar did.
- [ ] WordPress/gutenberg#82609 proposes a selection mode on `RangeCalendar` with a matching hover preview. Once it lands, the CSS rule that hides the preview goes away.
