### PR TITLE
Boost: isolate the legacy and modern dashboard presentation

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -5,13 +5,13 @@ import TimeAgo from '../time-ago/time-ago';
 import InfoIcon from '$svg/info';
 import RefreshIcon from '$svg/refresh';
 import { createInterpolateElement } from '@wordpress/element';
-import { Link } from 'react-router';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
 import { getProvidersWithErrors } from '../lib/critical-css-errors';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import { Button } from '@automattic/jetpack-components';
 import styles from './status.module.scss';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import { subpageHref } from '$lib/modern/routes';
 import type { FC } from 'react';
 
 type StatusTypes = {
@@ -96,7 +96,13 @@ const Status: FC< StatusTypes > = ( {
 									providersWithErrors.length
 								),
 								{
-									advanced: <Link to="/critical-css-advanced" onClick={ handleAdvancedClick } />,
+									advanced: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content -- createInterpolateElement supplies the content.
+										<a
+											href={ subpageHref( 'critical-css-advanced' ) }
+											onClick={ handleAdvancedClick }
+										/>
+									),
 								}
 							) }
 						</>

--- a/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.tsx
@@ -1,23 +1,19 @@
 import { __ } from '@wordpress/i18n';
 import LeftArrow from '$svg/left-arrow';
-import { useNavigate } from 'react-router';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { Button } from '@automattic/jetpack-components';
 import styles from './back-button.module.scss';
 import type { FC } from 'react';
 
-type BackButtonProps = {
-	route?: string;
-};
-
-const BackButton: FC< BackButtonProps > = ( { route = '/' } ) => {
-	const navigate = useNavigate();
+const BackButton: FC = () => {
+	const { returnToSettings } = useBoostNavigation();
 	const handleBack = () => {
 		recordBoostEvent( 'back_button_clicked', {
 			current_page: window.location.href.replace( window.location.origin, '' ),
-			destination: route,
+			destination: '/',
 		} );
-		navigate( route );
+		returnToSettings();
 	};
 
 	return (

--- a/projects/plugins/boost/app/assets/src/js/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/index.tsx
@@ -1,11 +1,15 @@
 import * as WPElement from '@wordpress/element';
 import Main from './main';
+import ModernApp from '$layout/modern/modern-app';
+import { detectMode, LEGACY_ROOT_ID, waitForSlots } from '$lib/modern/mode';
+
+const APP_ROOT_ID = 'jb-modern-root';
 
 /**
- * Initial render function.
+ * Render today's dashboard into the root PHP gives it.
  */
-function render() {
-	const container = document.getElementById( 'jb-admin-settings' );
+function renderLegacy() {
+	const container = document.getElementById( LEGACY_ROOT_ID );
 
 	if ( null === container ) {
 		return;
@@ -14,6 +18,36 @@ function render() {
 	const component = <Main />;
 
 	WPElement.createRoot( container ).render( component );
+}
+
+/**
+ * Render the modern app once the chassis has created its slots.
+ *
+ * The root lives in a container of our own and never in a chassis slot, so one
+ * root can portal into both slots and outlive whichever is showing.
+ */
+async function renderModern() {
+	const slots = await waitForSlots();
+
+	const container = document.createElement( 'div' );
+	container.id = APP_ROOT_ID;
+	container.hidden = true;
+	document.body.appendChild( container );
+
+	WPElement.createRoot( container ).render( <ModernApp slots={ slots } /> );
+}
+
+/**
+ * Initial render function.
+ */
+function render() {
+	if ( detectMode() === 'modern' ) {
+		renderModern();
+
+		return;
+	}
+
+	renderLegacy();
 }
 
 render();

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
@@ -1,0 +1,144 @@
+/* This project does not load jest-dom, so its matchers are not available here. */
+/* eslint-disable jest-dom/prefer-in-document */
+import { act, render, within } from '@testing-library/react';
+import { SETTINGS_SLOT_ID, SUBPAGE_SLOT_ID } from '$lib/modern/mode';
+import { LOCATION_CHANGE_EVENT } from '$lib/modern/routes';
+import ModernApp from './modern-app';
+import type { ModernSlots } from '$lib/modern/mode';
+
+const mockRecordBoostEvent = jest.fn();
+let mockShouldGetStarted = false;
+
+jest.mock( '$lib/utils/analytics', () => ( {
+	...jest.requireActual( '$lib/utils/analytics' ),
+	recordBoostEvent: ( ...args: unknown[] ) => mockRecordBoostEvent( ...args ),
+} ) );
+jest.mock( '$lib/stores/getting-started', () => ( {
+	useGettingStarted: () => ( {
+		shouldGetStarted: mockShouldGetStarted,
+		markGettingStartedComplete: jest.fn(),
+	} ),
+} ) );
+jest.mock( '@automattic/jetpack-react-data-sync-client', () => ( {
+	DataSyncProvider: ( { children }: { children: React.ReactNode } ) => children,
+} ) );
+jest.mock( '$features/critical-css/critical-css-context/critical-css-context-provider', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => children,
+} ) );
+jest.mock( './modern-settings', () => ( {
+	__esModule: true,
+	default: ( { hidden }: { hidden?: boolean } ) => <div data-testid="settings" hidden={ hidden } />,
+} ) );
+jest.mock( './modern-subpage', () => ( {
+	__esModule: true,
+	default: ( { subpage }: { subpage: string } ) => <div data-testid="subpage">{ subpage }</div>,
+} ) );
+
+const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
+
+const goTo = ( suffix: string ) => {
+	act( () => {
+		window.history.replaceState( null, '', `${ BASE_URL }${ suffix }` );
+		window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+	} );
+};
+
+const renderApp = () => {
+	const slots: ModernSlots = {
+		settings: document.createElement( 'div' ),
+		subpage: document.createElement( 'div' ),
+	};
+	slots.settings.id = SETTINGS_SLOT_ID;
+	slots.subpage.id = SUBPAGE_SLOT_ID;
+	document.body.append( slots.settings, slots.subpage );
+
+	return { slots, ...render( <ModernApp slots={ slots } /> ) };
+};
+
+describe( 'ModernApp', () => {
+	beforeEach( () => {
+		mockShouldGetStarted = false;
+		mockRecordBoostEvent.mockClear();
+		window.history.replaceState( null, '', BASE_URL );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'portals Settings into the settings slot and leaves the sub-page slot empty', () => {
+		const { slots } = renderApp();
+
+		expect( within( slots.settings ).getByTestId( 'settings' ) ).toBeTruthy();
+		expect( within( slots.subpage ).queryByTestId( 'subpage' ) ).toBeNull();
+	} );
+
+	it( 'keeps the Settings tree mounted while a sub-page shows', () => {
+		const { slots } = renderApp();
+		const settingsNode = within( slots.settings ).getByTestId( 'settings' );
+
+		goTo( '#/cache-debug-log' );
+
+		expect( within( slots.subpage ).getByText( 'cache-debug-log' ) ).toBeTruthy();
+		expect( within( slots.settings ).getByTestId( 'settings' ) ).toBe( settingsNode );
+	} );
+
+	it( 'renders one sub-page at a time', () => {
+		const { slots } = renderApp();
+
+		goTo( '#/cache-debug-log' );
+		goTo( '#/critical-css-advanced' );
+
+		expect( within( slots.subpage ).getAllByTestId( 'subpage' ) ).toHaveLength( 1 );
+		expect( within( slots.subpage ).getByText( 'critical-css-advanced' ) ).toBeTruthy();
+	} );
+
+	it( 'records one page view per visible route activation', () => {
+		renderApp();
+		goTo( '&tab=settings' );
+		goTo( '#/cache-debug-log' );
+
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_overview',
+			'page_view_settings',
+			'page_view_cache_debug_log',
+		] );
+	} );
+
+	it( 'does not record a second view for a repeated location event', () => {
+		renderApp();
+		goTo( '#/cache-debug-log' );
+		goTo( '#/cache-debug-log' );
+
+		expect( mockRecordBoostEvent ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'promotes a tab carried in the hash and records it once as Settings', () => {
+		renderApp();
+		goTo( '#/?tab=settings' );
+
+		expect( window.location.hash ).toBe( '' );
+		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( mockRecordBoostEvent ).toHaveBeenLastCalledWith( 'page_view_settings', { path: '/' } );
+	} );
+
+	it( 'redirects an onboarding user off a guarded route without recording it', () => {
+		mockShouldGetStarted = true;
+		const { slots } = renderApp();
+
+		expect( window.location.hash ).toBe( '#/getting-started' );
+		expect( within( slots.subpage ).getByText( 'getting-started' ) ).toBeTruthy();
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_getting_started',
+		] );
+	} );
+
+	it( 'leaves the onboarding page itself alone', () => {
+		mockShouldGetStarted = true;
+		window.history.replaceState( null, '', `${ BASE_URL }#/purchase-successful` );
+		const { slots } = renderApp();
+
+		expect( within( slots.subpage ).getByText( 'purchase-successful' ) ).toBeTruthy();
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.tsx
@@ -1,0 +1,63 @@
+import { StrictMode } from 'react';
+import { createPortal } from '@wordpress/element';
+import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
+import CriticalCssProvider from '$features/critical-css/critical-css-context/critical-css-context-provider';
+import { NoticeProvider } from '$features/notice/context';
+import { ModernNavigationProvider } from '$lib/navigation/navigation-context';
+import { useModernRoute } from '$lib/modern/use-modern-route';
+import { usePageView } from '$lib/modern/use-page-view';
+import ModernSettings from './modern-settings';
+import ModernSubpage from './modern-subpage';
+import { useOnboardingRedirect } from './use-onboarding-redirect';
+import type { ModernSlots } from '$lib/modern/mode';
+
+type ModernAppProps = {
+	slots: ModernSlots;
+};
+
+/**
+ * The routed half of the app: one Settings tree that stays mounted, and at most
+ * one sub-page, each portalled into the chassis slot that owns it.
+ *
+ * @param props       - Component props.
+ * @param props.slots - Chassis slots to portal into.
+ */
+const ModernRoutes = ( { slots }: ModernAppProps ) => {
+	const route = useModernRoute();
+	const redirecting = useOnboardingRedirect( route );
+
+	usePageView( route, ! redirecting );
+
+	return (
+		<>
+			{ createPortal( <ModernSettings hidden={ redirecting } />, slots.settings ) }
+			{ route.subpage &&
+				! redirecting &&
+				createPortal( <ModernSubpage subpage={ route.subpage } />, slots.subpage ) }
+		</>
+	);
+};
+
+/**
+ * The modern app: one persistent root for the page lifetime, holding the data,
+ * notice and critical CSS providers above both slots so moving between Settings
+ * and a sub-page never drops their state.
+ *
+ * @param props       - Component props.
+ * @param props.slots - Chassis slots to portal into.
+ */
+const ModernApp = ( { slots }: ModernAppProps ) => (
+	<StrictMode>
+		<DataSyncProvider>
+			<ModernNavigationProvider>
+				<NoticeProvider>
+					<CriticalCssProvider>
+						<ModernRoutes slots={ slots } />
+					</CriticalCssProvider>
+				</NoticeProvider>
+			</ModernNavigationProvider>
+		</DataSyncProvider>
+	</StrictMode>
+);
+
+export default ModernApp;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
@@ -1,0 +1,6 @@
+// Scoped below the chassis mount: modern styles must not reach the legacy root.
+.settings {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import { usePremiumFeatures } from '$lib/stores/premium-features';
+import NoticeManager from '$features/notice/manager';
+import Support from '$layout/settings-page/support/support';
+import Tips from '$layout/settings-page/tips/tips';
+import Index from '../../pages/index';
+import styles from './modern-settings.module.scss';
+
+type ModernSettingsProps = {
+	hidden?: boolean;
+};
+
+/**
+ * Settings as composed for the modern chassis.
+ *
+ * The chassis owns the page header, tabs and footer, and the Overview owns the
+ * speed scores, so neither is rendered here.
+ *
+ * @param props        - Component props.
+ * @param props.hidden - Hide while a redirect is pending, without unmounting.
+ */
+const ModernSettings = ( { hidden = false }: ModernSettingsProps ) => {
+	const premiumFeatures = usePremiumFeatures();
+	const hasPrioritySupport = premiumFeatures && premiumFeatures.includes( 'support' );
+
+	return (
+		<div className={ clsx( 'jb-modern-settings', styles.settings ) } hidden={ hidden }>
+			<div className="jb-section jb-section--main">
+				<Index />
+			</div>
+
+			<Tips />
+
+			{ hasPrioritySupport && <Support /> }
+
+			<NoticeManager />
+		</div>
+	);
+};
+
+export default ModernSettings;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
@@ -1,0 +1,30 @@
+import CacheDebugLog from '../../pages/cache-debug-log/cache-debug-log';
+import AdvancedCriticalCss from '../../pages/critical-css-advanced/critical-css-advanced';
+import GettingStarted from '../../pages/getting-started/getting-started';
+import PurchaseSuccess from '../../pages/purchase-success/purchase-success';
+import type { Subpage } from '$lib/modern/routes';
+
+type ModernSubpageProps = {
+	subpage: Subpage;
+};
+
+/**
+ * The retained sub-pages, each rendered full-page with no tab shell.
+ *
+ * @param props         - Component props.
+ * @param props.subpage - Sub-page to render.
+ */
+const ModernSubpage = ( { subpage }: ModernSubpageProps ) => {
+	switch ( subpage ) {
+		case 'cache-debug-log':
+			return <CacheDebugLog />;
+		case 'critical-css-advanced':
+			return <AdvancedCriticalCss />;
+		case 'getting-started':
+			return <GettingStarted />;
+		case 'purchase-successful':
+			return <PurchaseSuccess />;
+	}
+};
+
+export default ModernSubpage;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/use-onboarding-redirect.ts
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/use-onboarding-redirect.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useGettingStarted } from '$lib/stores/getting-started';
+import { navigateTo, subpageUrl } from '$lib/modern/routes';
+import type { ModernRoute } from '$lib/modern/routes';
+
+/**
+ * Routes that send an onboarding user to Getting Started, matching the legacy
+ * router's loader: Settings and the two sub-pages it guards, never the
+ * onboarding or purchase pages themselves.
+ *
+ * @param route - Route being shown.
+ * @return Whether the route is guarded.
+ */
+function isGuarded( route: ModernRoute ): boolean {
+	return (
+		route.subpage === null ||
+		route.subpage === 'cache-debug-log' ||
+		route.subpage === 'critical-css-advanced'
+	);
+}
+
+/**
+ * Send onboarding users to Getting Started, as today.
+ *
+ * @param route - Route being shown.
+ * @return Whether a redirect is pending, so the caller can hold the page view.
+ */
+export function useOnboardingRedirect( route: ModernRoute ): boolean {
+	const { shouldGetStarted } = useGettingStarted();
+	const redirecting = shouldGetStarted && isGuarded( route );
+
+	useEffect( () => {
+		if ( redirecting ) {
+			navigateTo( subpageUrl( 'getting-started' ), { replace: true } );
+		}
+	}, [ redirecting ] );
+
+	return redirecting;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/mode.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/mode.test.ts
@@ -1,0 +1,81 @@
+import {
+	detectMode,
+	LEGACY_ROOT_ID,
+	MODERN_ROOT_ID,
+	SETTINGS_SLOT_ID,
+	SUBPAGE_SLOT_ID,
+	waitForSlots,
+} from './mode';
+
+const addRoot = ( id: string ) => {
+	const root = document.createElement( 'div' );
+	root.id = id;
+	document.body.appendChild( root );
+
+	return root;
+};
+
+describe( 'detectMode', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'reads legacy from the legacy root', () => {
+		addRoot( LEGACY_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'legacy' );
+	} );
+
+	it( 'reads modern from the chassis root', () => {
+		addRoot( MODERN_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'modern' );
+	} );
+
+	it( 'returns null when neither root is present', () => {
+		expect( detectMode() ).toBeNull();
+	} );
+
+	it( 'prefers legacy when both roots are present', () => {
+		addRoot( MODERN_ROOT_ID );
+		addRoot( LEGACY_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'legacy' );
+	} );
+} );
+
+describe( 'waitForSlots', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'resolves immediately when both slots already exist', async () => {
+		const settings = addRoot( SETTINGS_SLOT_ID );
+		const subpage = addRoot( SUBPAGE_SLOT_ID );
+
+		await expect( waitForSlots() ).resolves.toEqual( { settings, subpage } );
+	} );
+
+	it( 'waits for slots the chassis has not rendered yet', async () => {
+		const pending = waitForSlots();
+		addRoot( SETTINGS_SLOT_ID );
+		const subpage = addRoot( SUBPAGE_SLOT_ID );
+
+		await expect( pending ).resolves.toEqual( {
+			settings: document.getElementById( SETTINGS_SLOT_ID ),
+			subpage,
+		} );
+	} );
+
+	it( 'stays pending while only one slot exists', async () => {
+		let settled = false;
+		waitForSlots().then( () => {
+			settled = true;
+		} );
+		addRoot( SETTINGS_SLOT_ID );
+
+		await Promise.resolve();
+
+		expect( settled ).toBe( false );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/mode.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/mode.ts
@@ -1,0 +1,79 @@
+/**
+ * Runtime boundary between today's dashboard and the modern wp-build chassis.
+ *
+ * PHP resolves `rsm_jetpack_ui_modernization_boost` once per request and renders
+ * exactly one root; this app reads the mode from which one is in the DOM.
+ */
+
+export const LEGACY_ROOT_ID = 'jb-admin-settings';
+export const MODERN_ROOT_ID = 'jetpack-boost-dashboard-wp-admin-app';
+export const SETTINGS_SLOT_ID = 'jb-settings-tab-mount';
+export const SUBPAGE_SLOT_ID = 'jb-subpage-mount';
+
+export type DashboardMode = 'legacy' | 'modern';
+
+export type ModernSlots = {
+	settings: HTMLElement;
+	subpage: HTMLElement;
+};
+
+/**
+ * Detect which dashboard PHP rendered.
+ *
+ * @param doc - Document to inspect. Defaults to the live document.
+ * @return The mode, or null when neither root is present.
+ */
+export function detectMode( doc: Document = document ): DashboardMode | null {
+	// Legacy wins if both are somehow present, so a chassis bug can't take today's dashboard away.
+	if ( doc.getElementById( LEGACY_ROOT_ID ) ) {
+		return 'legacy';
+	}
+
+	if ( doc.getElementById( MODERN_ROOT_ID ) ) {
+		return 'modern';
+	}
+
+	return null;
+}
+
+/**
+ * Find both chassis slots, if they are already rendered.
+ *
+ * @param doc - Document to inspect.
+ * @return Both slots, or null while either is missing.
+ */
+function findSlots( doc: Document ): ModernSlots | null {
+	const settings = doc.getElementById( SETTINGS_SLOT_ID );
+	const subpage = doc.getElementById( SUBPAGE_SLOT_ID );
+
+	return settings && subpage ? { settings, subpage } : null;
+}
+
+/**
+ * Resolve once the chassis has created both slots.
+ *
+ * This app can boot before the chassis renders, so the modern mount waits rather
+ * than assuming the slots exist. There is deliberately no timeout: without a
+ * chassis there is no tab shell to render into either.
+ *
+ * @param doc - Document to observe.
+ * @return Both slots.
+ */
+export function waitForSlots( doc: Document = document ): Promise< ModernSlots > {
+	const present = findSlots( doc );
+	if ( present ) {
+		return Promise.resolve( present );
+	}
+
+	return new Promise( resolve => {
+		const observer = new MutationObserver( () => {
+			const slots = findSlots( doc );
+			if ( slots ) {
+				observer.disconnect();
+				resolve( slots );
+			}
+		} );
+
+		observer.observe( doc.body, { childList: true, subtree: true } );
+	} );
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
@@ -1,0 +1,76 @@
+import { getSubpage, resolveRoute, settingsUrl, subpageHref, subpageUrl } from './routes';
+
+const url = ( suffix: string ) =>
+	`http://localhost/wp-admin/admin.php?page=jetpack-boost${ suffix }`;
+
+describe( 'resolveRoute', () => {
+	it.each( [ '', '#', '#/' ] )( 'treats %p as the Overview root', suffix => {
+		expect( resolveRoute( url( suffix ) ).route ).toEqual( { subpage: null, tab: 'overview' } );
+	} );
+
+	it( 'reads the tab from the outer query', () => {
+		expect( resolveRoute( url( '&tab=settings' ) ).route ).toEqual( {
+			subpage: null,
+			tab: 'settings',
+		} );
+	} );
+
+	it( 'promotes a tab carried in the hash to the outer query', () => {
+		const { route, normalizedUrl } = resolveRoute( url( '#/?tab=settings' ) );
+
+		expect( route ).toEqual( { subpage: null, tab: 'settings' } );
+		expect( normalizedUrl ).toBe( url( '&tab=settings' ) );
+	} );
+
+	it( 'parses the hash query before matching a sub-page', () => {
+		expect( resolveRoute( url( '#/cache-debug-log?x=1' ) ).route.subpage ).toBe(
+			'cache-debug-log'
+		);
+	} );
+
+	it( 'lets a recognised hash win over the tab', () => {
+		expect( resolveRoute( url( '&tab=settings#/critical-css-advanced' ) ).route.subpage ).toBe(
+			'critical-css-advanced'
+		);
+	} );
+
+	it( 'falls back to the root for an unrecognised hash', () => {
+		expect( resolveRoute( url( '#/nope' ) ).route ).toEqual( { subpage: null, tab: 'overview' } );
+	} );
+
+	it( 'normalizes nothing for a plain URL', () => {
+		expect( resolveRoute( url( '&tab=settings' ) ).normalizedUrl ).toBeNull();
+	} );
+} );
+
+describe( 'getSubpage', () => {
+	it( 'tolerates a trailing slash', () => {
+		expect( getSubpage( '#/getting-started/' ) ).toBe( 'getting-started' );
+	} );
+
+	it( 'returns null for the root', () => {
+		expect( getSubpage( '#/' ) ).toBeNull();
+	} );
+} );
+
+describe( 'settingsUrl', () => {
+	it( 'clears the hash and sets the tab', () => {
+		expect( settingsUrl( url( '#/cache-debug-log' ) ) ).toBe( url( '&tab=settings' ) );
+	} );
+
+	it( 'leaves an existing settings tab alone', () => {
+		expect( settingsUrl( url( '&tab=settings' ) ) ).toBe( url( '&tab=settings' ) );
+	} );
+} );
+
+describe( 'subpageUrl', () => {
+	it( 'keeps the outer query', () => {
+		expect( subpageUrl( 'getting-started', url( '&tab=settings' ) ) ).toBe(
+			url( '&tab=settings#/getting-started' )
+		);
+	} );
+
+	it( 'builds the same hash in both modes', () => {
+		expect( subpageHref( 'purchase-successful' ) ).toBe( '#/purchase-successful' );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
@@ -1,0 +1,162 @@
+/**
+ * URL rules for the modern chassis.
+ *
+ * The wp-build route is `/` with `?tab=overview|settings` in the outer query,
+ * owned by the chassis. Sub-pages keep today's hashes, and a recognised hash
+ * wins over the tab.
+ */
+
+export const SUBPAGES = [
+	'cache-debug-log',
+	'critical-css-advanced',
+	'getting-started',
+	'purchase-successful',
+] as const;
+
+export type Subpage = ( typeof SUBPAGES )[ number ];
+export type Tab = 'overview' | 'settings';
+
+export type ModernRoute = {
+	subpage: Subpage | null;
+	tab: Tab;
+};
+
+export type ResolvedRoute = {
+	route: ModernRoute;
+	/** URL to replace the current one with, when the hash carried a tab. */
+	normalizedUrl: string | null;
+};
+
+export const LOCATION_CHANGE_EVENT = 'jetpack-boost:location-change';
+
+/**
+ * Split a hash into its path and query, tolerating `#`, `#/` and trailing slashes.
+ *
+ * @param hash - Location hash, with or without the leading `#`.
+ * @return The bare path and its parsed query.
+ */
+function splitHash( hash: string ): { path: string; query: URLSearchParams } {
+	const [ path, query = '' ] = hash.replace( /^#/, '' ).split( '?' );
+
+	return {
+		path: path.replace( /^\//, '' ).replace( /\/$/, '' ),
+		query: new URLSearchParams( query ),
+	};
+}
+
+/**
+ * Read the sub-page out of a hash.
+ *
+ * @param hash - Location hash.
+ * @return The sub-page, or null for the root.
+ */
+export function getSubpage( hash: string ): Subpage | null {
+	const { path } = splitHash( hash );
+
+	return SUBPAGES.find( subpage => subpage === path ) ?? null;
+}
+
+/**
+ * Resolve a URL to the route it shows, and to the URL it should have.
+ *
+ * @param href - URL to resolve. Defaults to the current location.
+ * @return The route, plus a normalized URL when the hash carried a tab.
+ */
+export function resolveRoute( href: string = window.location.href ): ResolvedRoute {
+	const url = new URL( href );
+	const { path, query } = splitHash( url.hash );
+	const subpage = SUBPAGES.find( candidate => candidate === path ) ?? null;
+
+	if ( subpage ) {
+		return { route: { subpage, tab: readTab( url.searchParams ) }, normalizedUrl: null };
+	}
+
+	const hashTab = readTab( query );
+	if ( hashTab === 'settings' ) {
+		const normalized = new URL( url );
+		normalized.hash = '';
+		normalized.searchParams.set( 'tab', 'settings' );
+
+		return {
+			route: { subpage: null, tab: 'settings' },
+			normalizedUrl: normalized.toString(),
+		};
+	}
+
+	return { route: { subpage: null, tab: readTab( url.searchParams ) }, normalizedUrl: null };
+}
+
+/**
+ * Read the tab out of a query, defaulting to Overview.
+ *
+ * @param query - Query to read.
+ * @return The tab.
+ */
+function readTab( query: URLSearchParams ): Tab {
+	return query.get( 'tab' ) === 'settings' ? 'settings' : 'overview';
+}
+
+/**
+ * Build the URL for Settings: the hash cleared, the tab set.
+ *
+ * @param href - URL to derive from. Defaults to the current location.
+ * @return The Settings URL.
+ */
+export function settingsUrl( href: string = window.location.href ): string {
+	const url = new URL( href );
+	url.hash = '';
+	url.searchParams.set( 'tab', 'settings' );
+
+	return url.toString();
+}
+
+/**
+ * Build the hash that links to a sub-page. Identical in both modes.
+ *
+ * @param subpage - Sub-page to link to.
+ * @return The hash href.
+ */
+export function subpageHref( subpage: Subpage ): string {
+	return `#/${ subpage }`;
+}
+
+/**
+ * Build the URL for a sub-page, keeping the outer query.
+ *
+ * @param subpage - Sub-page to link to.
+ * @param href    - URL to derive from. Defaults to the current location.
+ * @return The sub-page URL.
+ */
+export function subpageUrl( subpage: Subpage, href: string = window.location.href ): string {
+	const url = new URL( href );
+	url.hash = subpageHref( subpage );
+
+	return url.toString();
+}
+
+/**
+ * Tell every listener the URL changed.
+ *
+ * The chassis wraps `history` and dispatches this too, so a handler may run
+ * twice for one navigation and must be idempotent.
+ */
+export function notifyLocationChange(): void {
+	window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+}
+
+/**
+ * Navigate to a URL without a reload.
+ *
+ * @param url             - Destination.
+ * @param options         - Navigation options.
+ * @param options.replace - Replace the current entry instead of pushing one.
+ */
+export function navigateTo( url: string, options: { replace?: boolean } = {} ): void {
+	if ( options.replace ) {
+		window.history.replaceState( null, '', url );
+	} else {
+		window.history.pushState( null, '', url );
+	}
+
+	notifyLocationChange();
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { LOCATION_CHANGE_EVENT, resolveRoute } from './routes';
+import type { ModernRoute } from './routes';
+
+const ROUTE_EVENTS = [ 'hashchange', 'popstate', LOCATION_CHANGE_EVENT ];
+
+/**
+ * Serialize a route so an unchanged URL doesn't re-render the app. The chassis
+ * dispatches its own location event alongside ours, so handlers run twice.
+ *
+ * @param route - Route to key.
+ * @return Stable key for the route.
+ */
+function routeKey( route: ModernRoute ): string {
+	return `${ route.subpage ?? '' }:${ route.tab }`;
+}
+
+/**
+ * Track the route the modern chassis is showing, normalizing the URL as it goes.
+ *
+ * @return The current route.
+ */
+export function useModernRoute(): ModernRoute {
+	const [ route, setRoute ] = useState< ModernRoute >( () => resolveRoute().route );
+
+	useEffect( () => {
+		const onLocationChange = () => {
+			const { route: next, normalizedUrl } = resolveRoute();
+
+			if ( normalizedUrl ) {
+				window.history.replaceState( null, '', normalizedUrl );
+			}
+
+			setRoute( current => ( routeKey( current ) === routeKey( next ) ? current : next ) );
+		};
+
+		ROUTE_EVENTS.forEach( event => window.addEventListener( event, onLocationChange ) );
+		onLocationChange();
+
+		return () =>
+			ROUTE_EVENTS.forEach( event => window.removeEventListener( event, onLocationChange ) );
+	}, [] );
+
+	return route;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-page-view.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-page-view.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { pageViewEventName, recordBoostEvent } from '$lib/utils/analytics';
+import type { ModernRoute } from './routes';
+
+/**
+ * Map a modern route to the page view it should record.
+ *
+ * @param route - Route being shown.
+ * @return Event name and the path property to send with it.
+ */
+export function pageViewFor( route: ModernRoute ): { name: string; path: string } {
+	if ( route.subpage ) {
+		return { name: pageViewEventName( `/${ route.subpage }` ), path: `/${ route.subpage }` };
+	}
+
+	return {
+		name: route.tab === 'settings' ? 'page_view_settings' : 'page_view_overview',
+		path: '/',
+	};
+}
+
+/**
+ * Record one page view per visible route activation.
+ *
+ * @param route   - Route being shown.
+ * @param enabled - False while a redirect is pending, so the route the user
+ *                never sees is not recorded.
+ */
+export function usePageView( route: ModernRoute, enabled: boolean ): void {
+	const lastRecorded = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		const { name, path } = pageViewFor( route );
+		if ( lastRecorded.current === name ) {
+			return;
+		}
+
+		lastRecorded.current = name;
+		recordBoostEvent( name, { path } );
+	}, [ route, enabled ] );
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router';
+import { navigateTo, settingsUrl } from '$lib/modern/routes';
+import type { ReactNode } from 'react';
+
+type NavigateOptions = {
+	replace?: boolean;
+};
+
+type BoostNavigation = {
+	/**
+	 * Return to Settings: `/` in legacy mode, `?tab=settings` with the hash
+	 * cleared in modern mode, where `/` would show the Overview instead.
+	 */
+	returnToSettings: ( options?: NavigateOptions ) => void;
+};
+
+const NavigationContext = createContext< BoostNavigation | null >( null );
+
+export function useBoostNavigation(): BoostNavigation {
+	const navigation = useContext( NavigationContext );
+
+	if ( ! navigation ) {
+		throw new Error( 'useBoostNavigation must be used inside a Boost navigation provider.' );
+	}
+
+	return navigation;
+}
+
+/**
+ * Navigation for the legacy hash router. Must render inside the router.
+ *
+ * @param props          - Component props.
+ * @param props.children - Tree to provide navigation to.
+ */
+export function LegacyNavigationProvider( { children }: { children: ReactNode } ) {
+	const navigate = useNavigate();
+	const navigation = useMemo< BoostNavigation >(
+		() => ( { returnToSettings: options => navigate( '/', options ) } ),
+		[ navigate ]
+	);
+
+	return <NavigationContext.Provider value={ navigation }>{ children }</NavigationContext.Provider>;
+}
+
+/**
+ * Navigation for the modern chassis, over the browser history.
+ *
+ * @param props          - Component props.
+ * @param props.children - Tree to provide navigation to.
+ */
+export function ModernNavigationProvider( { children }: { children: ReactNode } ) {
+	const navigation = useMemo< BoostNavigation >(
+		() => ( { returnToSettings: options => navigateTo( settingsUrl(), options ) } ),
+		[]
+	);
+
+	return <NavigationContext.Provider value={ navigation }>{ children }</NavigationContext.Provider>;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.ts
@@ -3,6 +3,20 @@ import analytics from '@automattic/jetpack-analytics';
 export type TracksEventProperties = { [ key: string ]: string | number };
 
 /**
+ * Derive a page-view event name from a route pathname.
+ *
+ * Both modes call this so the sub-page events keep the names they have today.
+ *
+ * @param {string} pathname - Route pathname, e.g. `/cache-debug-log`.
+ * @return {string} Event name, minus the `boost_` prefix.
+ */
+export function pageViewEventName( pathname: string ): string {
+	const path = pathname.replace( /[-/]/g, '_' );
+
+	return `page_view${ path === '_' ? '_settings' : path }`;
+}
+
+/**
  * Send an event to Tracks.
  *
  * @param {string}                eventName Event name, minus the jetpack_boost_ prefix.

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import actionLinkInterpolateVar from '$lib/utils/action-link-interpolate-var';
 import { InterpolateVars } from '$lib/utils/interplate-vars-types';
 import supportLinkInterpolateVar from '$lib/utils/support-link-interpolate-var';
@@ -10,11 +10,11 @@ import { Link } from '@wordpress/ui';
 
 function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
 	const regenerateAction = useRegenerateCriticalCssAction();
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	function retry() {
 		regenerateAction.mutate();
-		navigate( '/' );
+		returnToSettings();
 	}
 
 	const interpolateVars: InterpolateVars = {

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -7,7 +7,8 @@ import PurchaseSuccess from './pages/purchase-success/purchase-success';
 import SettingsPage from '$layout/settings-page/settings-page';
 import { useEffect, StrictMode } from 'react';
 import type { JSX } from 'react';
-import { recordBoostEvent } from '$lib/utils/analytics';
+import { pageViewEventName, recordBoostEvent } from '$lib/utils/analytics';
+import { LegacyNavigationProvider } from '$lib/navigation/navigation-context';
 import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
 import { useGettingStarted } from '$lib/stores/getting-started';
 import '../css/admin-style.scss';
@@ -29,9 +30,9 @@ const useBoostRouter = () => {
 			loader: checkForGettingStarted,
 			element: (
 				<SettingsPage>
-					<Tracks>
+					<LegacyRouteFrame>
 						<Index />
-					</Tracks>
+					</LegacyRouteFrame>
 				</SettingsPage>
 			),
 		},
@@ -39,9 +40,9 @@ const useBoostRouter = () => {
 			path: '/cache-debug-log',
 			loader: checkForGettingStarted,
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<CacheDebugLog />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 		{
@@ -49,26 +50,26 @@ const useBoostRouter = () => {
 			loader: checkForGettingStarted,
 			element: (
 				<SettingsPage>
-					<Tracks>
+					<LegacyRouteFrame>
 						<AdvancedCriticalCss />
-					</Tracks>
+					</LegacyRouteFrame>
 				</SettingsPage>
 			),
 		},
 		{
 			path: '/getting-started',
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<GettingStarted />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 		{
 			path: '/purchase-successful',
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<PurchaseSuccess />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 	] );
@@ -80,26 +81,21 @@ function Main() {
 }
 
 /**
- * Track the page view.
+ * Record the page view and provide navigation for a legacy route.
  *
  * @param props
  * @param props.children - The actual page to render
  */
-const Tracks = ( { children }: { children: JSX.Element } ) => {
+const LegacyRouteFrame = ( { children }: { children: JSX.Element } ) => {
 	const location = useLocation();
 
 	useEffect( () => {
-		let path = location.pathname.replace( /[-/]/g, '_' );
-		if ( path === '_' ) {
-			path = '_settings';
-		}
-
-		recordBoostEvent( `page_view${ path }`, {
+		recordBoostEvent( pageViewEventName( location.pathname ), {
 			path: location.pathname,
 		} );
 	}, [ location ] );
 
-	return children;
+	return <LegacyNavigationProvider>{ children }</LegacyNavigationProvider>;
 };
 
 export default () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -3,16 +3,16 @@ import { check, copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
 import clsx from 'clsx';
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
 import { useDebugLog } from '$features/page-cache/lib/stores';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import styles from './cache-debug-log.module.scss';
 
 const CacheDebugLog = () => {
 	const [ { data: debugLog } ] = useDebugLog();
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 	const [ hasCopied, setHasCopied ] = useState( false );
 	const copyTimer = useRef< ReturnType< typeof setTimeout > | undefined >();
 
@@ -31,7 +31,7 @@ const CacheDebugLog = () => {
 			current_page: window.location.href.replace( window.location.origin, '' ),
 			destination: '/',
 		} );
-		navigate( '/' );
+		returnToSettings();
 	};
 
 	const handleCopy = () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
@@ -11,11 +11,11 @@ import {
 	groupRecommendationsByStatus,
 } from '$features/critical-css/lib/critical-css-errors';
 import { BackButton, CloseButton } from '$features/ui';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import CriticalCssErrorDescription from '$features/critical-css/error-description/error-description';
 import InfoIcon from '$svg/info';
 import styles from './critical-css-advanced.module.scss';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 import clsx from 'clsx';
 import { Button } from '@automattic/jetpack-components';
 import {
@@ -51,12 +51,12 @@ export default function AdvancedCriticalCss() {
 	}
 
 	// If there are no issues at all, redirect to the main page.
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 	useEffect( () => {
 		if ( providersWithIssues.length === 0 ) {
-			navigate( '/' );
+			returnToSettings();
 		}
-	}, [ providersWithIssues, navigate ] );
+	}, [ providersWithIssues, returnToSettings ] );
 	const heading =
 		activeRecommendations.length === 0
 			? __( 'Congratulations, you have dealt with all the recommendations.', 'jetpack-boost' )

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
@@ -6,7 +6,7 @@ import { BoostPricingTable } from '$features/boost-pricing-table/boost-pricing-t
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
 import styles from './getting-started.module.scss';
 import { useGettingStarted } from '$lib/stores/getting-started';
-import { useNavigate } from 'react-router';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { __ } from '@wordpress/i18n';
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { useSingleModuleState } from '$features/module/lib/stores';
@@ -15,7 +15,7 @@ import type { FC } from 'react';
 const GettingStarted: FC = () => {
 	const [ selectedPlan, setSelectedPlan ] = useState< 'free' | 'premium' | false >( false );
 	const [ snackbarMessage, setSnackbarMessage ] = useState< string >( '' );
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	const {
 		site: { domain },
@@ -42,13 +42,13 @@ const GettingStarted: FC = () => {
 				if ( ! isPremium ) {
 					setCriticalCssState( true );
 				}
-				navigate( '/', { replace: true } );
+				returnToSettings( { replace: true } );
 			}
 		}
 	}, [
 		domain,
 		isPremium,
-		navigate,
+		returnToSettings,
 		selectedPlan,
 		setCriticalCssState,
 		shouldGetStarted,

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
@@ -3,15 +3,15 @@ import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { useSingleModuleState } from '$features/module/lib/stores';
-import { useNavigate } from 'react-router';
 import CardPage from '$layout/card-page/card-page';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import styles from './purchase-success.module.scss';
 import { isWoaHosting } from '$lib/utils/hosting';
 import type { FC } from 'react';
 
 const PurchaseSuccess: FC = () => {
 	const [ , setCloudCssState ] = useSingleModuleState( 'cloud_css' );
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	useEffect( () => {
 		setCloudCssState( true );
@@ -101,7 +101,7 @@ const PurchaseSuccess: FC = () => {
 			<Button
 				label={ __( 'Continue', 'jetpack-boost' ) }
 				variant="primary"
-				onClick={ () => navigate( '/' ) }
+				onClick={ () => returnToSettings() }
 				className="mt-3"
 			>
 				{ __( 'Continue', 'jetpack-boost' ) }

--- a/projects/plugins/boost/changelog/cycle-one-dashboard-presentation
+++ b/projects/plugins/boost/changelog/cycle-one-dashboard-presentation
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Isolate the legacy and modern dashboard presentation behind the disabled modernization filter.
+
+


### PR DESCRIPTION
Fixes BOOST-670

## Proposed changes

Make "behind the filter" true for the Settings and sub-page presentation, so the modern Settings work in BOOST-671 and BOOST-672 has a boundary to build inside. The change is inert with `rsm_jetpack_ui_modernization_boost` off.

* Read the mode from which root PHP rendered — `#jb-admin-settings` for legacy, the chassis root for modern — with no extra flag. Legacy wins if both are ever present, so a chassis bug cannot take today's dashboard away.
* Boot one persistent webpack root for the page lifetime in modern mode, portalling Settings into `#jb-settings-tab-mount` and at most one sub-page into `#jb-subpage-mount`. Data Sync, Notice and Critical CSS providers sit above both portals, so moving between Settings and a sub-page never remounts Settings or drops their caches.
* Wait for the chassis to create both slots before mounting, since this app can boot first.
* Implement navigation rules 1–3: `''`, `#` and `#/` are the Overview root, hash queries parse before matching, a recognised hash beats the tab, and a `?tab=settings` carried in the hash is promoted to the outer query.
* Route every "go back to the main page" through `returnToSettings()` — `/` in legacy mode, `?tab=settings` with the hash cleared in modern mode, where `/` would show the Overview instead. `BackButton` loses its `route` prop, which no caller passed.
* Keep the onboarding redirect as it is today, and record no page view for a route the user is redirected away from.
* Share the page-view name derivation between both modes so sub-page events keep their existing names, and add `page_view_overview`.
* Preserve today's legacy `Index` and sub-pages: same root, same routes, same events, same markup.

## Related product discussion/links

* Contract: BOOST-665 (mounts, routes, load order, file ownership)
* Chassis this builds on: #52037
* Parent: BOOST-633

## Does this pull request change what data or activity we track or use?

Yes, modern mode only. Sub-page and Settings page views keep their current event names; `page_view_overview` is new and fires when the Overview tab is activated. Nothing changes with the filter off.

## UI changes

**With the filter off (the default), nothing changes.** The legacy markup is identical, including the "advanced recommendations" link in the Critical CSS status: it stays a plain anchor rather than a `@wordpress/ui` `Link`, which would have applied its own colour, underline and focus ring to today's dashboard.

**With the filter on**, the Settings and sub-page presentation changes:

* Settings no longer renders `BoostAdminPage` (the "Boost" title, subtitle and "Use license key" action) or the `SpeedScore` panel. The chassis owns the page header, and the Overview owns the scores.
* Settings content is a flex column with 24px gaps in place of the legacy `jb-dashboard` section stack.
* `#/critical-css-advanced` renders full-page. It used to sit inside `SettingsPage`, so it showed the admin header, speed scores, Tips and Support around the recommendations.
* Leaving a sub-page returns to `?tab=settings` rather than `/`, which would now be the Overview.
* Switching Overview → Settings no longer remounts Settings, so in-progress form state survives the trip.

**Known rough edge, deferred:** `cache-debug-log`, `getting-started` and `purchase-successful` (via `CardPage`) each render their own `BoostAdminPage`, so with the filter on they show a second Boost header inside the chassis header. Refreshing those pages is [BOOST-672](https://linear.app/a8c/issue/BOOST-672/refresh-cache-log-and-critical-css-sub-pages); this PR is the boundary they will be refreshed inside.

## Testing instructions

Filter off (the default) — nothing should differ from trunk:

1. Build Boost: `pnpm jetpack build plugins/boost --no-pnpm-install --production`.
2. Open **Jetpack → Boost**. Confirm Settings renders as today.
3. Visit `#/cache-debug-log`, `#/critical-css-advanced`, `#/getting-started` and `#/purchase-successful`. Confirm each renders as today and that Back returns to Settings.
4. On a site with onboarding pending, confirm a guarded route still redirects to Getting Started.

Filter on:

1. `add_filter( 'rsm_jetpack_ui_modernization_boost', '__return_true' );` in an mu-plugin.
2. Open **Jetpack → Boost**. The chassis renders with Overview and Settings tabs; Settings shows this app's controls with no duplicate page header or speed scores.
3. Switch Overview → Settings → Overview. Confirm Settings does not remount: a half-filled control keeps its value.
4. Go to `#/cache-debug-log`, then Back. Confirm you land on `?tab=settings` with the hash cleared, not on the Overview, and that Settings still holds its state.
5. Load `#/?tab=settings`. Confirm the URL is rewritten to `?tab=settings` with no hash.
6. Load `#/cache-debug-log?x=1`. Confirm it opens the Cache Log.
7. Inspect the DOM: exactly one app root, and only one sub-page tree at a time.

Automated: `pnpm --dir projects/plugins/boost test` (91 tests, 30 new).

## Still open

* The legacy stylesheet's `body.jetpack_page_jetpack-boost` layout rule still reaches the modern chassis. Splitting it needs the webpack entry and `class-admin.php`, both Lane A files — proposed diff to follow, tracked against BOOST-670's CSS acceptance criterion.
* Promoting a hash tab writes the outer query the chassis router owns; BOOST-673 should confirm it observes the `replaceState`.
* The slot wait has no give-up policy, which is correct while the chassis always renders both slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzGT9kxxs229BAH6yUMoJ3

