### PR TITLE
Stats: take the dashboard's paywalls from the site's current features

### DIFF
--- a/projects/packages/plans/.phan/config.php
+++ b/projects/packages/plans/.phan/config.php
@@ -10,4 +10,15 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ), array( '+stubs' => array( 'wpcom' ) ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'+stubs'            => array( 'wpcom' ),
+		// Those same stubs declare the registry these files stand in for at runtime, which Phan
+		// reports as a redefinition.
+		'exclude_file_list' => array(
+			'tests/php/stubs/class-wpcom-features.php',
+			'tests/php/stubs/functions-wpcom-features.php',
+		),
+	)
+);

--- a/projects/packages/plans/changelog/allow-plan-refresh-request-args
+++ b/projects/packages/plans/changelog/allow-plan-refresh-request-args
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow a caller refreshing the plan from WordPress.com to pass its own request arguments, so a refresh in front of a page render can cap the timeout.

--- a/projects/packages/plans/changelog/fix-stats-475-plan-features
+++ b/projects/packages/plans/changelog/fix-stats-475-plan-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a helper that reads a WordPress.com-hosted site's features from the registry the site carries, rather than from the plan it last cached.

--- a/projects/packages/plans/composer.json
+++ b/projects/packages/plans/composer.json
@@ -5,7 +5,8 @@
 	"license": "GPL-2.0-or-later",
 	"require": {
 		"php": ">=7.4",
-		"automattic/jetpack-connection": "@dev"
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-constants": "@dev"
 	},
 	"require-dev": {
 		"yoast/phpunit-polyfills": "^4.0.0",

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -32,9 +32,11 @@ class Current_Plan {
 	/**
 	 * Atomic site-specific features available, cached for the request alongside the Simple ones.
 	 *
-	 * @var array Site-specific features, keyed on blog ID.
+	 * Not keyed on a blog ID: an Atomic site can only ever answer for itself.
+	 *
+	 * @var array|null Site-specific features.
 	 */
-	private static $atomic_site_specific_features = array();
+	private static $atomic_site_specific_features = null;
 
 	/**
 	 * The name of the option that will store the site's plan.
@@ -260,9 +262,14 @@ class Current_Plan {
 	 * @access public
 	 * @static
 	 *
+	 * @since $$next-version$$ Accepts request arguments.
+	 *
+	 * @param array $args Request arguments, as accepted by `Client::wpcom_json_api_request_as_blog()`.
+	 *                    A caller refreshing in front of a page render can cap `timeout` here; the
+	 *                    `http_request_timeout` filter cannot, because the client always sends one.
 	 * @return bool True if plan is updated, false if no update
 	 */
-	public static function refresh_from_wpcom() {
+	public static function refresh_from_wpcom( $args = array() ) {
 		$site_id = Manager::get_site_id();
 		if ( is_wp_error( $site_id ) ) {
 			return false;
@@ -272,7 +279,8 @@ class Current_Plan {
 
 		$response = Client::wpcom_json_api_request_as_blog(
 			sprintf( '/sites/%d?force=wpcom', $site_id ),
-			'1.1'
+			'1.1',
+			$args
 		);
 
 		$updated = self::update_from_sites_response( $response );
@@ -497,30 +505,38 @@ class Current_Plan {
 			return null;
 		}
 
-		$current_blog_id = get_current_blog_id();
-
-		if ( isset( self::$atomic_site_specific_features[ $current_blog_id ] ) ) {
-			return self::$atomic_site_specific_features[ $current_blog_id ];
+		if ( null !== self::$atomic_site_specific_features ) {
+			return self::$atomic_site_specific_features;
 		}
 
-		$purchases = \wpcom_get_site_purchases( $current_blog_id );
-		$active    = array();
+		// No blog ID anywhere below. wpcomsh resolves it from `jetpack_options`, where WordPress
+		// reports 1, and throws when the two disagree.
+		$purchases = \wpcom_get_site_purchases();
+
+		/*
+		 * A site whose Atomic persistent data has not synced reads exactly like one that bought
+		 * nothing, and answering would gate a paid site. Only WordPress.com can tell the two
+		 * apart, so report no answer and leave the caller its own fallback.
+		 */
+		if ( ! $purchases ) {
+			return null;
+		}
+
+		$active = array();
 
 		foreach ( \WPCOM_Features::get_feature_slugs() as $feature ) {
-			if ( \WPCOM_Features::has_feature( $feature, $purchases, 'wpcom', $current_blog_id ) ) {
+			if ( \WPCOM_Features::has_feature( $feature, $purchases, 'wpcom' ) ) {
 				$active[] = $feature;
 			}
 		}
 
 		// `available` names the plans that would grant each feature the site lacks, which only the
 		// WordPress.com product catalogue can answer. Callers here read `active`.
-		$features = array(
+		self::$atomic_site_specific_features = array(
 			'active'    => $active,
 			'available' => array(),
 		);
 
-		self::$atomic_site_specific_features[ $current_blog_id ] = $features;
-
-		return $features;
+		return self::$atomic_site_specific_features;
 	}
 }

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -30,6 +30,13 @@ class Current_Plan {
 	private static $simple_site_specific_features = array();
 
 	/**
+	 * Atomic site-specific features available, cached for the request alongside the Simple ones.
+	 *
+	 * @var array Site-specific features, keyed on blog ID.
+	 */
+	private static $atomic_site_specific_features = array();
+
+	/**
 	 * The name of the option that will store the site's plan.
 	 *
 	 * @var string
@@ -465,5 +472,55 @@ class Current_Plan {
 		self::$simple_site_specific_features[ $current_blog_id ] = $simple_site_specific_features;
 
 		return $simple_site_specific_features;
+	}
+
+	/**
+	 * Retrieve site-specific features from the WordPress.com registry the site itself carries.
+	 *
+	 * Simple sites read the store; Atomic sites read the purchases wpcomsh keeps in sync. Both
+	 * answer as of this request, where `self::PLAN_OPTION` is only as current as its last fetch.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array|null Active and available features, or null where the site carries no registry.
+	 */
+	public static function get_wpcom_site_specific_features() {
+		if ( defined( 'IS_WPCOM' ) && constant( 'IS_WPCOM' ) ) {
+			return self::get_simple_site_specific_features();
+		}
+
+		if (
+			! Constants::is_true( 'IS_ATOMIC' )
+			|| ! class_exists( '\WPCOM_Features' )
+			|| ! function_exists( 'wpcom_get_site_purchases' )
+		) {
+			return null;
+		}
+
+		$current_blog_id = get_current_blog_id();
+
+		if ( isset( self::$atomic_site_specific_features[ $current_blog_id ] ) ) {
+			return self::$atomic_site_specific_features[ $current_blog_id ];
+		}
+
+		$purchases = \wpcom_get_site_purchases( $current_blog_id );
+		$active    = array();
+
+		foreach ( \WPCOM_Features::get_feature_slugs() as $feature ) {
+			if ( \WPCOM_Features::has_feature( $feature, $purchases, 'wpcom', $current_blog_id ) ) {
+				$active[] = $feature;
+			}
+		}
+
+		// `available` names the plans that would grant each feature the site lacks, which only the
+		// WordPress.com product catalogue can answer. Callers here read `active`.
+		$features = array(
+			'active'    => $active,
+			'available' => array(),
+		);
+
+		self::$atomic_site_specific_features[ $current_blog_id ] = $features;
+
+		return $features;
 	}
 }

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -41,7 +41,8 @@ class Jetpack_Plan_Test extends TestCase {
 		if ( PHP_VERSION_ID < 80100 ) {
 			$cache->setAccessible( true );
 		}
-		$cache->setValue( null, array() );
+		$cache->setValue( null, null );
+		$GLOBALS['wpcom_test_site_purchases'] = array( (object) array( 'product_slug' => 'personal-bundle' ) );
 	}
 
 	/**
@@ -105,11 +106,22 @@ class Jetpack_Plan_Test extends TestCase {
 
 		$this->assertSame(
 			array(
-				'active'    => array( 'stats-paid' ),
+				'active'    => array( 'stats-paid', 'support' ),
 				'available' => array(),
 			),
 			Jetpack_Plan::get_wpcom_site_specific_features()
 		);
+	}
+
+	/**
+	 * Atomic persistent data that has not synced yet reads exactly like a site that bought
+	 * nothing, and answering would gate a paid site. Only WordPress.com can tell the two apart.
+	 */
+	public function test_wpcom_site_specific_features_are_absent_when_the_registry_has_no_purchases() {
+		Constants::set_constant( 'IS_ATOMIC', true );
+		$GLOBALS['wpcom_test_site_purchases'] = array();
+
+		$this->assertNull( Jetpack_Plan::get_wpcom_site_specific_features() );
 	}
 
 	public function test_update_from_sites_response_failure_to_update() {

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use WP_Error;
 
 /**
@@ -28,6 +29,19 @@ class Jetpack_Plan_Test extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		delete_option( 'jetpack_active_plan' );
+		$this->reset_atomic_feature_cache();
+	}
+
+	/**
+	 * Drop the per-request feature cache, which outlives the constants each test sets.
+	 */
+	private function reset_atomic_feature_cache() {
+		$cache = new ReflectionProperty( Jetpack_Plan::class, 'atomic_site_specific_features' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$cache->setAccessible( true );
+		}
+		$cache->setValue( null, array() );
 	}
 
 	/**
@@ -72,6 +86,30 @@ class Jetpack_Plan_Test extends TestCase {
 
 		$this->assertTrue( $updated );
 		$this->assertFalse( get_transient( $transient_key ), 'A stale record would overwrite the plan this refresh stored.' );
+	}
+
+	/**
+	 * A site with no WordPress.com feature registry has nothing more current than its cached
+	 * plan, and the caller has to be told so rather than handed an empty feature list.
+	 */
+	public function test_wpcom_site_specific_features_are_absent_without_a_registry() {
+		$this->assertNull( Jetpack_Plan::get_wpcom_site_specific_features() );
+	}
+
+	/**
+	 * An Atomic site carries the registry, so its features are read from the purchases it holds
+	 * rather than from a plan that may predate the last purchase.
+	 */
+	public function test_wpcom_site_specific_features_come_from_the_registry_on_atomic() {
+		Constants::set_constant( 'IS_ATOMIC', true );
+
+		$this->assertSame(
+			array(
+				'active'    => array( 'stats-paid' ),
+				'available' => array(),
+			),
+			Jetpack_Plan::get_wpcom_site_specific_features()
+		);
 	}
 
 	public function test_update_from_sites_response_failure_to_update() {

--- a/projects/packages/plans/tests/php/bootstrap.php
+++ b/projects/packages/plans/tests/php/bootstrap.php
@@ -14,3 +14,6 @@ define( 'WP_DEBUG', true );
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
+
+require_once __DIR__ . '/stubs/class-wpcom-features.php';
+require_once __DIR__ . '/stubs/functions-wpcom-features.php';

--- a/projects/packages/plans/tests/php/stubs/class-wpcom-features.php
+++ b/projects/packages/plans/tests/php/stubs/class-wpcom-features.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 		 * @return string[]
 		 */
 		public static function get_feature_slugs() {
-			return array( 'stats-paid', 'stats-commercial' );
+			return array( 'stats-paid', 'stats-commercial', 'support' );
 		}
 
 		/**
@@ -28,9 +28,20 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 		 * @param array  $purchases Site purchases.
 		 * @param string $site_type Site type, 'wpcom' or 'jetpack'.
 		 * @param int    $blog_id   Blog ID.
+		 * @throws \Error When handed a blog ID other than the current site's, as wpcomsh's sticker
+		 *                lookups do.
 		 * @return bool
 		 */
 		public static function has_feature( $feature, $purchases, $site_type = '', $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+			if ( null !== $blog_id && (int) $blog_id !== WPCOM_TEST_BLOG_ID ) {
+				throw new Error( 'Atomic sites cannot resolve stickers for a site other than the current one.' );
+			}
+
+			// Granted to every WordPress.com site, purchase or not, as `wpcom-all-sites` features are.
+			if ( 'support' === $feature ) {
+				return true;
+			}
+
 			foreach ( $purchases as $purchase ) {
 				if ( 'personal-bundle' === $purchase->product_slug && 'stats-paid' === $feature ) {
 					return true;
@@ -39,4 +50,13 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 			return false;
 		}
 	}
+}
+
+if ( ! defined( 'WPCOM_TEST_BLOG_ID' ) ) {
+	/**
+	 * The WordPress.com blog ID the stubs answer for. Deliberately not 1: on Atomic wpcomsh reads
+	 * the ID from `jetpack_options` while WordPress reports 1, and a caller passing the latter is
+	 * the bug these stubs exist to catch.
+	 */
+	define( 'WPCOM_TEST_BLOG_ID', 999 );
 }

--- a/projects/packages/plans/tests/php/stubs/class-wpcom-features.php
+++ b/projects/packages/plans/tests/php/stubs/class-wpcom-features.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Stand-in for the WordPress.com feature registry wpcomsh ships, which is not installable here.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+// phpcs:disable Generic.Classes.DuplicateClassName.Found -- each package's test suite needs its own copy, and only one is ever loaded.
+
+if ( ! class_exists( 'WPCOM_Features' ) ) {
+	/**
+	 * Minimal stand-in for wpcomsh's feature registry.
+	 */
+	class WPCOM_Features {
+		/**
+		 * Every feature slug the registry knows.
+		 *
+		 * @return string[]
+		 */
+		public static function get_feature_slugs() {
+			return array( 'stats-paid', 'stats-commercial' );
+		}
+
+		/**
+		 * Whether one of the purchases grants the feature.
+		 *
+		 * @param string $feature   Feature slug.
+		 * @param array  $purchases Site purchases.
+		 * @param string $site_type Site type, 'wpcom' or 'jetpack'.
+		 * @param int    $blog_id   Blog ID.
+		 * @return bool
+		 */
+		public static function has_feature( $feature, $purchases, $site_type = '', $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+			foreach ( $purchases as $purchase ) {
+				if ( 'personal-bundle' === $purchase->product_slug && 'stats-paid' === $feature ) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/projects/packages/plans/tests/php/stubs/functions-wpcom-features.php
+++ b/projects/packages/plans/tests/php/stubs/functions-wpcom-features.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Stand-in for the wpcomsh function that reads an Atomic site's purchases.
+ *
+ * @package automattic/jetpack-plans
+ */
+
+if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+	/**
+	 * The purchases wpcomsh keeps in sync on an Atomic site.
+	 *
+	 * @param int $blog_id Blog ID.
+	 * @return object[]
+	 */
+	function wpcom_get_site_purchases( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+		return array( (object) array( 'product_slug' => 'personal-bundle' ) );
+	}
+}

--- a/projects/packages/plans/tests/php/stubs/functions-wpcom-features.php
+++ b/projects/packages/plans/tests/php/stubs/functions-wpcom-features.php
@@ -10,9 +10,17 @@ if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 	 * The purchases wpcomsh keeps in sync on an Atomic site.
 	 *
 	 * @param int $blog_id Blog ID.
+	 * @throws \Error When asked for a site other than the current one, as wpcomsh does.
 	 * @return object[]
 	 */
-	function wpcom_get_site_purchases( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
-		return array( (object) array( 'product_slug' => 'personal-bundle' ) );
+	function wpcom_get_site_purchases( $blog_id = 0 ) {
+		if ( $blog_id && (int) $blog_id !== WPCOM_TEST_BLOG_ID ) {
+			throw new Error( 'Atomic sites do not support looking up features for sites other than the current site.' );
+		}
+
+		return $GLOBALS['wpcom_test_site_purchases'];
 	}
+
+	// A site holding one plan. A test covering an unsynced registry empties this.
+	$GLOBALS['wpcom_test_site_purchases'] = array( (object) array( 'product_slug' => 'personal-bundle' ) );
 }

--- a/projects/packages/stats-admin/changelog/fix-stats-475-plan-features
+++ b/projects/packages/stats-admin/changelog/fix-stats-475-plan-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Decide the dashboard's paywalls from the site's current features rather than from a plan it cached before its last upgrade.

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -188,12 +188,7 @@ JS;
 
 		set_transient( self::PLAN_REFRESH_TRANSIENT, 1, 15 * MINUTE_IN_SECONDS );
 
-		$cap_plan_refresh_timeout = static function () {
-			return 5;
-		};
-		add_filter( 'http_request_timeout', $cap_plan_refresh_timeout, PHP_INT_MAX );
-		Jetpack_Plan::refresh_from_wpcom();
-		remove_filter( 'http_request_timeout', $cap_plan_refresh_timeout, PHP_INT_MAX );
+		Jetpack_Plan::refresh_from_wpcom( array( 'timeout' => 5 ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-dashboard.php
+++ b/projects/packages/stats-admin/src/class-dashboard.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
+use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 
 /**
@@ -22,6 +23,13 @@ class Dashboard {
 	 * @var boolean
 	 */
 	private static $initialized = false;
+
+	/**
+	 * Transient that throttles the plan refresh below.
+	 *
+	 * @var string
+	 */
+	const PLAN_REFRESH_TRANSIENT = 'jetpack_stats_admin_plan_refresh';
 
 	/**
 	 * Priority for the dashboard menu
@@ -158,7 +166,34 @@ JS;
 	 * Initialize the admin resources.
 	 */
 	public function admin_init() {
+		$this->maybe_refresh_plan();
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
+	}
+
+	/**
+	 * Fill an empty plan cache before the config data that reads it is printed.
+	 *
+	 * The app cannot refresh the plan it paywalls on, so a site that never stored one renders as
+	 * free. Throttled and time-boxed, because WordPress.com can keep answering without a plan.
+	 */
+	private function maybe_refresh_plan() {
+		if ( ! Main::is_site_connected() || null !== Jetpack_Plan::get_wpcom_site_specific_features() ) {
+			return;
+		}
+
+		$plan = Jetpack_Plan::get();
+		if ( ! empty( $plan['features']['active'] ) || get_transient( self::PLAN_REFRESH_TRANSIENT ) ) {
+			return;
+		}
+
+		set_transient( self::PLAN_REFRESH_TRANSIENT, 1, 15 * MINUTE_IN_SECONDS );
+
+		$cap_plan_refresh_timeout = static function () {
+			return 5;
+		};
+		add_filter( 'http_request_timeout', $cap_plan_refresh_timeout, PHP_INT_MAX );
+		Jetpack_Plan::refresh_from_wpcom();
+		remove_filter( 'http_request_timeout', $cap_plan_refresh_timeout, PHP_INT_MAX );
 	}
 
 	/**

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -234,8 +234,16 @@ class Odyssey_Config_Data {
 
 	/**
 	 * Get the features of the current plan.
+	 *
+	 * The app cannot refresh what it paywalls on, so a WordPress.com-hosted site is asked
+	 * directly; a plan cached before an upgrade gates a feature the site has already paid for.
 	 */
 	protected function get_plan_features() {
+		$features = Jetpack_Plan::get_wpcom_site_specific_features();
+		if ( null !== $features ) {
+			return $features;
+		}
+
 		$plan = Jetpack_Plan::get();
 		if ( empty( $plan['features'] ) ) {
 			return array();

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
 use ReflectionProperty;
@@ -12,9 +13,28 @@ use ReflectionProperty;
  */
 class Dashboard_Test extends Stats_TestCase {
 	/**
+	 * How many site records WordPress.com was asked for.
+	 *
+	 * @var int
+	 */
+	private $site_record_requests = 0;
+
+	/**
+	 * The plan fetch this test owns, so it can be removed again.
+	 *
+	 * @var \Closure|null
+	 */
+	private $site_record_filter;
+
+	/**
 	 * Returning the environment into its initial state.
 	 */
 	public function tearDown(): void {
+		if ( $this->site_record_filter ) {
+			remove_filter( 'pre_http_request', $this->site_record_filter, 9 );
+			$this->site_record_filter = null;
+		}
+		delete_transient( Dashboard::PLAN_REFRESH_TRANSIENT );
 		wp_dequeue_script( 'jp-stats-dashboard' );
 		wp_deregister_script( 'jp-stats-dashboard' );
 		wp_dequeue_script( 'jp-stats-dashboard-bootstrap' );
@@ -147,5 +167,114 @@ class Dashboard_Test extends Stats_TestCase {
 		}
 
 		return $method->invoke( $dashboard );
+	}
+
+	/**
+	 * Answer the site record fetch with a Personal plan, counting the requests it takes.
+	 */
+	private function serve_a_personal_plan() {
+		$this->site_record_filter = function ( $response, $parsed_args, $url ) {
+			if ( strpos( $url, '/sites/999?' ) === false ) {
+				return $response;
+			}
+
+			++$this->site_record_requests;
+
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'ok',
+				),
+				'body'     => '{"plan":{"product_slug":"personal-bundle","features":{"active":["stats-paid"]}}}',
+			);
+		};
+
+		add_filter( 'pre_http_request', $this->site_record_filter, 9, 3 );
+	}
+
+	/**
+	 * A site that never stored a plan would print the paywalls of a free site, and the app cannot
+	 * correct that for itself, so opening the page fetches the plan first. See STATS-475.
+	 */
+	public function test_opening_the_page_fills_an_empty_plan_cache() {
+		$this->serve_a_personal_plan();
+
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 1, $this->site_record_requests );
+		$this->assertSame( array( 'stats-paid' ), Current_Plan::get()['features']['active'] );
+	}
+
+	/**
+	 * WordPress.com can keep answering without a plan, so the fetch is throttled rather than
+	 * repeated on every load of the page.
+	 */
+	public function test_the_plan_is_not_fetched_again_within_the_throttle() {
+		$this->site_record_filter = function ( $response, $parsed_args, $url ) {
+			if ( strpos( $url, '/sites/999?' ) === false ) {
+				return $response;
+			}
+
+			++$this->site_record_requests;
+
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'ok',
+				),
+				'body'     => '{}',
+			);
+		};
+		add_filter( 'pre_http_request', $this->site_record_filter, 9, 3 );
+
+		( new Dashboard() )->admin_init();
+		$this->reset_plan_caches();
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 1, $this->site_record_requests );
+	}
+
+	/**
+	 * A stored plan already carries the features the app needs.
+	 */
+	public function test_a_populated_plan_cache_is_left_alone() {
+		$this->serve_a_personal_plan();
+		update_option(
+			Current_Plan::PLAN_OPTION,
+			array(
+				'product_slug' => 'personal-bundle',
+				'features'     => array( 'active' => array( 'stats-paid' ) ),
+			),
+			true
+		);
+		$this->reset_plan_caches();
+
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 0, $this->site_record_requests );
+	}
+
+	/**
+	 * A site that answers feature checks from its own registry has nothing to gain from the fetch.
+	 */
+	public function test_a_site_with_a_feature_registry_does_not_fetch_the_plan() {
+		$this->serve_a_personal_plan();
+		$this->make_site_atomic();
+
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 0, $this->site_record_requests );
+	}
+
+	/**
+	 * An unconnected site cannot sign the request, and the page it gets offers a plan anyway.
+	 */
+	public function test_an_unconnected_site_does_not_fetch_the_plan() {
+		$this->serve_a_personal_plan();
+		$this->disconnect_site();
+
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 0, $this->site_record_requests );
 	}
 }

--- a/projects/packages/stats-admin/tests/php/Dashboard_Test.php
+++ b/projects/packages/stats-admin/tests/php/Dashboard_Test.php
@@ -27,6 +27,13 @@ class Dashboard_Test extends Stats_TestCase {
 	private $site_record_filter;
 
 	/**
+	 * The timeout the site record request carried.
+	 *
+	 * @var int|null
+	 */
+	private $site_record_timeout;
+
+	/**
 	 * Returning the environment into its initial state.
 	 */
 	public function tearDown(): void {
@@ -179,6 +186,7 @@ class Dashboard_Test extends Stats_TestCase {
 			}
 
 			++$this->site_record_requests;
+			$this->site_record_timeout = isset( $parsed_args['timeout'] ) ? (int) $parsed_args['timeout'] : null;
 
 			return array(
 				'response' => array(
@@ -203,6 +211,10 @@ class Dashboard_Test extends Stats_TestCase {
 
 		$this->assertSame( 1, $this->site_record_requests );
 		$this->assertSame( array( 'stats-paid' ), Current_Plan::get()['features']['active'] );
+
+		// The client always sends a timeout of its own, so `http_request_timeout` cannot cap this
+		// and the request has to carry the cap itself.
+		$this->assertSame( 5, $this->site_record_timeout );
 	}
 
 	/**
@@ -264,6 +276,20 @@ class Dashboard_Test extends Stats_TestCase {
 		( new Dashboard() )->admin_init();
 
 		$this->assertSame( 0, $this->site_record_requests );
+	}
+
+	/**
+	 * A registry holding nothing is a site whose data has not synced as readily as one that bought
+	 * nothing, so it is WordPress.com that has to settle it.
+	 */
+	public function test_a_site_whose_registry_has_no_purchases_fetches_the_plan() {
+		$this->serve_a_personal_plan();
+		$this->make_site_atomic();
+		$GLOBALS['wpcom_test_site_purchases'] = array();
+
+		( new Dashboard() )->admin_init();
+
+		$this->assertSame( 1, $this->site_record_requests );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\Jetpack\Stats_Admin;
 
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
 
 /**
@@ -24,6 +25,44 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 		$config_data = new Odyssey_Config_Data();
 		$this->assertTrue( strpos( $config_data->get_js_config_data( 'configData', array( 'testtesttest' ) ), 'window.configData' ) === 0 );
 		$this->assertTrue( strpos( $config_data->get_js_config_data( 'configData', array( 'testtesttest' ) ), 'testtesttest' ) > 0 );
+	}
+
+	/**
+	 * The app paywalls on the feature list printed here and has no route to refresh it, so a site
+	 * that can answer for itself must not be described by a plan it cached before its last
+	 * purchase. See STATS-475.
+	 */
+	public function test_config_data_features_come_from_the_site_itself_on_atomic() {
+		update_option( Current_Plan::PLAN_OPTION, array( 'product_slug' => 'jetpack_free' ), true );
+		$this->make_site_atomic();
+
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertSame(
+			array( 'stats-paid' ),
+			$data['intial_state']['sites']['features']['999']['data']['active']
+		);
+	}
+
+	/**
+	 * A site carrying no WordPress.com feature registry has only its cached plan to go on.
+	 */
+	public function test_config_data_features_fall_back_to_the_cached_plan() {
+		update_option(
+			Current_Plan::PLAN_OPTION,
+			array(
+				'product_slug' => 'personal-bundle',
+				'features'     => array( 'active' => array( 'stats-paid' ) ),
+			),
+			true
+		);
+
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertSame(
+			array( 'stats-paid' ),
+			$data['intial_state']['sites']['features']['999']['data']['active']
+		);
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Config_Data_Test.php
@@ -39,6 +39,30 @@ class Odyssey_Config_Data_Test extends Stats_TestCase {
 		$data = ( new Odyssey_Config_Data() )->get_data();
 
 		$this->assertSame(
+			array( 'stats-paid', 'support' ),
+			$data['intial_state']['sites']['features']['999']['data']['active']
+		);
+	}
+
+	/**
+	 * A registry with nothing in it cannot be told apart from a site that bought nothing, so the
+	 * cached plan is still the better answer.
+	 */
+	public function test_config_data_features_fall_back_when_the_registry_has_no_purchases() {
+		update_option(
+			Current_Plan::PLAN_OPTION,
+			array(
+				'product_slug' => 'personal-bundle',
+				'features'     => array( 'active' => array( 'stats-paid' ) ),
+			),
+			true
+		);
+		$this->make_site_atomic();
+		$GLOBALS['wpcom_test_site_purchases'] = array();
+
+		$data = ( new Odyssey_Config_Data() )->get_data();
+
+		$this->assertSame(
 			array( 'stats-paid' ),
 			$data['intial_state']['sites']['features']['999']['data']['active']
 		);

--- a/projects/packages/stats-admin/tests/php/bootstrap.php
+++ b/projects/packages/stats-admin/tests/php/bootstrap.php
@@ -29,3 +29,6 @@ function dbless_default_options() {
 
 // Initialize WordPress test environment
 \Automattic\Jetpack\Test_Environment::init();
+
+require_once __DIR__ . '/stubs/class-wpcom-features.php';
+require_once __DIR__ . '/stubs/functions-wpcom-features.php';

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack\Stats_Admin;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use PHPUnit\Framework\TestCase as PHPUnit_TestCase;
 use ReflectionProperty;
@@ -75,6 +77,29 @@ abstract class TestCase extends PHPUnit_TestCase {
 		// outlive the mocked options and the cleared database.
 		( new Connection_Manager() )->reset_connection_status();
 		$this->reset_stats_options();
+		$this->reset_plan_caches();
+	}
+
+	/**
+	 * Present the site as Atomic, where wpcomsh answers feature checks from the site's purchases.
+	 */
+	protected function make_site_atomic() {
+		Constants::set_constant( 'IS_ATOMIC', true );
+		$this->reset_plan_caches();
+	}
+
+	/**
+	 * Drop the plan and feature lists `Current_Plan` memoizes for the request.
+	 */
+	protected function reset_plan_caches() {
+		foreach ( array( 'active_plan_cache', 'atomic_site_specific_features' ) as $name ) {
+			$property = new ReflectionProperty( Current_Plan::class, $name );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$property->setAccessible( true );
+			}
+			$property->setValue( null, 'active_plan_cache' === $name ? null : array() );
+		}
 	}
 
 	/**
@@ -95,6 +120,8 @@ abstract class TestCase extends PHPUnit_TestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		wp_set_current_user( 0 );
+		Constants::clear_single_constant( 'IS_ATOMIC' );
+		$this->reset_plan_caches();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Posts::init()->clear_all_posts();

--- a/projects/packages/stats-admin/tests/php/class-testcase.php
+++ b/projects/packages/stats-admin/tests/php/class-testcase.php
@@ -98,8 +98,10 @@ abstract class TestCase extends PHPUnit_TestCase {
 			if ( PHP_VERSION_ID < 80100 ) {
 				$property->setAccessible( true );
 			}
-			$property->setValue( null, 'active_plan_cache' === $name ? null : array() );
+			$property->setValue( null, null );
 		}
+
+		$GLOBALS['wpcom_test_site_purchases'] = array( (object) array( 'product_slug' => 'personal-bundle' ) );
 	}
 
 	/**

--- a/projects/packages/stats-admin/tests/php/stubs/class-wpcom-features.php
+++ b/projects/packages/stats-admin/tests/php/stubs/class-wpcom-features.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Stand-in for the WordPress.com feature registry wpcomsh ships, which is not installable here.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+// phpcs:disable Generic.Classes.DuplicateClassName.Found -- each package's test suite needs its own copy, and only one is ever loaded.
+
+if ( ! class_exists( 'WPCOM_Features' ) ) {
+	/**
+	 * Minimal stand-in for wpcomsh's feature registry.
+	 */
+	class WPCOM_Features {
+		/**
+		 * Every feature slug the registry knows.
+		 *
+		 * @return string[]
+		 */
+		public static function get_feature_slugs() {
+			return array( 'stats-paid', 'stats-commercial' );
+		}
+
+		/**
+		 * Whether one of the purchases grants the feature.
+		 *
+		 * @param string $feature   Feature slug.
+		 * @param array  $purchases Site purchases.
+		 * @param string $site_type Site type, 'wpcom' or 'jetpack'.
+		 * @param int    $blog_id   Blog ID.
+		 * @return bool
+		 */
+		public static function has_feature( $feature, $purchases, $site_type = '', $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+			foreach ( $purchases as $purchase ) {
+				if ( 'personal-bundle' === $purchase->product_slug && 'stats-paid' === $feature ) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+}

--- a/projects/packages/stats-admin/tests/php/stubs/class-wpcom-features.php
+++ b/projects/packages/stats-admin/tests/php/stubs/class-wpcom-features.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 		 * @return string[]
 		 */
 		public static function get_feature_slugs() {
-			return array( 'stats-paid', 'stats-commercial' );
+			return array( 'stats-paid', 'stats-commercial', 'support' );
 		}
 
 		/**
@@ -28,9 +28,20 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 		 * @param array  $purchases Site purchases.
 		 * @param string $site_type Site type, 'wpcom' or 'jetpack'.
 		 * @param int    $blog_id   Blog ID.
+		 * @throws \Error When handed a blog ID other than the current site's, as wpcomsh's sticker
+		 *                lookups do.
 		 * @return bool
 		 */
 		public static function has_feature( $feature, $purchases, $site_type = '', $blog_id = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+			if ( null !== $blog_id && (int) $blog_id !== WPCOM_TEST_BLOG_ID ) {
+				throw new Error( 'Atomic sites cannot resolve stickers for a site other than the current one.' );
+			}
+
+			// Granted to every WordPress.com site, purchase or not, as `wpcom-all-sites` features are.
+			if ( 'support' === $feature ) {
+				return true;
+			}
+
 			foreach ( $purchases as $purchase ) {
 				if ( 'personal-bundle' === $purchase->product_slug && 'stats-paid' === $feature ) {
 					return true;
@@ -39,4 +50,13 @@ if ( ! class_exists( 'WPCOM_Features' ) ) {
 			return false;
 		}
 	}
+}
+
+if ( ! defined( 'WPCOM_TEST_BLOG_ID' ) ) {
+	/**
+	 * The WordPress.com blog ID the stubs answer for. Deliberately not 1: on Atomic wpcomsh reads
+	 * the ID from `jetpack_options` while WordPress reports 1, and a caller passing the latter is
+	 * the bug these stubs exist to catch.
+	 */
+	define( 'WPCOM_TEST_BLOG_ID', 999 );
 }

--- a/projects/packages/stats-admin/tests/php/stubs/functions-wpcom-features.php
+++ b/projects/packages/stats-admin/tests/php/stubs/functions-wpcom-features.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Stand-in for the wpcomsh function that reads an Atomic site's purchases.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
+	/**
+	 * The purchases wpcomsh keeps in sync on an Atomic site.
+	 *
+	 * @param int $blog_id Blog ID.
+	 * @return object[]
+	 */
+	function wpcom_get_site_purchases( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
+		return array( (object) array( 'product_slug' => 'personal-bundle' ) );
+	}
+}

--- a/projects/packages/stats-admin/tests/php/stubs/functions-wpcom-features.php
+++ b/projects/packages/stats-admin/tests/php/stubs/functions-wpcom-features.php
@@ -10,9 +10,17 @@ if ( ! function_exists( 'wpcom_get_site_purchases' ) ) {
 	 * The purchases wpcomsh keeps in sync on an Atomic site.
 	 *
 	 * @param int $blog_id Blog ID.
+	 * @throws \Error When asked for a site other than the current one, as wpcomsh does.
 	 * @return object[]
 	 */
-	function wpcom_get_site_purchases( $blog_id = 0 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- the signature mirrors wpcomsh's.
-		return array( (object) array( 'product_slug' => 'personal-bundle' ) );
+	function wpcom_get_site_purchases( $blog_id = 0 ) {
+		if ( $blog_id && (int) $blog_id !== WPCOM_TEST_BLOG_ID ) {
+			throw new Error( 'Atomic sites do not support looking up features for sites other than the current site.' );
+		}
+
+		return $GLOBALS['wpcom_test_site_purchases'];
 	}
+
+	// A site holding one plan. A test covering an unsynced registry empties this.
+	$GLOBALS['wpcom_test_site_purchases'] = array( (object) array( 'product_slug' => 'personal-bundle' ) );
 }

--- a/projects/plugins/backup/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/backup/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -1480,10 +1480,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/boost/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/boost/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -1397,10 +1397,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/jetpack/changelog/fix-stats-475-plan-features
+++ b/projects/plugins/jetpack/changelog/fix-stats-475-plan-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Stats: stop showing free-plan paywalls in wp-admin on a site whose plan already includes those stats.

--- a/projects/plugins/jetpack/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/jetpack/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2741,10 +2741,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1711,10 +1711,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/paypal-payment-buttons/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -678,10 +678,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/protect/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/protect/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -1459,10 +1459,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/search/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/search/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -1337,10 +1337,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/social/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/social/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -1384,10 +1384,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/starter-plugin/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/starter-plugin/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -1261,10 +1261,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/stats/changelog/fix-stats-475-plan-features
+++ b/projects/plugins/stats/changelog/fix-stats-475-plan-features
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop showing free-plan paywalls in wp-admin on a site whose plan already includes those stats.

--- a/projects/plugins/stats/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/stats/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -1261,10 +1261,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/videopress/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/videopress/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -1337,10 +1337,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "e429a1035b390485595aad18457de4de45ddd3f4"
+                "reference": "495096b1cc58b7091a2242c8acf276d69549d73e"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {

--- a/projects/plugins/wpcomsh/changelog/update-composer-lock-for-plans-constants
+++ b/projects/plugins/wpcomsh/changelog/update-composer-lock-for-plans-constants
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1827,10 +1827,11 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/plans",
-                "reference": "558843aaf5371dd08a6a7cf26a3a8fa8b1da03a9"
+                "reference": "72458595587f3e261be49a109509eaa64caba38d"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
                 "php": ">=7.4"
             },
             "require-dev": {


### PR DESCRIPTION
Fixes STATS-475

## Proposed changes

Odyssey Stats in wp-admin decides every paywall from the `sites.features` entry in its config data. `Odyssey_Config_Data::get_plan_features()` fills that from the plan cached in the `jetpack_active_plan` option, and the app registers no route that could refresh it — whatever PHP prints at page load is final.

`Current_Plan::get()` defaults a site with no cached plan to `features => ['active' => []]`. That JSON-encodes to `{"active":[]}`, which is truthy, so it sails past the "features not loaded, do not gate" guard in Calypso's `shouldGateStats` and falls through to the free-site `gatedStats` list. The site is shown a 7-day range and a paywalled Locations card whose CTA offers the plan it already has. Calypso reads the live site record over `/sites/%s/features` and renders the same site correctly, which is why the two disagree.

* `Current_Plan::get_wpcom_site_specific_features()` (new) reads the site's features from the WordPress.com registry the site itself carries: the store on Simple, the purchases wpcomsh keeps in sync on Atomic. It returns `null` on a host with no registry, so callers keep their own fallback. The Atomic path runs the same loop `Store_Product_List::get_site_specific_features_data()` runs on the WordPress.com side — `WPCOM_Features::get_feature_slugs()` filtered through one read of `wpcom_get_site_purchases()` — memoized for the request.
* `Odyssey_Config_Data::get_plan_features()` prefers that, and falls back to the cached plan as before.
* The Stats page fills an empty plan cache once before printing the config data, throttled to 15 minutes and capped at a 5 second timeout, mirroring the `?plan_upgraded` refresh in `Jetpack_Gutenberg::enqueue_block_editor_assets()`. This only ever runs where the first change cannot help: `shouldGateStats` sends self-hosted Jetpack sites down a different branch that never reads `sites.features`, so there the cache is the only source and the daily `jetpack_heartbeat` refresh is the only thing filling it.

`packages/plans` picks up an `automattic/jetpack-constants` requirement, so the usual lock file and changelog fan-out rides along.

The site in the report reached this state because it bought its plan before its Atomic transfer completed, and the transfer seeds `jetpack_active_plan` only for sites carrying a particular sticker. That looks like a separate bug on the WordPress.com side and is being checked independently; this PR is about the Stats dashboard not being able to notice or correct a stale cache in the first place.

## Related product discussion/links

* https://linear.app/a8c/issue/STATS-475/paid-personal-site-shown-the-free-plan-stats-gate-in-wp-admin-odyssey

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated:

* `jetpack test php packages/plans` — 15 tests. The new `test_wpcom_site_specific_features_*` pair covers the registry read and the null return where there is no registry.
* `jetpack test php packages/stats-admin` — 65 tests. `test_config_data_features_come_from_the_site_itself_on_atomic` fails without the config data change, reporting `active: []`, which is the exact shape that produces the bug in production. The five `Dashboard_Test` additions cover the refresh, its throttle, and the three cases that must not fetch.

On a WordPress.com-hosted site (Atomic is the case in the report; Simple exercises the other branch):

* On a site with an active Personal or higher plan, open Stats in wp-admin.
* The date range control should offer more than Last 7 Days, and the Locations card should render country data rather than an "Unlock site growth analytics" paywall.
* `window.configData.intial_state.sites.features[<blog_id>].data.active` in the console should list `stats-paid`, and should do so on a first page load, without visiting My Jetpack or the Jetpack dashboard first.
* To confirm the fix rather than a coincidentally warm cache: `wp option delete jetpack_active_plan`, reload Stats, and check that the paywalls stay away. Before this change that leaves the page gated as if the site were free.

On a free WordPress.com site, the paywalls should be unchanged — a 7-day range and a gated Locations card.

On a self-hosted Jetpack site, gating is unchanged; it is decided from purchases rather than from `sites.features`. Worth a smoke test that the Stats page still loads at normal speed on a site whose `jetpack_active_plan` is empty, since that is the one path that now makes a request.
