### PR TITLE
Jetpack: validate site verification codes

### DIFF
--- a/projects/plugins/jetpack/_inc/client/traffic/test/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/verification-services.jsx
@@ -1,0 +1,27 @@
+import { VerificationServicesComponent } from '../verification-services';
+
+describe( 'Site verification meta tag formatting', () => {
+	const component = new VerificationServicesComponent( {} );
+
+	it( 'wraps verification codes containing safe punctuation', () => {
+		expect( component.getMetaTag( 'google', '+token.value/with=safe:@~characters' ) ).toBe(
+			'<meta name="google-site-verification" content="+token.value/with=safe:@~characters" />'
+		);
+	} );
+
+	it( 'does not wrap values containing attribute delimiters', () => {
+		expect( component.getMetaTag( 'google', 'unsafe"attribute' ) ).toBe( 'unsafe"attribute' );
+	} );
+
+	it( 'escapes ampersands when formatting the meta tag', () => {
+		expect( component.getMetaTag( 'bing', 'token&value' ) ).toBe(
+			'<meta name="msvalidate.01" content="token&amp;value" />'
+		);
+	} );
+
+	it( 'does not double-escape stored HTML entities', () => {
+		expect( component.getMetaTag( 'bing', 'token&amp;value' ) ).toBe(
+			'<meta name="msvalidate.01" content="token&amp;value" />'
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
@@ -12,7 +12,7 @@ import SettingsGroup from 'components/settings-group';
 import TextInput from 'components/text-input';
 import GoogleVerificationService from './verification-services/google';
 
-class VerificationServicesComponent extends Component {
+export class VerificationServicesComponent extends Component {
 	static serviceIds = {
 		google: 'google-site-verification',
 		bing: 'msvalidate.01',
@@ -26,7 +26,7 @@ class VerificationServicesComponent extends Component {
 			return '';
 		}
 
-		if ( ! /^[a-z0-9_-]+$/i.test( content ) ) {
+		if ( ! /^(?!.*[<>"'])[!-~]+$/.test( content ) ) {
 			// User is probably editing the content
 			return content;
 		}
@@ -36,9 +36,11 @@ class VerificationServicesComponent extends Component {
 			return content;
 		}
 
+		const escapedContent = content.replace( /&(?!(?:#\d+|#x[\da-f]+|[a-z][\da-z]*);)/gi, '&amp;' );
+
 		return `<meta name="${
 			VerificationServicesComponent.serviceIds?.[ serviceName ] ?? ''
-		}" content="${ content }" />`;
+		}" content="${ escapedContent }" />`;
 	}
 
 	getSiteVerificationValue( service ) {

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3160,7 +3160,9 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_verification_service( $value, $request, $param ) {
-		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || jetpack_verification_get_code( $value ) !== false ) ) ) {
+		$validated_codes = is_string( $value ) ? jetpack_verification_validate( array( $param => $value ) ) : array();
+
+		if ( ! empty( $value ) && empty( $validated_codes[ $param ] ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3160,14 +3160,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_verification_service( $value, $request, $param ) {
-		$validated_codes = is_string( $value ) ? jetpack_verification_validate( array( $param => $value ) ) : array();
-
-		if ( ! empty( $value ) && empty( $validated_codes[ $param ] ) ) {
+		if ( ! empty( $value ) && ( ! is_string( $value ) || false === jetpack_verification_validate_code( $value ) ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(
 					/* Translators: Placeholder is a verification string used to verify a service like Google Webmaster Console. */
-					esc_html__( '%s must be an alphanumeric string or a verification tag.', 'jetpack' ),
+					esc_html__( '%s must be a valid verification code or verification tag.', 'jetpack' ),
 					$param
 				)
 			);

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -816,12 +816,8 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$grouped_options_current = (array) get_option( 'verification_services_codes' );
 					$grouped_options         = $grouped_options_current;
 
-					// Extracts the content attribute from the HTML meta tag if needed.
-					if ( preg_match( '#.*<meta name="(?:[^"]+)" content="([^"]+)" />.*#i', $value, $matches ) ) {
-						$grouped_options[ $option ] = $matches[1];
-					} else {
-						$grouped_options[ $option ] = $value;
-					}
+					$validated_code             = jetpack_verification_validate( array( $option => $value ) );
+					$grouped_options[ $option ] = $validated_code[ $option ];
 
 					// If option value was the same, consider it done.
 					$updated = $grouped_options_current !== $grouped_options

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -816,8 +816,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$grouped_options_current = (array) get_option( 'verification_services_codes' );
 					$grouped_options         = $grouped_options_current;
 
-					$validated_code             = jetpack_verification_validate( array( $option => $value ) );
-					$grouped_options[ $option ] = $validated_code[ $option ];
+					$validated_code = jetpack_verification_validate_code( $value );
+					if ( false === $validated_code ) {
+						$error = esc_html__( 'The site verification code is invalid.', 'jetpack' );
+						break;
+					}
+
+					$grouped_options[ $option ] = $validated_code;
 
 					// If option value was the same, consider it done.
 					$updated = $grouped_options_current !== $grouped_options

--- a/projects/plugins/jetpack/changelog/dsgcom-534-validate-site-verification-codes
+++ b/projects/plugins/jetpack/changelog/dsgcom-534-validate-site-verification-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Verification: Reject invalid verification codes instead of reporting a successful save.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1234,22 +1234,21 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'verification_services_codes':
-					$verification_codes = jetpack_verification_validate( $value );
-
-					foreach ( $value as $service_key => $raw_code ) {
-						if ( '' === $raw_code || null === $raw_code ) {
+					foreach ( $value as $raw_code ) {
+						if ( '' === $raw_code || null === $raw_code || false === $raw_code ) {
 							continue;
 						}
 
-						$validated_code = $verification_codes[ $service_key ] ?? '';
-						if ( '' === $validated_code ) {
+						if ( false === jetpack_verification_validate_code( $raw_code ) ) {
 							return new WP_Error(
 								'invalid_input',
-								__( 'Invalid site verification code. Enter only the content value from the meta tag.', 'jetpack' ),
+								__( 'Invalid site verification code. Enter a verification code or verification tag.', 'jetpack' ),
 								400
 							);
 						}
 					}
+
+					$verification_codes = jetpack_verification_validate( $value );
 
 					if ( update_option( 'verification_services_codes', $verification_codes ) ) {
 						$updated[ $key ] = $verification_codes;

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1236,6 +1236,21 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 				case 'verification_services_codes':
 					$verification_codes = jetpack_verification_validate( $value );
 
+					foreach ( $value as $service_key => $raw_code ) {
+						if ( '' === $raw_code || null === $raw_code ) {
+							continue;
+						}
+
+						$validated_code = isset( $verification_codes[ $service_key ] ) ? $verification_codes[ $service_key ] : '';
+						if ( '' === $validated_code ) {
+							return new WP_Error(
+								'invalid_input',
+								__( 'Invalid site verification code. Enter only the content value from the meta tag.', 'jetpack' ),
+								400
+							);
+						}
+					}
+
 					if ( update_option( 'verification_services_codes', $verification_codes ) ) {
 						$updated[ $key ] = $verification_codes;
 					}

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1241,7 +1241,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 							continue;
 						}
 
-						$validated_code = isset( $verification_codes[ $service_key ] ) ? $verification_codes[ $service_key ] : '';
+						$validated_code = $verification_codes[ $service_key ] ?? '';
 						if ( '' === $validated_code ) {
 							return new WP_Error(
 								'invalid_input',

--- a/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
+++ b/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
@@ -16,43 +16,36 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array - an array of supported services.
  */
 function jetpack_verification_services() {
-	$patterns = jetpack_verification_service_patterns();
-
 	return array(
 		'google'    => array(
-			'name'    => 'Google Search Console',
-			'key'     => 'google-site-verification',
-			'format'  => 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8',
-			'url'     => 'https://www.google.com/webmasters/tools/',
-			'pattern' => $patterns['google'],
+			'name'   => 'Google Search Console',
+			'key'    => 'google-site-verification',
+			'format' => 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8',
+			'url'    => 'https://www.google.com/webmasters/tools/',
 		),
 		'bing'      => array(
-			'name'    => 'Bing Webmaster Center',
-			'key'     => 'msvalidate.01',
-			'format'  => '12C1203B5086AECE94EB3A3D9830B2E',
-			'url'     => 'https://www.bing.com/toolbox/webmaster/',
-			'pattern' => $patterns['bing'],
+			'name'   => 'Bing Webmaster Center',
+			'key'    => 'msvalidate.01',
+			'format' => '12C1203B5086AECE94EB3A3D9830B2E',
+			'url'    => 'https://www.bing.com/toolbox/webmaster/',
 		),
 		'pinterest' => array(
-			'name'    => 'Pinterest Site Verification',
-			'key'     => 'p:domain_verify',
-			'format'  => 'f100679e6048d45e4a0b0b92dce1efce',
-			'url'     => 'https://pinterest.com/website/verify/',
-			'pattern' => $patterns['pinterest'],
+			'name'   => 'Pinterest Site Verification',
+			'key'    => 'p:domain_verify',
+			'format' => 'f100679e6048d45e4a0b0b92dce1efce',
+			'url'    => 'https://pinterest.com/website/verify/',
 		),
 		'yandex'    => array(
-			'name'    => 'Yandex.Webmaster',
-			'key'     => 'yandex-verification',
-			'format'  => '44d68e1216009f40',
-			'url'     => 'https://webmaster.yandex.com/sites/',
-			'pattern' => $patterns['yandex'],
+			'name'   => 'Yandex.Webmaster',
+			'key'    => 'yandex-verification',
+			'format' => '44d68e1216009f40',
+			'url'    => 'https://webmaster.yandex.com/sites/',
 		),
 		'facebook'  => array(
-			'name'    => 'Facebook Domain Verification',
-			'key'     => 'facebook-domain-verification',
-			'format'  => 'rvv8b23jxlp1lq41I9rwsvpzncy1fd',
-			'url'     => 'https://business.facebook.com/settings/',
-			'pattern' => $patterns['facebook'],
+			'name'   => 'Facebook Domain Verification',
+			'key'    => 'facebook-domain-verification',
+			'format' => 'rvv8b23jxlp1lq41I9rwsvpzncy1fd',
+			'url'    => 'https://business.facebook.com/settings/',
 		),
 	);
 }

--- a/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
+++ b/projects/plugins/jetpack/modules/verification-tools/blog-verification-tools.php
@@ -16,36 +16,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array - an array of supported services.
  */
 function jetpack_verification_services() {
+	$patterns = jetpack_verification_service_patterns();
+
 	return array(
 		'google'    => array(
-			'name'   => 'Google Search Console',
-			'key'    => 'google-site-verification',
-			'format' => 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8',
-			'url'    => 'https://www.google.com/webmasters/tools/',
+			'name'    => 'Google Search Console',
+			'key'     => 'google-site-verification',
+			'format'  => 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8',
+			'url'     => 'https://www.google.com/webmasters/tools/',
+			'pattern' => $patterns['google'],
 		),
 		'bing'      => array(
-			'name'   => 'Bing Webmaster Center',
-			'key'    => 'msvalidate.01',
-			'format' => '12C1203B5086AECE94EB3A3D9830B2E',
-			'url'    => 'https://www.bing.com/toolbox/webmaster/',
+			'name'    => 'Bing Webmaster Center',
+			'key'     => 'msvalidate.01',
+			'format'  => '12C1203B5086AECE94EB3A3D9830B2E',
+			'url'     => 'https://www.bing.com/toolbox/webmaster/',
+			'pattern' => $patterns['bing'],
 		),
 		'pinterest' => array(
-			'name'   => 'Pinterest Site Verification',
-			'key'    => 'p:domain_verify',
-			'format' => 'f100679e6048d45e4a0b0b92dce1efce',
-			'url'    => 'https://pinterest.com/website/verify/',
+			'name'    => 'Pinterest Site Verification',
+			'key'     => 'p:domain_verify',
+			'format'  => 'f100679e6048d45e4a0b0b92dce1efce',
+			'url'     => 'https://pinterest.com/website/verify/',
+			'pattern' => $patterns['pinterest'],
 		),
 		'yandex'    => array(
-			'name'   => 'Yandex.Webmaster',
-			'key'    => 'yandex-verification',
-			'format' => '44d68e1216009f40',
-			'url'    => 'https://webmaster.yandex.com/sites/',
+			'name'    => 'Yandex.Webmaster',
+			'key'     => 'yandex-verification',
+			'format'  => '44d68e1216009f40',
+			'url'     => 'https://webmaster.yandex.com/sites/',
+			'pattern' => $patterns['yandex'],
 		),
 		'facebook'  => array(
-			'name'   => 'Facebook Domain Verification',
-			'key'    => 'facebook-domain-verification',
-			'format' => 'rvv8b23jxlp1lq41I9rwsvpzncy1fd',
-			'url'    => 'https://business.facebook.com/settings/',
+			'name'    => 'Facebook Domain Verification',
+			'key'     => 'facebook-domain-verification',
+			'format'  => 'rvv8b23jxlp1lq41I9rwsvpzncy1fd',
+			'url'     => 'https://business.facebook.com/settings/',
+			'pattern' => $patterns['facebook'],
 		),
 	);
 }

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -6,6 +6,23 @@
  * @package jetpack
  */
 
+if ( ! function_exists( 'jetpack_verification_service_patterns' ) ) {
+	/**
+	 * Return the accepted character patterns for verification service codes.
+	 *
+	 * @return array<string, string> Verification service patterns.
+	 */
+	function jetpack_verification_service_patterns() {
+		return array(
+			'google'    => '/^[A-Za-z0-9_-]+$/',
+			'bing'      => '/^[A-Fa-f0-9]+$/',
+			'pinterest' => '/^[a-f0-9]+$/',
+			'yandex'    => '/^[a-f0-9]+$/',
+			'facebook'  => '/^[A-Za-z0-9_-]+$/',
+		);
+	}
+}
+
 if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	/**
 	 * Validate jetpack verification codes.
@@ -13,16 +30,38 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	 * @param array $verification_services_codes - array of verification codes.
 	 */
 	function jetpack_verification_validate( $verification_services_codes ) {
+		$service_patterns = jetpack_verification_service_patterns();
+
 		foreach ( $verification_services_codes as $key => $code ) {
+			$code = is_scalar( $code ) ? (string) $code : '';
+
 			// Parse html meta tag if it does not look like a valid code.
 			if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
 				$code = jetpack_verification_get_code( $code );
 			}
 
-			$code = esc_attr( trim( $code ) );
+			$code = esc_attr( trim( (string) $code ) );
 
 			// limit length to 100 chars.
 			$code = substr( $code, 0, 100 );
+
+			if ( '' !== $code && isset( $service_patterns[ $key ] ) && ! preg_match( $service_patterns[ $key ], $code ) ) {
+				if ( function_exists( 'add_settings_error' ) ) {
+					$services     = function_exists( 'jetpack_verification_services' ) ? jetpack_verification_services() : array();
+					$service_name = isset( $services[ $key ]['name'] ) ? $services[ $key ]['name'] : ucfirst( $key );
+					add_settings_error(
+						'verification_services_codes',
+						'invalid_' . $key . '_verification_code',
+						sprintf(
+							/* translators: %s: Name of the verification service. */
+							__( 'Invalid verification code for %s. Enter only the content value from the meta tag.', 'jetpack' ),
+							$service_name
+						)
+					);
+				}
+
+				$code = '';
+			}
 
 			/**
 			 * Fire after each Verification code was validated.

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 			if ( '' !== $code && isset( $service_patterns[ $key ] ) && ! preg_match( $service_patterns[ $key ], $code ) ) {
 				if ( function_exists( 'add_settings_error' ) ) {
 					$services     = function_exists( 'jetpack_verification_services' ) ? jetpack_verification_services() : array();
-					$service_name = isset( $services[ $key ]['name'] ) ? $services[ $key ]['name'] : ucfirst( $key );
+					$service_name = $services[ $key ]['name'] ?? ucfirst( $key );
 					add_settings_error(
 						'verification_services_codes',
 						'invalid_' . $key . '_verification_code',

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -13,24 +13,27 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	 * @param array $verification_services_codes - array of verification codes.
 	 */
 	function jetpack_verification_validate( $verification_services_codes ) {
-		$code_pattern = '/^[a-z0-9_-]+$/i';
+		// Allow printable ASCII except characters that can delimit HTML attributes or tags.
+		$code_pattern = '/^(?!.*[<>"\'])[!-~]+$/';
 
 		foreach ( $verification_services_codes as $key => $code ) {
-			$code = is_scalar( $code ) ? (string) $code : '';
+			$code = is_scalar( $code ) ? trim( (string) $code ) : '';
 
 			// Parse html meta tag if it does not look like a valid code.
 			if ( ! preg_match( $code_pattern, $code ) ) {
 				$code = jetpack_verification_get_code( $code );
 			}
 
-			$code = esc_attr( trim( (string) $code ) );
-
-			// limit length to 100 chars.
-			$code = substr( $code, 0, 100 );
+			$code = trim( (string) $code );
 
 			if ( '' !== $code && ! preg_match( $code_pattern, $code ) ) {
 				$code = '';
 			}
+
+			// limit length to 100 chars.
+			$code = substr( $code, 0, 100 );
+
+			$code = esc_attr( $code );
 
 			/**
 			 * Fire after each Verification code was validated.
@@ -60,7 +63,7 @@ if ( ! function_exists( 'jetpack_verification_get_code' ) ) {
 		$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
 		preg_match( $pattern, $code, $match );
 		if ( $match ) {
-			return urldecode( $match[1] );
+			return rawurldecode( $match[1] );
 		} else {
 			return false;
 		}

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -6,6 +6,42 @@
  * @package jetpack
  */
 
+if ( ! function_exists( 'jetpack_verification_validate_code' ) ) {
+	/**
+	 * Validate and normalize a site verification code.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $code Verification code or meta tag.
+	 * @return string|false Normalized code, or false when invalid.
+	 */
+	function jetpack_verification_validate_code( $code ) {
+		if ( ! is_scalar( $code ) ) {
+			return false;
+		}
+
+		// Allow printable ASCII except characters that can delimit HTML attributes or tags.
+		$code_pattern = '/^(?!.*[<>"\'])[!-~]+$/';
+		$code         = trim( (string) $code );
+
+		if ( '' === $code ) {
+			return '';
+		}
+
+		// Parse html meta tag if it does not look like a valid code.
+		if ( ! preg_match( $code_pattern, $code ) ) {
+			$code = jetpack_verification_get_code( $code );
+		}
+
+		$code = trim( (string) $code );
+		if ( '' === $code || ! preg_match( $code_pattern, $code ) ) {
+			return false;
+		}
+
+		return substr( $code, 0, 100 );
+	}
+}
+
 if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	/**
 	 * Validate jetpack verification codes.
@@ -13,27 +49,9 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	 * @param array $verification_services_codes - array of verification codes.
 	 */
 	function jetpack_verification_validate( $verification_services_codes ) {
-		// Allow printable ASCII except characters that can delimit HTML attributes or tags.
-		$code_pattern = '/^(?!.*[<>"\'])[!-~]+$/';
-
 		foreach ( $verification_services_codes as $key => $code ) {
-			$code = is_scalar( $code ) ? trim( (string) $code ) : '';
-
-			// Parse html meta tag if it does not look like a valid code.
-			if ( ! preg_match( $code_pattern, $code ) ) {
-				$code = jetpack_verification_get_code( $code );
-			}
-
-			$code = trim( (string) $code );
-
-			if ( '' !== $code && ! preg_match( $code_pattern, $code ) ) {
-				$code = '';
-			}
-
-			// limit length to 100 chars.
-			$code = substr( $code, 0, 100 );
-
-			$code = esc_attr( $code );
+			$code = jetpack_verification_validate_code( $code );
+			$code = false === $code ? '' : $code;
 
 			/**
 			 * Fire after each Verification code was validated.

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -6,23 +6,6 @@
  * @package jetpack
  */
 
-if ( ! function_exists( 'jetpack_verification_service_patterns' ) ) {
-	/**
-	 * Return the accepted character patterns for verification service codes.
-	 *
-	 * @return array<string, string> Verification service patterns.
-	 */
-	function jetpack_verification_service_patterns() {
-		return array(
-			'google'    => '/^[A-Za-z0-9_-]+$/',
-			'bing'      => '/^[A-Fa-f0-9]+$/',
-			'pinterest' => '/^[a-f0-9]+$/',
-			'yandex'    => '/^[a-f0-9]+$/',
-			'facebook'  => '/^[A-Za-z0-9_-]+$/',
-		);
-	}
-}
-
 if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	/**
 	 * Validate jetpack verification codes.
@@ -30,13 +13,13 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	 * @param array $verification_services_codes - array of verification codes.
 	 */
 	function jetpack_verification_validate( $verification_services_codes ) {
-		$service_patterns = jetpack_verification_service_patterns();
+		$code_pattern = '/^[a-z0-9_-]+$/i';
 
 		foreach ( $verification_services_codes as $key => $code ) {
 			$code = is_scalar( $code ) ? (string) $code : '';
 
 			// Parse html meta tag if it does not look like a valid code.
-			if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
+			if ( ! preg_match( $code_pattern, $code ) ) {
 				$code = jetpack_verification_get_code( $code );
 			}
 
@@ -45,7 +28,7 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 			// limit length to 100 chars.
 			$code = substr( $code, 0, 100 );
 
-			if ( '' !== $code && isset( $service_patterns[ $key ] ) && ! preg_match( $service_patterns[ $key ], $code ) ) {
+			if ( '' !== $code && ! preg_match( $code_pattern, $code ) ) {
 				if ( function_exists( 'add_settings_error' ) ) {
 					$services     = function_exists( 'jetpack_verification_services' ) ? jetpack_verification_services() : array();
 					$service_name = $services[ $key ]['name'] ?? ucfirst( $key );

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -29,20 +29,6 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 			$code = substr( $code, 0, 100 );
 
 			if ( '' !== $code && ! preg_match( $code_pattern, $code ) ) {
-				if ( function_exists( 'add_settings_error' ) ) {
-					$services     = function_exists( 'jetpack_verification_services' ) ? jetpack_verification_services() : array();
-					$service_name = $services[ $key ]['name'] ?? ucfirst( $key );
-					add_settings_error(
-						'verification_services_codes',
-						'invalid_' . $key . '_verification_code',
-						sprintf(
-							/* translators: %s: Name of the verification service. */
-							__( 'Invalid verification code for %s. Enter only the content value from the meta tag.', 'jetpack' ),
-							$service_name
-						)
-					);
-				}
-
 				$code = '';
 			}
 

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -18,6 +18,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/ai/test/tracks.js',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',
+		'<rootDir>/_inc/client/traffic/test/verification-services.jsx',
 	],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest-globals.gui.js' ],
 	coverageDirectory: baseConfig.coverageDirectory + '/gui',

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -198,14 +198,21 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	#[DataProvider( 'verification_service_provider' )]
 	public function test_validate_verification_service( $value, $expected ) {
 		$this->load_rest_endpoints_direct();
+		$validation_actions = 0;
+		$action_callback    = static function () use ( &$validation_actions ) {
+			++$validation_actions;
+		};
+		add_action( 'jetpack_site_verification_validate', $action_callback );
 
 		$result = Jetpack_Core_Json_Api_Endpoints::validate_verification_service( $value, new WP_REST_Request(), 'google' );
+		remove_action( 'jetpack_site_verification_validate', $action_callback );
 
 		if ( $expected ) {
 			$this->assertTrue( $result );
 		} else {
 			$this->assertWPError( $result );
 		}
+		$this->assertSame( 0, $validation_actions );
 	}
 
 	/**
@@ -221,6 +228,30 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 			'quote'                 => array( 'unsafe"attribute', false ),
 			'whitespace'            => array( "unsafe\nvalue", false ),
 		);
+	}
+
+	/**
+	 * Updating a verification code normalizes and stores it through the complete REST path.
+	 */
+	public function test_update_verification_service_stores_normalized_code() {
+		$this->load_rest_endpoints_direct();
+		require_once JETPACK__PLUGIN_DIR . 'modules/verification-tools/blog-verification-tools.php';
+		jetpack_verification_options_init();
+
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+		Jetpack::update_active_modules( array( 'verification-tools' ) );
+
+		$response = $this->create_and_get_request(
+			'module/verification-tools',
+			array( 'google' => '+token.value/with=safe:@~characters' ),
+			'POST'
+		);
+
+		$this->assertResponseStatus( 200, $response );
+		$stored_codes = get_option( 'verification_services_codes' );
+		$this->assertSame( '+token.value/with=safe:@~characters', $stored_codes['google'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -188,6 +188,42 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test verification service validation.
+	 *
+	 * @dataProvider verification_service_provider
+	 *
+	 * @param string $value    Verification value.
+	 * @param bool   $expected Expected validation result.
+	 */
+	#[DataProvider( 'verification_service_provider' )]
+	public function test_validate_verification_service( $value, $expected ) {
+		$this->load_rest_endpoints_direct();
+
+		$result = Jetpack_Core_Json_Api_Endpoints::validate_verification_service( $value, new WP_REST_Request(), 'google' );
+
+		if ( $expected ) {
+			$this->assertTrue( $result );
+		} else {
+			$this->assertWPError( $result );
+		}
+	}
+
+	/**
+	 * Provide safe and unsafe verification values.
+	 *
+	 * @return array
+	 */
+	public static function verification_service_provider() {
+		return array(
+			'printable punctuation' => array( 'verification.Code_123-+/=:@~', true ),
+			'google meta tag'       => array( '<meta name="google-site-verification" content="+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=" />', true ),
+			'angle bracket'         => array( 'unsafe<script', false ),
+			'quote'                 => array( 'unsafe"attribute', false ),
+			'whitespace'            => array( "unsafe\nvalue", false ),
+		);
+	}
+
+	/**
 	 * Test permission to see if users can view Jetpack admin screen.
 	 *
 	 * @since 4.4.0

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -185,6 +185,9 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	 * Invalid site verification codes return an actionable client error and are not saved.
 	 */
 	public function test_post_rejects_invalid_site_verification_code() {
+		$existing_codes = array( 'bing' => 'existing-code' );
+		update_option( 'verification_services_codes', $existing_codes );
+
 		$setting = wp_json_encode(
 			array( 'verification_services_codes' => array( 'bing' => 'not a valid token' ) ),
 			JSON_UNESCAPED_SLASHES
@@ -195,7 +198,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 		$this->assertWPError( $response );
 		$this->assertSame( 'invalid_input', $response->get_error_code() );
 		$this->assertSame( 400, $response->get_error_data() );
-		$this->assertFalse( get_option( 'verification_services_codes' ) );
+		$this->assertSame( $existing_codes, get_option( 'verification_services_codes' ) );
 	}
 
 	/**
@@ -217,6 +220,47 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 			array( 'bing' => '12C1203B5086AECE94EB3A3D9830B2E' ),
 			$response['updated']['verification_services_codes']
 		);
+		$this->assertSame(
+			array( 'bing' => '12C1203B5086AECE94EB3A3D9830B2E' ),
+			get_option( 'verification_services_codes' )
+		);
+	}
+
+	/**
+	 * A boolean false remains a supported way to clear a verification code.
+	 */
+	public function test_post_clears_site_verification_code_with_false() {
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'google' => false ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame(
+			array( 'google' => '' ),
+			$response['updated']['verification_services_codes']
+		);
+		$this->assertSame( array( 'google' => '' ), get_option( 'verification_services_codes' ) );
+	}
+
+	/**
+	 * A non-scalar verification code is rejected without clearing the stored value.
+	 */
+	public function test_post_rejects_non_scalar_site_verification_code() {
+		$existing_codes = array( 'google' => 'existing-code' );
+		update_option( 'verification_services_codes', $existing_codes );
+
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'google' => array() ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'invalid_input', $response->get_error_code() );
+		$this->assertSame( $existing_codes, get_option( 'verification_services_codes' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -182,6 +182,44 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Invalid site verification codes return an actionable client error and are not saved.
+	 */
+	public function test_post_rejects_invalid_site_verification_code() {
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'bing' => 'not-a-bing-token' ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'invalid_input', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data() );
+		$this->assertFalse( get_option( 'verification_services_codes' ) );
+	}
+
+	/**
+	 * A valid site verification meta tag is reduced to its content value and saved.
+	 */
+	public function test_post_saves_site_verification_code_from_meta_tag() {
+		$setting = wp_json_encode(
+			array(
+				'verification_services_codes' => array(
+					'bing' => '<meta name="msvalidate.01" content="12C1203B5086AECE94EB3A3D9830B2E" />',
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame(
+			array( 'bing' => '12C1203B5086AECE94EB3A3D9830B2E' ),
+			$response['updated']['verification_services_codes']
+		);
+	}
+
+	/**
 	 * The free tier description is capped to 500 characters to match the
 	 * paid-tier description field.
 	 */

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -186,7 +186,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	 */
 	public function test_post_rejects_invalid_site_verification_code() {
 		$setting = wp_json_encode(
-			array( 'verification_services_codes' => array( 'bing' => 'not-a-bing-token' ) ),
+			array( 'verification_services_codes' => array( 'bing' => 'not.a.valid.token' ) ),
 			JSON_UNESCAPED_SLASHES
 		);
 

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -186,7 +186,7 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	 */
 	public function test_post_rejects_invalid_site_verification_code() {
 		$setting = wp_json_encode(
-			array( 'verification_services_codes' => array( 'bing' => 'not.a.valid.token' ) ),
+			array( 'verification_services_codes' => array( 'bing' => 'not a valid token' ) ),
 			JSON_UNESCAPED_SLASHES
 		);
 

--- a/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
@@ -48,7 +48,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verification codes with valid service-specific characters are accepted.
+	 * Verification codes with valid characters are accepted for every service.
 	 *
 	 * @dataProvider valid_verification_code_provider
 	 *
@@ -56,7 +56,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 * @param string $code    Verification code.
 	 */
 	#[DataProvider( 'valid_verification_code_provider' )]
-	public function test_service_specific_valid_code_is_accepted( $service, $code ) {
+	public function test_valid_code_is_accepted_for_every_service( $service, $code ) {
 		$this->assertSame(
 			array( $service => $code ),
 			jetpack_verification_validate( array( $service => $code ) )
@@ -64,7 +64,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verification codes with invalid service-specific characters are rejected.
+	 * Verification codes with invalid characters are rejected for every service.
 	 *
 	 * @dataProvider invalid_verification_code_provider
 	 *
@@ -72,7 +72,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 * @param string $code    Verification code.
 	 */
 	#[DataProvider( 'invalid_verification_code_provider' )]
-	public function test_service_specific_invalid_code_is_rejected( $service, $code ) {
+	public function test_invalid_code_is_rejected_for_every_service( $service, $code ) {
 		$this->assertSame(
 			array( $service => '' ),
 			jetpack_verification_validate( array( $service => $code ) )
@@ -86,11 +86,11 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public static function valid_verification_code_provider() {
 		return array(
-			'google'    => array( 'google', 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8' ),
-			'bing'      => array( 'bing', '12C1203B5086AECE94EB3A3D9830B2E' ),
-			'pinterest' => array( 'pinterest', 'f100679e6048d45e4a0b0b92dce1efce' ),
-			'yandex'    => array( 'yandex', '44d68e1216009f40' ),
-			'facebook'  => array( 'facebook', 'rvv8b23jxlp1lq41I9rwsvpzncy1fd' ),
+			'google'    => array( 'google', 'verification_Code-123' ),
+			'bing'      => array( 'bing', 'verification_Code-123' ),
+			'pinterest' => array( 'pinterest', 'verification_Code-123' ),
+			'yandex'    => array( 'yandex', 'verification_Code-123' ),
+			'facebook'  => array( 'facebook', 'verification_Code-123' ),
 		);
 	}
 
@@ -101,11 +101,11 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public static function invalid_verification_code_provider() {
 		return array(
-			'bing with non-hex characters'     => array( 'bing', 'not-a-bing-token' ),
-			'pinterest with uppercase letters' => array( 'pinterest', 'ABCDEF123456' ),
-			'yandex with non-hex characters'   => array( 'yandex', 'not-a-yandex-token' ),
-			'google with spaces'               => array( 'google', 'not a google token' ),
-			'facebook with punctuation'        => array( 'facebook', 'not.a.facebook.token' ),
+			'google'    => array( 'google', 'invalid.code' ),
+			'bing'      => array( 'bing', 'invalid.code' ),
+			'pinterest' => array( 'pinterest', 'invalid.code' ),
+			'yandex'    => array( 'yandex', 'invalid.code' ),
+			'facebook'  => array( 'facebook', 'invalid.code' ),
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
@@ -17,8 +17,8 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test_jetpack_verification_validate_google_raw_code() {
 		$this->assertEquals(
-			array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ),
-			jetpack_verification_validate( array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ) ),
+			array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			jetpack_verification_validate( array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ) ),
 			'raw code should be accepeted'
 		);
 	}
@@ -29,8 +29,8 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test_jetpack_verification_validate_google_code_in_meta_double_quotes() {
 		$this->assertEquals(
-			array( 'test' => 'bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr' ),
-			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content="bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr" />' ) ),
+			array( 'test' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content="+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=" />' ) ),
 			'google-style meta tag with double quotes should be accepeted'
 		);
 	}
@@ -86,11 +86,12 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public static function valid_verification_code_provider() {
 		return array(
-			'google'    => array( 'google', 'verification_Code-123' ),
-			'bing'      => array( 'bing', 'verification_Code-123' ),
-			'pinterest' => array( 'pinterest', 'verification_Code-123' ),
-			'yandex'    => array( 'yandex', 'verification_Code-123' ),
-			'facebook'  => array( 'facebook', 'verification_Code-123' ),
+			'google'           => array( 'google', '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			'bing'             => array( 'bing', '12C1203B5086AECE94EB3A3D9830B2E' ),
+			'pinterest'        => array( 'pinterest', 'f100679e6048d45e4a0b0b92dce1efce' ),
+			'yandex'           => array( 'yandex', '44d68e1216009f40' ),
+			'facebook'         => array( 'facebook', 'rvv8b23jxlp1lq41I9rwsvpzncy1fd' ),
+			'safe punctuation' => array( 'google', 'verification.Code_123-+/=:@~' ),
 		);
 	}
 
@@ -101,11 +102,12 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public static function invalid_verification_code_provider() {
 		return array(
-			'google'    => array( 'google', 'invalid.code' ),
-			'bing'      => array( 'bing', 'invalid.code' ),
-			'pinterest' => array( 'pinterest', 'invalid.code' ),
-			'yandex'    => array( 'yandex', 'invalid.code' ),
-			'facebook'  => array( 'facebook', 'invalid.code' ),
+			'opening angle bracket'        => array( 'google', 'invalid<script' ),
+			'closing angle bracket'        => array( 'bing', 'invalid>script' ),
+			'double quote'                 => array( 'pinterest', 'invalid"code' ),
+			'single quote'                 => array( 'yandex', "invalid'code" ),
+			'control character'            => array( 'facebook', "invalid\ncode" ),
+			'unsafe character after limit' => array( 'google', '<meta name="google-site-verification" content="' . str_repeat( 'a', 100 ) . '<" />' ),
 		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
@@ -6,8 +6,10 @@ require __DIR__ . '/../../../../modules/verification-tools/verification-tools-ut
 
 /**
  * @covers ::jetpack_verification_validate
+ * @covers ::jetpack_verification_validate_code
  */
 #[CoversFunction( 'jetpack_verification_validate' )]
+#[CoversFunction( 'jetpack_verification_validate_code' )]
 class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -19,7 +21,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
 			jetpack_verification_validate( array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ) ),
-			'raw code should be accepeted'
+			'raw code should be accepted'
 		);
 	}
 
@@ -80,6 +82,22 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The validation action receives the same canonical code that is returned for storage.
+	 */
+	public function test_validation_action_receives_canonical_code() {
+		$action_code = null;
+		$callback    = static function ( $service, $code ) use ( &$action_code ) {
+			$action_code = $code;
+		};
+		add_action( 'jetpack_site_verification_validate', $callback, 10, 2 );
+
+		$validated = jetpack_verification_validate( array( 'google' => 'verification&Code' ) );
+
+		remove_action( 'jetpack_site_verification_validate', $callback, 10 );
+		$this->assertSame( $validated['google'], $action_code );
+	}
+
+	/**
 	 * Provide valid verification codes.
 	 *
 	 * @return array<string, array{string, string}> Test cases.
@@ -92,6 +110,7 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 			'yandex'           => array( 'yandex', '44d68e1216009f40' ),
 			'facebook'         => array( 'facebook', 'rvv8b23jxlp1lq41I9rwsvpzncy1fd' ),
 			'safe punctuation' => array( 'google', 'verification.Code_123-+/=:@~' ),
+			'ampersand'        => array( 'bing', 'verification&Code' ),
 		);
 	}
 

--- a/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 require __DIR__ . '/../../../../modules/verification-tools/verification-tools-utils.php';
 
 /**
@@ -43,6 +44,68 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 			array( 'test' => 'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub' ),
 			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content=\'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub\' />' ) ),
 			'google-style meta tag with single quotes should be accepeted'
+		);
+	}
+
+	/**
+	 * Verification codes with valid service-specific characters are accepted.
+	 *
+	 * @dataProvider valid_verification_code_provider
+	 *
+	 * @param string $service Verification service key.
+	 * @param string $code    Verification code.
+	 */
+	#[DataProvider( 'valid_verification_code_provider' )]
+	public function test_service_specific_valid_code_is_accepted( $service, $code ) {
+		$this->assertSame(
+			array( $service => $code ),
+			jetpack_verification_validate( array( $service => $code ) )
+		);
+	}
+
+	/**
+	 * Verification codes with invalid service-specific characters are rejected.
+	 *
+	 * @dataProvider invalid_verification_code_provider
+	 *
+	 * @param string $service Verification service key.
+	 * @param string $code    Verification code.
+	 */
+	#[DataProvider( 'invalid_verification_code_provider' )]
+	public function test_service_specific_invalid_code_is_rejected( $service, $code ) {
+		$this->assertSame(
+			array( $service => '' ),
+			jetpack_verification_validate( array( $service => $code ) )
+		);
+	}
+
+	/**
+	 * Provide valid verification codes.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public static function valid_verification_code_provider() {
+		return array(
+			'google'    => array( 'google', 'dBw5CvburAxi537Rp9qi5uG2174Vb6JwHwIRwPSLIK8' ),
+			'bing'      => array( 'bing', '12C1203B5086AECE94EB3A3D9830B2E' ),
+			'pinterest' => array( 'pinterest', 'f100679e6048d45e4a0b0b92dce1efce' ),
+			'yandex'    => array( 'yandex', '44d68e1216009f40' ),
+			'facebook'  => array( 'facebook', 'rvv8b23jxlp1lq41I9rwsvpzncy1fd' ),
+		);
+	}
+
+	/**
+	 * Provide invalid verification codes.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public static function invalid_verification_code_provider() {
+		return array(
+			'bing with non-hex characters'     => array( 'bing', 'not-a-bing-token' ),
+			'pinterest with uppercase letters' => array( 'pinterest', 'ABCDEF123456' ),
+			'yandex with non-hex characters'   => array( 'yandex', 'not-a-yandex-token' ),
+			'google with spaces'               => array( 'google', 'not a google token' ),
+			'facebook with punctuation'        => array( 'facebook', 'not.a.facebook.token' ),
 		);
 	}
 }


### PR DESCRIPTION
Fixes DSGCOM-534

## Proposed changes

* Accept printable ASCII verification-code characters while excluding whitespace and characters that can delimit HTML attributes or tags.
* Continue accepting a full verification meta tag by extracting and validating its `content` value.
* Use the same validation policy in the WordPress.com settings endpoint, Jetpack REST endpoint, and admin UI formatter.
* Return an HTTP 400 response when a supplied code is invalid, without replacing the stored value.
* Keep validation callbacks side-effect free and preserve supported empty-value clearing behavior.
* Add utility, endpoint, REST write-path, and UI coverage for accepted codes, rejected codes, meta-tag extraction, clearing, and HTML escaping.

## Related product discussion/links

* DSGCOM-534

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp docker phpunit jetpack -- --filter='Jetpack_Verification_Tools_Utils_Test|WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test|Jetpack_REST_API_endpoints_Test::test_(validate|update)_verification_service'` and confirm all 77 tests pass.
* Run `pnpm test-gui -- --runInBand _inc/client/traffic/test/verification-services.jsx` from `projects/plugins/jetpack` and confirm all 4 tests pass.
* Save a provider verification token containing `+`, `.`, `/`, `=`, `:`, `@`, or `~`; reload the settings page and confirm it is displayed as the provider's complete meta tag.
* Confirm the generated front-end meta tag contains the original verification value.
* Submit a value containing `<`, `>`, a quote, or a control character and confirm the request returns an error without changing the stored value.
