### PR TITLE
Premium Analytics: swap the ease question for a readiness one in the feedback modal

### DIFF
--- a/projects/packages/premium-analytics/changelog/uni-757-readiness-question
+++ b/projects/packages/premium-analytics/changelog/uni-757-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: ask whether the new Traffic tab is ready to replace the old one, instead of how it compares with the old one.

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
@@ -7,8 +7,11 @@ import { RadioControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/** How ready the reader thinks the new tab is. The value is what reaches Tracks. */
+export type StatsFeedbackReadiness = 'ready' | 'almost' | 'not_yet';
+
 // Tracks drops an event whose properties are oversized, so a pasted essay would
-// cost us the rating too.
+// cost us the answer too.
 const COMMENT_MAX_LENGTH = 1000;
 
 /**
@@ -27,12 +30,47 @@ function ratingOptions() {
 }
 
 /**
+ * The readiness answers, readiest first. `value` is what reaches Tracks.
+ *
+ * @return The options, in the order they are offered.
+ */
+function readinessOptions(): { value: StatsFeedbackReadiness; label: string }[] {
+	return [
+		{
+			value: 'ready',
+			label: __( "Yes, I'd be happy to switch now", 'jetpack-premium-analytics-pkg' ),
+		},
+		{
+			value: 'almost',
+			label: __( 'Almost — there are a few things missing', 'jetpack-premium-analytics-pkg' ),
+		},
+		{ value: 'not_yet', label: __( 'Not yet', 'jetpack-premium-analytics-pkg' ) },
+	];
+}
+
+/**
+ * The reader's readiness answer as Happiness reads it in the ticket body.
+ *
+ * Untranslated on purpose: this is triage copy, like the product name, not reader copy.
+ *
+ * @param readiness - The answer the reader picked.
+ * @return The question and its answer as one line.
+ */
+export function readinessSummary( readiness: StatsFeedbackReadiness ) {
+	const answers: Record< StatsFeedbackReadiness, string > = {
+		ready: 'Yes, ready to switch now',
+		almost: 'Almost, a few things missing',
+		not_yet: 'Not yet',
+	};
+
+	return `Ready to replace the old Traffic tab? ${ answers[ readiness ] }`;
+}
+
+/**
  * The question above a control whose own label is hidden.
  *
- * The control keeps the question as its accessible name, so this copy is for the
- * eye only and stays out of the accessibility tree rather than being read twice.
- * The label slot itself is an 11px uppercase caption, which a sentence-long
- * question reads badly as.
+ * Kept out of the accessibility tree so the control's accessible name is not read twice; the
+ * label slot itself is an 11px uppercase caption, which a sentence-long question reads badly as.
  *
  * @param {object} props          - Component props.
  * @param {string} props.children - The question.
@@ -42,7 +80,37 @@ function Question( { children }: { children: string } ) {
 	return <Text aria-hidden="true">{ children }</Text>;
 }
 
-type FeedbackFieldsProps = {
+type CommentFieldProps = {
+	question: string;
+	comment: string;
+	onCommentChange: ( comment: string ) => void;
+};
+
+/**
+ * The open question every feedback surface ends on.
+ *
+ * @param {CommentFieldProps} props                 - Component props.
+ * @param {string}            props.question        - The question above the box.
+ * @param {string}            props.comment         - The comment as typed.
+ * @param {Function}          props.onCommentChange - Called with the comment as typed.
+ * @return The field.
+ */
+function CommentField( { question, comment, onCommentChange }: CommentFieldProps ) {
+	return (
+		<Stack direction="column" gap="sm">
+			<Question>{ question }</Question>
+			<TextareaControl
+				hideLabelFromVision
+				label={ question }
+				value={ comment }
+				maxLength={ COMMENT_MAX_LENGTH }
+				onValueChange={ onCommentChange }
+			/>
+		</Stack>
+	);
+}
+
+type ComparisonFieldsProps = {
 	rating: StatsFeedbackRating | undefined;
 	onRatingChange: ( rating: StatsFeedbackRating ) => void;
 	comment: string;
@@ -51,24 +119,23 @@ type FeedbackFieldsProps = {
 };
 
 /**
- * The comparison scale and the comment box every feedback surface shares; each
- * surface asks its own open question under the scale.
+ * The comparison scale, above an open question the surface chooses.
  *
- * @param {FeedbackFieldsProps} props                 - Component props.
- * @param {number|undefined}    props.rating          - The score picked, if any.
- * @param {Function}            props.onRatingChange  - Called with the score picked.
- * @param {string}              props.comment         - The comment as typed.
- * @param {Function}            props.onCommentChange - Called with the comment as typed.
- * @param {string}              props.commentQuestion - The question above the comment box.
+ * @param {ComparisonFieldsProps} props                 - Component props.
+ * @param {number|undefined}      props.rating          - The score picked, if any.
+ * @param {Function}              props.onRatingChange  - Called with the score picked.
+ * @param {string}                props.comment         - The comment as typed.
+ * @param {Function}              props.onCommentChange - Called with the comment as typed.
+ * @param {string}                props.commentQuestion - The question above the comment box.
  * @return The two fields.
  */
-export function FeedbackFields( {
+export function ComparisonFields( {
 	rating,
 	onRatingChange,
 	comment,
 	onCommentChange,
 	commentQuestion,
-}: FeedbackFieldsProps ) {
+}: ComparisonFieldsProps ) {
 	const comparisonQuestion = __(
 		'Compared with the existing Traffic tab in Stats, the new Traffic tab is:',
 		'jetpack-premium-analytics-pkg'
@@ -92,16 +159,66 @@ export function FeedbackFields( {
 				/>
 			</Stack>
 
+			<CommentField
+				question={ commentQuestion }
+				comment={ comment }
+				onCommentChange={ onCommentChange }
+			/>
+		</>
+	);
+}
+
+type ReadinessFieldsProps = {
+	readiness: StatsFeedbackReadiness | undefined;
+	onReadinessChange: ( readiness: StatsFeedbackReadiness ) => void;
+	comment: string;
+	onCommentChange: ( comment: string ) => void;
+};
+
+/**
+ * The readiness question and the open question that follows it.
+ *
+ * @param {ReadinessFieldsProps} props                   - Component props.
+ * @param {string|undefined}     props.readiness         - The answer picked, if any.
+ * @param {Function}             props.onReadinessChange - Called with the answer picked.
+ * @param {string}               props.comment           - The comment as typed.
+ * @param {Function}             props.onCommentChange   - Called with the comment as typed.
+ * @return The two fields.
+ */
+export function ReadinessFields( {
+	readiness,
+	onReadinessChange,
+	comment,
+	onCommentChange,
+}: ReadinessFieldsProps ) {
+	const readinessQuestion = __(
+		'Is the new Traffic tab ready to replace the old one?',
+		'jetpack-premium-analytics-pkg'
+	);
+
+	const selectReadiness = useCallback(
+		( value: string ) => onReadinessChange( value as StatsFeedbackReadiness ),
+		[ onReadinessChange ]
+	);
+
+	return (
+		<>
 			<Stack direction="column" gap="sm">
-				<Question>{ commentQuestion }</Question>
-				<TextareaControl
+				<Question>{ readinessQuestion }</Question>
+				<RadioControl
 					hideLabelFromVision
-					label={ commentQuestion }
-					value={ comment }
-					maxLength={ COMMENT_MAX_LENGTH }
-					onValueChange={ onCommentChange }
+					label={ readinessQuestion }
+					options={ readinessOptions() }
+					selected={ readiness }
+					onChange={ selectReadiness }
 				/>
 			</Stack>
+
+			<CommentField
+				question={ __( "What's missing?", 'jetpack-premium-analytics-pkg' ) }
+				comment={ comment }
+				onCommentChange={ onCommentChange }
+			/>
 		</>
 	);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
@@ -53,6 +53,9 @@ function readinessOptions(): { value: StatsFeedbackReadiness; label: string }[] 
  *
  * Untranslated on purpose: this is triage copy, like the product name, not reader copy.
  *
+ * Bracketed, not newline separated: the endpoint runs the message through
+ * `sanitize_text_field`, which collapses every run of whitespace to one space.
+ *
  * @param readiness - The answer the reader picked.
  * @return The question and its answer as one line.
  */
@@ -63,7 +66,7 @@ export function readinessSummary( readiness: StatsFeedbackReadiness ) {
 		not_yet: 'Not yet',
 	};
 
-	return `Ready to replace the old Traffic tab? ${ answers[ readiness ] }`;
+	return `[Ready to replace the old Traffic tab? ${ answers[ readiness ] }]`;
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
@@ -199,6 +199,12 @@ export function ReadinessFields( {
 		'jetpack-premium-analytics-pkg'
 	);
 
+	// "What's missing?" reads oddly after "Yes", where nothing is missing by definition.
+	const commentQuestion =
+		readiness === 'ready'
+			? __( "Any other feedback you'd like to share?", 'jetpack-premium-analytics-pkg' )
+			: __( "What's missing?", 'jetpack-premium-analytics-pkg' );
+
 	const selectReadiness = useCallback(
 		( value: string ) => onReadinessChange( value as StatsFeedbackReadiness ),
 		[ onReadinessChange ]
@@ -218,7 +224,7 @@ export function ReadinessFields( {
 			</Stack>
 
 			<CommentField
-				question={ __( "What's missing?", 'jetpack-premium-analytics-pkg' ) }
+				question={ commentQuestion }
 				comment={ comment }
 				onCommentChange={ onCommentChange }
 			/>

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -57,7 +57,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 		if ( message ) {
 			// The endpoint has no readiness field, so the answer rides along in the message.
 			submitStatsUserFeedback( {
-				comment: `${ readinessSummary( readiness ) }\n\n${ message }`,
+				comment: `${ readinessSummary( readiness ) } ${ message }`,
 				productName: PRODUCT_NAME,
 			} ).catch( () => {
 				// The reader has already been thanked and Tracks may well have the submission;

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { submitStatsUserFeedback, type StatsFeedbackRating } from '@jetpack-premium-analytics/data';
+import { submitStatsUserFeedback } from '@jetpack-premium-analytics/data';
 import { Button, Dialog, Notice, Stack } from '@jetpack-premium-analytics/externals';
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
-import { FeedbackFields } from './feedback-fields';
+import { ReadinessFields, readinessSummary, type StatsFeedbackReadiness } from './feedback-fields';
 
 // Reaches Happiness as the subject line of the feedback email ("Feedback received
 // from …"), so it has to name the surface without any further context.
@@ -20,7 +20,7 @@ type FeedbackModalProps = {
 };
 
 /**
- * Comparison rating with an optional comment. Both reach Tracks as one event; a non-empty
+ * Readiness answer with an optional comment. Both reach Tracks as one event; a non-empty
  * comment also goes to the Stats feedback endpoint.
  *
  * @param {FeedbackModalProps} props         - Component props.
@@ -29,14 +29,9 @@ type FeedbackModalProps = {
  */
 export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	const trackEvent = useTrackEvent();
-	const [ rating, setRating ] = useState< StatsFeedbackRating >();
+	const [ readiness, setReadiness ] = useState< StatsFeedbackReadiness >();
 	const [ comment, setComment ] = useState( '' );
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
-
-	const blockerQuestion = __(
-		"What's the one thing we'd need to fix before this replaces the old Stats?",
-		'jetpack-premium-analytics-pkg'
-	);
 
 	const handleOpenChange = useCallback(
 		( isOpen: boolean ) => {
@@ -48,28 +43,30 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 	);
 
 	const submit = useCallback( () => {
-		if ( rating === undefined ) {
+		if ( readiness === undefined ) {
 			return;
 		}
 
 		const message = comment.trim();
 
-		trackEvent( 'jetpack_premium_analytics_feedback_submit', { rating, comment: message } );
+		trackEvent( 'jetpack_premium_analytics_feedback_submit', { readiness, comment: message } );
 
 		// Second channel, deliberately not awaited: Tracks is a pixel and ad blockers drop it
 		// silently, so the message also goes to Happiness where delivery is not the reader's
-		// browser's decision. A rating alone would only open an empty ticket.
+		// browser's decision. An answer alone would only open an empty ticket.
 		if ( message ) {
-			submitStatsUserFeedback( { rating, comment: message, productName: PRODUCT_NAME } ).catch(
-				() => {
-					// The reader has already been thanked and Tracks may well have the submission;
-					// a second, contradictory message would cost more than the lost email.
-				}
-			);
+			// The endpoint has no readiness field, so the answer rides along in the message.
+			submitStatsUserFeedback( {
+				comment: `${ readinessSummary( readiness ) }\n\n${ message }`,
+				productName: PRODUCT_NAME,
+			} ).catch( () => {
+				// The reader has already been thanked and Tracks may well have the submission;
+				// a second, contradictory message would cost more than the lost email.
+			} );
 		}
 
 		setHasSubmitted( true );
-	}, [ comment, rating, trackEvent ] );
+	}, [ comment, readiness, trackEvent ] );
 
 	return (
 		<Dialog.Root open onOpenChange={ handleOpenChange }>
@@ -110,12 +107,11 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 					<>
 						<Dialog.Content>
 							<Stack direction="column" gap="xl">
-								<FeedbackFields
-									rating={ rating }
-									onRatingChange={ setRating }
+								<ReadinessFields
+									readiness={ readiness }
+									onReadinessChange={ setReadiness }
 									comment={ comment }
 									onCommentChange={ setComment }
-									commentQuestion={ blockerQuestion }
 								/>
 							</Stack>
 						</Dialog.Content>
@@ -127,7 +123,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 							<Button
 								variant="solid"
 								size="compact"
-								disabled={ rating === undefined }
+								disabled={ readiness === undefined }
 								onClick={ submit }
 							>
 								{ __( 'Send feedback', 'jetpack-premium-analytics-pkg' ) }

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
@@ -215,6 +215,16 @@ describe( 'the readiness question', () => {
 
 		expect( screen.getByRole( 'textbox', { name: "What's missing?" } ) ).toBeInTheDocument();
 	} );
+
+	it( 'asks for anything else instead once the answer is that nothing is missing', async () => {
+		const user = await openModal();
+
+		await user.click( screen.getByRole( 'radio', { name: READY } ) );
+
+		expect(
+			screen.getByRole( 'textbox', { name: "Any other feedback you'd like to share?" } )
+		).toBeInTheDocument();
+	} );
 } );
 
 describe( 'the Tracks identity', () => {

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
@@ -41,6 +41,9 @@ jest.mock( './return-to-classic-stats', () => ( {
 
 const mockApiFetch = jest.fn();
 
+const READY = "Yes, I'd be happy to switch now";
+const ALMOST = 'Almost — there are a few things missing';
+
 // What the settings route echoes once the opt-in is off.
 const SETTINGS_OFF = { jetpack_premium_analytics_enabled: false };
 
@@ -108,22 +111,24 @@ describe( 'DashboardOptionsMenu', () => {
 		);
 	} );
 
-	it( 'reports the rating and comment as one event', async () => {
+	it( 'reports the readiness answer and comment as one event', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'A bit better' } ) );
+		await user.click( screen.getByRole( 'radio', { name: ALMOST } ) );
 		await user.type( screen.getByRole( 'textbox' ), '  Needs a date picker  ' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
 			'jetpack_premium_analytics_feedback_submit',
-			{ rating: 4, comment: 'Needs a date picker' }
+			{ readiness: 'almost', comment: 'Needs a date picker' }
 		);
 	} );
 
-	it( 'holds the submission until a rating is picked', async () => {
+	it( 'holds the submission until an answer is picked', async () => {
 		const user = await openModal();
 		const submit = screen.getByRole( 'button', { name: 'Send feedback' } );
+
+		expect( submit ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		await user.click( submit );
 
@@ -132,19 +137,19 @@ describe( 'DashboardOptionsMenu', () => {
 			expect.anything()
 		);
 
-		await user.click( screen.getByRole( 'radio', { name: 'Much worse' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Not yet' } ) );
 		await user.click( submit );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
 			'jetpack_premium_analytics_feedback_submit',
-			{ rating: 1, comment: '' }
+			{ readiness: 'not_yet', comment: '' }
 		);
 	} );
 
 	it( 'confirms the send rather than just closing', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Not yet' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		// Scoped to the dialog: `Notice` also mirrors the text into the a11y-speak live
@@ -166,7 +171,7 @@ describe( 'DashboardOptionsMenu', () => {
 	it( 'sends nothing when the reader backs out', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'Much better' } ) );
+		await user.click( screen.getByRole( 'radio', { name: READY } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 
 		expect( mockRecordEvent ).not.toHaveBeenCalledWith(
@@ -183,28 +188,32 @@ describe( 'DashboardOptionsMenu', () => {
 	} );
 } );
 
-describe( 'the rating scale', () => {
+describe( 'the readiness question', () => {
 	it( 'names the group with the question it answers', async () => {
 		await openModal();
 
 		expect( screen.getByRole( 'radiogroup' ) ).toHaveAccessibleName(
-			'Compared with the existing Traffic tab in Stats, the new Traffic tab is:'
+			'Is the new Traffic tab ready to replace the old one?'
 		);
 	} );
 
-	it( 'offers the five points worst to best', async () => {
+	it( 'offers the three answers, readiest first', async () => {
 		await openModal();
 
-		const scale = screen.getAllByRole< HTMLInputElement >( 'radio' );
+		const answers = screen.getAllByRole< HTMLInputElement >( 'radio' );
 
-		expect( scale.map( point => point.labels?.[ 0 ]?.textContent ) ).toEqual( [
-			'Much worse',
-			'A bit worse',
-			'About the same',
-			'A bit better',
-			'Much better',
+		expect( answers.map( answer => answer.labels?.[ 0 ]?.textContent ) ).toEqual( [
+			READY,
+			ALMOST,
+			'Not yet',
 		] );
-		expect( scale.map( point => point.value ) ).toEqual( [ '1', '2', '3', '4', '5' ] );
+		expect( answers.map( answer => answer.value ) ).toEqual( [ 'ready', 'almost', 'not_yet' ] );
+	} );
+
+	it( 'asks what is missing under it', async () => {
+		await openModal();
+
+		expect( screen.getByRole( 'textbox', { name: "What's missing?" } ) ).toBeInTheDocument();
 	} );
 } );
 
@@ -212,7 +221,7 @@ describe( 'the Tracks identity', () => {
 	it( 'identifies the reader and pins blog_id once, not per event', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
+		await user.click( screen.getByRole( 'radio', { name: READY } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		expect( mockRecordEvent ).toHaveBeenCalledTimes( 2 );
@@ -258,10 +267,15 @@ describe( 'the Tracks identity', () => {
 } );
 
 describe( 'the Happiness copy of the feedback', () => {
-	it( 'sends the message and the rating to the WPCOM feedback endpoint', async () => {
+	// The endpoint has no readiness field, so the answer has to survive as message text.
+	it.each( [
+		[ READY, 'Yes, ready to switch now' ],
+		[ ALMOST, 'Almost, a few things missing' ],
+		[ 'Not yet', 'Not yet' ],
+	] )( 'sends "%s" as message text, and no rating', async ( label, answer ) => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
+		await user.click( screen.getByRole( 'radio', { name: label } ) );
 		await user.type( screen.getByRole( 'textbox' ), '  Missing the date picker  ' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
@@ -272,22 +286,21 @@ describe( 'the Happiness copy of the feedback', () => {
 				data: {
 					source_url: window.location.href,
 					product_name: 'Jetpack Stats v2',
-					feedback: 'Missing the date picker',
-					rating: 2,
+					feedback: `Ready to replace the old Traffic tab? ${ answer }\n\nMissing the date picker`,
 				},
 			} )
 		);
 	} );
 
-	it( 'keeps a bare rating out of the support queue', async () => {
+	it( 'keeps a bare answer out of the support queue', async () => {
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'Much better' } ) );
+		await user.click( screen.getByRole( 'radio', { name: READY } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
 		expect( mockRecordEvent ).toHaveBeenLastCalledWith(
 			'jetpack_premium_analytics_feedback_submit',
-			{ rating: 5, comment: '' }
+			{ readiness: 'ready', comment: '' }
 		);
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
@@ -296,7 +309,7 @@ describe( 'the Happiness copy of the feedback', () => {
 		mockApiFetch.mockRejectedValue( new Error( 'throttled' ) );
 		const user = await openModal();
 
-		await user.click( screen.getByRole( 'radio', { name: 'About the same' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Not yet' } ) );
 		await user.type( screen.getByRole( 'textbox' ), 'Charts load slowly' );
 		await user.click( screen.getByRole( 'button', { name: 'Send feedback' } ) );
 
@@ -361,6 +374,21 @@ describe( 'switching the new Traffic tab off', () => {
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( mockRecordEvent ).not.toHaveBeenCalled();
 		expect( mockReturnToClassicStats ).not.toHaveBeenCalled();
+	} );
+
+	it( 'still asks how it compares, on the five points worst to best', async () => {
+		await openConfirmation();
+
+		const scale = screen.getAllByRole< HTMLInputElement >( 'radio' );
+
+		expect( scale.map( point => point.labels?.[ 0 ]?.textContent ) ).toEqual( [
+			'Much worse',
+			'A bit worse',
+			'About the same',
+			'A bit better',
+			'Much better',
+		] );
+		expect( scale.map( point => point.value ) ).toEqual( [ '1', '2', '3', '4', '5' ] );
 	} );
 
 	it( 'writes the opt-in off, reports it, and returns the reader to classic Stats', async () => {

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
@@ -286,7 +286,7 @@ describe( 'the Happiness copy of the feedback', () => {
 				data: {
 					source_url: window.location.href,
 					product_name: 'Jetpack Stats v2',
-					feedback: `Ready to replace the old Traffic tab? ${ answer }\n\nMissing the date picker`,
+					feedback: `[Ready to replace the old Traffic tab? ${ answer }] Missing the date picker`,
 				},
 			} )
 		);

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/switch-off-dialog.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/switch-off-dialog.tsx
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
-import { FeedbackFields } from '../feedback/feedback-fields';
+import { ComparisonFields } from '../feedback/feedback-fields';
 import { returnToClassicStats } from './return-to-classic-stats';
 
 // Reaches Happiness as the subject line, so it tells exit feedback from the in-product kind.
@@ -109,7 +109,7 @@ export function SwitchOffDialog( { onClose }: SwitchOffDialogProps ) {
 							</Dialog.Description>
 						</Stack>
 
-						<FeedbackFields
+						<ComparisonFields
 							rating={ rating }
 							onRatingChange={ setRating }
 							comment={ comment }

--- a/projects/plugins/jetpack/changelog/uni-757-readiness-question
+++ b/projects/plugins/jetpack/changelog/uni-757-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: ask whether the new Traffic tab is ready to replace the old one, instead of how it compares with the old one.

--- a/projects/plugins/premium-analytics/changelog/uni-757-readiness-question
+++ b/projects/plugins/premium-analytics/changelog/uni-757-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: ask whether the new Traffic tab is ready to replace the old one, instead of how it compares with the old one.

--- a/projects/plugins/wpcomsh/changelog/uni-757-readiness-question
+++ b/projects/plugins/wpcomsh/changelog/uni-757-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: ask whether the new Traffic tab is ready to replace the old one, instead of how it compares with the old one.


### PR DESCRIPTION
Fixes UNI-757

## Proposed changes
* The dashboard feedback modal now asks "Is the new Traffic tab ready to replace the old one?" instead of placing the new tab on a five point comparison scale.
* Three answers, in this order: "Yes, I'd be happy to switch now", "Almost — there are a few things missing", "Not yet".
* The open question under it is "What's missing?", and becomes "Any other feedback you'd like to share?" once the answer is "Yes, I'd be happy to switch now", where nothing is missing by definition.
* `jetpack_premium_analytics_feedback_submit` now carries `readiness` (`ready` | `almost` | `not_yet`) instead of `rating`.
* The Stats feedback endpoint has no readiness field, so the modal writes the answer into the message text and sends no `rating`.
* `FeedbackFields` splits into `ComparisonFields` and `ReadinessFields`; the switch off dialog keeps the comparison scale and its numeric `rating`, unchanged.

The switch off dialog was deliberately left alone: pressing "Switch it off" already answers the readiness question by action, so asking it again there would be redundant. That dialog shares the comment field but now supplies its own question above it.

## Related product discussion/links
* UNI-757

## Does this pull request change what data or activity we track or use?
Yes, for one existing event. `jetpack_premium_analytics_feedback_submit` keeps its name but swaps its main property: `rating` (an integer 1 to 5) is replaced by `readiness` (one of three fixed strings). No new category of data is collected; the free text `comment` property is unchanged, and the same answer also reaches the existing Stats feedback endpoint as message text rather than as a numeric field. The event name is kept deliberately: it still means "the reader sent feedback", so submission counts stay continuous across the swap. The cutover date is noted on STATS-460 so the gap in `rating` is not read as a drop in submissions.

## Testing instructions

* Build and activate Premium Analytics, then go to **Jetpack > Stats v2** in wp-admin.
* Open the **Page options** menu (top right) and choose **Any feedback?**.
* Confirm the modal asks "Is the new Traffic tab ready to replace the old one?" with exactly the three answers above, and that the box below is labelled "What's missing?".
* Pick "Yes, I'd be happy to switch now" and confirm the box relabels to "Any other feedback you'd like to share?". Pick either of the other two answers and confirm it goes back to "What's missing?".
* Confirm **Send feedback** stays disabled until an answer is picked.
* Pick an answer, type a comment, and submit with the network panel open. The `pixel.wp.com/t.gif` request should carry `readiness=<answer>` and **no** `rating`, and there should be a `POST` to `.../jetpack-stats/user-feedback`.
* Repeat with the comment box left empty. Tracks should still fire, and there should be **no** POST to `user-feedback` at all.
* Open **Page options > Switch off the preview** and confirm it still shows the five point "Much worse" to "Much better" scale with its own "What made you switch it off?" question.


## Before / after

Same site, same session, captured at the moment of the switch.

| Before (trunk) | After (this PR) |
| --- | --- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/change/uni-757-readiness-question/before-comparison-scale.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/change/uni-757-readiness-question/after-readiness-question.png) |

An answer picked and a comment typed:

<img src="https://github.com/Automattic/jetpack/raw/screenshots/change/uni-757-readiness-question/after-filled-send-enabled.png" width="450px" />

With "Yes, I'd be happy to switch now" picked, the open question changes:

<img src="https://github.com/Automattic/jetpack/raw/screenshots/change/uni-757-readiness-question/after-ready-any-other-feedback.png" width="450px" />
