### PR TITLE
VideoPress: add a "Learn more" support link to the admin page

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-admin-learn-more-link
+++ b/projects/packages/videopress/changelog/add-videopress-admin-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a "Learn more" support link to the admin page.

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -31,6 +31,7 @@ import { usePermission } from '../../hooks/use-permission';
 import { usePlan } from '../../hooks/use-plan';
 import useSelectVideoFiles from '../../hooks/use-select-video-files';
 import { NeedUserConnectionGlobalNotice } from '../global-notice';
+import PageSubTitle from '../page-subtitle';
 import PricingSection from '../pricing-section';
 import { ConnectSiteSettingsSection as SettingsSection } from '../site-settings-section';
 import { ConnectVideoStorageMeter } from '../video-storage-meter';
@@ -74,7 +75,7 @@ const Admin = () => {
 	return (
 		<AdminPage
 			title={ 'VideoPress' /** "VideoPress" is a product name, do not translate. */ }
-			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+			subTitle={ <PageSubTitle /> }
 		>
 			<div
 				className={ clsx( styles[ 'files-overlay' ], {

--- a/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/edit-video-details/index.tsx
@@ -36,6 +36,7 @@ import { usePermission } from '../../hooks/use-permission';
 import useUnloadPrevent from '../../hooks/use-unload-prevent';
 import { useVideosQuery } from '../../hooks/use-videos';
 import Input from '../input';
+import PageSubTitle from '../page-subtitle';
 import VideoDetails from '../video-details';
 import VideoDetailsActions from '../video-details-actions';
 import VideoThumbnail from '../video-thumbnail';
@@ -261,7 +262,7 @@ const EditVideoDetails = () => {
 
 			<AdminPage
 				breadcrumbs={ breadcrumbs }
-				subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+				subTitle={ <PageSubTitle /> }
 				actions={ headerActions }
 			>
 				<Container horizontalSpacing={ 0 }>

--- a/projects/packages/videopress/src/client/admin/components/page-subtitle/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/page-subtitle/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import SupportLink from '../../../components/support-link';
+
+/**
+ * Subtitle for the VideoPress admin page header, shared by the dashboard and
+ * the video details screen.
+ *
+ * @return The subtitle element.
+ */
+export default function PageSubTitle() {
+	return createInterpolateElement(
+		__(
+			'Professional quality, ad-free video hosting. <link>Learn more</link>.',
+			'jetpack-videopress-pkg'
+		),
+		{ link: <SupportLink /> }
+	);
+}

--- a/projects/packages/videopress/src/client/components/support-link/index.tsx
+++ b/projects/packages/videopress/src/client/components/support-link/index.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { useDispatch } from '@wordpress/data';
+import { Link } from '@wordpress/ui';
+/**
+ * Types
+ */
+import type { ReactNode } from 'react';
+
+type Props = {
+	children?: ReactNode;
+};
+
+const SUPPORT_POST_ID = 4458;
+
+// Holds the WordPress.com blue on every admin color scheme; the radius rounds
+// the focus ring's outline.
+const linkStyle = {
+	color: 'var(--color-link, #3858e9)',
+	borderRadius: 'var(--wpds-border-radius-sm, 2px)',
+};
+
+/**
+ * Links to the VideoPress support doc. WordPress.com sites open it in the Help
+ * Center; everywhere else it opens the Jetpack doc in a new tab.
+ *
+ * @param props          - Component props.
+ * @param props.children - Link text.
+ * @return The link element.
+ */
+export default function SupportLink( { children }: Props ) {
+	const helpCenter = useDispatch( 'automattic/help-center' ) as
+		| { setShowSupportDoc?: ( url: string, postId: number ) => void }
+		| undefined;
+	const setShowSupportDoc = helpCenter?.setShowSupportDoc;
+
+	const supportUrl = isWpcomPlatformSite()
+		? 'https://wordpress.com/support/videopress/'
+		: 'https://jetpack.com/support/jetpack-videopress/';
+
+	if ( setShowSupportDoc ) {
+		return (
+			<Link
+				href={ supportUrl }
+				onClick={ event => {
+					event.preventDefault();
+					setShowSupportDoc( supportUrl, SUPPORT_POST_ID );
+				} }
+				style={ linkStyle }
+			>
+				{ children }
+			</Link>
+		);
+	}
+
+	return (
+		<Link openInNewTab href={ supportUrl } style={ linkStyle }>
+			{ children }
+		</Link>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
@@ -1,6 +1,7 @@
 import AdminPage from '@automattic/jetpack-components/admin-page';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
+import PageSubTitle from '../page-subtitle';
 import './style.scss';
 
 type Props = {
@@ -26,10 +27,7 @@ export default function ConnectScreen( { onConnect, isConnecting }: Props ) {
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __(
-				'Host, manage, customize, and track your videos — all in one place.',
-				'jetpack-videopress-pkg'
-			) }
+			subTitle={ <PageSubTitle /> }
 		>
 			<Stack direction="column" gap="md" className="vp-connection-gate">
 				<Text variant="heading-2xl">

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -11,6 +11,7 @@ import useConnection from '@automattic/jetpack-connection/use-connection';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from 'react';
 import { VIDEOPRESS_ADMIN_PAGE } from '../../utils/constants';
+import PageSubTitle from '../page-subtitle';
 import './style.scss';
 
 /**
@@ -62,10 +63,7 @@ export default function PricingUpsell() {
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __(
-				'Host, manage, customize, and track your videos — all in one place.',
-				'jetpack-videopress-pkg'
-			) }
+			subTitle={ <PageSubTitle /> }
 		>
 			<div className="vp-connection-gate__upsell">
 				<PricingTable title={ title } items={ pricingItems }>

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -6,11 +6,11 @@ import useConnectionErrorNotice, {
 	ConnectionError,
 } from '@automattic/jetpack-connection/use-connection-error-notice';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { useNavigate } from '@wordpress/route';
 import { Stack, Tabs } from '@wordpress/ui';
 import DashboardTabs, { TAB_PATHS, type DashboardTab } from '../dashboard-tabs';
 import OnboardingModal from '../onboarding-modal';
+import PageSubTitle from '../page-subtitle';
 import './style.scss';
 import type { ReactNode } from 'react';
 
@@ -56,10 +56,7 @@ export default function DashboardLayout( { activeTab, children, actions, hideFoo
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __(
-				'Host, manage, customize, and track your videos — all in one place.',
-				'jetpack-videopress-pkg'
-			) }
+			subTitle={ <PageSubTitle /> }
 			actions={ actions }
 			showFooter={ ! hideFooter }
 		>

--- a/projects/packages/videopress/src/dashboard/components/page-subtitle/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/page-subtitle/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import SupportLink from '../../../client/components/support-link';
+
+/**
+ * Subtitle for the VideoPress admin page header, shared by the dashboard chrome
+ * and the pre-connection screens so every state of the page reads the same.
+ *
+ * @return The subtitle element.
+ */
+export default function PageSubTitle() {
+	return createInterpolateElement(
+		__(
+			'Host, manage, customize, and track your videos — all in one place. <link>Learn more</link>.',
+			'jetpack-videopress-pkg'
+		),
+		{ link: <SupportLink /> }
+	);
+}

--- a/projects/plugins/jetpack/changelog/add-videopress-admin-learn-more-link
+++ b/projects/plugins/jetpack/changelog/add-videopress-admin-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+VideoPress: Add a "Learn more" support link to the admin page.

--- a/projects/plugins/videopress/changelog/add-videopress-admin-learn-more-link
+++ b/projects/plugins/videopress/changelog/add-videopress-admin-learn-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a "Learn more" support link to the admin page.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Adds a "Learn more" link to the VideoPress admin page subtitle, pointing at the VideoPress support doc.
* Covers every header the page renders: the modernized dashboard and its two pre-connection screens, plus the legacy admin page and its video details screen. The subtitle copy differs between the two, so each keeps its own sentence and shares the link.
* On WordPress.com sites the link opens the doc inside the Help Center, the same behavior the Monetize page has. Self-hosted sites get the equivalent Jetpack doc in a new tab, following the pattern the Newsletter settings already use.

## Related product discussion/links
* EDI-654

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open the VideoPress admin page — Jetpack → VideoPress, or the Jetpack VideoPress plugin's own menu.
* Confirm the subtitle ends with "Learn more" and that it is a link.
* On an Atomic site, click it and confirm https://wordpress.com/support/videopress/ opens in the Help Center panel rather than a new tab.
* On a self-hosted site, confirm it opens https://jetpack.com/support/jetpack-videopress/ in a new tab, with the usual external-link icon.
* Open a video's details screen and confirm the same link appears in that header.
* On a site that is not yet connected, confirm it also appears on the connect screen and the pricing upsell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
