### PR TITLE
Premium Analytics: keep the onboarding welcome modal open on a click outside

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-onboarding-modal-outside-click
+++ b/projects/packages/premium-analytics/changelog/fix-pa-onboarding-modal-outside-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Onboarding: keep the welcome modal open on a click outside it, so the tour can still be started.

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/__tests__/onboarding-welcome-modal.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/__tests__/onboarding-welcome-modal.test.tsx
@@ -57,4 +57,15 @@ describe( 'OnboardingWelcomeModal', () => {
 		expect( onDismiss ).toHaveBeenCalledTimes( 1 );
 		expect( onDismiss ).toHaveBeenCalledWith( 'escape' );
 	} );
+
+	it( 'stays open on a click outside, without counting a dismissal', async () => {
+		const { onDismiss } = renderModal();
+
+		await userEvent.click( document.body );
+
+		expect(
+			screen.getByRole( 'dialog', { name: 'Welcome to the new Traffic page' } )
+		).toBeInTheDocument();
+		expect( onDismiss ).not.toHaveBeenCalled();
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/onboarding-welcome-modal.tsx
@@ -4,14 +4,13 @@ import { useCallback } from 'react';
 import { WidgetGridAnimation } from '../widget-grid-animation';
 import styles from './onboarding-welcome-modal.module.scss';
 
-/** How the reader closed the modal without starting: the close button, Escape or a click outside. */
-export type OnboardingDismissReason = 'close' | 'escape' | 'outside' | 'other';
+/** How the reader closed the modal without starting: the close button or Escape. */
+export type OnboardingDismissReason = 'close' | 'escape' | 'other';
 
-// Base UI names the cause on `onOpenChange`; these are the three a reader can produce.
+// Base UI names the cause on `onOpenChange`; these are the two a reader can produce.
 const DISMISS_REASONS: Record< string, OnboardingDismissReason > = {
 	'close-press': 'close',
 	'escape-key': 'escape',
-	'outside-press': 'outside',
 };
 
 type OpenChangeDetails = {
@@ -49,8 +48,10 @@ export function OnboardingWelcomeModal( {
 		[ onDismiss ]
 	);
 
+	// A click on the backdrop must not end the journey: the modal opens once per
+	// reader, so a stray click would lose the tour for good.
 	return (
-		<Dialog.Root open={ open } onOpenChange={ handleOpenChange }>
+		<Dialog.Root open={ open } onOpenChange={ handleOpenChange } disablePointerDismissal>
 			<Dialog.Popup size="small">
 				<Dialog.CloseIcon className={ styles.close } />
 				{ /* The stage lives in the scroll region so the copy and the button

--- a/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/stories/onboarding-welcome-modal.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/onboarding-welcome-modal/stories/onboarding-welcome-modal.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta< typeof OnboardingWelcomeModal > = {
 					'the tour.\n\n' +
 					'The consumer owns the open state. `onStart` fires when the reader ' +
 					'presses Take a quick tour; `onDismiss` when they close the dialog any other ' +
-					'way, naming which (the close button, Escape, a click outside). The ' +
+					'way, naming which (the close button or Escape; a click outside is ignored). The ' +
 					'onboarding hook decides what each one means for the journey.\n\n' +
 					'On viewports too short for the animation, the copy and the tour button ' +
 					'take the room instead; on the ones in between, the content scrolls ' +

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
@@ -1,4 +1,7 @@
 /**
+ * External dependencies
+ */
+/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -9,11 +12,11 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { DASHBOARD_ONBOARDING_KEY, DASHBOARD_PREFERENCES_SCOPE } from './constants';
 import { useTrackEvent } from './use-track-event';
+import type { OnboardingDismissReason } from '@jetpack-premium-analytics/ui';
 
 export type OnboardingPhase = 'closed' | 'modal' | 'tour';
 
-/** How the reader closed the journey without finishing it. */
-export type OnboardingDismissReason = 'close' | 'escape' | 'other';
+export type { OnboardingDismissReason };
 
 export type OnboardingOptions = {
 	/** Whether the reader is on the surface the journey introduces; nothing opens until then. */

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
@@ -1,7 +1,4 @@
 /**
- * External dependencies
- */
-/**
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-onboarding.ts
@@ -13,7 +13,7 @@ import { useTrackEvent } from './use-track-event';
 export type OnboardingPhase = 'closed' | 'modal' | 'tour';
 
 /** How the reader closed the journey without finishing it. */
-export type OnboardingDismissReason = 'close' | 'escape' | 'outside' | 'other';
+export type OnboardingDismissReason = 'close' | 'escape' | 'other';
 
 export type OnboardingOptions = {
 	/** Whether the reader is on the surface the journey introduces; nothing opens until then. */

--- a/projects/plugins/jetpack/changelog/fix-pa-onboarding-modal-outside-click
+++ b/projects/plugins/jetpack/changelog/fix-pa-onboarding-modal-outside-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the onboarding welcome modal open on a click outside it, so the tour can still be started.

--- a/projects/plugins/premium-analytics/changelog/fix-pa-onboarding-modal-outside-click
+++ b/projects/plugins/premium-analytics/changelog/fix-pa-onboarding-modal-outside-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Onboarding: keep the welcome modal open on a click outside it, so the tour can still be started.


### PR DESCRIPTION
Fixes UNI-750

## Proposed changes

* Keep the onboarding welcome modal open on a click outside it. The close button and Escape still dismiss it, and Take a quick tour still hands off to the tour.
* Drop `outside` from the onboarding dismiss reasons, since the modal can no longer produce it.

## Why

The onboarding opens once per reader per site, and the preference is written the moment it opens. A stray click on the backdrop therefore dismissed the modal for good, with no way back to the tour. Base UI's `disablePointerDismissal` on `Dialog.Root` keeps the backdrop click from closing it; the keyboard and the close button behave as before.

## Related product discussion/links

* UNI-750

## Does this pull request change what data or activity we track or use?

No new data. The `reason` property on `jetpack_premium_analytics_onboarding_dismiss` can no longer be `outside`; `close`, `escape` and `other` are unchanged.

## Testing instructions

1. Open the new Traffic tab (Jetpack → Stats → Traffic, or the standalone Premium Analytics plugin) on a site where the onboarding has not run yet. To run it again on a site where it has, reset the preference in the browser console and reload:

   ```js
   wp.data.dispatch( 'core/preferences' ).set( 'jetpack-premium-analytics/dashboard', 'onboardingCompletedAt', undefined );
   ```

2. With the welcome modal open, click on the dimmed backdrop outside it.
   * Before: the modal closes and cannot be brought back.
   * After: the modal stays open.
3. Press Escape, or click the close button: the modal closes, as before.
4. Reopen (reset the preference again) and click Take a quick tour: the tour starts, as before.
5. `pnpm jetpack test js packages/premium-analytics` passes; the new test covers the click outside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6EnRKyZ6hzCb2pm7Y4tXN
