### PR TITLE
Charts: date a naive dateString point in the provider's time zone

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -342,6 +342,9 @@ importers:
       '@babel/runtime':
         specifier: 7.29.7
         version: 7.29.7
+      '@date-fns/tz':
+        specifier: 1.4.1
+        version: 1.4.1
       '@react-spring/web':
         specifier: 10.1.1
         version: 10.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -404,7 +407,7 @@ importers:
         version: 2.1.1-next.v.202608281122.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: 0.21.0
-        version: 0.21.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.21.0(@date-fns/tz@1.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -474,7 +477,7 @@ importers:
         version: 4.0.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/components':
         specifier: 40.0.0
-        version: 40.0.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 40.0.0(@date-fns/tz@1.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/element':
         specifier: 8.6.0
         version: 8.6.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25637,6 +25640,72 @@ snapshots:
       - supports-color
       - vite
 
+  '@wordpress/components@40.0.0(@date-fns/tz@1.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@ariakit/react': 0.4.39(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/utc': 2.1.1
+      '@emotion/cache': 11.14.0
+      '@emotion/css': 11.13.5
+      '@emotion/react': 11.14.0(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/serialize': 1.3.3
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.31)(react@18.3.1))(@types/react@18.3.31)(react@18.3.1)
+      '@emotion/utils': 1.4.2
+      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/gradient-parser': 1.1.0
+      '@types/highlight-words-core': 1.2.3
+      '@use-gesture/react': 10.3.1(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/base-styles': 13.0.0
+      '@wordpress/compose': 8.7.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/date': 5.54.0
+      '@wordpress/deprecated': 4.54.0
+      '@wordpress/dom': 4.54.0
+      '@wordpress/element': 8.6.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/escape-html': 3.54.0
+      '@wordpress/hooks': 4.54.0
+      '@wordpress/html-entities': 4.54.0
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/is-shallow-equal': 5.54.0
+      '@wordpress/kebab-case': 1.1.0
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/rich-text': 7.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/style-runtime': 0.10.0
+      '@wordpress/ui': 0.21.0(@date-fns/tz@1.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.54.0
+      change-case: 4.1.2
+      clsx: 2.1.1
+      colord: 2.10.0
+      csstype: 3.2.3
+      date-fns: 4.4.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
+      framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gradient-parser: 1.2.0
+      highlight-words-core: 1.2.3
+      is-plain-object: 5.1.0
+      memize: 2.1.1
+      path-to-regexp: 6.3.0
+      re-resizable: 6.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-colorful: 5.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      remove-accents: 0.5.0
+      uuid: 14.0.2
+    optionalDependencies:
+      '@types/react': 18.3.31
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@emotion/is-prop-valid'
+      - '@types/react-dom'
+      - esbuild
+      - postcss
+      - stylelint
+      - supports-color
+      - vite
+
   '@wordpress/components@40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react': 0.4.39(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -31585,6 +31654,36 @@ snapshots:
       - '@date-fns/tz'
       - '@types/react-dom'
       - date-fns
+      - esbuild
+      - postcss
+      - stylelint
+      - vite
+
+  '@wordpress/ui@0.21.0(@date-fns/tz@1.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@base-ui/react': 1.8.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(date-fns@4.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@daypicker/react': 10.0.1(@types/react@18.3.31)(react@18.3.1)
+      '@wordpress/a11y': 4.54.0
+      '@wordpress/compose': 8.7.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/element': 8.6.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/i18n': 6.27.0
+      '@wordpress/icons': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/keycodes': 4.54.0(@types/react@18.3.31)
+      '@wordpress/primitives': 4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/private-apis': 1.54.0
+      '@wordpress/style-runtime': 0.10.0
+      '@wordpress/theme': 2.0.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/warning': 3.54.0
+      clsx: 2.1.1
+      date-fns: 4.4.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.5.0
+    optionalDependencies:
+      '@types/react': 18.3.31
+    transitivePeerDependencies:
+      - '@date-fns/tz'
+      - '@types/react-dom'
       - esbuild
       - postcss
       - stylelint

--- a/projects/js-packages/charts/changelog/charts-268-zoned-date-string
+++ b/projects/js-packages/charts/changelog/charts-268-zoned-date-string
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Date a naive dateString point in the provider's time zone, so every viewer reads the same day.
+LineChart, AreaChart, BarChart: Date a naive dateString point in the provider's time zone, so every viewer reads the same day.

--- a/projects/js-packages/charts/changelog/charts-268-zoned-date-string
+++ b/projects/js-packages/charts/changelog/charts-268-zoned-date-string
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date a naive dateString point in the provider's time zone, so every viewer reads the same day.

--- a/projects/js-packages/charts/package.json
+++ b/projects/js-packages/charts/package.json
@@ -72,6 +72,7 @@
 	"dependencies": {
 		"@automattic/number-formatters": "workspace:*",
 		"@babel/runtime": "7.29.7",
+		"@date-fns/tz": "1.4.1",
 		"@react-spring/web": "10.1.1",
 		"@visx/annotation": "^4.0.0",
 		"@visx/axis": "^4.0.0",

--- a/projects/js-packages/charts/src/charts/line-chart/test/zoned-date-string.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/zoned-date-string.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment <rootDir>/tests/environment-auckland.mjs
+ */
+import { render, screen } from '@testing-library/react';
+import { GlobalChartsProvider } from '../../../providers';
+import LineChart from '../line-chart';
+
+const mockRefCallback = jest.fn();
+jest.mock( '../../../hooks/use-element-size', () => ( {
+	useElementSize: () => [ mockRefCallback, 500, 300 ],
+} ) );
+
+// Naive day strings, the shape the Stats payload gives for day buckets.
+const data = [
+	{
+		label: 'Series A',
+		data: [
+			{ dateString: '2026-08-02', value: 1 },
+			{ dateString: '2026-08-03', value: 2 },
+			{ dateString: '2026-08-04', value: 3 },
+		],
+		options: {},
+	},
+];
+
+describe( 'dateString under a host time zone', () => {
+	it( 'dates a naive string in the host zone, not the viewer browser zone', () => {
+		render(
+			<GlobalChartsProvider locale="en-US" timeZone="Asia/Tokyo">
+				<LineChart width={ 500 } height={ 300 } withGradientFill={ false } data={ data } />
+			</GlobalChartsProvider>
+		);
+
+		const ticks = screen.getAllByText( /^[A-Z][a-z]{2} \d{1,2}$/ );
+		expect( ticks.map( tick => tick.textContent ) ).toEqual( [ 'Aug 2', 'Aug 3', 'Aug 4' ] );
+	} );
+} );

--- a/projects/js-packages/charts/src/hooks/test/use-chart-data-transform-zone.test.tsx
+++ b/projects/js-packages/charts/src/hooks/test/use-chart-data-transform-zone.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { GlobalChartsProvider } from '../../providers';
+import { useChartDataTransform } from '../use-chart-data-transform';
+import type { SeriesData } from '../../types';
+
+// One reference, reused across both renders, so only the zone can invalidate the memo.
+const data: SeriesData[] = [
+	{ label: 'Series A', data: [ { dateString: '2026-08-02', value: 1 } ] },
+];
+
+const Probe = () => {
+	const [ series ] = useChartDataTransform( data );
+	const point = series.data[ 0 ] as { date?: Date };
+
+	return <span data-testid="instant">{ point.date?.toISOString() }</span>;
+};
+
+describe( 'useChartDataTransform', () => {
+	it( 're-dates its points when only the provider time zone changes', () => {
+		const { rerender } = render(
+			<GlobalChartsProvider timeZone="Asia/Tokyo">
+				<Probe />
+			</GlobalChartsProvider>
+		);
+
+		expect( screen.getByTestId( 'instant' ) ).toHaveTextContent( '2026-08-01T15:00:00.000Z' );
+
+		rerender(
+			<GlobalChartsProvider timeZone="Pacific/Auckland">
+				<Probe />
+			</GlobalChartsProvider>
+		);
+
+		expect( screen.getByTestId( 'instant' ) ).toHaveTextContent( '2026-08-01T12:00:00.000Z' );
+	} );
+} );

--- a/projects/js-packages/charts/src/hooks/use-chart-data-transform.ts
+++ b/projects/js-packages/charts/src/hooks/use-chart-data-transform.ts
@@ -1,4 +1,7 @@
 import { useMemo } from 'react';
+// Imported from the module rather than the `providers` barrel: that barrel pulls
+// `use-chart-registration`, which imports this file's own barrel back.
+import { useChartFormatting } from '../providers/chart-context/hooks/use-chart-formatting';
 import { parseAsLocalDate } from '../utils';
 import type { SeriesData } from '../types';
 
@@ -7,7 +10,7 @@ import type { SeriesData } from '../types';
  *
  * This hook extracts the common data transformation logic used in both line-chart
  * and bar-chart components. It:
- * 1. Parses date strings into Date objects using parseAsLocalDate
+ * 1. Parses date strings into Date objects, dated in the provider's time zone
  * 2. Sorts data points by date when date properties are present
  * 3. Returns the original data unchanged when no date properties are found
  *
@@ -15,6 +18,10 @@ import type { SeriesData } from '../types';
  * @return {SeriesData[]} The transformed and sorted data
  */
 export const useChartDataTransform = ( data: SeriesData[] ) => {
+	// A naive `dateString` names no zone, so without this it would be read in the
+	// viewer's and then relabeled in the host's, and the two never cancel.
+	const { timeZone } = useChartFormatting();
+
 	return useMemo( () => {
 		// Check if the first data point has date or dateString properties
 		const firstPoint = data?.[ 0 ]?.data?.[ 0 ];
@@ -35,7 +42,7 @@ export const useChartDataTransform = ( data: SeriesData[] ) => {
 					if ( 'date' in point && point.date ) {
 						date = point.date;
 					} else if ( 'dateString' in point && point.dateString ) {
-						date = parseAsLocalDate( point.dateString );
+						date = parseAsLocalDate( point.dateString, timeZone );
 					}
 
 					return {
@@ -48,5 +55,5 @@ export const useChartDataTransform = ( data: SeriesData[] ) => {
 					return a.date.getTime() - b.date.getTime();
 				} ),
 		} ) );
-	}, [ data ] );
+	}, [ data, timeZone ] );
 };

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -84,8 +84,12 @@ provider's `timeZone`, and every viewer reads the day you wrote. Pass day bucket
 as `dateString` and the round trip closes; pass them as `Date` and you are back to
 choosing which midnight you meant.
 
-Outside a chart, `parseAsLocalDate( '2026-08-02', timeZone )` reads a naive string
-the same way, for a host labeling the same point in its own markup.
+<Canvas of={ ChartContextStories.HostTimeZoneDatesDayStrings } />
+
+A host labeling the same point in its own markup needs **both** halves in that
+zone, not just the parse: `parseAsLocalDate( '2026-08-02', timeZone )` and an
+`Intl.DateTimeFormat` constructed with the same `timeZone`. Moving only the parse
+is worse than moving neither, because the two no longer cancel.
 
 Two things neither prop reaches. `HeatmapChart` builds its labels in
 `buildCalendarHeatmapData`, a plain function the host calls outside the provider,

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -78,10 +78,14 @@ them.
 
 `timeZone` re-dates the instants you supply rather than relabeling them, so a
 value that is really a calendar day moves under it: `new Date( '2026-08-02' )` is
-UTC midnight, which is Aug 1 in `America/Los_Angeles`. A `dateString` point moves
-the same way but by a viewer-dependent amount, because `parseAsLocalDate` reads it
-as midnight in the browser's zone. Supply true instants alongside a `timeZone`, or
-set only `locale` for day-bucketed data. CHARTS-268 has the detail.
+UTC midnight, which is Aug 1 in `America/Los_Angeles`. A `dateString` point is not
+an instant, so it does not move: a naive string is read as midnight in the
+provider's `timeZone`, and every viewer reads the day you wrote. Pass day buckets
+as `dateString` and the round trip closes; pass them as `Date` and you are back to
+choosing which midnight you meant.
+
+Outside a chart, `parseAsLocalDate( '2026-08-02', timeZone )` reads a naive string
+the same way, for a host labeling the same point in its own markup.
 
 Two things neither prop reaches. `HeatmapChart` builds its labels in
 `buildCalendarHeatmapData`, a plain function the host calls outside the provider,

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
@@ -420,3 +420,60 @@ export const HostLocaleAndTimeZoneFormatDates: Story = {
 		}
 	},
 };
+
+// Naive day strings, the shape a Stats payload gives for day buckets.
+const HOST_DAY_DATA: SeriesData[] = [
+	{
+		label: 'Views',
+		data: Array.from( { length: 5 }, ( _, day ) => ( {
+			dateString: `2026-08-0${ day + 2 }`,
+			value: 40 + day * 6,
+		} ) ),
+		options: {},
+	},
+];
+
+/**
+ * The same day strings under two hosts, both landing on the day they name.
+ *
+ * A `dateString` names no instant, so it is read as midnight in the provider's `timeZone` rather
+ * than the viewer's. Switch your browser's own zone and nothing here moves; before CHARTS-268 the
+ * first column shifted a day for a viewer far enough east.
+ */
+export const HostTimeZoneDatesDayStrings: Story = {
+	render: () => (
+		<div style={ { display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '4rem' } }>
+			{ HOSTS.map( ( { testId, title, locale, timeZone } ) => (
+				<div key={ testId } data-testid={ `days-${ testId }` }>
+					<h3>{ title }</h3>
+					<GlobalChartsProvider locale={ locale } timeZone={ timeZone }>
+						<LineChart
+							data={ HOST_DAY_DATA }
+							width={ 350 }
+							height={ 200 }
+							withGradientFill={ false }
+							withTooltips
+							margin={ { bottom: 40 } }
+						/>
+					</GlobalChartsProvider>
+				</div>
+			) ) }
+		</div>
+	),
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Both columns start on Aug 2, the day the string names, whatever zone the browser is in.',
+			},
+		},
+	},
+	play: async ( { canvasElement } ) => {
+		const canvas = within( canvasElement );
+		const tokyo = within( canvas.getByTestId( 'days-tokyo' ) );
+		const losAngeles = within( canvas.getByTestId( 'days-los-angeles' ) );
+
+		await expect( await tokyo.findByText( '2. Aug.' ) ).toBeInTheDocument();
+		await expect( await losAngeles.findByText( 'Aug 2' ) ).toBeInTheDocument();
+	},
+};

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.stories.tsx
@@ -437,8 +437,7 @@ const HOST_DAY_DATA: SeriesData[] = [
  * The same day strings under two hosts, both landing on the day they name.
  *
  * A `dateString` names no instant, so it is read as midnight in the provider's `timeZone` rather
- * than the viewer's. Switch your browser's own zone and nothing here moves; before CHARTS-268 the
- * first column shifted a day for a viewer far enough east.
+ * than the viewer's: switch your browser's own zone and nothing here moves.
  */
 export const HostTimeZoneDatesDayStrings: Story = {
 	render: () => (

--- a/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
+++ b/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
@@ -11,6 +11,9 @@ const CASES: Array< [ string, string, string ] > = [
 	[ '2026-09-06', 'America/Santiago', '2026-09-06T04:00:00.000Z' ],
 	// And falls back at midnight, so this one happens twice; the first wins.
 	[ '2026-04-04 23:00:00', 'America/Santiago', '2026-04-05T02:00:00.000Z' ],
+	// Hours past a fall-back, where the first offset probe lands on the wrong side
+	// of the transition and only the second one is right.
+	[ '2026-11-01 08:00:00', 'America/Los_Angeles', '2026-11-01T16:00:00.000Z' ],
 ];
 
 // A string carrying its own offset is already an instant, so the zone must not move it.
@@ -37,6 +40,10 @@ export const describeZonedParsing = () => {
 			const fallback = parseAsLocalDate( '2026-08-02', 'Not/AZone' );
 
 			expect( fallback.getTime() ).toBe( parseAsLocalDate( '2026-08-02' ).getTime() );
+		} );
+
+		it( 'keeps a year below 100 out of the 1900s', () => {
+			expect( parseAsLocalDate( '0099-08-02', 'Asia/Tokyo' ).getUTCFullYear() ).toBe( 99 );
 		} );
 
 		it( 'reads a naive string in the runtime zone when no zone is supplied', () => {

--- a/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
+++ b/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
@@ -1,0 +1,53 @@
+import { parseAsLocalDate } from '../utils/date-parsing';
+
+// Every case asserts an absolute instant, so running the suite from more than one
+// worker zone is what proves the result does not depend on the viewer's.
+const CASES: Array< [ string, string, string ] > = [
+	// The shape the Stats payload gives for a day bucket.
+	[ '2026-08-02', 'Asia/Tokyo', '2026-08-01T15:00:00.000Z' ],
+	[ '2026-08-02 09:30:00', 'Asia/Tokyo', '2026-08-02T00:30:00.000Z' ],
+	[ '2026-08-02T09:30:00', 'Asia/Tokyo', '2026-08-02T00:30:00.000Z' ],
+	// Santiago springs forward at midnight, deleting this reading entirely.
+	[ '2026-09-06', 'America/Santiago', '2026-09-06T04:00:00.000Z' ],
+	// And falls back at midnight, so this one happens twice; the first wins.
+	[ '2026-04-04 23:00:00', 'America/Santiago', '2026-04-05T02:00:00.000Z' ],
+];
+
+// A string carrying its own offset is already an instant, so the zone must not move it.
+const INSTANT_CASES: Array< [ string, string ] > = [
+	[ '2026-08-02T00:00:00Z', '2026-08-02T00:00:00.000Z' ],
+	[ '2026-08-02T00:00:00+05:00', '2026-08-01T19:00:00.000Z' ],
+];
+
+/**
+ * The zone-aware half of `parseAsLocalDate`, run from whatever zone the caller's
+ * environment pins.
+ */
+export const describeZonedParsing = () => {
+	describe( 'parseAsLocalDate with a time zone', () => {
+		test.each( CASES )( 'reads %s in %s', ( dateString, timeZone, expected ) => {
+			expect( parseAsLocalDate( dateString, timeZone ).toISOString() ).toBe( expected );
+		} );
+
+		test.each( INSTANT_CASES )( 'leaves %s where it is', ( dateString, expected ) => {
+			expect( parseAsLocalDate( dateString, 'Asia/Tokyo' ).toISOString() ).toBe( expected );
+		} );
+
+		it( 'falls back to the runtime zone where Intl rejects the zone', () => {
+			const fallback = parseAsLocalDate( '2026-08-02', 'Not/AZone' );
+
+			expect( fallback.getTime() ).toBe( parseAsLocalDate( '2026-08-02' ).getTime() );
+		} );
+
+		it( 'reads a naive string in the runtime zone when no zone is supplied', () => {
+			const local = parseAsLocalDate( '2026-08-02' );
+
+			expect( [
+				local.getFullYear(),
+				local.getMonth(),
+				local.getDate(),
+				local.getHours(),
+			] ).toEqual( [ 2026, 7, 2, 0 ] );
+		} );
+	} );
+};

--- a/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
+++ b/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
@@ -1,5 +1,15 @@
 import { parseAsLocalDate } from '../utils/date-parsing';
 
+// `@wordpress/jest-console` registers the matcher but ships no types for it.
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace jest {
+		interface Matchers< R > {
+			toHaveWarnedWith( ...args: unknown[] ): R;
+		}
+	}
+}
+
 // Every case asserts an absolute instant, so running the suite from more than one
 // worker zone is what proves the result does not depend on the viewer's.
 const CASES: Array< [ string, string, string ] > = [
@@ -9,11 +19,22 @@ const CASES: Array< [ string, string, string ] > = [
 	[ '2026-08-02T09:30:00', 'Asia/Tokyo', '2026-08-02T00:30:00.000Z' ],
 	// Santiago springs forward at midnight, deleting this reading entirely.
 	[ '2026-09-06', 'America/Santiago', '2026-09-06T04:00:00.000Z' ],
-	// And falls back at midnight, so this one happens twice; the first wins.
+	// Berlin's gap runs the other way, its offset growing rather than shrinking, which is
+	// the shape most of Europe and North America has. Only this case tells the smaller of
+	// the two candidate offsets apart from the later probe.
+	[ '2026-03-29 02:30:00', 'Europe/Berlin', '2026-03-29T01:30:00.000Z' ],
+	// And Santiago falls back at midnight, so this reading happens twice.
 	[ '2026-04-04 23:00:00', 'America/Santiago', '2026-04-05T02:00:00.000Z' ],
+	// Which of the two an overlap resolves to follows the sign of the offset, so a zone
+	// east of UTC settles on the other one. Auckland is where this PR's own stories sit.
+	[ '2026-04-05 02:30:00', 'Pacific/Auckland', '2026-04-04T14:30:00.000Z' ],
 	// Hours past a fall-back, where the first offset probe lands on the wrong side
 	// of the transition and only the second one is right.
 	[ '2026-11-01 08:00:00', 'America/Los_Angeles', '2026-11-01T16:00:00.000Z' ],
+	// Nothing about this reading is remarkable in Tokyo; it is the worker zones that make it
+	// worth asserting, since Santiago deletes this local midnight and used to drag the
+	// answer an hour with it.
+	[ '2026-09-06', 'Asia/Tokyo', '2026-09-05T15:00:00.000Z' ],
 ];
 
 // A string carrying its own offset is already an instant, so the zone must not move it.
@@ -36,10 +57,13 @@ export const describeZonedParsing = () => {
 			expect( parseAsLocalDate( dateString, 'Asia/Tokyo' ).toISOString() ).toBe( expected );
 		} );
 
-		it( 'falls back to the runtime zone where Intl rejects the zone', () => {
+		it( 'falls back to the runtime zone where Intl rejects the zone, and says so', () => {
 			const fallback = parseAsLocalDate( '2026-08-02', 'Not/AZone' );
 
 			expect( fallback.getTime() ).toBe( parseAsLocalDate( '2026-08-02' ).getTime() );
+			expect( console ).toHaveWarnedWith(
+				'[Charts] timeZone "Not/AZone" is not a zone Intl accepts, so dates are read in the browser\'s zone. Pass an IANA name or a UTC offset such as "+05:30".'
+			);
 		} );
 
 		it( 'keeps a year below 100 out of the 1900s', () => {

--- a/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
+++ b/projects/js-packages/charts/src/test-utils/zoned-parsing-suite.ts
@@ -35,6 +35,11 @@ const CASES: Array< [ string, string, string ] > = [
 	// worth asserting, since Santiago deletes this local midnight and used to drag the
 	// answer an hour with it.
 	[ '2026-09-06', 'Asia/Tokyo', '2026-09-05T15:00:00.000Z' ],
+	// date-fns reads each field as one to N digits, so an unpadded string must land on the
+	// same instant as its padded twin. A one-digit fraction is 5ms to date-fns, not 500.
+	[ '2026-8-2', 'Asia/Tokyo', '2026-08-01T15:00:00.000Z' ],
+	[ '2026-08-02 9:30', 'Asia/Tokyo', '2026-08-02T00:30:00.000Z' ],
+	[ '2026-08-02T9:30:5.5', 'Asia/Tokyo', '2026-08-02T00:30:05.005Z' ],
 ];
 
 // A string carrying its own offset is already an instant, so the zone must not move it.
@@ -68,6 +73,7 @@ export const describeZonedParsing = () => {
 
 		it( 'keeps a year below 100 out of the 1900s', () => {
 			expect( parseAsLocalDate( '0099-08-02', 'Asia/Tokyo' ).getUTCFullYear() ).toBe( 99 );
+			expect( parseAsLocalDate( '99-08-02', 'Asia/Tokyo' ).getUTCFullYear() ).toBe( 99 );
 		} );
 
 		it( 'reads a naive string in the runtime zone when no zone is supplied', () => {

--- a/projects/js-packages/charts/src/utils/date-formatting.ts
+++ b/projects/js-packages/charts/src/utils/date-formatting.ts
@@ -1,10 +1,5 @@
+import { warnOnce } from './warn-once';
 import type { ChartFormatting } from '../types';
-
-/**
- * `process.env.NODE_ENV` is replaced by the bundler at build time. Declare a
- * minimal `process` locally so this file type-checks as source under `jetpack:src`.
- */
-declare const process: { env: Record< string, string | undefined > };
 
 // One `Intl.DateTimeFormat` per locale, zone and options triple. The axis formats
 // every bucket in the domain, and rebuilding the formatter is what costs; the tick
@@ -25,18 +20,6 @@ const getFormatter = (
 	}
 
 	return formatter;
-};
-
-const warned = new Set< string >();
-
-const warnOnce = ( key: string, message: string ): void => {
-	if ( warned.has( key ) || process.env.NODE_ENV === 'production' ) {
-		return;
-	}
-
-	warned.add( key );
-	// eslint-disable-next-line no-console
-	console.warn( `[Charts] ${ message }` );
 };
 
 const isUsable = ( formatting: ChartFormatting ): boolean => {

--- a/projects/js-packages/charts/src/utils/date-parsing.ts
+++ b/projects/js-packages/charts/src/utils/date-parsing.ts
@@ -32,8 +32,10 @@ const hasTimezone = ( dateString: string ): boolean => {
 
 // The wall clock, read off the string rather than back out of the parsed `Date`: date-fns
 // builds that with local setters, so a runtime zone whose own DST gap swallows the reading
-// hands back fields an hour out. Covers every naive shape in `formats` below.
-const NAIVE = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?)?$/;
+// hands back fields an hour out. Covers every naive shape in `formats` below, at the one to
+// N digits date-fns reads each field as; it takes a short fraction literally, so `.5` is 5ms.
+const NAIVE =
+	/^(\d{1,4})-(\d{1,2})-(\d{1,2})(?:[T ](\d{1,2}):(\d{1,2})(?::(\d{1,2})(?:\.(\d{1,3}))?)?)?$/;
 
 // `Date.UTC` reads a year below 100 as 1900 + year, which would silently re-date the first
 // century. `setUTCFullYear` has no such mapping.

--- a/projects/js-packages/charts/src/utils/date-parsing.ts
+++ b/projects/js-packages/charts/src/utils/date-parsing.ts
@@ -1,45 +1,16 @@
 /**
- * @file Date parsing utilities using date-fns, dated in a supplied zone or the runtime's own
+ * @file Date parsing: a naive string is dated in a supplied IANA zone, or the runtime's own
  *
- * This module provides utilities for parsing various date string formats and converting
- * them to dates using the battle-tested date-fns library. A format carrying timezone info
- * is a true instant and parses the same everywhere. A format without it is a wall-clock
- * reading, so it means nothing until a zone is named: it is read in the supplied
- * `timeZone`, or in the runtime's own when none is supplied.
+ * A string carrying an offset is already an instant and parses the same everywhere. A string
+ * without one is only a wall-clock reading, so it means nothing until a zone is named. See
+ * `parseAsLocalDate` for the supported formats.
  *
- * Note: And specifically it prevents format `YYYY-MM-DD` being parsed as UTC date.
- *
- * Key Features:
- * - Naive strings are read in the supplied zone, or the runtime's own
- * - Converts timezone-aware strings to their instant
- * - Robust input validation and error handling using date-fns
- * - TypeScript type safety
- * - Much smaller codebase than custom parsing
- *
- * Supported Formats, the first six read in the supplied zone and the last two
- * already instants:
- * - YYYY-MM-DD
- * - YYYY-MM-DD HH:mm:ss
- * - YYYY-MM-DD HH:mm
- * - YYYY-MM-DDTHH:mm:ss
- * - YYYY-MM-DDTHH:mm:ss.SSS
- * - YYYY-MM-DDTHH:mm
- * - YYYY-MM-DDTHH:mm:ssZ
- * - YYYY-MM-DDTHH:mm:ss±HH:mm
- *
- * @example
- * ```typescript
- * parseAsLocalDate("2025-01-01");                     // Local timezone
- * parseAsLocalDate("2025-01-01 14:30:00");            // Local timezone
- * parseAsLocalDate("2025-01-01 14:30");               // Local timezone
- * parseAsLocalDate("2025-01-01T14:30:45.123");        // Local timezone
- * parseAsLocalDate("2025-01-01T14:30:00Z");           // UTC 14:30 → Local equivalent
- * parseAsLocalDate("2025-01-01T14:30:00+05:00");      // +05:00 14:30 → Local equivalent
- * parseAsLocalDate("2025-01-01", "Asia/Tokyo");       // Midnight in Tokyo
- * ```
+ * Note: this specifically avoids date-fns's default of parsing `YYYY-MM-DD` as a UTC date.
  */
 
+import { tzOffset } from '@date-fns/tz';
 import { parse, parseISO, isValid } from 'date-fns';
+import { warnOnce } from './warn-once';
 
 /**
  * Checks if a date string contains timezone information
@@ -59,128 +30,69 @@ const hasTimezone = ( dateString: string ): boolean => {
 	return /[+-]\d{2}:?\d{2}$/.test( dateString.slice( tIndex + 1 ) );
 };
 
-// Enough of the calendar to invert a zone's offset. `en-US` with `h23` pins the
-// digits as Latin and the clock as 0-23; `asUtcMs` below counts in the Gregorian
-// calendar these parts are read on.
-const OFFSET_OPTIONS: Intl.DateTimeFormatOptions = {
-	year: 'numeric',
-	month: 'numeric',
-	day: 'numeric',
-	hour: 'numeric',
-	minute: 'numeric',
-	second: 'numeric',
-	hourCycle: 'h23',
-};
+// The wall clock, read off the string rather than back out of the parsed `Date`: date-fns
+// builds that with local setters, so a runtime zone whose own DST gap swallows the reading
+// hands back fields an hour out. Covers every naive shape in `formats` below.
+const NAIVE = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{3}))?)?)?$/;
 
-// One formatter per zone. Every point in a series is parsed through this, and
-// building an `Intl.DateTimeFormat` is what costs. `null` marks a zone `Intl`
-// rejected, so a bad zone is tried once rather than on every point.
-const offsetFormatters = new Map< string, Intl.DateTimeFormat | null >();
-
-const getOffsetFormatter = ( timeZone: string ): Intl.DateTimeFormat | null => {
-	if ( ! offsetFormatters.has( timeZone ) ) {
-		try {
-			offsetFormatters.set(
-				timeZone,
-				new Intl.DateTimeFormat( 'en-US', { ...OFFSET_OPTIONS, timeZone } )
-			);
-		} catch {
-			offsetFormatters.set( timeZone, null );
-		}
-	}
-
-	return offsetFormatters.get( timeZone ) ?? null;
-};
-
-// `Date.UTC` reads a year below 100 as 1900 + year, which would silently re-date
-// the first century. `setUTCFullYear` has no such mapping.
-const asUtcMs = ( fields: {
-	year: number;
-	month: number;
-	day: number;
-	hour: number;
-	minute: number;
-	second: number;
-	ms: number;
-} ): number => {
-	const date = new Date( 0 );
-	date.setUTCFullYear( fields.year, fields.month - 1, fields.day );
-	date.setUTCHours( fields.hour, fields.minute, fields.second, fields.ms );
-	return date.getTime();
-};
-
-// How far ahead of UTC `timeZone` was at this instant, in milliseconds.
-const zoneOffsetMs = ( instant: number, formatter: Intl.DateTimeFormat ): number => {
-	const parts = formatter.formatToParts( instant );
-	const read = ( type: Intl.DateTimeFormatPartTypes ) =>
-		Number( parts.find( part => part.type === type )?.value );
-
-	// Parts are truncated to the second, so compare against the same truncation.
-	return (
-		asUtcMs( {
-			year: read( 'year' ),
-			month: read( 'month' ),
-			day: read( 'day' ),
-			hour: read( 'hour' ),
-			minute: read( 'minute' ),
-			second: read( 'second' ),
-			ms: 0,
-		} ) -
-		Math.floor( instant / 1000 ) * 1000
+// `Date.UTC` reads a year below 100 as 1900 + year, which would silently re-date the first
+// century. `setUTCFullYear` has no such mapping.
+const asUtcMs = ( [ , ...fields ]: RegExpExecArray ): number => {
+	const [ year, month, day, hour, minute, second, ms ] = fields.map( field =>
+		Number( field ?? 0 )
 	);
+	const date = new Date( 0 );
+	date.setUTCFullYear( year, month - 1, day );
+	date.setUTCHours( hour, minute, second, ms );
+	return date.getTime();
 };
 
 /**
  * The instant a wall-clock reading names in a given zone.
  *
- * @param wallClock - A `Date` whose local getters carry the fields to read; the instant it points at is not used.
- * @param timeZone  - IANA zone the fields are read in.
- * @return The instant, or the wall clock unchanged where `Intl` rejects the zone.
+ * A reading a spring-forward gap deleted moves forward past the gap, and one a fall-back
+ * repeated resolves to a single instant. Neither is configurable: see CHARTS-268.
+ *
+ * @param wallClock - The reading, as the milliseconds it would be if it were UTC.
+ * @param timeZone  - IANA zone the reading is dated in.
+ * @return The instant, or `null` where `timeZone` is not a zone Intl accepts.
  */
-const wallClockToInstant = ( wallClock: Date, timeZone: string ): Date => {
-	const formatter = getOffsetFormatter( timeZone );
+const wallClockToInstant = ( wallClock: number, timeZone: string ): Date | null => {
+	// `tzOffset` answers NaN for a zone Intl cannot use. Falling back to the runtime's zone
+	// keeps the contract that this never throws, but it silently reinstates the very defect
+	// the argument exists to fix, so say so where a developer can see it.
+	const first = tzOffset( timeZone, new Date( wallClock ) );
 
-	// A zone Intl cannot use degrades to the runtime's own rather than throwing:
-	// this function is reached from a public helper whose contract is to return an
-	// invalid date, never to throw, and `GlobalChartsProvider` has already warned
-	// about an unusable zone before its own points get here.
-	if ( ! formatter ) {
-		return wallClock;
+	if ( Number.isNaN( first ) ) {
+		warnOnce(
+			`parse:timeZone:${ timeZone }`,
+			`timeZone ${ JSON.stringify(
+				timeZone
+			) } is not a zone Intl accepts, so dates are read in the browser's zone. Pass an IANA name or a UTC offset such as "+05:30".`
+		);
+		return null;
 	}
 
-	const fields = asUtcMs( {
-		year: wallClock.getFullYear(),
-		month: wallClock.getMonth() + 1,
-		day: wallClock.getDate(),
-		hour: wallClock.getHours(),
-		minute: wallClock.getMinutes(),
-		second: wallClock.getSeconds(),
-		ms: wallClock.getMilliseconds(),
-	} );
-
 	// The offset depends on the instant, so the first answer is only a guess: a DST
-	// transition between the two moves it. Re-reading the offset at the guess
-	// settles every reading the zone actually has.
-	const first = zoneOffsetMs( fields, formatter );
-	const guess = fields - first;
-	const second = zoneOffsetMs( guess, formatter );
+	// transition between the two moves it. Re-reading the offset at the guess settles
+	// every reading the zone actually has.
+	const guess = wallClock - first * 60000;
+	const second = tzOffset( timeZone, new Date( guess ) );
 
 	if ( first === second ) {
 		return new Date( guess );
 	}
 
-	const corrected = fields - second;
-	const third = zoneOffsetMs( corrected, formatter );
+	const corrected = wallClock - second * 60000;
+	const third = tzOffset( timeZone, new Date( corrected ) );
 
 	if ( second === third ) {
 		return new Date( corrected );
 	}
 
-	// A reading a spring-forward gap deleted, so no instant carries it. The smaller
-	// offset moves it forward past the gap: a day bucket in a zone that springs
-	// forward at midnight keeps its own calendar day instead of landing on the
-	// previous one.
-	return new Date( fields - Math.min( second, third ) );
+	// The smaller offset moves the reading forward past the gap, so a day bucket in a zone
+	// that springs forward at midnight keeps its own calendar day.
+	return new Date( wallClock - Math.min( second, third ) * 60000 );
 };
 
 /**
@@ -190,6 +102,10 @@ const wallClockToInstant = ( wallClock: Date, timeZone: string ): Date => {
  * is already an instant and is returned as one, whatever `timeZone` says. A string
  * without it is a wall-clock reading, dated in `timeZone` when one is supplied and
  * in the runtime's own zone when none is.
+ *
+ * A wall clock a DST gap deleted is moved forward past the gap; one a fall-back repeated
+ * resolves to a single instant. Neither policy is selectable. A zone `Intl` rejects falls
+ * back to the runtime's own, and warns once outside production.
  *
  * @param {string} dateString - The date string to parse into a date
  * @param {string} [timeZone] - IANA zone a naive string is read in; the runtime's own when absent, and ignored by a string that carries its own offset
@@ -221,10 +137,20 @@ export const parseAsLocalDate = ( dateString: string, timeZone?: string ): Date 
 	];
 
 	for ( const format of formats ) {
+		// date-fns still decides whether the string is a date at all, calendar rules included;
+		// only the fields it read are untrustworthy, and only when a zone was named.
 		const result = parse( trimmedString, format, new Date() );
-		if ( isValid( result ) ) {
-			return timeZone ? wallClockToInstant( result, timeZone ) : result;
+		if ( ! isValid( result ) ) {
+			continue;
 		}
+
+		if ( ! timeZone ) {
+			return result;
+		}
+
+		const fields = NAIVE.exec( trimmedString );
+
+		return ( fields && wallClockToInstant( asUtcMs( fields ), timeZone ) ) ?? result;
 	}
 
 	// If no format matched, return invalid date

--- a/projects/js-packages/charts/src/utils/date-parsing.ts
+++ b/projects/js-packages/charts/src/utils/date-parsing.ts
@@ -2,15 +2,16 @@
  * @file Date parsing utilities using date-fns for local timezone handling
  *
  * This module provides utilities for parsing various date string formats and converting
- * them to local timezone dates using the battle-tested date-fns library. For formats
- * without timezone info, they're treated as local. For formats with timezone info,
- * they're converted to the equivalent local time.
+ * them to dates using the battle-tested date-fns library. A format carrying timezone info
+ * is a true instant and parses the same everywhere. A format without it is a wall-clock
+ * reading, so it means nothing until a zone is named: it is read in the supplied
+ * `timeZone`, or in the runtime's own when none is supplied.
  *
  * Note: And specifically it prevents format `YYYY-MM-DD` being parsed as UTC date.
  *
  * Key Features:
- * - All parsed dates are in local timezone
- * - Converts timezone-aware strings to local equivalent
+ * - Naive strings are read in the supplied zone, or the runtime's own
+ * - Converts timezone-aware strings to their instant
  * - Robust input validation and error handling using date-fns
  * - TypeScript type safety
  * - Much smaller codebase than custom parsing
@@ -33,6 +34,7 @@
  * parseAsLocalDate("2025-01-01T14:30:45.123");        // Local timezone
  * parseAsLocalDate("2025-01-01T14:30:00Z");           // UTC 14:30 → Local equivalent
  * parseAsLocalDate("2025-01-01T14:30:00+05:00");      // +05:00 14:30 → Local equivalent
+ * parseAsLocalDate("2025-01-01", "Asia/Tokyo");       // Midnight in Tokyo
  * ```
  */
 
@@ -56,12 +58,137 @@ const hasTimezone = ( dateString: string ): boolean => {
 	return /[+-]\d{2}:?\d{2}$/.test( dateString.slice( tIndex + 1 ) );
 };
 
+// Enough of the calendar to invert a zone's offset. `en-US` with `h23` pins the
+// digits as Latin and the clock as 0-23; `Date.UTC` below counts in the Gregorian
+// calendar these parts are read on.
+const OFFSET_OPTIONS: Intl.DateTimeFormatOptions = {
+	year: 'numeric',
+	month: 'numeric',
+	day: 'numeric',
+	hour: 'numeric',
+	minute: 'numeric',
+	second: 'numeric',
+	hourCycle: 'h23',
+};
+
+// One formatter per zone. Every point in a series is parsed through this, and
+// building an `Intl.DateTimeFormat` is what costs. `null` marks a zone `Intl`
+// rejected, so a bad zone is tried once rather than on every point.
+const offsetFormatters = new Map< string, Intl.DateTimeFormat | null >();
+
+const getOffsetFormatter = ( timeZone: string ): Intl.DateTimeFormat | null => {
+	if ( ! offsetFormatters.has( timeZone ) ) {
+		try {
+			offsetFormatters.set(
+				timeZone,
+				new Intl.DateTimeFormat( 'en-US', { ...OFFSET_OPTIONS, timeZone } )
+			);
+		} catch {
+			offsetFormatters.set( timeZone, null );
+		}
+	}
+
+	return offsetFormatters.get( timeZone ) ?? null;
+};
+
+// `Date.UTC` reads a year below 100 as 1900 + year, which would silently re-date
+// the first century. `setUTCFullYear` has no such mapping.
+const asUtcMs = ( fields: {
+	year: number;
+	month: number;
+	day: number;
+	hour: number;
+	minute: number;
+	second: number;
+	ms: number;
+} ): number => {
+	const date = new Date( 0 );
+	date.setUTCFullYear( fields.year, fields.month - 1, fields.day );
+	date.setUTCHours( fields.hour, fields.minute, fields.second, fields.ms );
+	return date.getTime();
+};
+
+// How far ahead of UTC `timeZone` was at this instant, in milliseconds.
+const zoneOffsetMs = ( instant: number, formatter: Intl.DateTimeFormat ): number => {
+	const parts = formatter.formatToParts( instant );
+	const read = ( type: Intl.DateTimeFormatPartTypes ) =>
+		Number( parts.find( part => part.type === type )?.value );
+
+	// Parts are truncated to the second, so compare against the same truncation.
+	return (
+		asUtcMs( {
+			year: read( 'year' ),
+			month: read( 'month' ),
+			day: read( 'day' ),
+			hour: read( 'hour' ),
+			minute: read( 'minute' ),
+			second: read( 'second' ),
+			ms: 0,
+		} ) -
+		Math.floor( instant / 1000 ) * 1000
+	);
+};
+
+/**
+ * The instant a wall-clock reading names in a given zone.
+ *
+ * @param wallClock - A `Date` whose local getters carry the fields to read; the instant it points at is not used.
+ * @param timeZone  - IANA zone the fields are read in.
+ * @return The instant, or the wall clock unchanged where `Intl` rejects the zone.
+ */
+const wallClockToInstant = ( wallClock: Date, timeZone: string ): Date => {
+	const formatter = getOffsetFormatter( timeZone );
+
+	// A zone Intl cannot use degrades to the runtime's own rather than throwing:
+	// this function is reached from a public helper whose contract is to return an
+	// invalid date, never to throw, and `GlobalChartsProvider` has already warned
+	// about an unusable zone before its own points get here.
+	if ( ! formatter ) {
+		return wallClock;
+	}
+
+	const fields = asUtcMs( {
+		year: wallClock.getFullYear(),
+		month: wallClock.getMonth() + 1,
+		day: wallClock.getDate(),
+		hour: wallClock.getHours(),
+		minute: wallClock.getMinutes(),
+		second: wallClock.getSeconds(),
+		ms: wallClock.getMilliseconds(),
+	} );
+
+	// The offset depends on the instant, so the first answer is only a guess: a DST
+	// transition between the two moves it. Re-reading the offset at the guess
+	// settles every reading the zone actually has.
+	const first = zoneOffsetMs( fields, formatter );
+	const guess = fields - first;
+	const second = zoneOffsetMs( guess, formatter );
+
+	if ( first === second ) {
+		return new Date( guess );
+	}
+
+	const corrected = fields - second;
+	const third = zoneOffsetMs( corrected, formatter );
+
+	if ( second === third ) {
+		return new Date( corrected );
+	}
+
+	// A reading a spring-forward gap deleted, so no instant carries it. The smaller
+	// offset moves it forward past the gap: a day bucket in a zone that springs
+	// forward at midnight keeps its own calendar day instead of landing on the
+	// previous one.
+	return new Date( fields - Math.min( second, third ) );
+};
+
 /**
  * Parses any supported date string format and returns a local timezone date
  *
- * Uses date-fns for robust parsing and validation. For strings without timezone
- * info, treats as local timezone. For strings with timezone info, converts to
- * local timezone equivalent.
+ * Uses date-fns for robust parsing and validation. A string carrying timezone info
+ * is already an instant and is returned as one, whatever `timeZone` says. A string
+ * without it is a wall-clock reading, dated in `timeZone` when one is supplied and
+ * in the runtime's own zone when none is.
  *
  * Supports:
  * - YYYY-MM-DD (local)
@@ -72,10 +199,11 @@ const hasTimezone = ( dateString: string ): boolean => {
  * - YYYY-MM-DDTHH:mm (local)
  * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
  * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
- * @param {string} dateString - The date string to parse into a local timezone date
- * @return {Date} A Date object representing the parsed date in local timezone, or an invalid Date if parsing fails
+ * @param {string} dateString - The date string to parse into a date
+ * @param {string} [timeZone] - IANA zone a naive string is read in; the runtime's own when absent, and ignored by a string that carries its own offset
+ * @return {Date} A Date object representing the parsed instant, or an invalid Date if parsing fails
  */
-export const parseAsLocalDate = ( dateString: string ): Date => {
+export const parseAsLocalDate = ( dateString: string, timeZone?: string ): Date => {
 	const trimmedString = dateString.trim();
 
 	// If it has timezone information, parse as ISO and convert to local
@@ -103,7 +231,7 @@ export const parseAsLocalDate = ( dateString: string ): Date => {
 	for ( const format of formats ) {
 		const result = parse( trimmedString, format, new Date() );
 		if ( isValid( result ) ) {
-			return result;
+			return timeZone ? wallClockToInstant( result, timeZone ) : result;
 		}
 	}
 

--- a/projects/js-packages/charts/src/utils/date-parsing.ts
+++ b/projects/js-packages/charts/src/utils/date-parsing.ts
@@ -1,5 +1,5 @@
 /**
- * @file Date parsing utilities using date-fns for local timezone handling
+ * @file Date parsing utilities using date-fns, dated in a supplied zone or the runtime's own
  *
  * This module provides utilities for parsing various date string formats and converting
  * them to dates using the battle-tested date-fns library. A format carrying timezone info
@@ -16,15 +16,16 @@
  * - TypeScript type safety
  * - Much smaller codebase than custom parsing
  *
- * Supported Formats:
- * - YYYY-MM-DD (treated as local)
- * - YYYY-MM-DD HH:mm:ss (treated as local)
- * - YYYY-MM-DD HH:mm (treated as local)
- * - YYYY-MM-DDTHH:mm:ss (treated as local)
- * - YYYY-MM-DDTHH:mm:ss.SSS (treated as local)
- * - YYYY-MM-DDTHH:mm (treated as local)
- * - YYYY-MM-DDTHH:mm:ssZ (converted to local)
- * - YYYY-MM-DDTHH:mm:ss±HH:mm (converted to local)
+ * Supported Formats, the first six read in the supplied zone and the last two
+ * already instants:
+ * - YYYY-MM-DD
+ * - YYYY-MM-DD HH:mm:ss
+ * - YYYY-MM-DD HH:mm
+ * - YYYY-MM-DDTHH:mm:ss
+ * - YYYY-MM-DDTHH:mm:ss.SSS
+ * - YYYY-MM-DDTHH:mm
+ * - YYYY-MM-DDTHH:mm:ssZ
+ * - YYYY-MM-DDTHH:mm:ss±HH:mm
  *
  * @example
  * ```typescript
@@ -59,7 +60,7 @@ const hasTimezone = ( dateString: string ): boolean => {
 };
 
 // Enough of the calendar to invert a zone's offset. `en-US` with `h23` pins the
-// digits as Latin and the clock as 0-23; `Date.UTC` below counts in the Gregorian
+// digits as Latin and the clock as 0-23; `asUtcMs` below counts in the Gregorian
 // calendar these parts are read on.
 const OFFSET_OPTIONS: Intl.DateTimeFormatOptions = {
 	year: 'numeric',
@@ -183,22 +184,13 @@ const wallClockToInstant = ( wallClock: Date, timeZone: string ): Date => {
 };
 
 /**
- * Parses any supported date string format and returns a local timezone date
+ * Parses any supported date string format into an instant, dated in `timeZone` or the runtime's own
  *
  * Uses date-fns for robust parsing and validation. A string carrying timezone info
  * is already an instant and is returned as one, whatever `timeZone` says. A string
  * without it is a wall-clock reading, dated in `timeZone` when one is supplied and
  * in the runtime's own zone when none is.
  *
- * Supports:
- * - YYYY-MM-DD (local)
- * - YYYY-MM-DD HH:mm:ss (local)
- * - YYYY-MM-DD HH:mm (local)
- * - YYYY-MM-DDTHH:mm:ss (local)
- * - YYYY-MM-DDTHH:mm:ss.SSS (local)
- * - YYYY-MM-DDTHH:mm (local)
- * - YYYY-MM-DDTHH:mm:ssZ (UTC → local)
- * - YYYY-MM-DDTHH:mm:ss±HH:mm (offset → local)
  * @param {string} dateString - The date string to parse into a date
  * @param {string} [timeZone] - IANA zone a naive string is read in; the runtime's own when absent, and ignored by a string that carries its own offset
  * @return {Date} A Date object representing the parsed instant, or an invalid Date if parsing fails

--- a/projects/js-packages/charts/src/utils/test/date-parsing.auckland.test.ts
+++ b/projects/js-packages/charts/src/utils/test/date-parsing.auckland.test.ts
@@ -1,0 +1,6 @@
+/**
+ * @jest-environment <rootDir>/tests/environment-auckland.mjs
+ */
+import { describeZonedParsing } from '../../test-utils/zoned-parsing-suite';
+
+describeZonedParsing();

--- a/projects/js-packages/charts/src/utils/test/date-parsing.santiago.test.ts
+++ b/projects/js-packages/charts/src/utils/test/date-parsing.santiago.test.ts
@@ -1,0 +1,6 @@
+/**
+ * @jest-environment <rootDir>/tests/environment-santiago.mjs
+ */
+import { describeZonedParsing } from '../../test-utils/zoned-parsing-suite';
+
+describeZonedParsing();

--- a/projects/js-packages/charts/src/utils/test/date-parsing.test.ts
+++ b/projects/js-packages/charts/src/utils/test/date-parsing.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { describeZonedParsing } from '../../test-utils/zoned-parsing-suite';
 import { parseAsLocalDate } from '../date-parsing';
 
 describe( 'parseAsLocalDate', () => {
@@ -304,7 +305,7 @@ describe( 'parseAsLocalDate', () => {
 			];
 
 			const startTime = performance.now();
-			const results = testDates.map( parseAsLocalDate );
+			const results = testDates.map( dateString => parseAsLocalDate( dateString ) );
 			const endTime = performance.now();
 
 			// Should complete quickly (this is more of a smoke test)
@@ -316,3 +317,7 @@ describe( 'parseAsLocalDate', () => {
 		} );
 	} );
 } );
+
+// The test script pins TZ=UTC, so this run is a second viewer zone for the same
+// table `date-parsing.auckland.test.ts` asserts.
+describeZonedParsing();

--- a/projects/js-packages/charts/src/utils/warn-once.ts
+++ b/projects/js-packages/charts/src/utils/warn-once.ts
@@ -1,0 +1,23 @@
+/**
+ * `process.env.NODE_ENV` is replaced by the bundler at build time. Declare a
+ * minimal `process` locally so this file type-checks as source under `jetpack:src`.
+ */
+declare const process: { env: Record< string, string | undefined > };
+
+const warned = new Set< string >();
+
+/**
+ * Warns about a host-supplied value once per process, and never in production.
+ *
+ * @param key     - Identifies the value, so a bad prop on every point warns once.
+ * @param message - What the host got wrong and what happens instead.
+ */
+export const warnOnce = ( key: string, message: string ): void => {
+	if ( warned.has( key ) || process.env.NODE_ENV === 'production' ) {
+		return;
+	}
+
+	warned.add( key );
+	// eslint-disable-next-line no-console
+	console.warn( `[Charts] ${ message }` );
+};

--- a/projects/js-packages/charts/tests/environment-auckland.mjs
+++ b/projects/js-packages/charts/tests/environment-auckland.mjs
@@ -1,3 +1,3 @@
 import { zonedEnvironment } from './zone-environment.mjs';
 
-export default zonedEnvironment( 'America/Los_Angeles' );
+export default zonedEnvironment( 'Pacific/Auckland' );

--- a/projects/js-packages/charts/tests/environment-santiago.mjs
+++ b/projects/js-packages/charts/tests/environment-santiago.mjs
@@ -1,0 +1,3 @@
+import { zonedEnvironment } from './zone-environment.mjs';
+
+export default zonedEnvironment( 'America/Santiago' );

--- a/projects/js-packages/charts/tests/zone-environment.mjs
+++ b/projects/js-packages/charts/tests/zone-environment.mjs
@@ -1,0 +1,34 @@
+/* global process */
+import BaseEnvironment from 'jetpack-js-tools/jest/fix-environment-jsdom.mjs';
+
+// Read at import time, before any instance has changed it.
+const PINNED_TZ = process.env.TZ;
+
+/**
+ * jsdom, with the worker's time zone pinned to the given zone.
+ *
+ * `TZ=UTC` in the test script is what hid every time-zone bug in the date
+ * formatters, but a test file cannot lift it: Jest sandboxes `process.env` per
+ * file, so assigning `TZ` there never reaches the ICU the runtime formats with.
+ * An environment runs in the worker's own process, outside that sandbox.
+ *
+ * @param {string} timeZone - IANA zone the worker runs in.
+ * @return {Function} An environment class Jest can instantiate.
+ */
+export const zonedEnvironment = timeZone =>
+	class ZonedEnvironment extends BaseEnvironment {
+		constructor( config, context ) {
+			process.env.TZ = timeZone;
+			super( config, context );
+		}
+
+		async teardown() {
+			// Workers are reused, and the next file expects the script's own TZ.
+			if ( PINNED_TZ === undefined ) {
+				delete process.env.TZ;
+			} else {
+				process.env.TZ = PINNED_TZ;
+			}
+			await super.teardown();
+		}
+	};

--- a/projects/js-packages/charts/tests/zone-environment.mjs
+++ b/projects/js-packages/charts/tests/zone-environment.mjs
@@ -7,10 +7,8 @@ const PINNED_TZ = process.env.TZ;
 /**
  * jsdom, with the worker's time zone pinned to the given zone.
  *
- * `TZ=UTC` in the test script is what hid every time-zone bug in the date
- * formatters, but a test file cannot lift it: Jest sandboxes `process.env` per
- * file, so assigning `TZ` there never reaches the ICU the runtime formats with.
- * An environment runs in the worker's own process, outside that sandbox.
+ * Must run here rather than in a test file: Jest sandboxes `process.env` per file, so a `TZ`
+ * assignment there never reaches the ICU the runtime formats with.
  *
  * @param {string} timeZone - IANA zone the worker runs in.
  * @return {Function} An environment class Jest can instantiate.


### PR DESCRIPTION
Fixes CHARTS-268

## Proposed changes

A `dateString` point such as `'2026-08-02'` names a calendar day, not an instant, so it means nothing until some zone is named. The library read it as midnight in the viewer's browser zone and then labeled it in the host's `timeZone`, and those two halves do not cancel: one string rendered as `Aug 1` for a viewer in Auckland and `Aug 2` for one in Los Angeles. Reading it in the host's zone closes that round trip.

* Parse a `dateString` point in the provider's `timeZone` instead of the viewer's browser zone.
* Read the wall clock off the string rather than back out of a parsed `Date`, whose fields a viewer zone that deletes the local midnight silently rewrites.
* Give the public `parseAsLocalDate` an optional `timeZone`, so a host labeling the same point outside a chart stays in step with the axis.
* Settle a reading that a daylight saving change deleted or repeated onto a single instant, and warn once for a zone `Intl` cannot use rather than falling back in silence.
* Invert the offset with `tzOffset` from `@date-fns/tz`, already pinned in the lockfile, which retires the hand rolled `Intl` formatter cache.
* Add a story pairing a host `timeZone` with `dateString` points, and run one parsing table from three viewer zones.

## Related product discussion/links

* CHARTS-268
* CHARTS-264, the feature that surfaced this, and #51812 where it was recorded as a known limitation
* #51813, the sibling `getBucketInfo` defect, which is deliberately not touched here

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Storybook, `JS Packages/Charts Library/Global Context`:

* Open **Host Time Zone Dates Day Strings**. Both columns start on `Aug 2`, the day the strings name, whatever zone your own machine is in.
* On trunk that story does not exist. To see the old behavior, open the story on this branch and temporarily drop the second argument at `use-chart-data-transform.ts:45`. From a viewer zone east of `America/Los_Angeles` the right hand column slides back to `Aug 1` while the left hand column stays put.
* Open **Host Locale And Time Zone Format Dates** and confirm it is unchanged. Its points are `Date` instants, which this PR does not touch.

One layer does not show in a browser. Havana and Santiago move their clocks at midnight, so a viewer in either used to get an instant an hour out even with a `timeZone` supplied, and no screenshot from a zone without that gap can tell the two apart. `tests/environment-santiago.mjs` is what pins it: run the parsing table from that worker and `'2026-09-06'` in `Asia/Tokyo` is red before the fix and green after.

Automated:

* `jp test js js-packages/charts`

## Screenshots

The **Host Time Zone Dates Day Strings** story, captured from a browser in `Asia/Taipei`. Both columns are fed the same five naive day strings, `2026-08-02` through `2026-08-06`.

Before, the strings are read as midnight in the viewer's zone, so the `America/Los_Angeles` column slides back a day. After, they are read as midnight in each host's own zone, so both columns start on the day the string names. The `Asia/Tokyo` column does not move in this pair because Taipei is only an hour behind Tokyo; from a viewer far enough east it moves too.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/change/charts-268/before-day-strings.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/change/charts-268/after-day-strings.png) |
