### PR TITLE
Restore the repo-wide agent file layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -368,9 +368,6 @@ An inline `@phan-suppress-next-line <Rule> -- <reason>` is acceptable ONLY as a 
 - The "phan: Update wpcom stubs" PR is machine-generated and gets rebased/recreated on every job run — never hand-edit it, your changes will be overwritten.
 - `.phan/stubs/wpcom-stubs.php` is likewise generated (its header says so). Never edit it directly to add a symbol — add it to `stub-defs.php` in wpcom instead.
 
-## Maintaining this file
+## Maintaining This File
 
-Keep this file for knowledge useful to almost every future agent session in this project.
-Do not repeat what the codebase already shows; point to the authoritative file or command instead.
-Prefer rewriting or pruning existing entries over appending new ones.
-When updating this file, preserve this bar for all agents and keep entries concise.
+If you discover a pattern or pitfall not covered here, mention it to the developer so they can decide whether to update this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,0 @@
-<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
-@AGENTS.md


### PR DESCRIPTION
## Proposed changes

While reviewing https://github.com/Automattic/jetpack/pull/52080, I noticed it unintentionally re-added a root `CLAUDE.md` and reworded the `AGENTS.md` maintenance note. Neither change was part of that PR's purpose.

The repository intentionally uses `.claude/CLAUDE.md`, which imports `AGENTS.md`, after removing the repo-wide Claude file in commit 74afce71. This restores that layout by removing the root `CLAUDE.md` and restoring the original final maintenance section in `AGENTS.md`.

## Related product discussion/links

* https://github.com/Automattic/jetpack/pull/52080
* https://github.com/Automattic/jetpack/commit/74afce71

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Inspect the diff: only the root `CLAUDE.md` deletion and the final maintenance section of root `AGENTS.md` should change.
* Confirm `git diff 4d815d63^ HEAD -- AGENTS.md` is empty.
* Confirm `.claude/CLAUDE.md` still contains `@../AGENTS.md`, resolving to the root `AGENTS.md`.

Validation: diff whitespace checks, the monorepo changelog check, and pre-push filename collision and changelog checks passed. No project changelog entry is needed for these root files. `bin/check` is not present in this repository.
