### PR TITLE
Forms: stop the placeholder picker from creating a form per click

### DIFF
--- a/projects/packages/forms/changelog/forms-784-duplicate-form-picker
+++ b/projects/packages/forms/changelog/forms-784-duplicate-form-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent extra forms from being created when the block placeholder is clicked more than once.

--- a/projects/packages/forms/src/blocks/contact-form/editor.scss
+++ b/projects/packages/forms/src/blocks/contact-form/editor.scss
@@ -280,6 +280,27 @@
 			text-align: left;
 		}
 	}
+
+	// The placeholder root is a flex container with a block gap, so this
+	// wrapper re-creates it or the picker and the shells below lose spacing.
+	.form-placeholder__body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--wp--style--block-gap, 1.5rem);
+	}
+
+	.form-placeholder__body.is-creating-form {
+		// Belt and braces: inert already covers every supported browser, but it is
+		// a no-op on React 19, where an empty-string attribute is dropped.
+		pointer-events: none;
+
+		// Dim the controls only. The instructions line doubles as the status
+		// message while the form is being created, so it stays at full contrast.
+		.block-editor-block-variation-picker__variations,
+		.form-placeholder__shell {
+			opacity: 0.5;
+		}
+	}
 }
 
 .is-form-empty .block-editor-inserter {

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.jsx
@@ -9,12 +9,13 @@ import { Button, Modal, SelectControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
 import { FORM_POST_TYPE } from '../shared/util/constants.js';
+import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.jsx';
 import './util/form-styles.js';
 import applyVariationToFormBlock from './util/apply-variation.js';
 import { createSyncedForm } from './util/create-synced-form.ts';
@@ -39,6 +40,10 @@ const FORMS_QUERY = {
 export default function VariationPicker( { blockName, setAttributes, clientId, classNames } ) {
 	const registry = useRegistry();
 	const [ isPatternsModalOpen, setIsPatternsModalOpen ] = useState( false );
+	const [ isCreatingForm, setIsCreatingForm ] = useState( false );
+	// Read synchronously inside the click handler; state updates land too late to
+	// stop a second click that fires before React re-renders.
+	const isCreatingFormRef = useRef( false );
 	const { replaceInnerBlocks, selectBlock } = useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const isCentralFormManagementEnabled = hasFeatureFlag( 'central-form-management' );
@@ -120,6 +125,92 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		return msg;
 	};
 
+	const applyVariationLocally = variation =>
+		applyVariationToFormBlock( {
+			batch: registry.batch,
+			setAttributes,
+			replaceInnerBlocks,
+			selectBlock,
+			clientId,
+			variation,
+			createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
+		} );
+
+	const onVariationSelect = async ( nextVariation = defaultVariation ) => {
+		/*
+		 * Editing a jetpack_form post directly, or with central form management off,
+		 * applies the variation to this block inline: no synced form post, no ref.
+		 */
+		if (
+			isEditingJetpackFormPost ||
+			! isCentralFormManagementEnabled ||
+			nextVariation.name === 'regular-form'
+		) {
+			applyVariationLocally( nextVariation );
+			return;
+		}
+
+		/*
+		 * Creating the form post is a round trip and the picker stays clickable until
+		 * the ref lands, so without this guard every extra click publishes another form.
+		 */
+		if ( isCreatingFormRef.current ) {
+			return;
+		}
+		isCreatingFormRef.current = true;
+		setIsCreatingForm( true );
+
+		// We're editing a regular post/page - create a synced form with ref
+		try {
+			// Create inner blocks from template
+			const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
+
+			// Create the full jetpack/contact-form block with attributes and inner blocks
+			const formBlock = createBlock(
+				'jetpack/contact-form',
+				nextVariation.attributes || {},
+				innerBlocks
+			);
+
+			// Create synced form post and get its ID
+			const formId = await createSyncedForm(
+				formBlock,
+				nextVariation.title || 'Form',
+				currentPostId
+			);
+
+			// Set ONLY ref attribute
+			registry.batch( () => {
+				setAttributes( { ref: formId } );
+				selectBlock( clientId );
+			} );
+
+			// Show success notice
+			createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
+				type: 'snackbar',
+				isDismissible: true,
+			} );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Failed to create synced form:', error );
+			// Fallback to applying variation locally
+			applyVariationLocally( nextVariation );
+		} finally {
+			isCreatingFormRef.current = false;
+			setIsCreatingForm( false );
+		}
+	};
+
+	// Both branches above replace this block's content, so the picker unmounts on
+	// success; the skeleton only shows while the form post is being created.
+	if ( isCreatingForm ) {
+		return (
+			<div className={ clsx( classNames, 'is-placeholder' ) }>
+				<ContactFormSkeletonLoader />
+			</div>
+		);
+	}
+
 	return (
 		<div className={ clsx( classNames, 'is-placeholder' ) }>
 			<BlockVariationPicker
@@ -127,73 +218,7 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 				label={ blockType?.title }
 				instructions={ getInstructions() }
 				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
-				onSelect={ async ( nextVariation = defaultVariation ) => {
-					// If we're editing a jetpack-form post directly, or central form management
-					// is disabled, use the "old" behavior: apply the variation directly to this
-					// block by setting attributes and inner blocks, without creating a synced
-					// form post (i.e., without creating or updating a ref). This avoids relying
-					// on central form management when it is not available or not appropriate.
-					if (
-						isEditingJetpackFormPost ||
-						! isCentralFormManagementEnabled ||
-						nextVariation.name === 'regular-form'
-					) {
-						applyVariationToFormBlock( {
-							batch: registry.batch,
-							setAttributes,
-							replaceInnerBlocks,
-							selectBlock,
-							clientId,
-							variation: nextVariation,
-							createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
-						} );
-					} else {
-						// We're editing a regular post/page - create a synced form with ref
-						try {
-							// Create inner blocks from template
-							const innerBlocks = createBlocksFromInnerBlocksTemplate( nextVariation.innerBlocks );
-
-							// Create the full jetpack/contact-form block with attributes and inner blocks
-							const formBlock = createBlock(
-								'jetpack/contact-form',
-								nextVariation.attributes || {},
-								innerBlocks
-							);
-
-							// Create synced form post and get its ID
-							const formId = await createSyncedForm(
-								formBlock,
-								nextVariation.title || 'Form',
-								currentPostId
-							);
-
-							// Set ONLY ref attribute
-							registry.batch( () => {
-								setAttributes( { ref: formId } );
-								selectBlock( clientId );
-							} );
-
-							// Show success notice
-							createSuccessNotice( __( 'New form created.', 'jetpack-forms' ), {
-								type: 'snackbar',
-								isDismissible: true,
-							} );
-						} catch ( error ) {
-							// eslint-disable-next-line no-console
-							console.error( 'Failed to create synced form:', error );
-							// Fallback to applying variation locally
-							applyVariationToFormBlock( {
-								batch: registry.batch,
-								setAttributes,
-								replaceInnerBlocks,
-								selectBlock,
-								clientId,
-								variation: nextVariation,
-								createBlocksFromTemplate: createBlocksFromInnerBlocksTemplate,
-							} );
-						}
-					}
-				} }
+				onSelect={ onVariationSelect }
 			/>
 			{ ! isCentralFormManagementEnabled && (
 				<div className="form-placeholder__shell">

--- a/projects/packages/forms/src/blocks/contact-form/variation-picker.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/variation-picker.jsx
@@ -5,7 +5,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
-import { Button, Modal, SelectControl } from '@wordpress/components';
+import { Button, Modal, SelectControl, VisuallyHidden } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -15,7 +15,6 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import clsx from 'clsx';
 import { FORM_POST_TYPE } from '../shared/util/constants.js';
-import ContactFormSkeletonLoader from './components/jetpack-contact-form-skeleton-loader.jsx';
 import './util/form-styles.js';
 import applyVariationToFormBlock from './util/apply-variation.js';
 import { createSyncedForm } from './util/create-synced-form.ts';
@@ -100,6 +99,10 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		// Each translated string is assigned to a variable to prevent the minifier
 		// from collapsing them into a single __() call with a ternary argument,
 		// which breaks the i18n string literal requirement.
+		if ( isCreatingForm ) {
+			const msg = __( 'Creating your form…', 'jetpack-forms' );
+			return msg;
+		}
 		if ( isCentralFormManagementEnabled && showFormPicker ) {
 			const msg = __(
 				'Start by selecting one of these templates or select an existing form below.',
@@ -201,55 +204,61 @@ export default function VariationPicker( { blockName, setAttributes, clientId, c
 		}
 	};
 
-	// Both branches above replace this block's content, so the picker unmounts on
-	// success; the skeleton only shows while the form post is being created.
-	if ( isCreatingForm ) {
-		return (
-			<div className={ clsx( classNames, 'is-placeholder' ) }>
-				<ContactFormSkeletonLoader />
-			</div>
-		);
-	}
+	const instructions = getInstructions();
 
 	return (
 		<div className={ clsx( classNames, 'is-placeholder' ) }>
-			<BlockVariationPicker
-				icon={ blockType?.icon?.src }
-				label={ blockType?.title }
-				instructions={ getInstructions() }
-				variations={ variations.filter( v => ! v.hiddenFromPicker ) }
-				onSelect={ onVariationSelect }
-			/>
-			{ ! isCentralFormManagementEnabled && (
-				<div className="form-placeholder__shell">
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						onClick={ () => setIsPatternsModalOpen( true ) }
-					>
-						{ __( 'Browse form patterns', 'jetpack-forms' ) }
-					</Button>
-				</div>
-			) }
-			{ showFormPicker && (
-				<div className="form-placeholder__shell">
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Or select an existing form', 'jetpack-forms' ) }
-						options={ [
-							{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },
-							...jetpackForms.map( form => ( {
-								label:
-									decodeEntities( form.title?.rendered || '' ) ||
-									__( '(Untitled)', 'jetpack-forms' ),
-								value: form.id.toString(),
-							} ) ),
-						] }
-						onChange={ onFormSelect }
-					/>
-				</div>
-			) }
+			{ /* Mounted unconditionally: a live region inserted together with its text
+			     is not announced, and inert hides the visible copy from assistive tech. */ }
+			<VisuallyHidden role="status">
+				{ isCreatingForm ? __( 'Creating your form…', 'jetpack-forms' ) : '' }
+			</VisuallyHidden>
+			{ /* inert stops clicks that would otherwise go nowhere; it is not what
+			     prevents the duplicate form. */ }
+			<div
+				className={ clsx( 'form-placeholder__body', {
+					'is-creating-form': isCreatingForm,
+				} ) }
+				inert={ isCreatingForm ? '' : undefined }
+			>
+				<BlockVariationPicker
+					icon={ blockType?.icon?.src }
+					label={ blockType?.title }
+					instructions={ instructions }
+					variations={ variations.filter( v => ! v.hiddenFromPicker ) }
+					onSelect={ onVariationSelect }
+				/>
+				{ ! isCentralFormManagementEnabled && (
+					<div className="form-placeholder__shell">
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							onClick={ () => setIsPatternsModalOpen( true ) }
+						>
+							{ __( 'Browse form patterns', 'jetpack-forms' ) }
+						</Button>
+					</div>
+				) }
+				{ showFormPicker && (
+					<div className="form-placeholder__shell">
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Or select an existing form', 'jetpack-forms' ) }
+							options={ [
+								{ label: __( 'Select a form…', 'jetpack-forms' ), value: '' },
+								...jetpackForms.map( form => ( {
+									label:
+										decodeEntities( form.title?.rendered || '' ) ||
+										__( '(Untitled)', 'jetpack-forms' ),
+									value: form.id.toString(),
+								} ) ),
+							] }
+							onChange={ onFormSelect }
+						/>
+					</div>
+				) }
+			</div>
 			{ isPatternsModalOpen && (
 				<Modal
 					className="form-placeholder__patterns-modal"

--- a/projects/packages/forms/tests/js/contact-form/variation-picker.test.jsx
+++ b/projects/packages/forms/tests/js/contact-form/variation-picker.test.jsx
@@ -1,0 +1,199 @@
+/**
+ * Tests for the contact form VariationPicker
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCallback } from 'react';
+
+const mockCreateSyncedForm = jest.fn();
+const mockSetAttributes = jest.fn();
+const mockSelectBlock = jest.fn();
+const mockReplaceInnerBlocks = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+
+const VARIATIONS = [
+	{
+		name: 'contact-form',
+		title: 'Contact Form',
+		attributes: { variationName: 'contact-form' },
+		innerBlocks: [ [ 'jetpack/field-name', {} ] ],
+	},
+	{
+		name: 'rsvp-form',
+		title: 'RSVP Form',
+		attributes: { variationName: 'rsvp-form' },
+		innerBlocks: [ [ 'jetpack/field-name', {} ] ],
+	},
+];
+
+await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', () => ( {
+	hasFeatureFlag: flag => flag === 'central-form-management',
+} ) );
+
+/*
+ * Mirrors Gutenberg's BlockVariationPicker: one always-enabled button per
+ * variation, and no awareness that onSelect returns a promise.
+ */
+const VariationButton = ( { variation, onSelect } ) => {
+	const handleClick = useCallback( () => onSelect( variation ), [ variation, onSelect ] );
+	return <button onClick={ handleClick }>{ variation.title }</button>;
+};
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	__experimentalBlockVariationPicker: ( { variations, onSelect } ) => (
+		<ul>
+			{ variations.map( variation => (
+				<li key={ variation.name }>
+					<VariationButton variation={ variation } onSelect={ onSelect } />
+				</li>
+			) ) }
+		</ul>
+	),
+	__experimentalBlockPatternSetup: () => <div />,
+	store: 'core/block-editor',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
+	createBlock: ( name, attributes, innerBlocks ) => ( { name, attributes, innerBlocks } ),
+	store: 'core/blocks',
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	Button: ( { children, ...props } ) => <button { ...props }>{ children }</button>,
+	Modal: ( { children } ) => <div>{ children }</div>,
+	SelectControl: () => <div />,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( { store: 'core' } ) );
+await jest.unstable_mockModule( '@wordpress/editor', () => ( { store: 'core/editor' } ) );
+await jest.unstable_mockModule( '@wordpress/notices', () => ( { store: 'core/notices' } ) );
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( { __: str => str } ) );
+await jest.unstable_mockModule( '@wordpress/html-entities', () => ( {
+	decodeEntities: str => str,
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useRegistry: () => ( { batch: fn => fn() } ),
+	useSelect: selector =>
+		selector( store => {
+			if ( store === 'core/blocks' ) {
+				return {
+					getBlockType: () => ( { title: 'Form', icon: { src: 'form' } } ),
+					getBlockVariations: () => VARIATIONS,
+					getDefaultBlockVariation: () => VARIATIONS[ 0 ],
+				};
+			}
+			if ( store === 'core/editor' ) {
+				return {
+					getCurrentPostType: () => 'page',
+					getCurrentPostId: () => 42,
+				};
+			}
+			if ( store === 'core' ) {
+				return { getEntityRecords: () => [] };
+			}
+			return {};
+		} ),
+	useDispatch: store => {
+		if ( store === 'core/notices' ) {
+			return { createSuccessNotice: mockCreateSuccessNotice };
+		}
+		return { replaceInnerBlocks: mockReplaceInnerBlocks, selectBlock: mockSelectBlock };
+	},
+} ) );
+
+await jest.unstable_mockModule(
+	'../../../src/blocks/contact-form/util/create-synced-form.ts',
+	() => ( { createSyncedForm: mockCreateSyncedForm } )
+);
+
+await jest.unstable_mockModule(
+	'../../../src/blocks/contact-form/util/form-styles.js',
+	() => ( {} )
+);
+
+await jest.unstable_mockModule(
+	'../../../src/blocks/contact-form/components/jetpack-contact-form-skeleton-loader.jsx',
+	() => ( { default: () => <div data-testid="skeleton-loader" /> } )
+);
+
+await jest.unstable_mockModule( '../../../src/blocks/shared/util/constants.js', () => ( {
+	FORM_POST_TYPE: 'jetpack_form',
+} ) );
+
+const { default: VariationPicker } = await import(
+	'../../../src/blocks/contact-form/variation-picker.jsx'
+);
+
+const renderPicker = () =>
+	render(
+		<VariationPicker
+			blockName="jetpack/contact-form"
+			setAttributes={ mockSetAttributes }
+			clientId="test-client-id"
+			classNames="wp-block-jetpack-contact-form"
+		/>
+	);
+
+describe( 'VariationPicker', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'creates a synced form and sets the ref when a variation is selected', async () => {
+		mockCreateSyncedForm.mockResolvedValue( 99 );
+
+		renderPicker();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Contact Form' } ) );
+
+		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetAttributes ).toHaveBeenCalledWith( { ref: 99 } );
+	} );
+
+	it( 'hides the variations while the form is being created', async () => {
+		mockCreateSyncedForm.mockReturnValue( new Promise( () => {} ) );
+
+		renderPicker();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Contact Form' } ) );
+
+		expect( screen.queryByRole( 'button', { name: 'Contact Form' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'RSVP Form' } ) ).not.toBeInTheDocument();
+		expect( screen.getByTestId( 'skeleton-loader' ) ).toBeInTheDocument();
+	} );
+
+	/*
+	 * userEvent awaits a re-render between clicks, which is what now hides the
+	 * buttons; batching the clicks in one act() is what reaches the guard itself.
+	 */
+	/* eslint-disable testing-library/no-unnecessary-act, testing-library/prefer-user-event */
+	it( 'creates one form only, even when clicks land before the picker re-renders', async () => {
+		mockCreateSyncedForm.mockReturnValue( new Promise( () => {} ) );
+
+		renderPicker();
+		const contactForm = screen.getByRole( 'button', { name: 'Contact Form' } );
+		const rsvpForm = screen.getByRole( 'button', { name: 'RSVP Form' } );
+
+		await act( async () => {
+			fireEvent.click( contactForm );
+			fireEvent.click( contactForm );
+			fireEvent.click( rsvpForm );
+		} );
+
+		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 1 );
+	} );
+	/* eslint-enable testing-library/no-unnecessary-act, testing-library/prefer-user-event */
+
+	it( 'falls back to an inline form when creation fails, without leaving the picker locked', async () => {
+		mockCreateSyncedForm.mockRejectedValue( new Error( 'nope' ) );
+
+		renderPicker();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Contact Form' } ) );
+
+		expect( console ).toHaveErrored();
+		expect( mockSetAttributes ).toHaveBeenCalledWith( VARIATIONS[ 0 ].attributes );
+		expect( mockReplaceInnerBlocks ).toHaveBeenCalled();
+		expect( screen.getByRole( 'button', { name: 'Contact Form' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/forms/tests/js/contact-form/variation-picker.test.jsx
+++ b/projects/packages/forms/tests/js/contact-form/variation-picker.test.jsx
@@ -38,18 +38,22 @@ await jest.unstable_mockModule( '@automattic/jetpack-shared-extension-utils', ()
  */
 const VariationButton = ( { variation, onSelect } ) => {
 	const handleClick = useCallback( () => onSelect( variation ), [ variation, onSelect ] );
+	// ds-allow: button -- test double for Gutenberg's picker; the real Button is mocked away.
 	return <button onClick={ handleClick }>{ variation.title }</button>;
 };
 
 await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
-	__experimentalBlockVariationPicker: ( { variations, onSelect } ) => (
-		<ul>
-			{ variations.map( variation => (
-				<li key={ variation.name }>
-					<VariationButton variation={ variation } onSelect={ onSelect } />
-				</li>
-			) ) }
-		</ul>
+	__experimentalBlockVariationPicker: ( { variations, onSelect, instructions } ) => (
+		<>
+			<p>{ instructions }</p>
+			<ul>
+				{ variations.map( variation => (
+					<li key={ variation.name }>
+						<VariationButton variation={ variation } onSelect={ onSelect } />
+					</li>
+				) ) }
+			</ul>
+		</>
 	),
 	__experimentalBlockPatternSetup: () => <div />,
 	store: 'core/block-editor',
@@ -61,9 +65,11 @@ await jest.unstable_mockModule( '@wordpress/blocks', () => ( {
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/components', () => ( {
+	// ds-allow: button -- this mock IS the Button stand-in for @wordpress/components.
 	Button: ( { children, ...props } ) => <button { ...props }>{ children }</button>,
 	Modal: ( { children } ) => <div>{ children }</div>,
 	SelectControl: () => <div />,
+	VisuallyHidden: ( { children, ...props } ) => <span { ...props }>{ children }</span>,
 } ) );
 
 await jest.unstable_mockModule( '@wordpress/core-data', () => ( { store: 'core' } ) );
@@ -114,11 +120,6 @@ await jest.unstable_mockModule(
 	() => ( {} )
 );
 
-await jest.unstable_mockModule(
-	'../../../src/blocks/contact-form/components/jetpack-contact-form-skeleton-loader.jsx',
-	() => ( { default: () => <div data-testid="skeleton-loader" /> } )
-);
-
 await jest.unstable_mockModule( '../../../src/blocks/shared/util/constants.js', () => ( {
 	FORM_POST_TYPE: 'jetpack_form',
 } ) );
@@ -137,6 +138,9 @@ const renderPicker = () =>
 		/>
 	);
 
+// eslint-disable-next-line testing-library/no-node-access -- inert sits on a presentational wrapper with no role or accessible name, and jsdom does not simulate its effect; no accessible query reaches it.
+const placeholderBody = container => container.querySelector( '.form-placeholder__body' );
+
 describe( 'VariationPicker', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -152,20 +156,32 @@ describe( 'VariationPicker', () => {
 		expect( mockSetAttributes ).toHaveBeenCalledWith( { ref: 99 } );
 	} );
 
-	it( 'hides the variations while the form is being created', async () => {
+	it( 'keeps the templates on screen but inert while the form is being created', async () => {
 		mockCreateSyncedForm.mockReturnValue( new Promise( () => {} ) );
 
-		renderPicker();
+		const { container } = renderPicker();
 		await userEvent.click( screen.getByRole( 'button', { name: 'Contact Form' } ) );
 
-		expect( screen.queryByRole( 'button', { name: 'Contact Form' } ) ).not.toBeInTheDocument();
-		expect( screen.queryByRole( 'button', { name: 'RSVP Form' } ) ).not.toBeInTheDocument();
-		expect( screen.getByTestId( 'skeleton-loader' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Contact Form' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'RSVP Form' } ) ).toBeInTheDocument();
+
+		const body = placeholderBody( container );
+		expect( body ).toHaveAttribute( 'inert' );
+		expect( body ).toHaveClass( 'is-creating-form' );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Creating your form…' );
+		expect( screen.getByText( 'Creating your form…', { selector: 'p' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'announces nothing until a form is actually being created', () => {
+		renderPicker();
+
+		// The region must already be mounted, or the later text swap is not announced.
+		expect( screen.getByRole( 'status' ) ).toBeEmptyDOMElement();
 	} );
 
 	/*
-	 * userEvent awaits a re-render between clicks, which is what now hides the
-	 * buttons; batching the clicks in one act() is what reaches the guard itself.
+	 * userEvent awaits a re-render between clicks, which is what makes the body
+	 * inert; batching the clicks in one act() is what reaches the guard itself.
 	 */
 	/* eslint-disable testing-library/no-unnecessary-act, testing-library/prefer-user-event */
 	it( 'creates one form only, even when clicks land before the picker re-renders', async () => {
@@ -195,5 +211,9 @@ describe( 'VariationPicker', () => {
 		expect( mockSetAttributes ).toHaveBeenCalledWith( VARIATIONS[ 0 ].attributes );
 		expect( mockReplaceInnerBlocks ).toHaveBeenCalled();
 		expect( screen.getByRole( 'button', { name: 'Contact Form' } ) ).toBeInTheDocument();
+
+		// Visible is not the same as usable: the ref guard must have been released too.
+		await userEvent.click( screen.getByRole( 'button', { name: 'Contact Form' } ) );
+		expect( mockCreateSyncedForm ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/forms-784-duplicate-form-picker
+++ b/projects/plugins/jetpack/changelog/forms-784-duplicate-form-picker
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Prevent extra forms from being created when the block placeholder is clicked more than once.


### PR DESCRIPTION
Fixes FORMS-784

## Proposed changes

* The contact form placeholder picker created one form per click. `variation-picker.jsx` awaited `createSyncedForm()` — the REST POST that publishes a `jetpack_form` post — before setting the block's `ref`. Gutenberg's `BlockVariationPicker` keeps its buttons enabled and has no idea `onSelect` returns a promise, and nothing in our handler re-rendered before the `await`, so the picker stayed mounted and fully clickable for the whole round trip. Every click in that window published another form. Only the last-resolving `ref` stuck; the rest were orphaned into the Forms dashboard and the picker's own "select an existing form" dropdown.
* Guard the handler with a ref read synchronously on click, so a second click that lands before React re-renders is ignored.
* Swap the picker for `ContactFormSkeletonLoader` while the form is being created. That removes the click target entirely and gives feedback during the request, and it is the same skeleton the block already shows once `ref` is set, so the transition is seamless.
* The two sibling paths that create synced forms already guard this way — `use-create-synced-form-on-insertion.ts` with a `hasAttemptedCreation` ref, `convert-form-toolbar.tsx` with `lockPostSaving`. The picker was the one unguarded async entry point.

The local-apply branch (editing a `jetpack_form` post directly, central form management off, or the `regular-form` variation) is synchronous and was never affected. It is deduped into a helper here but otherwise unchanged.

## Related product discussion/links

* FORMS-784

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs a site where the block editor can create synced forms (the `central-form-management` flag defaults on).

* Create a new post or page.
* Insert the **Form** block. You should get the placeholder with the template picker.
* Double-click one of the templates, for example **Contact Form**. A single, ordinary double-click is enough; you do not need to be fast.
* Go to **Jetpack → Forms**, or run `wp post list --post_type=jetpack_form`.

Before this change you get two forms from that one double-click, both titled "Contact Form", and the block references only the first. On trunk I measured the picker still showing all seven templates, all enabled, 120ms after the first click.

After this change you get one form. The picker is replaced by the loading skeleton as soon as you click, so there is nothing left to double-click.

Also worth checking, since the handler was restructured:

* A single click on any template still creates one form and selects the block.
* Editing a `jetpack_form` post directly still applies the variation inline, with no new form post created.
* The **Regular Form** variation still applies inline.
* Blocking the REST request (DevTools → Network → offline, then click a template) still falls back to an inline form and leaves the picker usable rather than stuck on the skeleton.
