### PR TITLE
Premium Analytics: keep dialog focus rings from being clipped

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-dialog-focus-ring-clipping
+++ b/projects/packages/premium-analytics/changelog/fix-pa-dialog-focus-ring-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dialogs: keep the comment field's focus ring from being clipped by the dialog footer.

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.module.scss
@@ -1,6 +1,0 @@
-// TODO: drop when @wordpress/ui fixes this upstream. `Dialog.Content` loses its
-// bottom padding under a `Dialog.Footer` and also scrolls, clipping the last
-// field's focus outline; this gives back the outline's offset plus its width.
-.body {
-	padding-block-end: calc(var(--wpds-border-width-focus) * 2);
-}

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-modal.tsx
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
 import { FeedbackFields } from './feedback-fields';
-import styles from './feedback-modal.module.scss';
 
 // Reaches Happiness as the subject line of the feedback email ("Feedback received
 // from …"), so it has to name the surface without any further context.
@@ -101,7 +100,7 @@ export function FeedbackModal( { onClose }: FeedbackModalProps ) {
 				) : (
 					<>
 						<Dialog.Content>
-							<Stack className={ styles.body } direction="column" gap="xl">
+							<Stack direction="column" gap="xl">
 								<FeedbackFields
 									rating={ rating }
 									onRatingChange={ setRating }

--- a/projects/packages/premium-analytics/routes/dashboard/overlay-focus-ring.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/overlay-focus-ring.scss
@@ -1,0 +1,10 @@
+// Pinned chrome zeroes the scroll container's block padding on that edge,
+// clipping a focus ring, which sits twice the focus width outside its control.
+// Drop when @wordpress/ui ships https://github.com/WordPress/gutenberg/pull/82443.
+header ~ [data-wp-ui-overlay-scroll-container] {
+	padding-block-start: calc(var(--wpds-border-width-focus) * 2);
+}
+
+[data-wp-ui-overlay-scroll-container]:has(~ footer) {
+	padding-block-end: calc(var(--wpds-border-width-focus) * 2);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/overlay-focus-ring.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/overlay-focus-ring.scss
@@ -8,3 +8,13 @@ header ~ [data-wp-ui-overlay-scroll-container] {
 [data-wp-ui-overlay-scroll-container]:has(~ footer) {
 	padding-block-end: calc(var(--wpds-border-width-focus) * 2);
 }
+
+// The chrome gives that clearance back, so the gap matches trunk. `- 1px` is
+// the separator slot; an unlayered rule cannot read the layered value.
+header:has(~ [data-wp-ui-overlay-scroll-container]) {
+	padding-block-end: calc(var(--wpds-dimension-gap-lg) - 1px - var(--wpds-border-width-focus) * 2);
+}
+
+[data-wp-ui-overlay-scroll-container] ~ footer {
+	padding-block-start: calc(var(--wpds-dimension-gap-lg) - 1px - var(--wpds-border-width-focus) * 2);
+}

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -49,6 +49,7 @@ import {
 	useOnboarding,
 	useSectionDateFilter,
 } from './hooks';
+import './overlay-focus-ring.scss';
 import styles from './stage.module.scss';
 import type { DateRange, YearSurfacePresetId } from '@jetpack-premium-analytics/datetime';
 

--- a/projects/plugins/jetpack/changelog/fix-pa-dialog-focus-ring-clipping
+++ b/projects/plugins/jetpack/changelog/fix-pa-dialog-focus-ring-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the dialog focus ring from being clipped by the dialog footer.

--- a/projects/plugins/premium-analytics/changelog/fix-pa-dialog-focus-ring-clipping
+++ b/projects/plugins/premium-analytics/changelog/fix-pa-dialog-focus-ring-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dialogs: keep the focus ring from being clipped by the dialog footer.


### PR DESCRIPTION
## Proposed changes
* Replace the per-dialog padding hack in the feedback modal with one stylesheet that covers every Premium Analytics dialog.
* Stop the dialog footer clipping the last field's focus ring, which is what the switch off dialog was showing.
* Reserve the same clearance at the top edge, for a dialog whose content sits under a pinned header.
* Take the same clearance back out of the adjacent header and footer padding, so the gaps match trunk.

`@wordpress/ui` zeroes `Dialog.Content`'s block padding on the edge that meets pinned chrome, and the scroll container then clips a focus ring, which sits twice the focus width outside its control. This was fixed upstream in WordPress/gutenberg#82443, but no released version carries it yet, so this is a local shim to drop on the next `@wordpress/ui` bump. It mirrors both halves of the upstream change, so the bump is a no-op. It keys off `<header>` / `<footer>`, so it does not reach `AlertDialog`, which renders its chrome as `<div>`s; Premium Analytics does not use `AlertDialog`.

## Related product discussion/links
* https://github.com/Automattic/jetpack/pull/51968#discussion_r3933068098
* https://github.com/WordPress/gutenberg/pull/82443

p1788862795137939-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the Stats v2 dashboard, then open Page options in the page header.
* Choose "Switch off the preview", click into the comment box, and confirm the blue focus ring is a closed rectangle with an even gap on all four sides. On trunk its bottom edge is cut off.
* Do the same with "Any feedback?". That dialog also has a header, so confirm the ring is fully visible there too.

Measured on the switch off dialog on a 2x display, where `--wpds-border-width-focus` is 1.5px, toggling each half of the shim off in devtools:

| | content `padding-block-end` | footer `padding-block-start` | gap | focus ring |
|---|---|---|---|---|
| trunk | 0px | 15px | 15.91px | 2.73px clipped |
| content side only | 3px | 15px | 18.91px | visible |
| this PR | 3px | 12px | 15.91px | visible |

The feedback modal pins both edges and reports 12px / 3px / 3px / 12px, so each gap is 16px there too. On a 1x display the clearance is 4px and the chrome padding 11px.

### Screenshots

Captured on a Jurassic Ninja site running this branch. "Before" is the same page with the shim switched off, since this change adds nothing else.

Switch off dialog:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-dialog-focus-ring-clipping/before-switch-off.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-dialog-focus-ring-clipping/after-switch-off.png) |

Feedback modal, which has a pinned header as well as a footer, after the change:

![feedback modal](https://github.com/Automattic/jetpack/raw/screenshots/fix/pa-dialog-focus-ring-clipping/after-feedback-modal.png)


