### PR TITLE
Admin page layout: keep dashboard sidebars beside the content on boot 0.21

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -162,18 +162,22 @@ $jp-breakpoint-mobile: 782px;
 	// a `display: block` div); `:has()` targets the whole chain regardless
 	// of depth. `min-width: 0` + `min-height: 0` let flex items shrink on
 	// both axes (defaults to content size which can cause overflow).
-	// `:not(:has(.boot-layout__stage))` stops the chain at the boot stage. A
-	// `@wordpress/boot` dashboard mounts <AdminPage> inside `.boot-layout__stage`,
-	// and the containers above it — `.boot-layout`, `.boot-layout__surfaces`
-	// (boot's stage|inspector flex ROW), and boot's `display: contents`
+	// The `:not(:has(...))` guard stops the chain at the boot stage. A
+	// `@wordpress/boot` dashboard mounts <AdminPage> inside boot's stage, and
+	// the containers above it — boot's layout root, its surfaces wrapper
+	// (the stage|inspector flex ROW), and boot's `display: contents`
 	// theme-provider wrapper — own that side-by-side layout. Flex-columning them
 	// would stack the inspector below the page and collapse boot's surfaces gap.
-	// Those ancestors all *contain* `.boot-layout__stage`, so the guard drops
-	// them while still flexing the stage (and anything below it) that the
-	// footer-pin chain needs. On non-boot pages nothing matches
-	// `.boot-layout__stage`, so the guard is always true and behavior is
-	// unchanged.
-	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage)) {
+	// Those ancestors all *contain* the stage, so the guard drops them while
+	// still flexing the stage (and anything below it) that the footer-pin chain
+	// needs. On non-boot pages nothing matches either selector, so the guard is
+	// always true and behavior is unchanged.
+	// The stage is `.boot-layout__stage` up to boot 0.20. From boot 0.21
+	// (WordPress/gutenberg#81756) boot's layout styles are CSS Modules and the
+	// class is `_<hash>__stage`, so the attribute selector matches the local
+	// name whatever the hash is — same technique as
+	// `packages/wp-build-polyfills` uses for the layout root.
+	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage, [class*="__stage"])) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -175,15 +175,13 @@ $jp-breakpoint-mobile: 782px;
 	// The stage is `.boot-layout__stage` up to boot 0.20. From boot 0.21
 	// (WordPress/gutenberg#81756) boot's layout styles are CSS Modules and the
 	// class is `<hash>__stage`, so match the local name whatever the hash is.
-	// The wildcard is scoped to wp-build's mount element — the hook that same
-	// PR moved to for identifying generated pages — so a stray `*__stage`
-	// class elsewhere in a dashboard cannot silently drop the flex chain.
-	// `:where()` keeps the guard at its original (1,2,0).
-	// `packages/wp-build-polyfills` pins this contract in a test.
-	$boot-mount: ":where([id$='-wp-admin-app'])";
-	$boot-stage: ".boot-layout__stage, #{$boot-mount} [class*='__stage']";
-
-	#wpbody-content :has(.jp-admin-page):not(:has(#{$boot-stage})) {
+	// The wildcard is deliberately unanchored: `:has()` resolves its argument
+	// relative to the subject, so it can only ask about descendants — scoping
+	// it to an ancestor (wp-build's `[id$="-wp-admin-app"]` mount) makes the
+	// condition unsatisfiable and silently disables the whole guard.
+	// `packages/wp-build-polyfills` pins the class name in a test, so a rename
+	// fails CI instead of stacking a dashboard sidebar.
+	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage, [class*="__stage"])) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -174,10 +174,16 @@ $jp-breakpoint-mobile: 782px;
 	// always true and behavior is unchanged.
 	// The stage is `.boot-layout__stage` up to boot 0.20. From boot 0.21
 	// (WordPress/gutenberg#81756) boot's layout styles are CSS Modules and the
-	// class is `_<hash>__stage`, so the attribute selector matches the local
-	// name whatever the hash is — same technique as
-	// `packages/wp-build-polyfills` uses for the layout root.
-	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage, [class*="__stage"])) {
+	// class is `<hash>__stage`, so match the local name whatever the hash is.
+	// The wildcard is scoped to wp-build's mount element — the hook that same
+	// PR moved to for identifying generated pages — so a stray `*__stage`
+	// class elsewhere in a dashboard cannot silently drop the flex chain.
+	// `:where()` keeps the guard at its original (1,2,0).
+	// `packages/wp-build-polyfills` pins this contract in a test.
+	$boot-mount: ":where([id$='-wp-admin-app'])";
+	$boot-stage: ".boot-layout__stage, #{$boot-mount} [class*='__stage']";
+
+	#wpbody-content :has(.jp-admin-page):not(:has(#{$boot-stage})) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
+++ b/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
@@ -1,4 +1,5 @@
 Significance: patch
-Type: fixed
+Type: changed
+Comment: Comment only: document why the boot stage guard cannot be anchored to an ancestor.
 
-Admin page layout: scope the boot stage match to wp-build's mount element.
+

--- a/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
+++ b/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page layout: scope the boot stage match to wp-build's mount element.

--- a/projects/js-packages/base-styles/changelog/fix-forms-single-response-sidebar-layout
+++ b/projects/js-packages/base-styles/changelog/fix-forms-single-response-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page layout: stop the flex chain at the boot stage again, so a dashboard's sidebar panel keeps its side-by-side layout on boot 0.21 and later.

--- a/projects/packages/activity-log/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/activity-log/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/activity-log/src/js/components/ActivityLog/upsell-callout.scss
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/upsell-callout.scss
@@ -24,11 +24,10 @@
 .jp-activity-log__upsell-callout-image {
 	display: block;
 	// Target 360px, capped at the container width on narrow screens. We set
-	// the size via `width` (not `width: 100%; max-width: 360px`) so it holds
-	// up under wp-build's boot layout, which applies
-	// `.boot-layout-container .boot-layout img { max-width: 100% }` at higher
-	// specificity than a single class — that override would otherwise beat a
-	// `max-width: 360px` and let the image stretch to fill the row.
+	// the size via `width` (not `width: 100%; max-width: 360px`) because
+	// wp-build's boot layout applies its own `max-width: 100%` to images, and a
+	// `max-width: 360px` here would be the one that loses when boot's rule is
+	// declared later.
 	width: 360px;
 	max-width: 100%;
 	height: auto;

--- a/projects/packages/forms/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/forms/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Restore multi-page printing of a single response.

--- a/projects/packages/forms/changelog/fix-forms-single-response-scroll-container
+++ b/projects/packages/forms/changelog/fix-forms-single-response-scroll-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Scroll a single response from the page edge instead of from inside the reading column.

--- a/projects/packages/forms/routes/response/style.scss
+++ b/projects/packages/forms/routes/response/style.scss
@@ -2,15 +2,14 @@
  * Standalone single response page (wp-build route) styles.
  */
 
+// This is the page's scrollable middle (the shared admin-page-layout mixin puts
+// `overflow: auto` on `.jp-admin-page__page`'s non-header child). It must stay
+// full width, or the scrollbar renders at the reading column's edge instead of
+// the window's. The measure therefore lives on the card below, not here.
 .jp-forms__single-response {
-	// `width: 100%` keeps the column a constant width regardless of each
-	// response's content. The page content area is a flex column, and an item
-	// with only `max-width` + auto inline margins shrink-wraps to its content
-	// (so width jumped per response); a definite width clamped by max-width
-	// pins it at a consistent, readable measure.
-	width: 100%;
-	max-width: 768px;
-	margin-inline: auto;
+	// No `width: 100%`: these boxes are content-box, so a full width plus the
+	// inline padding would overflow by exactly that padding and put a horizontal
+	// scrollbar on the page. As a stretched flex item it already fills the row.
 	padding-block: 24px;
 	padding-inline: 16px;
 }
@@ -55,6 +54,16 @@
 }
 
 .jp-forms__single-response-card {
+	// `width: 100%` keeps the column a constant width regardless of each
+	// response's content: this is a flex item, and one with only `max-width` +
+	// auto inline margins shrink-wraps to its content (so width jumped per
+	// response); a definite width clamped by max-width pins it at a consistent,
+	// readable measure. `border-box` so the 1px border stays inside that width
+	// rather than overflowing the scroll container.
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 768px;
+	margin-inline: auto;
 	background-color: #fff;
 	border: 1px solid #e0e0e0;
 	border-radius: 8px;
@@ -208,6 +217,8 @@
 	}
 
 	.jp-forms__single-response-card {
+		max-width: none;
+		margin-inline: 0;
 		border: none;
 		border-radius: 0;
 		overflow: visible;

--- a/projects/packages/forms/routes/response/style.scss
+++ b/projects/packages/forms/routes/response/style.scss
@@ -161,18 +161,24 @@
 
 	// `@wordpress/boot`'s stage is a second scroll container above
 	// `.jp-admin-page`, so unwind it too and let the document grow with it.
+	// Boot's own classes come in two shapes; see the guard in
+	// `@automattic/jetpack-base-styles/admin-page-layout` for why.
 	html.wp-toolbar,
 	body.wp-admin,
 	#wpwrap,
 	.boot-layout,
 	.boot-layout__surfaces,
 	.boot-layout__stage,
+	[class*="__layout"],
+	[class*="__surfaces"],
+	[class*="__stage"],
 	.jp-admin-page,
 	.jp-admin-page__page,
 	.jp-admin-page__page > :not(:first-child):not(.jetpack-footer),
 	.jp-admin-page__page > :not(:first-child):not(.jetpack-footer) > * {
-		// `position` matters as much as `overflow`: `.boot-layout` is absolute, and
-		// browsers print only the first page of an out-of-flow subtree.
+		// `position` matters as much as `overflow`: boot's layout root is
+		// absolute, and browsers print only the first page of an out-of-flow
+		// subtree.
 		position: static !important;
 		inset: auto !important;
 		display: block !important;

--- a/projects/packages/premium-analytics/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/premium-analytics/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
@@ -88,9 +88,9 @@ $section-header-visual-stacked-max-inline-size: $section-header-stacked-max-inli
 	background: var(--wpds-color-background-surface-neutral-weak);
 	color: var(--wpds-color-foreground-content-neutral-weak);
 
-	// The boot shell's `.boot-layout-container .boot-layout img` reset outranks
-	// a class here, so the box comes back through the square aspect ratio
-	// rather than a specificity contest.
+	// The boot shell resets images to `max-width: 100%; height: auto`, so the
+	// box comes back through the square aspect ratio rather than by fighting
+	// that reset.
 	img {
 		inline-size: 100%;
 		block-size: 100%;

--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -121,7 +121,7 @@ body.toplevel_page_jetpack-seo {
 // rest of Jetpack.
 
 // Two systems place Jetpack toasts and they disagree. `@wordpress/boot` renders
-// one `<SnackbarNotices className="boot-notices__snackbar">` per wp-build page
+// one `<SnackbarNotices>` per wp-build page
 // and pins it bottom-center; `<GlobalNotices>` in
 // @automattic/jetpack-components pins top-right, which is what Newsletter,
 // My Jetpack and VideoPress show.
@@ -141,13 +141,17 @@ body.toplevel_page_jetpack-seo {
 // but this one targets a class we don't own — so without the scope it would
 // move the snackbars on any other wp-build screen this stylesheet loaded on.
 
-// It also settles specificity. Boot injects its rule at runtime as
-// `.boot-layout .boot-notices__snackbar` (0,2,0); the body class puts this at
-// (0,3,1), so it wins outright rather than depending on load order.
+// It also settles specificity. Boot injects its rule at runtime as a
+// layout-scoped descendant (0,2,0); the body class puts this at (0,3,1), so it
+// wins outright rather than depending on load order. Boot's classes come in two
+// shapes; see the guard in `@automattic/jetpack-base-styles/admin-page-layout`
+// for why. Both selectors below are (0,2,0), so the specificity holds either
+// way.
 body.jetpack_page_jetpack-seo,
 body.toplevel_page_jetpack-seo {
 
-	.boot-layout .boot-notices__snackbar {
+	.boot-layout .boot-notices__snackbar,
+	[class*="__layout"] [class*="__notices-snackbar"] {
 		inset-block-start: auto;
 		inset-block-end: 0;
 		inset-inline: 0;

--- a/projects/packages/seo/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/seo/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move the dashboard's toast notices back to the top right.

--- a/projects/packages/videopress/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/videopress/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -68,11 +68,10 @@
 		}
 	}
 
-	// Override wp-build's `.boot-layout-container .boot-layout img { height:
-	// auto }` reset (specificity 0,2,1) without referencing wp-build's class
-	// names. Our own class chain has specificity (0,3,0), which beats the
-	// reset and lets the img fill its parent in both grid (large) and table
-	// (32x32) cells.
+	// Override wp-build's boot `img { height: auto }` reset without referencing
+	// boot's class names. That reset is wrapped in `:where()` (0,0,1), and our
+	// own class chain is (0,3,0), so the img fills its parent in both grid
+	// (large) and table (32x32) cells.
 	&__viewport &__thumbnail &__thumbnail-image {
 		width: 100%;
 		height: 100%;

--- a/projects/packages/wp-build-polyfills/changelog/address-review-boot-stage-anchor
+++ b/projects/packages/wp-build-polyfills/changelog/address-review-boot-stage-anchor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Test-only: pin the boot layout class contract.
+
+

--- a/projects/packages/wp-build-polyfills/tests/js/boot-layout-class-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/boot-layout-class-contract.test.js
@@ -1,0 +1,75 @@
+/**
+ * Pins the Boot layout class names our stylesheets select on.
+ *
+ * `admin-page-layout.scss` stops its flex chain at Boot's stage, and the Forms
+ * single-response print styles unwind Boot's stage and surfaces. Neither can be
+ * expressed without naming Boot's internal classes, which Boot documents as
+ * private — so a rename is a silent, total failure: a dead class inside
+ * `:not(:has())` makes the guard permanently true and the rule it guards starts
+ * applying everywhere. That is exactly how the 0.20 → 0.21 bump
+ * (WordPress/gutenberg#81756, plain classes → CSS Modules) shipped a stacked
+ * dashboard sidebar with nothing failing.
+ *
+ * Boot bakes its CSS Modules hashes in at publish time, so the class is a
+ * literal in the installed package and readable without a build.
+ */
+
+const assert = require( 'node:assert/strict' );
+const { readFileSync } = require( 'node:fs' );
+const path = require( 'node:path' );
+const { describe, it } = require( 'node:test' );
+
+// Local name => the file that renders an element carrying it.
+const RENDERED_CLASSES = {
+	stage: 'components/app/router.mjs',
+	inspector: 'components/app/router.mjs',
+	layout: 'components/root/single-page.mjs',
+	surfaces: 'components/root/single-page.mjs',
+};
+
+const bootBuildDir = () =>
+	path.join( path.dirname( require.resolve( '@wordpress/boot/package.json' ) ), 'build-module' );
+
+/**
+ * Class tokens ending in the given CSS Modules local name.
+ *
+ * Matches both shapes the guard supports: Boot's pre-0.21 `boot-layout__stage`
+ * and the hashed `d12c9efe707e6cb3__stage`.
+ *
+ * @param {string} source - File contents to scan.
+ * @param {string} local  - CSS Modules local name, e.g. `stage`.
+ * @return {string[]} Matching class tokens.
+ */
+function classTokens( source, local ) {
+	const pattern = new RegExp( `[A-Za-z0-9_-]*__${ local }(?![A-Za-z0-9_-])`, 'g' );
+	return [ ...new Set( source.match( pattern ) || [] ) ];
+}
+
+describe( 'boot layout class contract', () => {
+	for ( const [ local, file ] of Object.entries( RENDERED_CLASSES ) ) {
+		it( `still renders a class ending in __${ local }`, () => {
+			const source = readFileSync( path.join( bootBuildDir(), file ), 'utf8' );
+			const tokens = classTokens( source, local );
+
+			assert.ok(
+				tokens.length > 0,
+				`@wordpress/boot no longer renders a "${ local }" class in ${ file }. ` +
+					'Update the selectors in js-packages/base-styles/admin-page-layout.scss ' +
+					'and packages/forms/routes/response/style.scss to match, then update this test.'
+			);
+		} );
+	}
+
+	it( 'keeps the stage class matching the selector base-styles ships', () => {
+		const source = readFileSync( path.join( bootBuildDir(), RENDERED_CLASSES.stage ), 'utf8' );
+		const [ stage ] = classTokens( source, 'stage' );
+
+		// `[class*="__stage"]` in admin-page-layout.scss. Asserted as the
+		// substring test the stylesheet actually performs, not as an equality
+		// check against a hash that legitimately changes every Boot release.
+		assert.ok(
+			stage.includes( '__stage' ),
+			`Boot's stage class "${ stage }" no longer contains "__stage".`
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/plugins/jetpack/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Restore multi-page printing of a single response. SEO: Move the dashboard's toast notices back to the top right.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-response-scroll-container
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-response-scroll-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Scroll a single response from the page edge instead of from inside the reading column.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-response-sidebar-layout
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-response-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Show a selected response beside the responses list again instead of below it. Also fixes the same sidebar layout on the Newsletter and SEO dashboards.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Fix the dashboard sidebar (boot's inspector) rendering *below* the page content instead of beside it on the Forms responses, Newsletter and SEO dashboards.
* Fix the remaining selectors elsewhere in the monorepo that relied on the same removed classes: printing a single Forms response, and toast placement on the SEO dashboard.
* Unrelated, carried here for convenience: scroll a single Forms response from the page edge rather than from inside its 768px reading column.

`admin-page-layout.scss` walks every ancestor of `<AdminPage>` inside `#wpbody-content` and makes it a flex column, so `<JetpackFooter>` can be pinned to the bottom. That chain has to stop at `@wordpress/boot`'s stage, because the containers above it — boot's layout root and its `surfaces` wrapper — are the stage|inspector flex **row** that owns the side-by-side layout. Flex-columning them stacks the inspector under the page.

The guard that stopped the chain was `:not(:has(.boot-layout__stage))`. From boot 0.21 (WordPress/gutenberg#81756, Gutenberg 23.9) boot's layout styles are CSS Modules, so that class no longer exists — the guard silently became permanently true and the chain ran straight through boot's row. Verified on a test site: the emitted classes are `d12c9efe707e6cb3__stage` / `_7ffe3a3db6f69647__inspector`, and `boot-layout__stage` appears nowhere.

The fix matches the CSS Modules local name whatever the hash is, keeping the old class for boot ≤ 0.20:

```scss
#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage, [class*="__stage"])) {
```

This is the same technique `packages/wp-build-polyfills` already uses for boot's layout root (`[class*="__layout-single-page"]`).

## Before / after

Captured on a live Jurassic Ninja site at 1440x900, on WordPress 7.1 with the Gutenberg 23.9.1 plugin active — the configuration that actually serves Boot 0.21. Each "before" restores the pre-fix selector on the same build rather than simulating the broken state, so the two shots differ only by the selector this PR changes. Submitter IPs are masked to a documentation address.

**Responses inspector** — a selected response renders under the list instead of beside it:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-single-response-sidebar-layout/before-sidebar.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-single-response-sidebar-layout/after-sidebar.png) |

**SEO toasts** — Boot's bottom-centre default instead of Jetpack's top-right:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-single-response-sidebar-layout/before-seo-toast.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-single-response-sidebar-layout/after-seo-toast.png) |

### The rest of the fallout

`.boot-layout__stage` was not the only selector reaching into boot's shell. A `git grep boot-layout` turns up two more live rules that had silently stopped matching:

* **`packages/forms/routes/response/style.scss`** — the `@media print` block unwinds boot's layout root, surfaces and stage so a long response paginates. All three selectors are dead on boot 0.21. I could **not** demonstrate a user-visible difference here, though: printing an ~11k-character response produced 3 pages both with and without the new selectors on WP 7.1 + Gutenberg 23.9.1, so the rest of the print block appears to carry it on its own in this configuration. Treat this as dead-selector cleanup that restores the block's intent, not as a demonstrated regression.
* **`packages/seo/_inc/admin-page-layout.scss`** — `.boot-layout .boot-notices__snackbar` moved boot's bottom-centre toasts to the top right, matching the rest of Jetpack. Dead, so SEO's toasts had drifted back to the bottom centre.

Both keep the old class as a fallback alongside the new attribute selector, since boot can also arrive from WP Core at an older version.

Three further references (activity-log, premium-analytics, videopress) were comments, not code, and are corrected here rather than fixed. They each described boot's image reset as `.boot-layout-container .boot-layout img` "at higher specificity than a single class". That selector never existed: the rule has always been wrapped in `:where()` — today `:where(.<hash>__layout) img` — so it is (0,0,1), *weaker* than a single class, not stronger. The code was right; the stated reason for it was not.

### Single response scroll container (independent of the above)

`.jp-forms__single-response` was doing two jobs: the shared mixin makes `.jp-admin-page__page`'s non-header child the scrollable middle, and this route also put the 768px reading measure on that same element. The scroll container was therefore 768px wide, so its scrollbar rendered at the column's edge (x≈1196 in a 1440 viewport) rather than the window's.

The measure moves to `.jp-forms__single-response-card`, leaving the middle full width. Two sizing notes, because both are easy to reintroduce:

* These boxes are `content-box` — `max-width: 768px` measured 800px wide. The scroller therefore cannot carry `width: 100%` next to `padding-inline: 16px`, or it overflows by exactly that padding and adds a horizontal scrollbar. It is a stretched flex item, so it needs no width at all.
* The card *does* need `width: 100%`, because `margin-inline: auto` disables flex stretch and it would otherwise shrink-wrap, making the column width jump per response. It gets `box-sizing: border-box` so its 1px border stays inside that width.

This is not caused by the boot change — verified by measuring the page with and without the old guard applied: byte-identical scroll containers. It is bundled here only to avoid a second round trip through the same file.

### Root cause

The classes were removed by [WordPress/gutenberg#81756](https://github.com/WordPress/gutenberg/pull/81756) ("Boot: Migrate styles to CSS Modules", 2026-08-20), and reached us via #51701 (2026-09-02) which bumped `@wordpress/boot` 0.20.0 → 0.21.0.

Worth noting for future bumps: this failure mode is silent in both directions. A dead class inside `:not(:has(…))` makes the guard permanently *true*, so the rule it guards starts applying everywhere rather than erroring, and a dead class in a plain rule just stops matching. Nothing fails to build and no test notices. Gutenberg filed the change under `Internal` — correctly, since the boot README states its internal shell is private and offers no stable styling hooks — so the burden of finding consumers is ours. A `git grep` for the removed class names at bump time would have caught all of this.

Notes on the approach:

* **Why not just drop the rule.** The chain is what gives `.jp-admin-page` a flex parent; without it `flex: 1 1 auto` is inert, and since boot's stage is a fixed-height scroll container the footer would ride up under short content on every wp-build dashboard.
* **Why `[class*="__stage"]` and not `[class^="_"]…`.** The hash prefix is not consistent — the inspector's class has a leading underscore, the stage's does not.
* **Scope.** Only the three boot routes that export an `inspector` (`forms/responses`, `newsletter/dashboard`, `seo/content`) show the stacked sidebar; all three ship in the Jetpack plugin only, hence the single plugin changelog entry. On non-boot pages neither selector matches, so behaviour there is unchanged.
* The two `*__stage` BEM classes elsewhere in the monorepo (`videopress-playlist__stage`, `vp-chapters-preview__stage`) are block-editor/front-end components. The mixin only ever evaluates inside `#wpbody-content` on `body.jetpack_page_*` dashboards, so they can't reach the guard.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build and deploy a site running this branch (`jetpack build --deps plugins/jetpack`, then rsync the plugin).
* Check no *other* active plugin ships an older `jetpack-wp-build-polyfills`. Boot is resolved across plugins, so an older copy (e.g. a stock `jetpack-videopress`) wins and serves the pre-CSS-Modules classes — under which the guard still matches and the sidebar bug cannot reproduce at all.
* Go to **Jetpack → Forms** (`/wp-admin/admin.php?page=jetpack-forms-responses-wp-admin`). Submit a couple of responses first if the inbox is empty.
* Click a response row. **Expected:** the response opens in a sidebar panel to the *right* of the responses list. Before this change it appeared stacked below the list.
* Confirm the same on **Jetpack → Newsletter** — select a subscriber and check the inspector opens beside the list, not under it.
* And on the **SEO** dashboard. Two things gate it on a plain site: the product itself (`add_filter( 'rsm_jetpack_seo', '__return_true' );` in a mu-plugin, unless the site's plan includes SEO) and the module (`wp jetpack module activate seo-tools`). With both in place the page is **Jetpack → SEO**, `/wp-admin/admin.php?page=jetpack-seo` — note `jetpack-seo-dashboard` is the internal wp-build screen-id alias, not a URL. On the Content screen, use a row's edit action to open the per-post SEO editor; it should appear beside the list.
* Check the footer is still pinned to the bottom of the viewport on a dashboard with short content (e.g. Jetpack → Backup, VideoPress), and that those pages are otherwise unchanged.

Then the two follow-on fixes:

* **Forms print.** Open a single response (its own page, not the inbox sidebar) and print to PDF. **Expected:** a long response flows across multiple pages with the admin chrome dropped — unchanged by this PR as far as I could measure (see above), so this is a no-regression check rather than a fix to verify. Use a response with a long answer; a short one fits on one page either way.
* **Single response scroll.** Open a long response on its own page. **Expected:** the vertical scrollbar sits at the right edge of the window, the reading column stays centred at its usual width, and there is no horizontal scrollbar.
* **SEO toasts.** On **Jetpack → SEO** → Content, open a post's SEO editor and save a change. **Expected:** the confirmation toast appears at the **top right**, matching Newsletter and My Jetpack. Before this change it sat at the bottom centre. Below 600px it is a full-width strip at the bottom by design — check at desktop width.
