### PR TITLE
SEO: stop the Settings tab crashing on a cleared page title structure

### DIFF
--- a/projects/packages/seo/_inc/data/settings-store.ts
+++ b/projects/packages/seo/_inc/data/settings-store.ts
@@ -1,5 +1,6 @@
 import { createReduxStore, register } from '@wordpress/data';
 import { getPreloaded, SETTINGS_PATH } from './get-preloaded';
+import { normalizeTitleFormats } from './title-format-tokens';
 import type { SettingsResponse } from './settings-types';
 
 /**
@@ -25,8 +26,18 @@ interface SetSettingsAction {
 	settings: SettingsResponse;
 }
 
+/**
+ * Guard the one field whose server shape is looser than its type: a page type
+ * cleared through the site-settings API is stored, and can arrive, as `''`.
+ *
+ * @param settings - A settings snapshot from the bootstrap, a fetch, or a save.
+ * @return The snapshot with `title_formats` coerced to token lists.
+ */
+const sanitize = ( settings: SettingsResponse | null ): SettingsResponse | null =>
+	settings ? { ...settings, title_formats: normalizeTitleFormats( settings.title_formats ) } : null;
+
 const DEFAULT_STATE: State = {
-	settings: getPreloaded< SettingsResponse >( SETTINGS_PATH ) ?? null,
+	settings: sanitize( getPreloaded< SettingsResponse >( SETTINGS_PATH ) ?? null ),
 };
 
 const actions = {
@@ -56,7 +67,7 @@ const selectors = {
 const store = createReduxStore( STORE_NAME, {
 	reducer( state: State = DEFAULT_STATE, action: SetSettingsAction ): State {
 		if ( action.type === 'SET_SETTINGS' ) {
-			return { settings: action.settings };
+			return { settings: sanitize( action.settings ) };
 		}
 		return state;
 	},

--- a/projects/packages/seo/_inc/data/test/settings-store.test.ts
+++ b/projects/packages/seo/_inc/data/test/settings-store.test.ts
@@ -26,4 +26,18 @@ describe( 'settings-store', () => {
 		registry.dispatch( settingsStore ).setSettings( next );
 		expect( registry.select( settingsStore ).getSettings() ).toEqual( next );
 	} );
+
+	it( 'coerces a cleared title format from the server into an empty list', () => {
+		const registry = makeRegistry();
+		const fromServer = {
+			...SEEDED_SETTINGS,
+			// What a site that cleared a page type in Calypso actually stores.
+			title_formats: { front_page: '', posts: [ { type: 'token', value: 'post_title' } ] },
+		} as unknown as SettingsResponse;
+		registry.dispatch( settingsStore ).setSettings( fromServer );
+		expect( registry.select( settingsStore ).getSettings()?.title_formats ).toEqual( {
+			front_page: [],
+			posts: [ { type: 'token', value: 'post_title' } ],
+		} );
+	} );
 } );

--- a/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
+++ b/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
@@ -10,6 +10,7 @@ import {
 	buildPreview,
 	buildPreviewParts,
 	fromDisplay,
+	normalizeTitleFormats,
 	stringToTokens,
 	toDisplay,
 	tokensToString,
@@ -331,5 +332,27 @@ describe( 'preview parts', () => {
 			{ kind: 'literal', text: ' - ' },
 			{ kind: 'value', text: 'We make things' },
 		] );
+	} );
+} );
+
+describe( 'normalizeTitleFormats', () => {
+	it( 'turns a cleared page type stored as an empty string into an empty list', () => {
+		expect( normalizeTitleFormats( { front_page: '', posts: [] } ) ).toEqual( {
+			front_page: [],
+			posts: [],
+		} );
+	} );
+
+	it( 'keeps well-formed tokens and drops anything else in a list', () => {
+		const token: TitleFormatToken = { type: 'token', value: 'site_name' };
+		expect(
+			normalizeTitleFormats( { pages: [ token, 'junk', { type: 'nope', value: 'x' }, null ] } )
+		).toEqual( { pages: [ token ] } );
+	} );
+
+	it( 'returns an empty map for a non-object payload', () => {
+		expect( normalizeTitleFormats( undefined ) ).toEqual( {} );
+		expect( normalizeTitleFormats( '' ) ).toEqual( {} );
+		expect( normalizeTitleFormats( [] ) ).toEqual( {} );
 	} );
 } );

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -339,10 +339,10 @@ const isTitleFormatToken = ( value: unknown ): value is TitleFormatToken =>
 	typeof ( value as TitleFormatToken ).value === 'string';
 
 /**
- * Coerce a server payload's `title_formats` into a map of token lists. The
- * stored option can hold an empty string for a cleared page type (the site
- * settings API accepts it and Calypso sends it), and older servers pass it
- * through; rendering `''` as a list crashed the Settings tab.
+ * Coerce a server payload's `title_formats` into one token list per page type.
+ *
+ * The stored option holds `''` for a page type cleared from Calypso, and an older
+ * server passes that through as-is.
  *
  * @param formats - The raw `title_formats` value.
  * @return One token list per page type, empty where the input was unusable.

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -324,3 +324,36 @@ export const stringToTokens = ( input: string, allowedTokenIds?: string[] ): Tit
 		.split( LABEL_PATTERN )
 		.filter( segment => segment !== '' )
 		.map( segment => fromDisplay( segment, allowedTokenIds ) );
+
+/**
+ * Whether a value is one canonical `{ type, value }` token.
+ *
+ * @param value - Anything read from the server or the store.
+ * @return True for a well-formed token.
+ */
+const isTitleFormatToken = ( value: unknown ): value is TitleFormatToken =>
+	!! value &&
+	typeof value === 'object' &&
+	( ( value as TitleFormatToken ).type === 'string' ||
+		( value as TitleFormatToken ).type === 'token' ) &&
+	typeof ( value as TitleFormatToken ).value === 'string';
+
+/**
+ * Coerce a server payload's `title_formats` into a map of token lists. The
+ * stored option can hold an empty string for a cleared page type (the site
+ * settings API accepts it and Calypso sends it), and older servers pass it
+ * through; rendering `''` as a list crashed the Settings tab.
+ *
+ * @param formats - The raw `title_formats` value.
+ * @return One token list per page type, empty where the input was unusable.
+ */
+export const normalizeTitleFormats = ( formats: unknown ): Record< string, TitleFormatToken[] > => {
+	if ( ! formats || typeof formats !== 'object' || Array.isArray( formats ) ) {
+		return {};
+	}
+	const normalized: Record< string, TitleFormatToken[] > = {};
+	for ( const [ pageType, format ] of Object.entries( formats as Record< string, unknown > ) ) {
+		normalized[ pageType ] = Array.isArray( format ) ? format.filter( isTitleFormatToken ) : [];
+	}
+	return normalized;
+};

--- a/projects/packages/seo/changelog/fix-settings-tab-cleared-title-format-crash
+++ b/projects/packages/seo/changelog/fix-settings-tab-cleared-title-format-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+SEO: Fix the Settings tab failing to load on sites where a page title structure had been cleared from WordPress.com.

--- a/projects/packages/seo/changelog/fix-settings-tab-cleared-title-format-crash
+++ b/projects/packages/seo/changelog/fix-settings-tab-cleared-title-format-crash
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-SEO: Fix the Settings tab failing to load on sites where a page title structure had been cleared from WordPress.com.
+Fix the Settings tab failing to load on sites where a page title structure had been cleared from WordPress.com.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -195,6 +195,42 @@ class Dashboard_Data {
 	}
 
 	/**
+	 * Coerce the stored title formats into what the Settings tab can render: a
+	 * page type maps to a list of `{ type, value }` tokens, or to an empty list.
+	 *
+	 * The stored option is looser than that. The site-settings API accepts an
+	 * empty string as "clear this page type" (`are_valid_title_formats()`), and
+	 * Calypso sends exactly that, so `'front_page' => ''` is a normal stored value.
+	 * Handing it to the client crashed the tab (JETPACK-2284).
+	 *
+	 * @param mixed $stored Raw option value.
+	 * @return array<string, array<int, array{type: string, value: string}>>
+	 */
+	public static function normalize_title_formats( $stored ) {
+		if ( ! is_array( $stored ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $stored as $page_type => $format ) {
+			$tokens = array();
+			if ( is_array( $format ) ) {
+				foreach ( $format as $item ) {
+					if ( is_array( $item ) && isset( $item['type'] ) && isset( $item['value'] ) && is_string( $item['type'] ) && is_string( $item['value'] ) ) {
+						$tokens[] = array(
+							'type'  => $item['type'],
+							'value' => $item['value'],
+						);
+					}
+				}
+			}
+			$normalized[ (string) $page_type ] = $tokens;
+		}
+
+		return $normalized;
+	}
+
+	/**
 	 * Build the editable Settings state the Settings tab hydrates from.
 	 *
 	 * Read-only bootstrap only. Most writes go through the existing
@@ -211,10 +247,7 @@ class Dashboard_Data {
 		// Read the stored values directly: Jetpack_SEO_Titles::get_custom_title_formats()
 		// intentionally hides them while another SEO plugin controls output, but the
 		// dashboard must still show the saved values without allowing edits.
-		$title_formats = get_option( 'advanced_seo_title_formats', array() );
-		if ( ! is_array( $title_formats ) ) {
-			$title_formats = array();
-		}
+		$title_formats = self::normalize_title_formats( get_option( 'advanced_seo_title_formats', array() ) );
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Utils lives in plugins/jetpack and is guarded by class_exists.
 		$title_formats_editable = class_exists( 'Jetpack_SEO_Utils' ) && Jetpack_SEO_Utils::is_enabled_jetpack_seo();
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Utils lives in plugins/jetpack and is guarded by class_exists.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -195,13 +195,12 @@ class Dashboard_Data {
 	}
 
 	/**
-	 * Coerce the stored title formats into what the Settings tab can render: a
-	 * page type maps to a list of `{ type, value }` tokens, or to an empty list.
+	 * Coerce the stored title formats into one `{ type, value }` token list per page type.
 	 *
-	 * The stored option is looser than that. The site-settings API accepts an
-	 * empty string as "clear this page type" (`are_valid_title_formats()`), and
-	 * Calypso sends exactly that, so `'front_page' => ''` is a normal stored value.
-	 * Handing it to the client crashed the tab (JETPACK-2284).
+	 * The site-settings API stores a cleared page type as `''` (see JETPACK-2284), so the
+	 * option is looser than the Settings tab's type; anything not a token list becomes `array()`.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param mixed $stored Raw option value.
 	 * @return array<string, array<int, array{type: string, value: string}>>

--- a/projects/packages/seo/tests/php/DashboardDataTest.php
+++ b/projects/packages/seo/tests/php/DashboardDataTest.php
@@ -262,6 +262,56 @@ class DashboardDataTest extends SeoTestCase {
 	}
 
 	/**
+	 * A page type cleared through the site-settings API is stored as an empty
+	 * string; the Settings tab must receive an empty list for it, not a string.
+	 */
+	public function test_get_settings_data_coerces_cleared_title_formats_to_lists() {
+		update_option(
+			'advanced_seo_title_formats',
+			array(
+				'front_page' => '',
+				'posts'      => array(
+					array(
+						'type'  => 'token',
+						'value' => 'post_title',
+					),
+					'not a token',
+				),
+				'pages'      => 'garbage',
+				'archives'   => array(
+					'type'  => 'token',
+					'value' => 'archive_title',
+				),
+			)
+		);
+
+		$formats = (array) Dashboard_Data::get_settings_data()['title_formats'];
+
+		$this->assertSame( array(), $formats['front_page'] );
+		$this->assertSame(
+			array(
+				array(
+					'type'  => 'token',
+					'value' => 'post_title',
+				),
+			),
+			$formats['posts']
+		);
+		$this->assertSame( array(), $formats['pages'] );
+		// An associative entry is one token's shape at the wrong depth, not a list.
+		$this->assertSame( array(), $formats['archives'] );
+	}
+
+	/**
+	 * A non-array option value yields no formats rather than a fatal.
+	 */
+	public function test_normalize_title_formats_rejects_non_arrays() {
+		$this->assertSame( array(), Dashboard_Data::normalize_title_formats( '' ) );
+		$this->assertSame( array(), Dashboard_Data::normalize_title_formats( false ) );
+		$this->assertSame( array(), Dashboard_Data::normalize_title_formats( 'a:1:{}' ) );
+	}
+
+	/**
 	 * Stored title formats stay visible but read-only while conflicting SEO output
 	 * disables Jetpack SEO, preventing a blank dashboard save from erasing them.
 	 */

--- a/projects/plugins/jetpack/changelog/fix-settings-tab-cleared-title-format-crash
+++ b/projects/plugins/jetpack/changelog/fix-settings-tab-cleared-title-format-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: Store a cleared page title structure as an empty list instead of an empty string.

--- a/projects/plugins/jetpack/changelog/fix-settings-tab-cleared-title-format-crash
+++ b/projects/plugins/jetpack/changelog/fix-settings-tab-cleared-title-format-crash
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-SEO: Store a cleared page title structure as an empty list instead of an empty string.
+SEO: Fix the Settings tab failing to load after a page title structure was cleared from WordPress.com.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
@@ -309,6 +309,12 @@ class Jetpack_SEO_Titles {
 	 */
 	public static function sanitize_title_formats( $title_formats ) {
 		foreach ( $title_formats as &$format_array ) {
+			// The API accepts an empty string as "clear this page type"; store it as
+			// the empty list every reader expects, and don't iterate a string.
+			if ( ! is_array( $format_array ) ) {
+				$format_array = array();
+				continue;
+			}
 			foreach ( $format_array as &$item ) {
 				if ( 'string' === $item['type'] ) {
 					// From `wp_strip_all_tags`, but omitting the `trim` portion since we want spacing preserved.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
@@ -350,7 +350,10 @@ class Jetpack_SEO_Titles {
 			'archives'   => array(),
 		);
 
+		// Sanitize the stored formats too: a page type saved as '' before this guard
+		// existed would otherwise survive every partial save from Calypso.
 		$previous_formats = self::get_custom_title_formats();
+		$previous_formats = is_array( $previous_formats ) ? self::sanitize_title_formats( $previous_formats ) : array();
 
 		$result = array_merge( $empty_formats, $previous_formats, $new_formats );
 

--- a/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
@@ -181,4 +181,61 @@ class Jetpack_SEO_Titles_Test extends WP_UnitTestCase {
 			}
 		}
 	}
+
+	/**
+	 * The site-settings API accepts '' as "clear this page type"; it must be stored
+	 * as the empty list every reader expects.
+	 */
+	public function test_sanitize_title_formats_stores_a_cleared_page_type_as_an_empty_list() {
+		$sanitized = Jetpack_SEO_Titles::sanitize_title_formats(
+			array(
+				'front_page' => '',
+				'posts'      => array(
+					array(
+						'type'  => 'string',
+						'value' => '<b>Bold</b> | ',
+					),
+					array(
+						'type'  => 'token',
+						'value' => 'post_title',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array(), $sanitized['front_page'] );
+		$this->assertSame( 'Bold | ', $sanitized['posts'][0]['value'] );
+		$this->assertSame( 'post_title', $sanitized['posts'][1]['value'] );
+	}
+
+	/**
+	 * A '' already stored for an untouched page type is repaired on the next save.
+	 */
+	public function test_update_title_formats_repairs_a_stored_empty_string() {
+		update_option(
+			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION,
+			array(
+				'front_page' => '',
+				'posts'      => array(),
+				'pages'      => array(),
+				'groups'     => array(),
+				'archives'   => array(),
+			)
+		);
+
+		$result = Jetpack_SEO_Titles::update_title_formats(
+			array(
+				'pages' => array(
+					array(
+						'type'  => 'token',
+						'value' => 'page_title',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array(), $result['front_page'] );
+		$this->assertSame( 'page_title', $result['pages'][0]['value'] );
+		$this->assertSame( array(), get_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION )['front_page'] );
+	}
 }


### PR DESCRIPTION
## Proposed changes

Jetpack → SEO → Settings dies with `e.map is not a function` on some sites. JETPACK-2284.

I went looking for where the array stopped being an array. It's the stored option. `advanced_seo_title_formats` is supposed to map each page type to a list of tokens, but it can also hold an empty string. Calypso sends `''` when you clear a title structure (the comment in `form.jsx` literally says "we specifically want to clear the format") and `are_valid_title_formats()` accepts it. So any site that ever cleared a format in Calypso has `'front_page' => ''` sitting in the option. The new Settings tab treats every page type as a list, calls `.map` on it, and falls over.

Yoast is a red herring. The "SEO tools are not enabled" banner in the ticket is the conflicting-plugin gate on Overview. The rows still throw with Yoast off.

The fix is three small pieces, so a broken site both loads and repairs itself:

* **Read**: `Dashboard_Data::normalize_title_formats()` hands the tab a clean list per page type, whatever is stored.
* **Client**: `normalizeTitleFormats()` runs in the settings store on seed and on every set, so an older server can't crash it either.
* **Write**: `sanitize_title_formats()` stores a cleared page type as `[]` instead of `''`, and `update_title_formats()` sanitizes the previously stored formats too. That last bit matters because Calypso only sends the page types you changed, so without it the `''` would survive every save from there.

I had four separate review passes go over this (root cause, correctness, WordPress.com scope, repo conventions). No blockers came back; the previous-formats repair and the write-path tests came out of them.

One scope note. Same package runs on Simple, but as of 31 Aug the Simple dashboard wasn't rendering at all, so today this is Atomic in practice. It will show up on Simple the moment that ships, and those sites are already carrying the `''`. I couldn't count how many, per-site options aren't in the warehouse.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/JETPACK-2284
* Calypso writer: `client/my-sites/site-settings/seo-settings/form.jsx`, `submitSeoForm`

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated, all run locally: `cd projects/packages/seo && composer phpunit` (200 tests), `pnpm run test` (290), `pnpm run typecheck`. New tests: `DashboardDataTest::test_get_settings_data_coerces_cleared_title_formats_to_lists`, the `normalizeTitleFormats` cases in `title-format-tokens.test.ts`, the store test, and the two write-path cases in `Jetpack_SEO_Titles_Test`.

Manual, on a Jetpack site where the SEO dashboard is visible and `seo-tools` is active:

1. Put the broken shape in place directly: `wp option update advanced_seo_title_formats '{"front_page":"","posts":[],"pages":[],"groups":[],"archives":[]}' --format=json`. On an Atomic site you can instead clear the Front Page title structure in Calypso (Marketing → Traffic → SEO) and save.
2. On trunk, open Jetpack → SEO → Settings. It fails with `e.map is not a function`.
3. On this branch, reload. The tab renders and the Front page row previews the default title.
4. Save any one title row from the tab, then `wp option get advanced_seo_title_formats --format=json`. `front_page` is now `[]`.
5. Control: set a real Front page structure in Calypso and reload the tab. It displays and previews.

I couldn't run the plugin PHPUnit suite locally (needs the Docker environment), so `Jetpack_SEO_Titles_Test` is on CI.
