### PR TITLE
Premium Analytics: expand the feedback confirmation message

### DIFF
--- a/projects/packages/premium-analytics/changelog/uni-758-feedback-confirmation
+++ b/projects/packages/premium-analytics/changelog/uni-758-feedback-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Feedback: tell readers where their feedback went and that they can send more, instead of a one-line thank you.

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -86,8 +86,17 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 					<>
 						<Dialog.Content>
 							<Notice.Root intent="success">
+								<Notice.Title>
+									{ __(
+										'Thanks, your feedback has gone to the team.',
+										'jetpack-premium-analytics-pkg'
+									) }
+								</Notice.Title>
 								<Notice.Description>
-									{ __( 'Thank you. This helps.', 'jetpack-premium-analytics-pkg' ) }
+									{ __(
+										"It'll help us decide what to fix before the new Traffic tab replaces the old one. You can send more any time from the same menu.",
+										'jetpack-premium-analytics-pkg'
+									) }
 								</Notice.Description>
 							</Notice.Root>
 						</Dialog.Content>

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
@@ -149,8 +149,12 @@ describe( 'DashboardOptionsMenu', () => {
 
 		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
 		// region on `body`, so an unscoped query matches twice.
+		const dialog = within( screen.getByRole( 'dialog' ) );
+		expect( dialog.getByText( 'Thanks, your feedback has gone to the team.' ) ).toBeInTheDocument();
 		expect(
-			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you. This helps.' )
+			dialog.getByText(
+				"It'll help us decide what to fix before the new Traffic tab replaces the old one. You can send more any time from the same menu."
+			)
 		).toBeInTheDocument();
 		expect( screen.queryByRole( 'radiogroup' ) ).not.toBeInTheDocument();
 
@@ -296,8 +300,12 @@ describe( 'the Happiness copy of the feedback', () => {
 		await user.type( screen.getByRole( 'textbox' ), 'Charts load slowly' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
+		const dialog = within( screen.getByRole( 'dialog' ) );
+		expect( dialog.getByText( 'Thanks, your feedback has gone to the team.' ) ).toBeInTheDocument();
 		expect(
-			within( screen.getByRole( 'dialog' ) ).getByText( 'Thank you. This helps.' )
+			dialog.getByText(
+				"It'll help us decide what to fix before the new Traffic tab replaces the old one. You can send more any time from the same menu."
+			)
 		).toBeInTheDocument();
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/uni-758-feedback-confirmation
+++ b/projects/plugins/jetpack/changelog/uni-758-feedback-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: tell readers where their feedback went and that they can send more, instead of a one-line thank you.

--- a/projects/plugins/premium-analytics/changelog/uni-758-feedback-confirmation
+++ b/projects/plugins/premium-analytics/changelog/uni-758-feedback-confirmation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Feedback: tell readers where their feedback went and that they can send more, instead of a one-line thank you.


### PR DESCRIPTION
Fixes UNI-758

## Proposed changes

* Replace the post-submit confirmation in the Stats v2 feedback modal, which read "Thank you. This helps.", with copy that says where the feedback went and what it is used for.
* Render it as a `Notice.Title` plus a `Notice.Description` so the headline and the explanation read as two parts.
* Cover both sentences in the options-menu tests, on the success path and on the endpoint-failure path.

The copy is Gary's from UNI-758, with a comma added to the first line ("Thanks, your feedback has gone to the team.") because the issue text was missing one.

## Related product discussion/links

* UNI-758

## Does this pull request change what data or activity we track or use?

No. The submission path is untouched: the same Tracks event fires, and a non-empty comment still reaches the Stats feedback endpoint.

## Testing instructions

1. Open Stats v2 on a connected site: **Stats v2** in the admin menu.
2. Open the page options menu (the three dots at the top right) and pick **Any feedback?**.
3. Pick any rating and press **Send feedback**.
4. The success notice should read "Thanks, your feedback has gone to the team." in bold, followed by "It'll help us decide what to fix before the new Traffic tab replaces the old one. You can send more any time from the same menu."
* **Done** should still close the modal, and reopening the menu should let you send feedback again.


Note: Step 3 sends a real submission. The dashboard does not pass `is_testing`, so a comment reaches Happiness and opens a Zendesk ticket. Either add `is_testing: true` to the body in `submitStatsUserFeedback` while you test, or **resolve the ticket afterwards**.

![Feedback confirmation notice](https://github.com/Automattic/jetpack/raw/screenshots/change/uni-758-feedback-confirmation/after-confirmation.png)

