### PR TITLE
Charts: Add below-axis tooltip placement and styling options

### DIFF
--- a/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
+++ b/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Line chart: Add options to place tooltips below the x-axis and customize tooltip and crosshair styles.
+Line chart: Add options to place tooltips below the x-axis label band and customize tooltip and crosshair styles.

--- a/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
+++ b/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Line chart: Add an option to place tooltips below the x-axis.

--- a/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
+++ b/projects/js-packages/charts/changelog/add-line-chart-below-axis-tooltip
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Line chart: Add an option to place tooltips below the x-axis.
+Line chart: Add options to place tooltips below the x-axis and customize tooltip and crosshair styles.

--- a/projects/js-packages/charts/changelog/merge-accessible-tooltip-styles
+++ b/projects/js-packages/charts/changelog/merge-accessible-tooltip-styles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AccessibleTooltip: Merge supplied styles with the default box styles instead of replacing them; use unstyled to remove the box styles.

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -221,6 +221,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			smoothing = true,
 			curveType,
 			renderTooltip = renderDefaultTooltip,
+			tooltipPlacement,
 			withStartGlyphs = false,
 			withEndGlyphs = false,
 			animation,
@@ -676,6 +677,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 												<AccessibleTooltip
 													detectBounds
 													snapTooltipToDatumX
+													tooltipPlacement={ tooltipPlacement }
 													snapTooltipToDatumY
 													showSeriesGlyphs
 													renderTooltip={ tooltipRenderer }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -108,11 +108,13 @@ const TooltipDate: FC< { date?: Date; displayResolution: Exclude< TickResolution
  * one row per visible series (label + formatted value), sorted descending by
  * value. Reused by AreaChart, which has the same multi-series shape.
  *
- * @param params - visx `RenderTooltipParams< DataPointDate >`, plus the chart's optional `bucketInfo`.
+ * @param params        - visx tooltip data and the chart's optional `bucketInfo`.
+ * @param inheritStyles - Inherit the container's surface and text color.
  * @return Tooltip JSX, or `null` when no datum is hovered.
  */
 export const renderDefaultTooltip = (
-	params: RenderTooltipParams< DataPointDate > & { bucketInfo?: BucketInfo }
+	params: RenderTooltipParams< DataPointDate > & { bucketInfo?: BucketInfo },
+	inheritStyles = false
 ) => {
 	const { tooltipData, bucketInfo } = params;
 	const nearestDatum = tooltipData?.nearestDatum?.datum;
@@ -126,7 +128,11 @@ export const renderDefaultTooltip = (
 		.sort( ( a, b ) => b.value - a.value );
 
 	return (
-		<div className={ styles[ 'line-chart__tooltip' ] }>
+		<div
+			className={ styles[ 'line-chart__tooltip' ] }
+			data-testid="line-chart-tooltip-content"
+			style={ inheritStyles ? { background: 'inherit', color: 'inherit' } : undefined }
+		>
 			<div className={ styles[ 'line-chart__tooltip-date' ] }>
 				<TooltipDate
 					date={ nearestDatum.date }
@@ -479,8 +485,10 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 		// default or custom, so a heading keyed on it can't disagree with the axis.
 		const tooltipRenderer = useMemo(
 			() => ( params: RenderTooltipParams< DataPointDate > ) =>
-				renderTooltip( { ...params, bucketInfo } ),
-			[ renderTooltip, bucketInfo ]
+				renderTooltip === renderDefaultTooltip
+					? renderDefaultTooltip( { ...params, bucketInfo }, Boolean( tooltipStyle ) )
+					: renderTooltip( { ...params, bucketInfo } ),
+			[ renderTooltip, bucketInfo, tooltipStyle ]
 		);
 
 		if ( error ) {
@@ -679,7 +687,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 													detectBounds
 													snapTooltipToDatumX
 													tooltipPlacement={ tooltipPlacement }
-													{ ...( tooltipStyle && { style: tooltipStyle } ) }
+													style={ tooltipStyle }
 													snapTooltipToDatumY
 													showSeriesGlyphs
 													renderTooltip={ tooltipRenderer }

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -222,6 +222,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 			curveType,
 			renderTooltip = renderDefaultTooltip,
 			tooltipPlacement,
+			tooltipStyle,
 			withStartGlyphs = false,
 			withEndGlyphs = false,
 			animation,
@@ -678,6 +679,7 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 													detectBounds
 													snapTooltipToDatumX
 													tooltipPlacement={ tooltipPlacement }
+													{ ...( tooltipStyle && { style: tooltipStyle } ) }
 													snapTooltipToDatumY
 													showSeriesGlyphs
 													renderTooltip={ tooltipRenderer }
@@ -685,6 +687,8 @@ const LineChartInternal = forwardRef< ChartInstanceRef, LineChartProps >(
 													glyphStyle={ glyphStyle }
 													showVerticalCrosshair={ withTooltipCrosshairs?.showVertical }
 													showHorizontalCrosshair={ withTooltipCrosshairs?.showHorizontal }
+													verticalCrosshairStyle={ withTooltipCrosshairs?.verticalStyle }
+													horizontalCrosshairStyle={ withTooltipCrosshairs?.horizontalStyle }
 													selectedIndex={ selectedIndex }
 													tooltipRef={ tooltipRef }
 													keyboardFocusedClassName={

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -19,7 +19,7 @@ Main chart component with responsive behavior by default.
 | `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
 | `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
 | `withTooltips` | `boolean` | `true` | Enable interactive tooltips |
-| `tooltipPlacement` | `'auto' \| 'below-axis'` | `'auto'` | Position the tooltip near the datum or below the bottom x-axis, anchored at the datum's x coordinate |
+| `tooltipPlacement` | `'auto' \| 'below-axis'` | `'auto'` | Position the tooltip near the datum or below the bottom x-axis label band, anchored at the datum's x coordinate |
 | `tooltipStyle` | `CSSProperties` | - | Override the outer tooltip container's styles |
 | `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean; verticalStyle?: SVGProps<SVGLineElement>; horizontalStyle?: SVGProps<SVGLineElement> }?` | - | Show crosshair guides with optional SVG line properties for each direction |
 | `zoomable` | `boolean?` | `false` | Enable drag-to-zoom on the X axis. Dragging horizontally rescales the X axis to the selected range; a "Reset zoom" button appears in the top-right while zoomed |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -20,7 +20,8 @@ Main chart component with responsive behavior by default.
 | `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
 | `withTooltips` | `boolean` | `true` | Enable interactive tooltips |
 | `tooltipPlacement` | `'auto' \| 'below-axis'` | `'auto'` | Position the tooltip near the datum or below the bottom x-axis, anchored at the datum's x coordinate |
-| `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean }?` | - | Show crosshair guides with tooltips |
+| `tooltipStyle` | `CSSProperties` | - | Override the outer tooltip container's styles |
+| `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean; verticalStyle?: SVGProps<SVGLineElement>; horizontalStyle?: SVGProps<SVGLineElement> }?` | - | Show crosshair guides with optional SVG line properties for each direction |
 | `zoomable` | `boolean?` | `false` | Enable drag-to-zoom on the X axis. Dragging horizontally rescales the X axis to the selected range; a "Reset zoom" button appears in the top-right while zoomed |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where lines scale up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
 | `showLegend` | `boolean` | `false` | Display chart legend |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -19,6 +19,7 @@ Main chart component with responsive behavior by default.
 | `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
 | `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
 | `withTooltips` | `boolean` | `true` | Enable interactive tooltips |
+| `tooltipPlacement` | `'auto' \| 'below-axis'` | `'auto'` | Position the tooltip near the datum or below the bottom x-axis, anchored at the datum's x coordinate |
 | `withTooltipCrosshairs` | `{ showVertical?: boolean; showHorizontal?: boolean }?` | - | Show crosshair guides with tooltips |
 | `zoomable` | `boolean?` | `false` | Enable drag-to-zoom on the X axis. Dragging horizontally rescales the X axis to the selected range; a "Reset zoom" button appears in the top-right while zoomed |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where lines scale up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -525,7 +525,7 @@ Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis w
 	/>` }
 />
 
-Set `tooltipStyle` to customize the outer tooltip container. The below-axis pointer inherits its background. A custom `renderTooltip` controls the content and can inherit the container's text color, as shown above; the default renderer retains its own content styles.
+Set `tooltipStyle` to customize the outer tooltip container; supplied properties override the computed styles, while unspecified properties retain their defaults. The below-axis pointer inherits its background. A custom `renderTooltip` controls the content and can inherit the container's text color, as shown above; the default renderer retains its own content styles.
 
 Use `withTooltipCrosshairs.verticalStyle` to turn the vertical guide into a broad translucent highlight, as shown above. Both `verticalStyle` and `horizontalStyle` accept SVG line properties, such as `strokeWidth`, `strokeOpacity`, and `strokeDasharray`; their corresponding `showVertical` or `showHorizontal` option enables the guide.
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -503,9 +503,9 @@ Tooltips render inside the chart's own wrapper, not in a `document.body` portal,
 
 ### Below-Axis Tooltips
 
-Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis with its pointer touching the axis at the active datum's x coordinate. The panel centers on the datum and clamps horizontally at the nearest clipping ancestor or viewport edge. It stays below the axis even when there is insufficient vertical space; an ancestor that clips overflow can still cut it off. The default `"auto"` placement keeps the existing flipping and clamping behavior.
+Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis label band with its pointer touching the bottom of that band at the active datum's x coordinate. The panel centers on the datum and clamps horizontally at the nearest clipping ancestor or viewport edge. The band ends at the plot bottom plus the bottom margin. The panel stays below the band even when there is insufficient vertical space; an ancestor that clips overflow can still cut it off. The default `"auto"` placement keeps the existing flipping and clamping behavior.
 
-<Canvas of={ TooltipStories.BelowAxis } />
+<Canvas of={ TooltipStories.BelowAxisDefaultRenderer } />
 
 <Source
 	language="tsx"
@@ -514,10 +514,10 @@ Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis w
 	<LineChart
 		data={ data }
 		tooltipPlacement="below-axis"
-		tooltipStyle={ { background: '#1e1e1e', color: '#fff' } }
-		renderTooltip={ ( { tooltipData } ) => (
-			<span>{ tooltipData?.nearestDatum?.datum.value }</span>
-		) }
+		tooltipStyle={ {
+			background: 'var(--a8c-charts-color-tooltip-surface)',
+			color: 'var(--a8c-charts-color-label-inverse)',
+		} }
 		withTooltipCrosshairs={ {
 			showVertical: true,
 			verticalStyle: { strokeWidth: 40, strokeOpacity: 0.12 },
@@ -525,7 +525,9 @@ Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis w
 	/>` }
 />
 
-Set `tooltipStyle` to customize the outer tooltip container; supplied properties override the computed styles, while unspecified properties retain their defaults. The below-axis pointer inherits its background. A custom `renderTooltip` controls the content and can inherit the container's text color, as shown above; the default renderer retains its own content styles.
+Set `tooltipStyle` to customize the tooltip surface and text color; supplied properties override the computed styles, while unspecified properties retain their defaults. The default renderer inherits these colors, and the below-axis pointer inherits the background. A custom `renderTooltip` can supply its own content styles.
+
+The public `AccessibleTooltip` component's `style` prop also merges with the computed box styles instead of replacing them. Use its `unstyled` prop to strip the box styles.
 
 Use `withTooltipCrosshairs.verticalStyle` to turn the vertical guide into a broad translucent highlight, as shown above. Both `verticalStyle` and `horizontalStyle` accept SVG line properties, such as `strokeWidth`, `strokeOpacity`, and `strokeDasharray`; their corresponding `showVertical` or `showHorizontal` option enables the guide.
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -514,8 +514,20 @@ Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis w
 	<LineChart
 		data={ data }
 		tooltipPlacement="below-axis"
+		tooltipStyle={ { background: '#1e1e1e', color: '#fff' } }
+		renderTooltip={ ( { tooltipData } ) => (
+			<span>{ tooltipData?.nearestDatum?.datum.value }</span>
+		) }
+		withTooltipCrosshairs={ {
+			showVertical: true,
+			verticalStyle: { strokeWidth: 40, strokeOpacity: 0.12 },
+		} }
 	/>` }
 />
+
+Set `tooltipStyle` to customize the outer tooltip container. The below-axis pointer inherits its background. A custom `renderTooltip` controls the content and can inherit the container's text color, as shown above; the default renderer retains its own content styles.
+
+Use `withTooltipCrosshairs.verticalStyle` to turn the vertical guide into a broad translucent highlight, as shown above. Both `verticalStyle` and `horizontalStyle` accept SVG line properties, such as `strokeWidth`, `strokeOpacity`, and `strokeDasharray`; their corresponding `showVertical` or `showHorizontal` option enables the guide.
 
 The panel can extend beyond the chart wrapper without a portal or consumer CSS overrides. Leave space below the chart when it sits inside a clipping container. Keyboard navigation, screen reader announcements, and custom `renderTooltip` content are unchanged.
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas, Story, Source } from '@storybook/addon-docs/blocks';
 import * as LineChartStories from './index.stories';
 import * as GlyphStories from './glyph.stories';
+import * as TooltipStories from './tooltip.stories';
 
 <Meta title="JS Packages/Charts Library/Charts/Line Chart" of={ LineChartStories } />
 
@@ -498,7 +499,25 @@ hourly data. A custom `renderTooltip` is handed the same classification as
 	/>` }
 />
 
-Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. `detectBounds` keeps the box inside the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), or inside the viewport when nothing clips, flipping and then clamping it; it may reach past the chart wrapper into that ancestor. Only an ancestor smaller than the box itself can still cut it off.
+Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. With the default placement, `detectBounds` keeps the box inside the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), or inside the viewport when nothing clips, flipping and then clamping it; it may reach past the chart wrapper into that ancestor. Only an ancestor smaller than the box itself can still cut it off.
+
+### Below-Axis Tooltips
+
+Set `tooltipPlacement="below-axis"` to place the panel below the bottom x-axis with its pointer touching the axis at the active datum's x coordinate. The panel centers on the datum and clamps horizontally at the nearest clipping ancestor or viewport edge. It stays below the axis even when there is insufficient vertical space; an ancestor that clips overflow can still cut it off. The default `"auto"` placement keeps the existing flipping and clamping behavior.
+
+<Canvas of={ TooltipStories.BelowAxis } />
+
+<Source
+	language="tsx"
+	code={ `import { LineChart } from '@automattic/charts';
+
+	<LineChart
+		data={ data }
+		tooltipPlacement="below-axis"
+	/>` }
+/>
+
+The panel can extend beyond the chart wrapper without a portal or consumer CSS overrides. Leave space below the chart when it sits inside a clipping container. Keyboard navigation, screen reader announcements, and custom `renderTooltip` content are unchanged.
 
 ### Pointer Events
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
@@ -163,3 +163,18 @@ WiderThanClippingCard.parameters = {
 		},
 	},
 };
+
+export const BelowAxis: StoryObj< typeof LineChart > = Template.bind( {} );
+BelowAxis.args = {
+	...tooltipStoryArgs,
+	height: 220,
+	tooltipPlacement: 'below-axis',
+};
+BelowAxis.parameters = {
+	docs: {
+		description: {
+			story:
+				'Hover a datum or focus the chart and use the arrow keys. The tooltip stays below the x-axis and can extend past the chart. At horizontal edges, the panel shifts while its pointer stays anchored to the datum.',
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
@@ -169,7 +169,10 @@ BelowAxis.args = {
 	...tooltipStoryArgs,
 	height: 220,
 	tooltipPlacement: 'below-axis',
-	tooltipStyle: { background: '#1e1e1e', color: '#fff' },
+	tooltipStyle: {
+		background: 'var(--a8c-charts-color-tooltip-surface)',
+		color: 'var(--a8c-charts-color-label-inverse)',
+	},
 	renderTooltip: renderWideTooltip( 120 ),
 	withTooltipCrosshairs: {
 		showVertical: true,
@@ -180,7 +183,21 @@ BelowAxis.parameters = {
 	docs: {
 		description: {
 			story:
-				'Hover a datum or focus the chart and use the arrow keys. A broad translucent crosshair highlights the active column. The tooltip stays below the x-axis and can extend past the chart. At horizontal edges, the panel shifts while its pointer stays anchored to the datum.',
+				'Hover a datum or focus the chart and use the arrow keys. A broad translucent crosshair highlights the active column. The tooltip stays below the x-axis label band and can extend past the chart. Its pointer touches the bottom of that band. At horizontal edges, the panel shifts while its pointer stays anchored to the datum.',
+		},
+	},
+};
+
+export const BelowAxisDefaultRenderer: StoryObj< typeof LineChart > = Template.bind( {} );
+BelowAxisDefaultRenderer.args = {
+	...BelowAxis.args,
+	renderTooltip: undefined,
+};
+BelowAxisDefaultRenderer.parameters = {
+	docs: {
+		description: {
+			story:
+				'The default renderer inherits the tooltip surface and text colors. The panel clears the x-axis label band, and its pointer uses the same background.',
 		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/tooltip.stories.tsx
@@ -169,12 +169,18 @@ BelowAxis.args = {
 	...tooltipStoryArgs,
 	height: 220,
 	tooltipPlacement: 'below-axis',
+	tooltipStyle: { background: '#1e1e1e', color: '#fff' },
+	renderTooltip: renderWideTooltip( 120 ),
+	withTooltipCrosshairs: {
+		showVertical: true,
+		verticalStyle: { strokeWidth: 40, strokeOpacity: 0.12 },
+	},
 };
 BelowAxis.parameters = {
 	docs: {
 		description: {
 			story:
-				'Hover a datum or focus the chart and use the arrow keys. The tooltip stays below the x-axis and can extend past the chart. At horizontal edges, the panel shifts while its pointer stays anchored to the datum.',
+				'Hover a datum or focus the chart and use the arrow keys. A broad translucent crosshair highlights the active column. The tooltip stays below the x-axis and can extend past the chart. At horizontal edges, the panel shifts while its pointer stays anchored to the datum.',
 		},
 	},
 };

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -104,34 +104,40 @@ describe( 'LineChart', () => {
 		);
 	};
 
-	test( 'passes custom tooltip container and crosshair styles to the rendered elements', async () => {
-		const user = userEvent.setup();
-		renderWithTheme( {
-			withTooltipCrosshairs: {
-				showVertical: true,
-				showHorizontal: true,
-				verticalStyle: { stroke: 'purple', strokeWidth: 40, strokeOpacity: 0.12 },
-				horizontalStyle: { stroke: 'orange', strokeDasharray: '4 2' },
-			},
-			tooltipPlacement: 'below-axis',
-			tooltipStyle: { backgroundColor: 'black', color: 'white', boxShadow: 'none' },
-		} );
-		screen.getByRole( 'grid', { name: /line chart/i } ).focus();
-		await user.keyboard( '{ArrowRight}' );
+	test.each( [ 'auto', 'below-axis' ] as const )(
+		'passes custom tooltip container and crosshair styles with %s placement',
+		async tooltipPlacement => {
+			const user = userEvent.setup();
+			renderWithTheme( {
+				withTooltipCrosshairs: {
+					showVertical: true,
+					showHorizontal: true,
+					verticalStyle: { stroke: 'purple', strokeWidth: 40, strokeOpacity: 0.12 },
+					horizontalStyle: { stroke: 'orange', strokeDasharray: '4 2' },
+				},
+				tooltipPlacement,
+				tooltipStyle: { backgroundColor: 'black', color: 'white', boxShadow: 'none' },
+			} );
+			screen.getByRole( 'grid', { name: /line chart/i } ).focus();
+			await user.keyboard( '{ArrowRight}' );
 
-		const vertical = screen.getByTestId( 'xy-chart-tooltip-crosshair-vertical' );
-		expect( vertical ).toHaveAttribute( 'stroke', 'purple' );
-		expect( vertical ).toHaveAttribute( 'stroke-width', '40' );
-		expect( vertical ).toHaveAttribute( 'stroke-opacity', '0.12' );
-		const horizontal = screen.getByTestId( 'xy-chart-tooltip-crosshair-horizontal' );
-		expect( horizontal ).toHaveAttribute( 'stroke', 'orange' );
-		expect( horizontal ).toHaveAttribute( 'stroke-dasharray', '4 2' );
-		expect( screen.getByTestId( 'bounded-tooltip' ) ).toHaveStyle( {
-			'background-color': 'rgb(0, 0, 0)',
-			color: 'rgb(255, 255, 255)',
-			'box-shadow': 'none',
-		} );
-	} );
+			const vertical = screen.getByTestId( 'xy-chart-tooltip-crosshair-vertical' );
+			expect( vertical ).toHaveAttribute( 'stroke', 'purple' );
+			expect( vertical ).toHaveAttribute( 'stroke-width', '40' );
+			expect( vertical ).toHaveAttribute( 'stroke-opacity', '0.12' );
+			const horizontal = screen.getByTestId( 'xy-chart-tooltip-crosshair-horizontal' );
+			expect( horizontal ).toHaveAttribute( 'stroke', 'orange' );
+			expect( horizontal ).toHaveAttribute( 'stroke-dasharray', '4 2' );
+			expect( screen.getByTestId( 'bounded-tooltip' ) ).toHaveStyle( {
+				'background-color': 'rgb(0, 0, 0)',
+				color: 'rgb(255, 255, 255)',
+				'box-shadow': 'none',
+			} );
+			expect( screen.getByTestId( 'line-chart-tooltip-content' ) ).toHaveStyle( {
+				color: 'rgb(255, 255, 255)',
+			} );
+		}
+	);
 
 	describe( 'Data Validation', () => {
 		test( 'handles empty data array', () => {

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -104,6 +104,35 @@ describe( 'LineChart', () => {
 		);
 	};
 
+	test( 'passes custom tooltip container and crosshair styles to the rendered elements', async () => {
+		const user = userEvent.setup();
+		renderWithTheme( {
+			withTooltipCrosshairs: {
+				showVertical: true,
+				showHorizontal: true,
+				verticalStyle: { stroke: 'purple', strokeWidth: 40, strokeOpacity: 0.12 },
+				horizontalStyle: { stroke: 'orange', strokeDasharray: '4 2' },
+			},
+			tooltipPlacement: 'below-axis',
+			tooltipStyle: { backgroundColor: 'black', color: 'white', boxShadow: 'none' },
+		} );
+		screen.getByRole( 'grid', { name: /line chart/i } ).focus();
+		await user.keyboard( '{ArrowRight}' );
+
+		const vertical = screen.getByTestId( 'xy-chart-tooltip-crosshair-vertical' );
+		expect( vertical ).toHaveAttribute( 'stroke', 'purple' );
+		expect( vertical ).toHaveAttribute( 'stroke-width', '40' );
+		expect( vertical ).toHaveAttribute( 'stroke-opacity', '0.12' );
+		const horizontal = screen.getByTestId( 'xy-chart-tooltip-crosshair-horizontal' );
+		expect( horizontal ).toHaveAttribute( 'stroke', 'orange' );
+		expect( horizontal ).toHaveAttribute( 'stroke-dasharray', '4 2' );
+		expect( screen.getByTestId( 'bounded-tooltip' ) ).toHaveStyle( {
+			backgroundColor: 'rgb(0, 0, 0)',
+			color: 'rgb(255, 255, 255)',
+			boxShadow: 'none',
+		} );
+	} );
+
 	describe( 'Data Validation', () => {
 		test( 'handles empty data array', () => {
 			renderWithTheme( { data: [] } );

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -127,9 +127,9 @@ describe( 'LineChart', () => {
 		expect( horizontal ).toHaveAttribute( 'stroke', 'orange' );
 		expect( horizontal ).toHaveAttribute( 'stroke-dasharray', '4 2' );
 		expect( screen.getByTestId( 'bounded-tooltip' ) ).toHaveStyle( {
-			backgroundColor: 'rgb(0, 0, 0)',
+			'background-color': 'rgb(0, 0, 0)',
 			color: 'rgb(255, 255, 255)',
-			boxShadow: 'none',
+			'box-shadow': 'none',
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -1225,44 +1225,53 @@ describe( 'LineChart', () => {
 		} );
 
 		describe( 'Arrow Key Navigation', () => {
-			test( 'right arrow key navigates to next data point', async () => {
-				const user = userEvent.setup();
-				renderWithTheme( {
-					data: [
-						{
-							label: 'Series A',
-							data: [
-								{ date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' },
-								{ date: new Date( '2024-01-02' ), value: 20, label: 'Jan 2' },
-							],
-							options: {},
-						},
-						{
-							label: 'Series B',
-							data: [
-								{ date: new Date( '2024-01-01' ), value: 15, label: 'Jan 1' },
-								{ date: new Date( '2024-01-02' ), value: 25, label: 'Jan 2' },
-							],
-							options: {},
-						},
-					],
-				} );
+			test.each( [ 'auto', 'below-axis' ] as const )(
+				'right arrow key navigates with %s tooltips',
+				async tooltipPlacement => {
+					const user = userEvent.setup();
+					renderWithTheme( {
+						tooltipPlacement,
+						data: [
+							{
+								label: 'Series A',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: 10, label: 'Jan 1' },
+									{ date: new Date( '2024-01-02' ), value: 20, label: 'Jan 2' },
+								],
+								options: {},
+							},
+							{
+								label: 'Series B',
+								data: [
+									{ date: new Date( '2024-01-01' ), value: 15, label: 'Jan 1' },
+									{ date: new Date( '2024-01-02' ), value: 25, label: 'Jan 2' },
+								],
+								options: {},
+							},
+						],
+					} );
 
-				const chart = screen.getByRole( 'grid', { name: /line chart/i } );
-				chart.focus();
+					const chart = screen.getByRole( 'grid', { name: /line chart/i } );
+					chart.focus();
 
-				// Single tab should focus on the first tooltip.
-				await user.keyboard( '{ArrowRight}' );
-				expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveFocus();
-				expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'Series A' );
-				expect( screen.queryByTestId( 'chart-tooltip-1' ) ).not.toBeInTheDocument();
+					// Single tab should focus on the first tooltip.
+					await user.keyboard( '{ArrowRight}' );
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveFocus();
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveAttribute( 'role', 'tooltip' );
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveAttribute(
+						'aria-atomic',
+						'true'
+					);
+					expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveTextContent( 'Series A' );
+					expect( screen.queryByTestId( 'chart-tooltip-1' ) ).not.toBeInTheDocument();
 
-				// Second tab should focus on the second tooltip.
-				await user.keyboard( '{ArrowRight}' );
-				expect( screen.getByTestId( 'chart-tooltip-1' ) ).toHaveFocus();
-				expect( screen.getByTestId( 'chart-tooltip-1' ) ).toHaveTextContent( 'Series B' );
-				expect( screen.queryByTestId( 'chart-tooltip-0' ) ).not.toBeInTheDocument();
-			} );
+					// Second tab should focus on the second tooltip.
+					await user.keyboard( '{ArrowRight}' );
+					expect( screen.getByTestId( 'chart-tooltip-1' ) ).toHaveFocus();
+					expect( screen.getByTestId( 'chart-tooltip-1' ) ).toHaveTextContent( 'Series B' );
+					expect( screen.queryByTestId( 'chart-tooltip-0' ) ).not.toBeInTheDocument();
+				}
+			);
 
 			test( 'left arrow key navigates to previous data point', async () => {
 				const user = userEvent.setup();

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -10,7 +10,7 @@ import type {
 } from '../../types';
 import type { RenderTooltipParams, XyChartTooltipProps } from '../../visx/types';
 import type { GlyphProps } from '@visx/xychart';
-import type { ReactNode, SVGProps, FC } from 'react';
+import type { ReactNode, SVGProps, FC, CSSProperties } from 'react';
 
 export type LineChartAnnotationProps = {
 	datum: DataPointDate;
@@ -46,6 +46,8 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] >, SeriesVi
 	 * @default 'auto'
 	 */
 	tooltipPlacement?: XyChartTooltipProps< DataPointDate >[ 'tooltipPlacement' ];
+	/** Inline styles for the tooltip container. */
+	tooltipStyle?: CSSProperties;
 	withStartGlyphs?: boolean;
 	withEndGlyphs?: boolean;
 	renderGlyph?: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode;
@@ -54,6 +56,8 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] >, SeriesVi
 	withTooltipCrosshairs?: {
 		showVertical?: boolean;
 		showHorizontal?: boolean;
+		verticalStyle?: SVGProps< SVGLineElement >;
+		horizontalStyle?: SVGProps< SVGLineElement >;
 	};
 	/**
 	 * Enable drag-to-zoom on the X axis. The user drags horizontally to

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -42,11 +42,11 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] >, SeriesVi
 		params: RenderTooltipParams< DataPointDate > & { bucketInfo?: BucketInfo }
 	) => ReactNode;
 	/**
-	 * Place the panel below the bottom x-axis with a pointer at the datum x; horizontal bounds still apply.
+	 * Place the panel below the x-axis tick labels with a pointer at the datum x; horizontal bounds still apply.
 	 * @default 'auto'
 	 */
 	tooltipPlacement?: XyChartTooltipProps< DataPointDate >[ 'tooltipPlacement' ];
-	/** Inline styles for the tooltip container. */
+	/** Inline container styles; the default tooltip content inherits the surface and text color. */
 	tooltipStyle?: CSSProperties;
 	withStartGlyphs?: boolean;
 	withEndGlyphs?: boolean;

--- a/projects/js-packages/charts/src/charts/line-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/line-chart/types.ts
@@ -8,7 +8,7 @@ import type {
 	AnnotationStyles,
 	DataPoint,
 } from '../../types';
-import type { RenderTooltipParams } from '../../visx/types';
+import type { RenderTooltipParams, XyChartTooltipProps } from '../../visx/types';
 import type { GlyphProps } from '@visx/xychart';
 import type { ReactNode, SVGProps, FC } from 'react';
 
@@ -41,6 +41,11 @@ export interface LineChartProps extends BaseChartProps< SeriesData[] >, SeriesVi
 	renderTooltip?: (
 		params: RenderTooltipParams< DataPointDate > & { bucketInfo?: BucketInfo }
 	) => ReactNode;
+	/**
+	 * Place the panel below the bottom x-axis with a pointer at the datum x; horizontal bounds still apply.
+	 * @default 'auto'
+	 */
+	tooltipPlacement?: XyChartTooltipProps< DataPointDate >[ 'tooltipPlacement' ];
 	withStartGlyphs?: boolean;
 	withEndGlyphs?: boolean;
 	renderGlyph?: < Datum extends object >( props: GlyphProps< Datum > ) => ReactNode;

--- a/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/accessible-tooltip.tsx
@@ -215,7 +215,7 @@ export const useKeyboardNavigation = ( {
 	const tooltipRef = useCallback(
 		( element: HTMLDivElement | null ) => {
 			if ( element && selectedIndex !== undefined ) {
-				element.focus();
+				element.focus( { preventScroll: true } );
 			}
 		},
 		[ selectedIndex ]

--- a/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
@@ -9,9 +9,11 @@ export type BoundedTooltipProps = Omit< TooltipProps, 'left' | 'top' | 'applyPos
 	/** Anchor, in the coordinates of the positioned wrapper the box renders into. */
 	left?: number;
 	top?: number;
+	placement?: 'auto' | 'below-axis';
 };
 
 const DEFAULT_OFFSET = 10;
+const POINTER_HEIGHT = 6;
 
 const isClipping = ( element: Element ) => {
 	const { overflow, overflowX, overflowY } = getComputedStyle( element );
@@ -33,10 +35,8 @@ const findClippingAncestor = ( wrapper: Element ): Element | null => {
 };
 
 /**
- * Where the box goes, in wrapper coordinates. Below and to the right of the
- * anchor; flipped to the other side when that side clips less, as visx's
- * `TooltipWithBounds` decides it; then clamped so the box stays inside
- * `bounds` whenever it fits at all.
+ * Flip and clamp the box in wrapper coordinates, or pin it below the axis
+ * with horizontal clamping only.
  *
  * @param params            - Anchor, offsets, the box size and the bounds to keep inside.
  * @param params.left       - Anchor x, in wrapper coordinates.
@@ -44,8 +44,9 @@ const findClippingAncestor = ( wrapper: Element ): Element | null => {
  * @param params.offsetLeft - Gap between the anchor and the box, horizontally.
  * @param params.offsetTop  - Gap between the anchor and the box, vertically.
  * @param params.box        - Rendered size of the box.
+ * @param params.placement  - Fixed below-axis placement or automatic flipping.
  * @param params.bounds     - Edges the box must keep inside, in wrapper coordinates.
- * @return The box's top-left corner, rounded to whole pixels.
+ * @return The box's top-left corner; fixed placement preserves the axis's subpixel y.
  */
 export const getBoundedPosition = ( {
 	left,
@@ -54,6 +55,7 @@ export const getBoundedPosition = ( {
 	offsetTop,
 	box,
 	bounds,
+	placement = 'auto',
 }: {
 	left: number;
 	top: number;
@@ -61,6 +63,7 @@ export const getBoundedPosition = ( {
 	offsetTop: number;
 	box: Size;
 	bounds: Bounds;
+	placement?: BoundedTooltipProps[ 'placement' ];
 } ) => {
 	const rightX = left + offsetLeft;
 	const leftX = left - offsetLeft - box.width;
@@ -74,10 +77,17 @@ export const getBoundedPosition = ( {
 	const upOverflow = bounds.top - upY;
 	let y = downOverflow > 0 && downOverflow > upOverflow ? upY : downY;
 
+	if ( placement === 'below-axis' ) {
+		x = left - box.width / 2;
+	}
+
 	x = Math.min( Math.max( x, bounds.left ), Math.max( bounds.left, bounds.right - box.width ) );
 	y = Math.min( Math.max( y, bounds.top ), Math.max( bounds.top, bounds.bottom - box.height ) );
 
-	return { x: Math.round( x ), y: Math.round( y ) };
+	return {
+		x: Math.round( x ),
+		y: placement === 'below-axis' ? top + POINTER_HEIGHT : Math.round( y ),
+	};
 };
 
 /**
@@ -98,6 +108,7 @@ export const getBoundedPosition = ( {
  * @param props.style      - Box styles; visx's defaults unless `unstyled`.
  * @param props.unstyled   - Skip `style` and leave the box bare.
  * @param props.children   - Box content.
+ * @param props.placement  - Fixed below-axis placement or automatic flipping.
  * @return The tooltip box.
  */
 export const BoundedTooltip = ( {
@@ -108,6 +119,7 @@ export const BoundedTooltip = ( {
 	style = defaultStyles,
 	unstyled = false,
 	children,
+	placement = 'auto',
 	...rest
 }: BoundedTooltipProps ) => {
 	const nodeRef = useRef< HTMLDivElement >( null );
@@ -136,6 +148,7 @@ export const BoundedTooltip = ( {
 			top,
 			offsetLeft,
 			offsetTop,
+			placement,
 			box: { width: own.width, height: own.height },
 			bounds: {
 				left: clipRect.left - wrapperRect.left,
@@ -148,10 +161,10 @@ export const BoundedTooltip = ( {
 			current && current.x === next.x && current.y === next.y ? current : next
 		);
 		// `children` re-runs the measurement when the content, and so the box size, changes.
-	}, [ left, top, offsetLeft, offsetTop, children ] );
+	}, [ left, top, offsetLeft, offsetTop, children, placement ] );
 
 	const x = position?.x ?? left + offsetLeft;
-	const y = position?.y ?? top + offsetTop;
+	const y = position?.y ?? top + ( placement === 'below-axis' ? POINTER_HEIGHT : offsetTop );
 
 	return (
 		<Tooltip
@@ -166,6 +179,22 @@ export const BoundedTooltip = ( {
 			} }
 			{ ...rest }
 		>
+			{ placement === 'below-axis' && (
+				<span
+					aria-hidden="true"
+					data-testid="tooltip-axis-pointer"
+					style={ {
+						position: 'absolute',
+						left: left - x - POINTER_HEIGHT,
+						top: -POINTER_HEIGHT,
+						width: POINTER_HEIGHT * 2,
+						height: POINTER_HEIGHT,
+						background: 'inherit',
+						clipPath: 'polygon(50% 0, 100% 100%, 0 100%)',
+						pointerEvents: 'none',
+					} }
+				/>
+			) }
 			{ children }
 		</Tooltip>
 	);

--- a/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
@@ -91,14 +91,8 @@ export const getBoundedPosition = ( {
 };
 
 /**
- * visx's `Tooltip`, positioned like its `TooltipWithBounds` but kept inside the
- * nearest clipping ancestor — or the viewport when there is none — rather than
- * inside its own parent. Rendered in-tree, a tooltip's parent is the chart
- * wrapper, which is often narrower than the box; measuring against the parent
- * alone would let the box spill into an `overflow: hidden` card and be cut off.
- *
- * Re-measures on every render, so a box whose content changes width between
- * two hovers is placed for its current size.
+ * Position visx's `Tooltip` against the nearest clipping ancestor or viewport.
+ * Below-axis placement applies horizontal bounds only; see `getBoundedPosition`.
  *
  * @param props            - visx `Tooltip` props.
  * @param props.left       - Anchor x, in wrapper coordinates.

--- a/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, defaultStyles } from '@visx/tooltip';
 import { useLayoutEffect, useRef, useState } from 'react';
+import type { TooltipPlacement } from '../../../visx/types';
 import type { TooltipProps } from '@visx/tooltip';
 
 type Bounds = { left: number; top: number; right: number; bottom: number };
@@ -9,11 +10,14 @@ export type BoundedTooltipProps = Omit< TooltipProps, 'left' | 'top' | 'applyPos
 	/** Anchor, in the coordinates of the positioned wrapper the box renders into. */
 	left?: number;
 	top?: number;
-	placement?: 'auto' | 'below-axis';
+	placement?: TooltipPlacement;
 };
 
 const DEFAULT_OFFSET = 10;
 const POINTER_HEIGHT = 6;
+
+const clamp = ( position: number, min: number, max: number, size: number ) =>
+	Math.min( Math.max( position, min ), Math.max( min, max - size ) );
 
 const isClipping = ( element: Element ) => {
 	const { overflow, overflowX, overflowY } = getComputedStyle( element );
@@ -65,6 +69,13 @@ export const getBoundedPosition = ( {
 	bounds: Bounds;
 	placement?: BoundedTooltipProps[ 'placement' ];
 } ) => {
+	if ( placement === 'below-axis' ) {
+		return {
+			x: Math.round( clamp( left - box.width / 2, bounds.left, bounds.right, box.width ) ),
+			y: top + POINTER_HEIGHT,
+		};
+	}
+
 	const rightX = left + offsetLeft;
 	const leftX = left - offsetLeft - box.width;
 	const rightOverflow = rightX + box.width - bounds.right;
@@ -77,16 +88,12 @@ export const getBoundedPosition = ( {
 	const upOverflow = bounds.top - upY;
 	let y = downOverflow > 0 && downOverflow > upOverflow ? upY : downY;
 
-	if ( placement === 'below-axis' ) {
-		x = left - box.width / 2;
-	}
-
-	x = Math.min( Math.max( x, bounds.left ), Math.max( bounds.left, bounds.right - box.width ) );
-	y = Math.min( Math.max( y, bounds.top ), Math.max( bounds.top, bounds.bottom - box.height ) );
+	x = clamp( x, bounds.left, bounds.right, box.width );
+	y = clamp( y, bounds.top, bounds.bottom, box.height );
 
 	return {
 		x: Math.round( x ),
-		y: placement === 'below-axis' ? top + POINTER_HEIGHT : Math.round( y ),
+		y: Math.round( y ),
 	};
 };
 

--- a/projects/js-packages/charts/src/components/tooltip/test/accessible-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/accessible-tooltip.test.tsx
@@ -59,6 +59,19 @@ describe( 'AccessibleTooltip', () => {
 		document.body.removeChild( scope );
 	} );
 
+	it( 'focuses keyboard tooltips without scrolling their ancestors', async () => {
+		const focus = jest.spyOn( HTMLElement.prototype, 'focus' );
+		try {
+			renderChart();
+			await openTooltip();
+
+			expect( screen.getByTestId( 'chart-tooltip-0' ) ).toHaveFocus();
+			expect( focus ).toHaveBeenCalledWith( { preventScroll: true } );
+		} finally {
+			focus.mockRestore();
+		}
+	} );
+
 	it( 'falls back to the catalog default when the role is unset', async () => {
 		renderChart();
 

--- a/projects/js-packages/charts/src/components/tooltip/test/bounded-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/bounded-tooltip.test.tsx
@@ -105,6 +105,47 @@ describe( 'BoundedTooltip', () => {
 		expect( screen.getByTestId( 'box' ) ).toHaveStyle( { transform: 'translate(-40px, 60px)' } );
 	} );
 
+	test.each( [
+		{ anchor: 20, x: 0, pointerLeft: 14 },
+		{ anchor: 150, x: 46, pointerLeft: 98 },
+		{ anchor: 280, x: 92, pointerLeft: 182 },
+	] )(
+		'keeps the below-axis pointer at x=$anchor after clamping',
+		( { anchor, x, pointerLeft } ) => {
+			jest.spyOn( Element.prototype, 'getBoundingClientRect' ).mockImplementation( function (
+				this: Element
+			) {
+				return this.classList.contains( 'visx-tooltip' )
+					? rect( 0, 0, 208, 36 )
+					: rect( 0, 0, 300, 100 );
+			} );
+
+			render(
+				<div style={ { overflow: 'hidden' } }>
+					<div style={ { position: 'relative' } }>
+						<BoundedTooltip placement="below-axis" left={ anchor } top={ 100 } data-testid="box">
+							content
+						</BoundedTooltip>
+					</div>
+				</div>
+			);
+
+			expect( screen.getByTestId( 'box' ) ).toHaveStyle( {
+				transform: `translate(${ x }px, 106px)`,
+			} );
+			expect( screen.getByTestId( 'tooltip-axis-pointer' ) ).toHaveStyle( {
+				left: `${ pointerLeft }px`,
+				top: '-6px',
+				width: '12px',
+				height: '6px',
+			} );
+			expect( screen.getByTestId( 'tooltip-axis-pointer' ) ).toHaveAttribute(
+				'aria-hidden',
+				'true'
+			);
+		}
+	);
+
 	test( 'falls back to the viewport when nothing clips', () => {
 		jest.spyOn( Element.prototype, 'getBoundingClientRect' ).mockImplementation( function (
 			this: Element

--- a/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
@@ -131,7 +131,7 @@ describe( 'XyChartTooltip', () => {
 		);
 	} );
 
-	test( 'anchors below the x-axis without moving datum glyphs or crosshairs', async () => {
+	test( 'anchors below the x-axis label band without moving datum glyphs or crosshairs', async () => {
 		const originalRect = Element.prototype.getBoundingClientRect;
 		const rectSpy = jest
 			.spyOn( Element.prototype, 'getBoundingClientRect' )
@@ -156,7 +156,7 @@ describe( 'XyChartTooltip', () => {
 			);
 
 			const box = await screen.findByTestId( 'tooltip-box' );
-			expect( box ).toHaveStyle( { transform: 'translate(70px, 76px)' } );
+			expect( box ).toHaveStyle( { transform: 'translate(70px, 106px)' } );
 			expect( screen.getByTestId( 'wrapper' ) ).toContainElement( box );
 			expect( screen.getByTestId( 'tooltip-axis-pointer' ) ).toHaveStyle( {
 				left: '34px',
@@ -292,22 +292,25 @@ describe( 'XyChartTooltip', () => {
 		await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( { zIndex: '9' } );
 	} );
 
-	test( 'preserves the default background and stacking with a partial style override', async () => {
-		const { unmount } = renderChart( { tooltipPlacement: 'below-axis' } );
-		const defaultBox = await screen.findByTestId( 'tooltip-box' );
-		const background = defaultBox.style.backgroundColor;
-		expect( background ).not.toBe( '' );
-		expect( background ).not.toBe( 'transparent' );
-		unmount();
+	test.each( [ 'auto', 'below-axis' ] as const )(
+		'preserves %s background and stacking with a partial style override',
+		async tooltipPlacement => {
+			const { unmount } = renderChart( { tooltipPlacement } );
+			const defaultBox = await screen.findByTestId( 'tooltip-box' );
+			const background = defaultBox.style.backgroundColor;
+			expect( background ).not.toBe( '' );
+			expect( background ).not.toBe( 'transparent' );
+			unmount();
 
-		renderChart( { tooltipPlacement: 'below-axis', style: { color: 'red' } } );
+			renderChart( { tooltipPlacement, style: { color: 'red' } } );
 
-		await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( {
-			backgroundColor: background,
-			zIndex: '3',
-			color: 'rgb(255, 0, 0)',
-		} );
-	} );
+			await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( {
+				backgroundColor: background,
+				zIndex: '3',
+				color: 'rgb(255, 0, 0)',
+			} );
+		}
+	);
 
 	test( 'accepts the portal-era options without passing them to the box', async () => {
 		renderChart( { scroll: true, debounce: 50, resizeObserverPolyfill: undefined } );

--- a/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
@@ -295,7 +295,7 @@ describe( 'XyChartTooltip', () => {
 	test( 'preserves the default background and stacking with a partial style override', async () => {
 		const { unmount } = renderChart( { tooltipPlacement: 'below-axis' } );
 		const defaultBox = await screen.findByTestId( 'tooltip-box' );
-		const background = defaultBox.style.background;
+		const background = defaultBox.style.backgroundColor;
 		expect( background ).not.toBe( '' );
 		expect( background ).not.toBe( 'transparent' );
 		unmount();
@@ -303,7 +303,7 @@ describe( 'XyChartTooltip', () => {
 		renderChart( { tooltipPlacement: 'below-axis', style: { color: 'red' } } );
 
 		await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( {
-			background,
+			backgroundColor: background,
 			zIndex: '3',
 			color: 'rgb(255, 0, 0)',
 		} );

--- a/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
@@ -292,6 +292,23 @@ describe( 'XyChartTooltip', () => {
 		await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( { zIndex: '9' } );
 	} );
 
+	test( 'preserves the default background and stacking with a partial style override', async () => {
+		const { unmount } = renderChart( { tooltipPlacement: 'below-axis' } );
+		const defaultBox = await screen.findByTestId( 'tooltip-box' );
+		const background = defaultBox.style.background;
+		expect( background ).not.toBe( '' );
+		expect( background ).not.toBe( 'transparent' );
+		unmount();
+
+		renderChart( { tooltipPlacement: 'below-axis', style: { color: 'red' } } );
+
+		await expect( screen.findByTestId( 'tooltip-box' ) ).resolves.toHaveStyle( {
+			background,
+			zIndex: '3',
+			color: 'rgb(255, 0, 0)',
+		} );
+	} );
+
 	test( 'accepts the portal-era options without passing them to the box', async () => {
 		renderChart( { scroll: true, debounce: 50, resizeObserverPolyfill: undefined } );
 

--- a/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/xy-chart-tooltip.test.tsx
@@ -131,6 +131,54 @@ describe( 'XyChartTooltip', () => {
 		);
 	} );
 
+	test( 'anchors below the x-axis without moving datum glyphs or crosshairs', async () => {
+		const originalRect = Element.prototype.getBoundingClientRect;
+		const rectSpy = jest
+			.spyOn( Element.prototype, 'getBoundingClientRect' )
+			.mockImplementation( function ( this: Element ) {
+				const rect = originalRect.call( this );
+				return this.classList.contains( 'visx-tooltip' )
+					? { ...rect, width: 80, height: 30, right: rect.left + 80, bottom: rect.top + 30 }
+					: rect;
+			} );
+
+		try {
+			renderChart(
+				{
+					tooltipPlacement: 'below-axis',
+					snapTooltipToDatumY: true,
+					showDatumGlyph: true,
+					showVerticalCrosshair: true,
+					showHorizontalCrosshair: true,
+				},
+				undefined,
+				{ top: 10, right: 20, bottom: 30, left: 40 }
+			);
+
+			const box = await screen.findByTestId( 'tooltip-box' );
+			expect( box ).toHaveStyle( { transform: 'translate(70px, 76px)' } );
+			expect( screen.getByTestId( 'wrapper' ) ).toContainElement( box );
+			expect( screen.getByTestId( 'tooltip-axis-pointer' ) ).toHaveStyle( {
+				left: '34px',
+				top: '-6px',
+			} );
+			expect( screen.getByTestId( 'xy-chart-tooltip-glyph-group-A' ) ).toHaveAttribute(
+				'transform',
+				'translate(110, 40)'
+			);
+			expect( screen.getByTestId( 'xy-chart-tooltip-crosshair-vertical' ) ).toHaveAttribute(
+				'y2',
+				'70'
+			);
+			expect( screen.getByTestId( 'xy-chart-tooltip-crosshair-horizontal' ) ).toHaveAttribute(
+				'y1',
+				'40'
+			);
+		} finally {
+			rectSpy.mockRestore();
+		}
+	} );
+
 	test( 'draws one glyph per series in the SVG at the datum position', async () => {
 		renderChart( { showSeriesGlyphs: true }, BOTH_SERIES );
 

--- a/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
@@ -193,7 +193,7 @@ const XyChartTooltipContent = < Datum extends object >( {
 	const boxStyle: CSSProperties = {
 		...defaultStyles,
 		zIndex,
-		background: theme?.backgroundColor ?? 'white',
+		backgroundColor: theme?.backgroundColor ?? 'white',
 		boxShadow: `0 1px 2px ${
 			theme?.htmlLabel?.color ? `${ theme.htmlLabel.color }55` : '#22222255'
 		}`,

--- a/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
@@ -83,6 +83,7 @@ const XyChartTooltipContent = < Datum extends object >( {
 	verticalCrosshairStyle,
 	horizontalCrosshairStyle,
 	detectBounds = true,
+	tooltipPlacement = 'auto',
 	zIndex = DEFAULT_TOOLTIP_Z_INDEX,
 	...rest
 }: XyChartTooltipContentProps< Datum > ) => {
@@ -125,9 +126,12 @@ const XyChartTooltipContent = < Datum extends object >( {
 	const nearestDatum = tooltipContext.tooltipData?.nearestDatum;
 	let { tooltipLeft, tooltipTop } = tooltipContext;
 
-	if ( nearestDatum && ( snapTooltipToDatumX || snapTooltipToDatumY ) ) {
+	if (
+		nearestDatum &&
+		( snapTooltipToDatumX || snapTooltipToDatumY || tooltipPlacement === 'below-axis' )
+	) {
 		const { left, top } = getDatumLeftTop( nearestDatum.key, nearestDatum.datum );
-		if ( snapTooltipToDatumX && isValidNumber( left ) ) {
+		if ( ( snapTooltipToDatumX || tooltipPlacement === 'below-axis' ) && isValidNumber( left ) ) {
 			tooltipLeft = left;
 		}
 		if ( snapTooltipToDatumY && isValidNumber( top ) ) {
@@ -183,7 +187,8 @@ const XyChartTooltipContent = < Datum extends object >( {
 	const marginTop = margin?.top ?? 0;
 	const marginLeft = margin?.left ?? 0;
 
-	const TooltipComponent = detectBounds ? BoundedTooltip : Tooltip;
+	const TooltipComponent =
+		detectBounds || tooltipPlacement === 'below-axis' ? BoundedTooltip : Tooltip;
 	const boxStyle: CSSProperties = {
 		...defaultStyles,
 		zIndex,
@@ -229,10 +234,11 @@ const XyChartTooltipContent = < Datum extends object >( {
 				createPortal(
 					<TooltipComponent
 						left={ tooltipLeft }
-						top={ tooltipTop }
+						top={ tooltipPlacement === 'below-axis' ? marginTop + innerHeight : tooltipTop }
 						style={ boxStyle }
 						applyPositionStyle
 						{ ...tooltipProps }
+						{ ...( tooltipPlacement === 'below-axis' && { placement: tooltipPlacement } ) }
 					>
 						{ tooltipContent }
 					</TooltipComponent>,

--- a/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
@@ -85,6 +85,7 @@ const XyChartTooltipContent = < Datum extends object >( {
 	detectBounds = true,
 	tooltipPlacement = 'auto',
 	zIndex = DEFAULT_TOOLTIP_Z_INDEX,
+	style,
 	...rest
 }: XyChartTooltipContentProps< Datum > ) => {
 	const tooltipProps = Object.fromEntries(
@@ -197,6 +198,7 @@ const XyChartTooltipContent = < Datum extends object >( {
 			theme?.htmlLabel?.color ? `${ theme.htmlLabel.color }55` : '#22222255'
 		}`,
 		...theme?.htmlLabel,
+		...style,
 	};
 
 	return (

--- a/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/xy-chart-tooltip.tsx
@@ -236,7 +236,11 @@ const XyChartTooltipContent = < Datum extends object >( {
 				createPortal(
 					<TooltipComponent
 						left={ tooltipLeft }
-						top={ tooltipPlacement === 'below-axis' ? marginTop + innerHeight : tooltipTop }
+						top={
+							tooltipPlacement === 'below-axis'
+								? marginTop + innerHeight + ( margin?.bottom ?? 0 )
+								: tooltipTop
+						}
 						style={ boxStyle }
 						applyPositionStyle
 						{ ...tooltipProps }
@@ -264,10 +268,10 @@ const XyChartTooltipContent = < Datum extends object >( {
  * Render it as a child of `XYChart`. The element wrapping that `XYChart` must
  * be `position: relative` with the SVG at its origin, and `isolation: isolate`:
  * the box is placed with the SVG-local coordinates visx reports, and the
- * isolation keeps the box's `zIndex` from competing with page chrome. The box
- * flips and clamps to stay inside the nearest ancestor that clips its overflow
- * (or the viewport), so it may extend past the chart wrapper but is never cut
- * off unless that ancestor is smaller than the box itself.
+ * isolation keeps the box's `zIndex` from competing with page chrome. Automatic
+ * placement flips and clamps inside the nearest clipping ancestor or viewport.
+ * Below-axis placement stays below the label band with horizontal clamping only,
+ * so a clipping ancestor can cut it off vertically.
  *
  * @param props - visx's `Tooltip` options. `scroll`, `debounce` and `resizeObserverPolyfill` are accepted and ignored.
  * @return An anchor in the SVG, plus the overlay and the tooltip box while the tooltip is open.

--- a/projects/js-packages/charts/src/visx/types.ts
+++ b/projects/js-packages/charts/src/visx/types.ts
@@ -31,10 +31,8 @@ export type XyChartTooltipProps< Datum extends object > = {
 	horizontalCrosshairStyle?: SVGProps< SVGLineElement >;
 	glyphStyle?: SVGProps< SVGCircleElement >;
 	/**
-	 * Flip and clamp the tooltip box so it stays inside the nearest ancestor
-	 * that clips its overflow, or the viewport when there is none. The box may
-	 * leave the chart wrapper. (It used to keep a body-level portal inside the
-	 * viewport.)
+	 * Flip and clamp automatic placement inside the nearest clipping ancestor or viewport.
+	 * Below-axis placement always applies horizontal bounds only, regardless of this option.
 	 * @default true
 	 */
 	detectBounds?: boolean;
@@ -51,8 +49,7 @@ export type XyChartTooltipProps< Datum extends object > = {
 	 */
 	scroll?: boolean;
 	/**
-	 * @deprecated Accepted and ignored. Nothing measures the box any more, so
-	 * there is no measurement to debounce.
+	 * @deprecated Accepted and ignored. Layout-effect measurements are not debounced.
 	 */
 	debounce?: number;
 	/**

--- a/projects/js-packages/charts/src/visx/types.ts
+++ b/projects/js-packages/charts/src/visx/types.ts
@@ -12,15 +12,19 @@ export interface RenderTooltipGlyphProps< Datum extends object > extends GlyphPr
 	isNearestDatum: boolean;
 }
 
+export type TooltipPlacement = 'auto' | 'below-axis';
+
 export type XyChartTooltipProps< Datum extends object > = {
 	renderTooltip: ( params: RenderTooltipParams< Datum > ) => ReactNode;
 	renderGlyph?: ( params: RenderTooltipGlyphProps< Datum > ) => ReactNode;
 	/**
-	 * Keep the panel below the bottom x-axis, centered at the datum x and horizontally clamped.
+	 * Keep the panel below the x-axis label band, centered at the datum x and horizontally clamped.
 	 * Vertical bounds do not move this placement; clipping ancestors can still cut it off.
 	 * @default 'auto'
 	 */
-	tooltipPlacement?: 'auto' | 'below-axis';
+	tooltipPlacement?: TooltipPlacement;
+	/** Merge overrides with the default box styles; use `unstyled` to strip the box styling. */
+	style?: VisxTooltipProps[ 'style' ];
 	snapTooltipToDatumX?: boolean;
 	snapTooltipToDatumY?: boolean;
 	showVerticalCrosshair?: boolean;

--- a/projects/js-packages/charts/src/visx/types.ts
+++ b/projects/js-packages/charts/src/visx/types.ts
@@ -15,6 +15,12 @@ export interface RenderTooltipGlyphProps< Datum extends object > extends GlyphPr
 export type XyChartTooltipProps< Datum extends object > = {
 	renderTooltip: ( params: RenderTooltipParams< Datum > ) => ReactNode;
 	renderGlyph?: ( params: RenderTooltipGlyphProps< Datum > ) => ReactNode;
+	/**
+	 * Keep the panel below the bottom x-axis, centered at the datum x and horizontally clamped.
+	 * Vertical bounds do not move this placement; clipping ancestors can still cut it off.
+	 * @default 'auto'
+	 */
+	tooltipPlacement?: 'auto' | 'below-axis';
 	snapTooltipToDatumX?: boolean;
 	snapTooltipToDatumY?: boolean;
 	showVerticalCrosshair?: boolean;


### PR DESCRIPTION
Superseded by https://github.com/Automattic/jetpack/pull/52143.