### PR TITLE
Premium Analytics: replace the post detail heatmap with an All-time traffic table

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-widget
+++ b/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Post detail: Replace the daily Traffic activity heatmap with an All-time traffic table of monthly views; picking a month reads the page over it.

--- a/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-widget
+++ b/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-widget
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Post detail: Replace the daily Traffic activity heatmap with an All-time traffic table of monthly views; picking a month reads the page over it.
+Post detail: Replace the daily Traffic activity heatmap with an All-time traffic table of monthly views, and picking a month applies it as the page's period.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -6,7 +6,7 @@ import { setSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { EN_US_SETTINGS, ES_ES_SETTINGS, settingsFor } from '../__fixtures__/wp-date-settings';
-import { formatDate, formatMondayFirstWeekday, formatWeekday } from '../format-date';
+import { formatDate, formatMondayFirstWeekday, formatMonth, formatWeekday } from '../format-date';
 
 // Midnight UTC, matching the fixtures' timezone, so no day shift is in play.
 const JUNE_21 = new Date( '2025-06-21T00:00:00+00:00' );
@@ -23,6 +23,15 @@ describe( 'formatDate', () => {
 
 		it( 'defaults to "medium"', () => {
 			expect( formatDate( JUNE_21 ) ).toBe( 'June 21, 2025' );
+		} );
+
+		it( 'names a month, full and abbreviated', () => {
+			expect( formatMonth( 0 ) ).toBe( 'January' );
+			expect( formatMonth( 11, { short: true } ) ).toBe( 'Dec' );
+		} );
+
+		it( 'returns an empty string for a month index out of range', () => {
+			expect( formatMonth( 12 ) ).toBe( '' );
 		} );
 
 		it( 'formats "short" as the site format without its year', () => {
@@ -73,6 +82,11 @@ describe( 'formatDate', () => {
 
 		it( 'formats a weekday in the site locale', () => {
 			expect( formatWeekday( 6 ) ).toBe( 'sábado' );
+		} );
+
+		it( 'names a month in the site locale, not the browser one', () => {
+			expect( formatMonth( 5 ) ).toBe( 'junio' );
+			expect( formatMonth( 5, { short: true } ) ).toBe( 'jun' );
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -122,6 +122,24 @@ export const formatWeekday = ( weekday: number ): string => {
 export const formatMondayFirstWeekday = ( weekday: number ): string =>
 	formatWeekday( ( weekday + 1 ) % 7 );
 
+/**
+ * Return a month name in the site's locale.
+ *
+ * Read from WordPress's own translation tables, like `formatWeekday`, so the
+ * months match the rest of wp-admin rather than the browser's locale.
+ *
+ * @param month         - Zero-based month index (`0` = January).
+ * @param options       - Naming options.
+ * @param options.short - Pick the abbreviated name.
+ * @return The localized month name.
+ */
+export const formatMonth = ( month: number, options: { short?: boolean } = {} ): string => {
+	const { l10n } = getSettings();
+	const months = ( options.short ? l10n.monthsShort : l10n.months ) as string[];
+
+	return months?.[ month ] ?? '';
+};
+
 /** 12-hour clock tokens, zero-padded and not. */
 const TWELVE_HOUR_TOKENS = new Set( [ 'g', 'h' ] );
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -2,6 +2,7 @@ export {
 	formatDate,
 	formatHourOfDay,
 	formatMondayFirstWeekday,
+	formatMonth,
 	formatWeekday,
 	type DateFormatName,
 } from './format-date';

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -2,6 +2,7 @@ export {
 	formatDate,
 	formatHourOfDay,
 	formatMondayFirstWeekday,
+	formatMonth,
 	formatWeekday,
 	formatDateRange,
 	formatDateRangeCompact,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -292,6 +292,7 @@ export {
 	type DataPointDate,
 	type GeoChartError,
 	type GeoData,
+	type HeatmapColumn,
 	type GoogleDataTableColumn,
 	type GoogleDataTableRow,
 	type HeatmapTooltipData,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/stats-post.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/stats-post.ts
@@ -30,15 +30,41 @@ const mockPostDailyViews: Array< [ string, number ] > = Array.from(
 	}
 );
 
+type YearTable = { total: number; months: Record< string, number > };
+
+/**
+ * The endpoint's per-year tables, rolled up from the daily series: each
+ * month's views and the year's total. Months are keyed `1`-`12`.
+ */
+function rollUpYears( series: Array< [ string, number ] > ) {
+	const years: Record< string, YearTable > = {};
+
+	series.forEach( ( [ date, views ] ) => {
+		const year = date.slice( 0, 4 );
+		const month = String( Number( date.slice( 5, 7 ) ) );
+
+		years[ year ] = years[ year ] ?? { total: 0, months: {} };
+		years[ year ].months[ month ] = ( years[ year ].months[ month ] ?? 0 ) + views;
+		years[ year ].total += views;
+	} );
+
+	return { years };
+}
+
+// Published on the series' first day, so the post's life and its stats agree.
+const mockPostPublishedAt = `${ mockPostDailyViews[ 0 ][ 0 ] } 10:00:00`;
+
 export const mockStatsPostData = {
 	views: mockPostDailyViews.reduce( ( total, [ , views ] ) => total + views, 0 ),
 	like_count: 24,
 	data: mockPostDailyViews,
+	...rollUpYears( mockPostDailyViews ),
 	post: {
 		ID: 779,
 		post_title: 'Ten things I learned building my first WordPress theme',
 		post_type: 'post',
-		post_date_gmt: '2026-06-22 10:00:00',
+		post_date: mockPostPublishedAt,
+		post_date_gmt: mockPostPublishedAt,
 		comment_count: '8',
 	},
 };

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -2,7 +2,7 @@ import { PA_COLUMN_COUNT } from '../../grid';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as full-width highlights and Post views rows, Likes, Comments and UTM side by side, then a full-width Traffic activity', () => {
+	it( 'composes Post traffic as full-width highlights and Post views rows, Likes, Comments and UTM side by side, then a full-width All-time traffic', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
@@ -31,8 +31,8 @@ describe( 'post detail tab layouts', () => {
 				placement: { width: 1, height: 2, order: 5 },
 			},
 			{
-				uuid: 'post-traffic-activity',
-				type: 'jpa/post-traffic-activity',
+				uuid: 'post-all-time-traffic',
+				type: 'jpa/post-all-time-traffic',
 				placement: { width: PA_COLUMN_COUNT, height: 2, order: 6 },
 			},
 		] );

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -41,9 +41,9 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			placement: { width: 1, height: 2, order: 5 },
 		},
 		{
-			uuid: 'post-traffic-activity',
-			// Full width: the heatmap lays a whole year out across its columns.
-			type: 'jpa/post-traffic-activity',
+			uuid: 'post-all-time-traffic',
+			// Full width: the table lays twelve months out across its columns.
+			type: 'jpa/post-all-time-traffic',
 			placement: { width: PA_COLUMN_COUNT, height: 2, order: 6 },
 		},
 	],

--- a/projects/packages/premium-analytics/tests/groups/widgets-api-fetch-only.test.tsx
+++ b/projects/packages/premium-analytics/tests/groups/widgets-api-fetch-only.test.tsx
@@ -2,6 +2,7 @@
 
 import '../../widgets/latest-post/__tests__/use-latest-post.test';
 import '../../widgets/popular-post/__tests__/use-popular-post.test';
+import '../../widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test';
 import '../../widgets/post-detail-highlights/__tests__/use-post-highlights.test';
 import '../../widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test';
 import '../../widgets/traffic-chart/__tests__/use-traffic-chart.test';

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import { buildAllTimeTrafficRows } from '../build-all-time-traffic-rows';
+import type { StatsPostResponse } from '@jetpack-premium-analytics/data';
+
+// The endpoint keys months `1`-`12` and leaves out months without views.
+const RESPONSE: StatsPostResponse = {
+	years: {
+		'2025': { total: 30, months: { '11': 10, '12': 20 } },
+		'2026': { total: 45, months: { '1': 5, '3': 40 } },
+	},
+};
+
+const TODAY = { year: 2026, month: 2 };
+
+describe( 'buildAllTimeTrafficRows', () => {
+	it( 'returns one row per year of the post, newest first', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY );
+
+		expect( rows.map( row => row.year ) ).toEqual( [ 2026, 2025 ] );
+	} );
+
+	it( 'draws every month of the post life, zeroing the ones the endpoint left out', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY );
+
+		expect( rows[ 1 ].months ).toEqual( [
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			'before',
+			10,
+			20,
+		] );
+		// February is inside the life but unreported; April onward is the future.
+		expect( rows[ 0 ].months ).toEqual( [
+			5,
+			0,
+			40,
+			'after',
+			'after',
+			'after',
+			'after',
+			'after',
+			'after',
+			'after',
+			'after',
+			'after',
+		] );
+	} );
+
+	it( 'starts the life at the publish month when that is earlier than the first stats', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY, { year: 2025, month: 8 } );
+
+		expect( rows[ 1 ].months.slice( 7, 11 ) ).toEqual( [ 'before', 0, 0, 10 ] );
+	} );
+
+	it( 'keeps stats from before the publish month', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY, { year: 2026, month: 0 } );
+
+		expect( rows[ 1 ].months.slice( 10 ) ).toEqual( [ 10, 20 ] );
+	} );
+
+	it( 'keeps the table open through the current month when the endpoint runs behind', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, { year: 2026, month: 5 } );
+
+		expect( rows[ 0 ].months[ 5 ] ).toBe( 0 );
+		expect( rows[ 0 ].months[ 6 ] ).toBe( 'after' );
+	} );
+
+	it( 'returns no rows without yearly stats', () => {
+		expect( buildAllTimeTrafficRows( undefined, TODAY ) ).toEqual( [] );
+		expect( buildAllTimeTrafficRows( { years: {} }, TODAY ) ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
@@ -4,7 +4,7 @@
 import { monthRange } from '../period-range';
 
 const bounds = {
-	publishedAt: new Date( '2026-04-10T16:27:32Z' ),
+	lifeStartsAt: new Date( '2026-04-10T16:27:32Z' ),
 	timeZone: 'UTC',
 	now: new Date( '2026-09-09T12:00:00Z' ),
 };
@@ -17,7 +17,7 @@ describe( 'monthRange', () => {
 		} );
 	} );
 
-	it( 'starts the publish month on the publish day', () => {
+	it( 'starts the first month on the day the life starts', () => {
 		expect( monthRange( { year: 2026, month: 3 }, bounds ) ).toEqual( {
 			from: new Date( '2026-04-10T00:00:00.000Z' ),
 			to: new Date( '2026-04-30T23:59:59.999Z' ),
@@ -46,12 +46,12 @@ describe( 'monthRange', () => {
 		expect( monthRange( { year: 2026, month: 9 }, bounds ) ).toBeNull();
 	} );
 
-	it( 'opens the whole month without a publish date', () => {
-		expect( monthRange( { year: 2026, month: 0 }, { ...bounds, publishedAt: undefined } ) ).toEqual(
-			{
-				from: new Date( '2026-01-01T00:00:00.000Z' ),
-				to: new Date( '2026-01-31T23:59:59.999Z' ),
-			}
-		);
+	it( 'opens the whole month without a life start', () => {
+		expect(
+			monthRange( { year: 2026, month: 0 }, { ...bounds, lifeStartsAt: undefined } )
+		).toEqual( {
+			from: new Date( '2026-01-01T00:00:00.000Z' ),
+			to: new Date( '2026-01-31T23:59:59.999Z' ),
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import { monthRange } from '../period-range';
+
+const bounds = {
+	publishedAt: new Date( '2026-04-10T16:27:32Z' ),
+	timeZone: 'UTC',
+	now: new Date( '2026-09-09T12:00:00Z' ),
+};
+
+describe( 'monthRange', () => {
+	it( 'opens a whole month inside the post life', () => {
+		expect( monthRange( { year: 2026, month: 5 }, bounds ) ).toEqual( {
+			from: new Date( '2026-06-01T00:00:00.000Z' ),
+			to: new Date( '2026-06-30T23:59:59.999Z' ),
+		} );
+	} );
+
+	it( 'starts the publish month on the publish day', () => {
+		expect( monthRange( { year: 2026, month: 3 }, bounds ) ).toEqual( {
+			from: new Date( '2026-04-10T00:00:00.000Z' ),
+			to: new Date( '2026-04-30T23:59:59.999Z' ),
+		} );
+	} );
+
+	it( 'ends the current month now', () => {
+		expect( monthRange( { year: 2026, month: 8 }, bounds ) ).toEqual( {
+			from: new Date( '2026-09-01T00:00:00.000Z' ),
+			to: bounds.now,
+		} );
+	} );
+
+	it( 'reads the month on the site calendar', () => {
+		const range = monthRange(
+			{ year: 2026, month: 5 },
+			{ ...bounds, timeZone: 'America/New_York' }
+		);
+
+		expect( range?.from.toISOString() ).toBe( '2026-06-01T04:00:00.000Z' );
+		expect( range?.to.toISOString() ).toBe( '2026-07-01T03:59:59.999Z' );
+	} );
+
+	it( 'has nothing to open before the post existed or after today', () => {
+		expect( monthRange( { year: 2026, month: 2 }, bounds ) ).toBeNull();
+		expect( monthRange( { year: 2026, month: 9 }, bounds ) ).toBeNull();
+	} );
+
+	it( 'opens the whole month without a publish date', () => {
+		expect( monthRange( { year: 2026, month: 0 }, { ...bounds, publishedAt: undefined } ) ).toEqual(
+			{
+				from: new Date( '2026-01-01T00:00:00.000Z' ),
+				to: new Date( '2026-01-31T23:59:59.999Z' ),
+			}
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.chart.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { useStatsPost } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import PostAllTimeTrafficRender from '../render';
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+const mockOnChange = jest.fn();
+const mockOnApply = jest.fn();
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	useReportDateFilters: () => ( {
+		onChange: ( ...args: unknown[] ) => mockOnChange( ...args ),
+		onApply: () => mockOnApply(),
+		timeZone: 'UTC',
+	} ),
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsPost: jest.fn(),
+} ) );
+
+const NOW = new Date( '2026-03-15T12:00:00.000Z' );
+
+// The chart's responsive wrapper asks for a ResizeObserver jsdom does not have.
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+
+// The real chart, unlike the sibling file's mock: the widget reads its clicks
+// off the chart's own markup, so this is what pins that contract.
+describe( 'PostAllTimeTraffic on the real HeatmapChart', () => {
+	beforeAll( () => {
+		( globalThis as { ResizeObserver?: unknown } ).ResizeObserver = ResizeObserverStub;
+	} );
+
+	beforeEach( () => {
+		mockOnChange.mockReset();
+		mockOnApply.mockReset();
+		jest.mocked( useStatsPost ).mockReturnValue( {
+			data: {
+				years: { '2025': { total: 30, months: { '11': 10, '12': 20 } } },
+				post: { ID: 779, post_date: '2025-11-10 16:27:32' },
+			},
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			error: null,
+			refetch: jest.fn(),
+		} as unknown as ReturnType< typeof useStatsPost > );
+		jest.useFakeTimers();
+		jest.setSystemTime( NOW );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'applies a clicked month through the chart markup', async () => {
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		render(
+			<PostAllTimeTrafficRender
+				attributes={ {
+					reportParams: {
+						from: '2026-01-01T00:00:00.000+00:00',
+						to: '2026-01-31T23:59:59.999+00:00',
+						post_id: 779,
+					},
+				} }
+			/>
+		);
+
+		// The chart names a cell from its column, row and value.
+		await user.click( screen.getByRole( 'gridcell', { name: 'Nov 2025: 10' } ) );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			{
+				from: new Date( '2025-11-10T00:00:00.000Z' ),
+				to: new Date( '2025-11-30T23:59:59.999Z' ),
+			},
+			'custom'
+		);
+		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -74,6 +74,7 @@ jest.mock( '@jetpack-premium-analytics/externals', () => {
 							key={ `${ columnIndex }-${ row }` }
 							id={ `cell-${ columnIndex }-${ row }` }
 							role="gridcell"
+							tabIndex={ -1 }
 							aria-label={ `${ column.label } ${ rowLabel }` }
 							data-column={ columnIndex }
 							data-row={ row }
@@ -194,6 +195,16 @@ describe( 'PostAllTimeTraffic widget', () => {
 
 		expect( mockOnChange ).toHaveBeenCalledWith( NOVEMBER_2025, 'custom' );
 		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'opens the keyboard-selected month on Enter after a click left the focus on a cell', async () => {
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		renderWidget();
+
+		screen.getByRole( 'gridcell', { name: 'Nov 2025' } ).focus();
+		await user.keyboard( '{Enter}' );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( NOVEMBER_2025, 'custom' );
 	} );
 
 	it( 'leaves the page alone for keys that do not activate', async () => {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -125,6 +125,9 @@ const NOVEMBER_2025 = {
 	to: new Date( '2025-11-30T23:59:59.999Z' ),
 };
 
+// The current year closes the table, so the clock is pinned: the rows are 2026 and 2025.
+const NOW = new Date( '2026-03-15T12:00:00.000Z' );
+
 // `null` renders the widget without a post scope.
 function renderWidget( postId: number | null = 779 ) {
 	return render(
@@ -146,6 +149,12 @@ describe( 'PostAllTimeTraffic widget', () => {
 		mockOnApply.mockReset();
 		mockUseStatsPost.mockReset();
 		mockUseStatsPost.mockReturnValue( statsPostResult( RESPONSE ) );
+		jest.useFakeTimers();
+		jest.setSystemTime( NOW );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	it( 'lays the years out newest first over the site month names', () => {
@@ -167,7 +176,7 @@ describe( 'PostAllTimeTraffic widget', () => {
 	} );
 
 	it( 'applies a clicked month to the page as a custom range cut to the post life', async () => {
-		const user = userEvent.setup();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		renderWidget();
 
 		await user.click( screen.getByRole( 'gridcell', { name: 'Nov 2025' } ) );
@@ -177,7 +186,7 @@ describe( 'PostAllTimeTraffic widget', () => {
 	} );
 
 	it( 'opens the keyboard-selected month on Enter', async () => {
-		const user = userEvent.setup();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		renderWidget();
 
 		screen.getByRole( 'grid', { name: 'heatmap' } ).focus();
@@ -188,7 +197,7 @@ describe( 'PostAllTimeTraffic widget', () => {
 	} );
 
 	it( 'leaves the page alone for keys that do not activate', async () => {
-		const user = userEvent.setup();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		renderWidget();
 
 		screen.getByRole( 'grid', { name: 'heatmap' } ).focus();
@@ -219,7 +228,7 @@ describe( 'PostAllTimeTraffic widget', () => {
 		mockUseStatsPost.mockReturnValue(
 			statsPostResult( undefined, { isError: true, error: new Error( 'boom' ), refetch } )
 		);
-		const user = userEvent.setup();
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		renderWidget();
 
 		expect(

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import { useStatsPost } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import PostAllTimeTrafficRender from '../render';
+import type { HeatmapColumn } from '@jetpack-premium-analytics/widgets-toolkit';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+// The click lands in the page's date-filter controller, so a recorder stands in for it.
+const mockOnChange = jest.fn();
+const mockOnApply = jest.fn();
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	useReportDateFilters: () => ( {
+		onChange: ( ...args: unknown[] ) => mockOnChange( ...args ),
+		onApply: () => mockOnApply(),
+		timeZone: 'UTC',
+	} ),
+} ) );
+
+// Keep visx out of jsdom while keeping the cell markup the widget reads: a grid
+// naming its selected cell, and one `gridcell` per month carrying its indexes.
+jest.mock( '@jetpack-premium-analytics/externals', () => {
+	const actual = jest.requireActual( '@jetpack-premium-analytics/externals' );
+
+	const HeatmapChart = ( {
+		data,
+		rowLabels = [],
+		children,
+	}: {
+		data: HeatmapColumn[];
+		rowLabels?: string[];
+		children?: ReactNode;
+	} ) => (
+		<div
+			role="grid"
+			tabIndex={ 0 }
+			aria-label="heatmap"
+			aria-activedescendant="cell-10-1"
+			data-testid="heatmap"
+			data-column-labels={ data.map( column => column.label ).join( '|' ) }
+			data-row-labels={ rowLabels.join( '|' ) }
+			// One entry per row: its twelve months, `.` for filler, `x` for no views, `-` for a blank one.
+			data-rows={ rowLabels
+				.map( ( _label, row ) =>
+					data
+						.map( column => {
+							const cell = column.data[ row ];
+
+							if ( cell?.placeholder ) {
+								return '.';
+							}
+
+							if ( cell?.hidden ) {
+								return '-';
+							}
+
+							return cell?.value === null ? 'x' : cell?.value;
+						} )
+						.join( ',' )
+				)
+				.join( '|' ) }
+		>
+			{ rowLabels.map( ( rowLabel, row ) =>
+				data.map( ( column, columnIndex ) =>
+					column.data[ row ]?.hidden || column.data[ row ]?.placeholder ? null : (
+						<div
+							key={ `${ columnIndex }-${ row }` }
+							id={ `cell-${ columnIndex }-${ row }` }
+							role="gridcell"
+							aria-label={ `${ column.label } ${ rowLabel }` }
+							data-column={ columnIndex }
+							data-row={ row }
+						>
+							{ column.data[ row ]?.value }
+						</div>
+					)
+				)
+			) }
+			{ children }
+		</div>
+	);
+	HeatmapChart.Legend = ( { lessLabel, moreLabel }: { lessLabel: string; moreLabel: string } ) => (
+		<div data-testid="legend">{ `${ lessLabel }/${ moreLabel }` }</div>
+	);
+
+	return { ...actual, HeatmapChart };
+} );
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsPost: jest.fn(),
+} ) );
+
+const mockUseStatsPost = jest.mocked( useStatsPost );
+
+function statsPostResult( data: unknown, overrides: Record< string, unknown > = {} ) {
+	return {
+		data,
+		isLoading: false,
+		isFetching: false,
+		isError: false,
+		error: null,
+		refetch: jest.fn(),
+		...overrides,
+	} as unknown as ReturnType< typeof useStatsPost >;
+}
+
+const RESPONSE = {
+	years: {
+		'2025': { total: 30, months: { '11': 10, '12': 20 } },
+		'2026': { total: 45, months: { '1': 5, '3': 40 } },
+	},
+	post: { ID: 779, post_date: '2025-11-10 16:27:32' },
+};
+
+const NOVEMBER_2025 = {
+	from: new Date( '2025-11-10T00:00:00.000Z' ),
+	to: new Date( '2025-11-30T23:59:59.999Z' ),
+};
+
+// `null` renders the widget without a post scope.
+function renderWidget( postId: number | null = 779 ) {
+	return render(
+		<PostAllTimeTrafficRender
+			attributes={ {
+				reportParams: {
+					from: '2026-01-01T00:00:00.000+00:00',
+					to: '2026-01-31T23:59:59.999+00:00',
+					...( postId === null ? {} : { post_id: postId } ),
+				},
+			} }
+		/>
+	);
+}
+
+describe( 'PostAllTimeTraffic widget', () => {
+	beforeEach( () => {
+		mockOnChange.mockReset();
+		mockOnApply.mockReset();
+		mockUseStatsPost.mockReset();
+		mockUseStatsPost.mockReturnValue( statsPostResult( RESPONSE ) );
+	} );
+
+	it( 'lays the years out newest first over the site month names', () => {
+		renderWidget();
+
+		const heatmap = screen.getByTestId( 'heatmap' );
+		expect( heatmap ).toHaveAttribute( 'data-row-labels', '2026|2025' );
+		expect( heatmap.dataset.columnLabels?.split( '|' ) ).toHaveLength( 12 );
+		// The current year runs on to the clock's month, so only its opening is pinned.
+		const rows = heatmap.dataset.rows?.split( '|' ) ?? [];
+		// February had no views: a zero, as the endpoint reports it.
+		expect( rows[ 0 ]?.startsWith( '5,0,40' ) ).toBe( true );
+		// The months still to come are filler too, so the row stays a whole year.
+		expect( rows[ 0 ]?.split( ',' ) ).toHaveLength( 12 );
+		expect( rows[ 0 ] ).not.toContain( '-' );
+		// Published in November: the months before it are filler.
+		expect( rows[ 1 ] ).toBe( '.,.,.,.,.,.,.,.,.,.,10,20' );
+		expect( screen.getByTestId( 'legend' ) ).toHaveTextContent( 'Fewer views/More views' );
+	} );
+
+	it( 'applies a clicked month to the page as a custom range cut to the post life', async () => {
+		const user = userEvent.setup();
+		renderWidget();
+
+		await user.click( screen.getByRole( 'gridcell', { name: 'Nov 2025' } ) );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( NOVEMBER_2025, 'custom' );
+		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'opens the keyboard-selected month on Enter', async () => {
+		const user = userEvent.setup();
+		renderWidget();
+
+		screen.getByRole( 'grid', { name: 'heatmap' } ).focus();
+		await user.keyboard( '{Enter}' );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( NOVEMBER_2025, 'custom' );
+		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'leaves the page alone for keys that do not activate', async () => {
+		const user = userEvent.setup();
+		renderWidget();
+
+		screen.getByRole( 'grid', { name: 'heatmap' } ).focus();
+		await user.keyboard( '{ArrowRight}' );
+
+		expect( mockOnChange ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the scopeless empty state without a post', () => {
+		mockUseStatsPost.mockReturnValue( statsPostResult( undefined ) );
+		renderWidget( null );
+
+		expect(
+			screen.getByText( 'Open a post or page report to see its all-time traffic here.' )
+		).toBeInTheDocument();
+		expect( mockUseStatsPost ).toHaveBeenCalledWith( expect.objectContaining( { postId: 0 } ) );
+	} );
+
+	it( 'reports a post with no views as empty', () => {
+		mockUseStatsPost.mockReturnValue( statsPostResult( { years: {}, post: { ID: 779 } } ) );
+		renderWidget();
+
+		expect( screen.getByText( 'No views yet.' ) ).toBeInTheDocument();
+	} );
+
+	it( 'offers a retry when the request fails with nothing on screen', async () => {
+		const refetch = jest.fn();
+		mockUseStatsPost.mockReturnValue(
+			statsPostResult( undefined, { isError: true, error: new Error( 'boom' ), refetch } )
+		);
+		const user = userEvent.setup();
+		renderWidget();
+
+		expect(
+			screen.getByText( "We couldn't load this post's traffic. Please try again in a moment." )
+		).toBeInTheDocument();
+		await user.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+		expect( refetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -186,6 +186,24 @@ describe( 'PostAllTimeTraffic widget', () => {
 		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'opens a month the endpoint reports before the publish day in full', async () => {
+		mockUseStatsPost.mockReturnValue(
+			statsPostResult( { ...RESPONSE, post: { ID: 779, post_date: '2026-01-10 16:27:32' } } )
+		);
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		renderWidget();
+
+		await user.click( screen.getByRole( 'gridcell', { name: 'Nov 2025' } ) );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			{
+				from: new Date( '2025-11-01T00:00:00.000Z' ),
+				to: new Date( '2025-11-30T23:59:59.999Z' ),
+			},
+			'custom'
+		);
+	} );
+
 	it( 'opens the keyboard-selected month on Enter', async () => {
 		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 		renderWidget();

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { queryClientWrapper as wrapper } from '../../test-utils';
+import usePostAllTimeTraffic from '../use-post-all-time-traffic';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+const STATS_POST_RESPONSE = {
+	years: { '2026': { total: 45, months: { '1': 5, '3': 40 } } },
+	post: { ID: 779, post_date: '2026-01-10 16:27:32' },
+};
+
+describe( 'usePostAllTimeTraffic', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
+	} );
+
+	it( 'requests the yearly tables and the post row, and builds the rows from them', async () => {
+		const { result } = renderHook( () => usePostAllTimeTraffic( 779 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.rows ).toHaveLength( 1 ) );
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( String( mockApiFetch.mock.calls[ 0 ][ 0 ].path ) ).toMatch(
+			/stats\/post\/779.*fields=years(%2C|,)post/
+		);
+
+		expect( result.current.rows[ 0 ].year ).toBe( 2026 );
+		expect( result.current.rows[ 0 ].months.slice( 0, 3 ) ).toEqual( [ 5, 0, 40 ] );
+		expect( result.current.publishedAt?.toISOString() ).toBe( '2026-01-10T16:27:32.000Z' );
+	} );
+
+	it( 'never requests without a post scope', () => {
+		const { result } = renderHook( () => usePostAllTimeTraffic( 0 ), { wrapper } );
+
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+		expect( result.current.rows ).toEqual( [] );
+		expect( result.current.publishedAt ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
@@ -19,11 +19,20 @@ const STATS_POST_RESPONSE = {
 	post: { ID: 779, post_date: '2026-01-10 16:27:32' },
 };
 
+// The current year closes the table, so the clock is pinned to the fixture's year.
+const NOW = new Date( '2026-03-15T12:00:00.000Z' );
+
 describe( 'usePostAllTimeTraffic', () => {
 	beforeEach( () => {
 		queryClient.clear();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
+		jest.useFakeTimers();
+		jest.setSystemTime( NOW );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
 	} );
 
 	it( 'requests the yearly tables and the post row, and builds the rows from them', async () => {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
@@ -47,7 +47,19 @@ describe( 'usePostAllTimeTraffic', () => {
 
 		expect( result.current.rows[ 0 ].year ).toBe( 2026 );
 		expect( result.current.rows[ 0 ].months.slice( 0, 3 ) ).toEqual( [ 5, 0, 40 ] );
-		expect( result.current.publishedAt?.toISOString() ).toBe( '2026-01-10T16:27:32.000Z' );
+		expect( result.current.lifeStartsAt?.toISOString() ).toBe( '2026-01-10T16:27:32.000Z' );
+	} );
+
+	it( 'starts the life at an earlier month the endpoint reports for a rescheduled post', async () => {
+		mockApiFetch.mockResolvedValue( {
+			...STATS_POST_RESPONSE,
+			post: { ID: 779, post_date: '2026-03-05 10:00:00' },
+		} );
+		const { result } = renderHook( () => usePostAllTimeTraffic( 779 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.rows ).toHaveLength( 1 ) );
+
+		expect( result.current.lifeStartsAt?.toISOString() ).toBe( '2026-01-01T00:00:00.000Z' );
 	} );
 
 	it( 'never requests without a post scope', () => {
@@ -55,6 +67,6 @@ describe( 'usePostAllTimeTraffic', () => {
 
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( result.current.rows ).toEqual( [] );
-		expect( result.current.publishedAt ).toBeUndefined();
+		expect( result.current.lifeStartsAt ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import type { StatsPostResponse, StatsPostYear } from '@jetpack-premium-analytics/data';
+
+export const MONTHS_IN_YEAR = 12;
+
+/** A calendar month; `month` is zero-based, as `Date` counts it. */
+export type MonthKey = { year: number; month: number };
+
+/**
+ * A month's figure, or why there is none: `before` predates the post, `after`
+ * is still to come.
+ */
+export type AllTimeTrafficMonth = number | 'before' | 'after';
+
+export type AllTimeTrafficRow = {
+	year: number;
+	/** One entry per calendar month, January first. */
+	months: AllTimeTrafficMonth[];
+};
+
+const monthOrder = ( { year, month }: MonthKey ) => year * MONTHS_IN_YEAR + month;
+
+/** Every month the endpoint reports, as orders. The API keys months `1`-`12`. */
+function reportedMonths( years: Record< string, StatsPostYear > ): number[] {
+	return Object.entries( years ).flatMap( ( [ year, stats ] ) =>
+		Object.keys( stats.months ).map( monthNumber =>
+			monthOrder( { year: Number( year ), month: Number( monthNumber ) - 1 } )
+		)
+	);
+}
+
+/**
+ * Turns the endpoint's per-year tables into one row per year, newest first.
+ *
+ * `years` carries each month's views. A month the endpoint leaves out inside
+ * the post's life is a zero, so the grid stays complete, the way the daily
+ * heatmap draws every day of its range.
+ *
+ * @param response  - The sanitized `stats/post` response.
+ * @param today     - The site's current month, which closes the last row.
+ * @param published - The month the post was published; defaults to the first
+ *                  reported month.
+ * @return One row per year of the post's life, newest first. Empty without stats.
+ */
+export function buildAllTimeTrafficRows(
+	response: StatsPostResponse | undefined,
+	today: MonthKey,
+	published?: MonthKey
+): AllTimeTrafficRow[] {
+	const years = response?.years ?? {};
+	const reported = reportedMonths( years );
+
+	if ( reported.length === 0 ) {
+		return [];
+	}
+
+	// A post can carry stats from before its publish date (a rescheduled one),
+	// so its life starts at whichever comes first.
+	const firstOrder = Math.min( ...reported, published ? monthOrder( published ) : Infinity );
+	const lastOrder = Math.max( monthOrder( today ), ...reported );
+	const firstYear = Math.floor( firstOrder / MONTHS_IN_YEAR );
+	const lastYear = Math.floor( lastOrder / MONTHS_IN_YEAR );
+	const rows: AllTimeTrafficRow[] = [];
+
+	for ( let year = lastYear; year >= firstYear; year-- ) {
+		const stats = years[ String( year ) ];
+		const months = Array.from(
+			{ length: MONTHS_IN_YEAR },
+			( _month, month ): AllTimeTrafficMonth => {
+				const order = monthOrder( { year, month } );
+
+				if ( order < firstOrder ) {
+					return 'before';
+				}
+
+				if ( order > lastOrder ) {
+					return 'after';
+				}
+
+				return stats?.months[ String( month + 1 ) ] ?? 0;
+			}
+		);
+
+		rows.push( { year, months } );
+	}
+
+	return rows;
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/package.json
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-post-all-time-traffic",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
+		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
+		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/routing": "link:../../packages/routing",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/widget-primitives": "0.6.2-next.v.202609031004.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
@@ -13,8 +13,8 @@ import {
 import type { MonthKey } from './build-all-time-traffic-rows';
 
 export type PeriodBounds = {
-	/** When the post was published; the range never starts before that day. */
-	publishedAt?: Date;
+	/** Where the post's life starts; the range never starts before that day. */
+	lifeStartsAt?: Date;
 	/** The site timezone the calendar month is read in. */
 	timeZone: string;
 	/** The range never ends after this instant. Defaults to the clock. */
@@ -30,7 +30,7 @@ export type PeriodBounds = {
  * @return The range to apply, or `null`.
  */
 export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | null {
-	const { publishedAt, timeZone, now = new Date() } = bounds;
+	const { lifeStartsAt, timeZone, now = new Date() } = bounds;
 	// The bucket the traffic chart opens on a click, cut at the clock.
 	const bucket = drillDateRange(
 		createTZDateFromParts( [ key.year, key.month, 1 ], timeZone ),
@@ -42,8 +42,8 @@ export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | n
 		return null;
 	}
 
-	const publishedDay = publishedAt ? startOfDayTZ( publishedAt, timeZone ) : undefined;
-	const from = publishedDay && publishedDay > bucket.from ? publishedDay : bucket.from;
+	const firstDay = lifeStartsAt ? startOfDayTZ( lifeStartsAt, timeZone ) : undefined;
+	const from = firstDay && firstDay > bucket.from ? firstDay : bucket.from;
 
 	return from.getTime() <= bucket.to.getTime() ? { from, to: bucket.to } : null;
 }

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import {
+	createTZDateFromParts,
+	drillDateRange,
+	startOfDayTZ,
+	type DateRange,
+} from '@jetpack-premium-analytics/datetime';
+/**
+ * Internal dependencies
+ */
+import type { MonthKey } from './build-all-time-traffic-rows';
+
+export type PeriodBounds = {
+	/** When the post was published; the range never starts before that day. */
+	publishedAt?: Date;
+	/** The site timezone the calendar month is read in. */
+	timeZone: string;
+	/** The range never ends after this instant. Defaults to the clock. */
+	now?: Date;
+};
+
+/**
+ * The page range for a month of the table: the calendar month in the site
+ * timezone, cut to the post's life. `null` when none of it is inside.
+ *
+ * @param key    - The month to open.
+ * @param bounds - The post's life.
+ * @return The range to apply, or `null`.
+ */
+export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | null {
+	const { publishedAt, timeZone, now = new Date() } = bounds;
+	// The bucket the traffic chart opens on a click, cut at the clock.
+	const bucket = drillDateRange(
+		createTZDateFromParts( [ key.year, key.month, 1 ], timeZone ),
+		'month',
+		now
+	);
+
+	if ( ! bucket?.from || ! bucket.to ) {
+		return null;
+	}
+
+	const publishedDay = publishedAt ? startOfDayTZ( publishedAt, timeZone ) : undefined;
+	const from = publishedDay && publishedDay > bucket.from ? publishedDay : bucket.from;
+
+	return from.getTime() <= bucket.to.getTime() ? { from, to: bucket.to } : null;
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -49,7 +49,7 @@ function PostAllTimeTrafficInner() {
 	const { reportParams } = useWidgetRootContext();
 	const postId = toPostId( reportParams.post_id );
 
-	const { rows, publishedAt, isLoading, isFetching, isError, error, refetch } =
+	const { rows, lifeStartsAt, isLoading, isFetching, isError, error, refetch } =
 		usePostAllTimeTraffic( postId );
 
 	// Bound to the route hosting the widget: a month picked here becomes the
@@ -65,14 +65,14 @@ function PostAllTimeTrafficInner() {
 			}
 
 			const month = Number( cell.getAttribute( 'data-column' ) );
-			const range = monthRange( { year: row.year, month }, { publishedAt, timeZone } );
+			const range = monthRange( { year: row.year, month }, { lifeStartsAt, timeZone } );
 
 			if ( range ) {
 				onChange( range, PRESET_CUSTOM );
 				onApply();
 			}
 		},
-		[ rows, publishedAt, timeZone, onChange, onApply ]
+		[ rows, lifeStartsAt, timeZone, onChange, onApply ]
 	);
 
 	// The chart owns the cells, so the click is read off its markup.

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -59,12 +59,12 @@ function PostAllTimeTrafficInner() {
 	const openMonth = useCallback(
 		( cell: Element ) => {
 			const row = rows[ Number( cell.getAttribute( 'data-row' ) ) ];
-			const month = Number( cell.getAttribute( 'data-column' ) );
 
-			if ( ! row || ! ( month < MONTHS_IN_YEAR ) ) {
+			if ( ! row ) {
 				return;
 			}
 
+			const month = Number( cell.getAttribute( 'data-column' ) );
 			const range = monthRange( { year: row.year, month }, { publishedAt, timeZone } );
 
 			if ( range ) {
@@ -87,15 +87,19 @@ function PostAllTimeTrafficInner() {
 		[ openMonth ]
 	);
 
-	// Focus stays on the grid, which names the selected cell through
-	// `aria-activedescendant`; Enter and Space open it the way a click does.
+	// The grid names the selected cell through `aria-activedescendant`; Enter
+	// and Space open it the way a click does. A click leaves the focus on the
+	// cell itself (the chart gives cells `tabIndex={ -1 }`), so the grid is
+	// looked up from whichever of the two the key lands on.
 	const handleKeyDown = useCallback(
 		( event: KeyboardEvent< HTMLDivElement > ) => {
 			if ( event.key !== 'Enter' && event.key !== ' ' ) {
 				return;
 			}
 
-			const activeId = ( event.target as Element ).getAttribute( 'aria-activedescendant' );
+			const activeId = ( event.target as Element )
+				.closest( '[role="grid"]' )
+				?.getAttribute( 'aria-activedescendant' );
 			const cell = activeId ? document.getElementById( activeId ) : null;
 
 			if ( cell && event.currentTarget.contains( cell ) && cell.matches( CELL_SELECTOR ) ) {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -1,0 +1,212 @@
+/**
+ * External dependencies
+ */
+import { toPostId } from '@jetpack-premium-analytics/data';
+import { PRESET_CUSTOM } from '@jetpack-premium-analytics/datetime';
+import { Stack } from '@jetpack-premium-analytics/externals';
+import { formatMonth } from '@jetpack-premium-analytics/formatters';
+import { reports } from '@jetpack-premium-analytics/icons';
+import { useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import {
+	CalendarHeatmapTooltip,
+	HeatmapChart,
+	HeatmapSkeleton,
+	WidgetRoot,
+	WidgetState,
+	describeError,
+	formatViewCount,
+	useWidgetRootContext,
+	type HeatmapColumn,
+	type HeatmapTooltipData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { useCallback, useMemo, type KeyboardEvent, type MouseEvent } from 'react';
+/**
+ * Internal dependencies
+ */
+import { MONTHS_IN_YEAR } from './build-all-time-traffic-rows';
+import { monthRange } from './period-range';
+import styles from './style.module.css';
+import usePostAllTimeTraffic from './use-post-all-time-traffic';
+import type { PostAllTimeTrafficAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type PostAllTimeTrafficRenderAttributes = PostAllTimeTrafficAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type PostAllTimeTrafficWidgetProps = WidgetRenderProps< PostAllTimeTrafficRenderAttributes >;
+
+// Below the floors the grid scrolls rather than crushing its cells; the cap
+// keeps a young post's rows at the design height.
+const MIN_CELL_WIDTH = 56;
+const MIN_CELL_HEIGHT = 28;
+const MAX_CELL_HEIGHT = 40;
+
+// The chart's own cell markup, which a click or the keyboard selection lands on.
+const CELL_SELECTOR = '[role="gridcell"][data-column][data-row]';
+
+function PostAllTimeTrafficInner() {
+	const { reportParams } = useWidgetRootContext();
+	const postId = toPostId( reportParams.post_id );
+
+	const { rows, publishedAt, isLoading, isFetching, isError, error, refetch } =
+		usePostAllTimeTraffic( postId );
+
+	// Bound to the route hosting the widget: a month picked here becomes the
+	// page's period, read over by the other cards while this one stays all-time.
+	const { onChange, onApply, timeZone } = useReportDateFilters();
+
+	const openMonth = useCallback(
+		( cell: Element ) => {
+			const row = rows[ Number( cell.getAttribute( 'data-row' ) ) ];
+			const month = Number( cell.getAttribute( 'data-column' ) );
+
+			if ( ! row || ! ( month < MONTHS_IN_YEAR ) ) {
+				return;
+			}
+
+			const range = monthRange( { year: row.year, month }, { publishedAt, timeZone } );
+
+			if ( range ) {
+				onChange( range, PRESET_CUSTOM );
+				onApply();
+			}
+		},
+		[ rows, publishedAt, timeZone, onChange, onApply ]
+	);
+
+	// The chart owns the cells, so the click is read off its markup.
+	const handleClick = useCallback(
+		( event: MouseEvent< HTMLDivElement > ) => {
+			const cell = ( event.target as Element ).closest( CELL_SELECTOR );
+
+			if ( cell ) {
+				openMonth( cell );
+			}
+		},
+		[ openMonth ]
+	);
+
+	// Focus stays on the grid, which names the selected cell through
+	// `aria-activedescendant`; Enter and Space open it the way a click does.
+	const handleKeyDown = useCallback(
+		( event: KeyboardEvent< HTMLDivElement > ) => {
+			if ( event.key !== 'Enter' && event.key !== ' ' ) {
+				return;
+			}
+
+			const activeId = ( event.target as Element ).getAttribute( 'aria-activedescendant' );
+			const cell = activeId ? document.getElementById( activeId ) : null;
+
+			if ( cell && event.currentTarget.contains( cell ) && cell.matches( CELL_SELECTOR ) ) {
+				event.preventDefault();
+				openMonth( cell );
+			}
+		},
+		[ openMonth ]
+	);
+
+	// Keep stale rows visible when a background refetch fails.
+	const showError = isError && rows.length === 0;
+
+	// No per-cell label: the chart names a cell from its column and row, the
+	// month and the year here. A month without views reads 0, as the endpoint
+	// reports it; the months outside the post's life are filler.
+	const columns = useMemo< HeatmapColumn[] >(
+		() =>
+			Array.from( { length: MONTHS_IN_YEAR }, ( _column, month ) => ( {
+				label: formatMonth( month, { short: true } ),
+				data: rows.map( row => {
+					const value = row.months[ month ];
+
+					if ( typeof value !== 'number' ) {
+						return { value: null, placeholder: true };
+					}
+
+					return { value };
+				} ),
+			} ) ),
+		[ rows ]
+	);
+
+	const yearLabels = useMemo( () => rows.map( row => String( row.year ) ), [ rows ] );
+
+	const renderTooltip = useCallback(
+		( { value, columnLabel, rowLabel }: HeatmapTooltipData ) => (
+			<CalendarHeatmapTooltip
+				value={ value }
+				// Named from the column and row, the way the chart names a cell to a
+				// screen reader: "Aug 2026".
+				cellLabel={ `${ columnLabel ?? '' } ${ rowLabel ?? '' }`.trim() }
+				emptyLabel={ __( 'No views', 'jetpack-premium-analytics-pkg' ) }
+				formatValue={ formatViewCount }
+			/>
+		),
+		[]
+	);
+
+	return (
+		<WidgetState
+			isLoading={ isLoading }
+			isFetching={ isFetching }
+			isError={ showError }
+			isEmpty={ postId <= 0 || rows.length === 0 }
+			// Gated by the same predicate as `isError`, so the two cannot disagree.
+			error={
+				showError
+					? describeError( error, {
+							retryDescription: __(
+								"We couldn't load this post's traffic. Please try again in a moment.",
+								'jetpack-premium-analytics-pkg'
+							),
+							onRetry: refetch,
+					  } )
+					: null
+			}
+			empty={ {
+				icon: reports,
+				description:
+					postId > 0
+						? __( 'No views yet.', 'jetpack-premium-analytics-pkg' )
+						: __(
+								'Open a post or page report to see its all-time traffic here.',
+								'jetpack-premium-analytics-pkg'
+						  ),
+			} }
+			renderLoading={ <HeatmapSkeleton /> }
+		>
+			{ /* The grid inside is the interactive element; this only delegates its
+			     clicks and keyboard activation to the month they land on. */ }
+			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
+			<div className={ styles.root } onClick={ handleClick } onKeyDown={ handleKeyDown }>
+				<HeatmapChart
+					data={ columns }
+					rowLabels={ yearLabels }
+					minCellWidth={ MIN_CELL_WIDTH }
+					minCellHeight={ MIN_CELL_HEIGHT }
+					maxCellHeight={ MAX_CELL_HEIGHT }
+					primaryColor="var(--wp-admin-theme-color, #3858e9)"
+					withTooltips
+					renderTooltip={ renderTooltip }
+					className={ styles.chart }
+				>
+					{ /* Wrapped so the scale sits centred: the chart lays its trailing content out full width. */ }
+					<Stack direction="row" justify="center">
+						<HeatmapChart.Legend
+							lessLabel={ __( 'Fewer views', 'jetpack-premium-analytics-pkg' ) }
+							moreLabel={ __( 'More views', 'jetpack-premium-analytics-pkg' ) }
+						/>
+					</Stack>
+				</HeatmapChart>
+			</div>
+		</WidgetState>
+	);
+}
+
+export default function PostAllTimeTraffic( { attributes = {} }: PostAllTimeTrafficWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<PostAllTimeTrafficInner />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
@@ -1,0 +1,221 @@
+/**
+ * The All-time traffic widget is the post detail Traffic view's history card:
+ * every month of the scoped post's views, one row per year. It reads the
+ * post's whole life regardless of the page period, and picking a month
+ * applies that month to the page. The post scope arrives through
+ * `reportParams.post_id` (seeded from the detail page URL in product); the
+ * `hasPostScope` control toggles it to exercise the scopeless empty state.
+ *
+ * Data comes from the proxied `stats/post/{id}` endpoint, covered by the
+ * shared report mocks' `stats-post` fixture, whose yearly tables roll up a
+ * deterministic daily series ending today.
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
+import { withStoryRouter } from '../../stories/with-story-router';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
+import PostAllTimeTrafficRender from '../render';
+import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+// Any post ID resolves to the shared `stats-post` fixture; this one matches
+// the fixture's own post row for coherence.
+const MOCK_POST_ID = 779;
+
+const POST_ALL_TIME_TRAFFIC_RENDER_MODULE = 'storybook/post-all-time-traffic';
+
+const POST_STATS_REQUEST_PATH = `stats/post/${ MOCK_POST_ID }`;
+
+interface PostAllTimeTrafficStoryControls {
+	hasPostScope: boolean;
+}
+
+function getPostAllTimeTrafficAttributes(
+	{ hasPostScope }: PostAllTimeTrafficStoryControls,
+	withComparison = false
+): ComponentProps< typeof PostAllTimeTrafficRender >[ 'attributes' ] {
+	return {
+		reportParams: {
+			...getDefaultQueryParams( withComparison ),
+			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
+		},
+	};
+}
+
+function renderPostAllTimeTraffic( controls: PostAllTimeTrafficStoryControls ) {
+	return <PostAllTimeTrafficRender attributes={ getPostAllTimeTrafficAttributes( controls ) } />;
+}
+
+const hasPostScopeArgType = {
+	control: 'boolean',
+	description: 'Include the `post_id` report param the post detail page seeds from its URL.',
+} as const;
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/PostAllTimeTraffic',
+	component: PostAllTimeTrafficRender,
+	tags: [ 'autodocs' ],
+	// The widget applies a picked month through the route's date filters, so it
+	// needs a router even in the close-up stories that mount it without a dashboard.
+	decorators: [ withStoryRouter ],
+	argTypes: {
+		hasPostScope: hasPostScopeArgType,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "All-time traffic" widget: every month of the scoped post\'s views, one row per year. It always covers the post\'s whole life, whatever period the page shows, and picking a month applies that month to the page. Without a post scope the widget renders a scopeless empty state.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof PostAllTimeTrafficRender > & PostAllTimeTrafficStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< PostAllTimeTrafficStoryControls >;
+
+/**
+ * Default — the scoped post's monthly views across its life.
+ */
+export const Default: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * NoPostScope — the widget without a `post_id` report param, as when added
+ * outside a post detail page. Renders the scopeless empty state without
+ * firing a stats request.
+ */
+export const NoPostScope: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Loading — the first fetch is still in flight, so the widget shows its
+ * heatmap skeleton. The mock is forced to never resolve for this story.
+ */
+export const Loading: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'loading' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Error — the fetch failed with a permission 403: neutral copy, no retry.
+ */
+export const Error: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'error' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * ErrorRetryable — the proxy's `no_connection` 403, which can heal after
+ * reconnecting, so the widget offers a Retry action.
+ */
+export const ErrorRetryable: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'error-retryable' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+/**
+ * Empty — a scoped post the endpoint has no yearly stats for.
+ */
+export const Empty: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true },
+	// Off the shared autodocs page — path-keyed override; see setReportMockState.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( POST_STATS_REQUEST_PATH, 'empty' );
+		return () => setReportMockState( POST_STATS_REQUEST_PATH, null );
+	},
+};
+
+interface PostAllTimeTrafficDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		PostAllTimeTrafficStoryControls {}
+
+/**
+ * Mounts the real `WidgetDashboard` with this single widget so it renders
+ * exactly as it does in product (framed card, sizing, host environment).
+ */
+function PostAllTimeTrafficDashboardStory( {
+	hasPostScope,
+	...dashboardArgs
+}: PostAllTimeTrafficDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
+			renderModule={ POST_ALL_TIME_TRAFFIC_RENDER_MODULE }
+			renderComponent={ PostAllTimeTrafficRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getPostAllTimeTrafficAttributes( { hasPostScope }, true ) }
+		/>
+	);
+}
+
+/**
+ * Mirrors the production placement (full width × 2 rows).
+ */
+export const WidgetDashboardWithWidget: StoryObj< PostAllTimeTrafficDashboardStoryProps > = {
+	render: args => <PostAllTimeTrafficDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 3,
+		widgetHeight: 2,
+		hasPostScope: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		hasPostScope: hasPostScopeArgType,
+	},
+};

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
@@ -1,0 +1,26 @@
+/* The height chain from the tile down: WidgetState's blocks are 100%, so is
+ * this, and the chart below fills it rather than hugging its rows. */
+.root {
+	block-size: 100%;
+}
+
+.root [role="gridcell"][data-column] {
+	cursor: pointer;
+}
+
+/* A height-capped chart sizes itself to its rows. Here it fills the tile so
+ * the grid alone scrolls and the scale stays put under it; the selectors are
+ * specific enough to beat the chart's own modifier classes. */
+.root .chart {
+	block-size: 100%;
+}
+
+/* `align-content: start`: the label row is the grid's only auto track, so
+ * stretching would hand it the leftover height. */
+.root .chart [role="grid"] {
+	flex: 1 1 0;
+	min-block-size: 0;
+	block-size: auto;
+	align-content: start;
+	overflow: auto;
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
@@ -2,22 +2,56 @@
  * External dependencies
  */
 import { useStatsPost } from '@jetpack-premium-analytics/data';
-import { localTZDate, parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
+import {
+	createTZDateFromParts,
+	localTZDate,
+	parseSiteDateTime,
+	reportingTimeZone,
+} from '@jetpack-premium-analytics/datetime';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { buildAllTimeTrafficRows, type AllTimeTrafficRow } from './build-all-time-traffic-rows';
+import {
+	buildAllTimeTrafficRows,
+	type AllTimeTrafficRow,
+	type MonthKey,
+} from './build-all-time-traffic-rows';
 
 export interface PostAllTimeTrafficState {
 	rows: AllTimeTrafficRow[];
-	/** When the post was published, read from the endpoint's post row. */
-	publishedAt: Date | undefined;
+	/** Where the post's life starts, which a picked period never precedes. */
+	lifeStartsAt: Date | undefined;
 	isLoading: boolean;
 	isFetching: boolean;
 	isError: boolean;
 	error: unknown;
 	refetch: () => void;
+}
+
+/**
+ * The publish day, unless the endpoint reports an earlier month: a rescheduled
+ * post keeps the views from before its new date, and those months open whole.
+ */
+function lifeStart(
+	rows: AllTimeTrafficRow[],
+	publishedAt: Date | undefined,
+	publishedMonth: MonthKey | undefined
+): Date | undefined {
+	const oldest = rows[ rows.length - 1 ];
+	const month = oldest?.months.findIndex( value => typeof value === 'number' ) ?? -1;
+
+	if ( ! oldest || month < 0 ) {
+		return publishedAt;
+	}
+
+	if ( publishedMonth && oldest.year === publishedMonth.year && month === publishedMonth.month ) {
+		return publishedAt;
+	}
+
+	return new Date(
+		createTZDateFromParts( [ oldest.year, month, 1 ], reportingTimeZone() ).getTime()
+	);
 }
 
 /**
@@ -44,21 +78,26 @@ export default function usePostAllTimeTraffic( postId: number ): PostAllTimeTraf
 		);
 	}, [ data ] );
 
-	const rows = useMemo( () => {
+	const { rows, lifeStartsAt } = useMemo( () => {
 		// Read in the site timezone so the months fall on the site's own calendar.
 		const today = localTZDate();
 		const published = publishedAt ? localTZDate( publishedAt ) : undefined;
-
-		return buildAllTimeTrafficRows(
+		const publishedMonth = published && {
+			year: published.getFullYear(),
+			month: published.getMonth(),
+		};
+		const built = buildAllTimeTrafficRows(
 			data,
 			{ year: today.getFullYear(), month: today.getMonth() },
-			published && { year: published.getFullYear(), month: published.getMonth() }
+			publishedMonth
 		);
+
+		return { rows: built, lifeStartsAt: lifeStart( built, publishedAt, publishedMonth ) };
 	}, [ data, publishedAt ] );
 
 	return {
 		rows,
-		publishedAt,
+		lifeStartsAt,
 		isLoading,
 		isFetching,
 		isError,

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { useStatsPost } from '@jetpack-premium-analytics/data';
+import { localTZDate, parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { buildAllTimeTrafficRows, type AllTimeTrafficRow } from './build-all-time-traffic-rows';
+
+export interface PostAllTimeTrafficState {
+	rows: AllTimeTrafficRow[];
+	/** When the post was published, read from the endpoint's post row. */
+	publishedAt: Date | undefined;
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	error: unknown;
+	refetch: () => void;
+}
+
+/**
+ * Every month of the post's views, one row per year. All-time regardless of
+ * the page's period: the endpoint's yearly tables cover the post's whole life.
+ * A `postId` of 0 disables the request.
+ *
+ * @param postId - The post the page is scoped to.
+ * @return The rows and the request's state.
+ */
+export default function usePostAllTimeTraffic( postId: number ): PostAllTimeTrafficState {
+	const { data, isLoading, isFetching, isError, error, refetch } = useStatsPost( {
+		postId,
+		fields: [ 'years', 'post' ],
+	} );
+
+	// Same reading as the page header: a site-local wall time, or the GMT stamp
+	// pinned to UTC when that is all the row carries.
+	const publishedAt = useMemo( () => {
+		const post = data?.post;
+
+		return parseSiteDateTime(
+			post?.post_date ?? ( post?.post_date_gmt ? `${ post.post_date_gmt }Z` : undefined )
+		);
+	}, [ data ] );
+
+	const rows = useMemo( () => {
+		// Read in the site timezone so the months fall on the site's own calendar.
+		const today = localTZDate();
+		const published = publishedAt ? localTZDate( publishedAt ) : undefined;
+
+		return buildAllTimeTrafficRows(
+			data,
+			{ year: today.getFullYear(), month: today.getMonth() },
+			published && { year: published.getFullYear(), month: published.getMonth() }
+		);
+	}, [ data, publishedAt ] );
+
+	return {
+		rows,
+		publishedAt,
+		isLoading,
+		isFetching,
+		isError,
+		error,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.json
@@ -1,0 +1,10 @@
+{
+	"name": "jpa/post-all-time-traffic",
+	"title": "All-time traffic",
+	"description": "Every month of views for the post or page being viewed, across its whole life.",
+	"help": {
+		"content": "Every month of views for the post or page being viewed, shaded by how it compares to the rest. Always the full history: the period above doesn't narrow it. Pick a month to read the rest of the page over it."
+	},
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.ts
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { calendar } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * No configurable attributes: the widget always shows the post the page is
+ * scoped to (via `reportParams.post_id`). `Record< never, never >` so the
+ * render-only type can compose host fields such as `reportParams`.
+ */
+export type PostAllTimeTrafficAttributes = Record< never, never >;
+
+export default {
+	icon: calendar,
+	attributes: [] as WidgetAttributeField< PostAllTimeTrafficAttributes >[],
+	example: {
+		attributes: {},
+	},
+};

--- a/projects/plugins/jetpack/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/jetpack/changelog/update-post-all-time-traffic-widget
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap; picking a month reads the page over it.
+Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap, and picking a month applies it as the page's period.

--- a/projects/plugins/jetpack/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/jetpack/changelog/update-post-all-time-traffic-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap; picking a month reads the page over it.

--- a/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-widget
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Post detail: Show a post's monthly views across its whole life, in place of the daily heatmap; picking a month reads the page over it.
+Post detail: Show a post's monthly views across its whole life, in place of the daily heatmap, and picking a month applies it as the page's period.

--- a/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Post detail: Show a post's monthly views across its whole life, in place of the daily heatmap; picking a month reads the page over it.

--- a/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-widget
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap; picking a month reads the page over it.
+Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap, and picking a month applies it as the page's period.

--- a/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-widget
+++ b/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Premium Analytics: Show a post's monthly views across its whole life on its detail page, in place of the daily heatmap; picking a month reads the page over it.


### PR DESCRIPTION
Fixes UNI-769. Part of UNI-755; the same replacement is filed as WOOA7S-2046.

## Proposed changes

The post and page detail Traffic tab ends with a daily views heatmap ("Traffic activity") that only covers the page's period. The design replaces it with an "All-time traffic" table: every month of the post's views, one row per year, always the whole history whatever period the page shows.

### The widget

`jpa/post-all-time-traffic` draws the table on the stock `HeatmapChart`: twelve month columns, one row per year, newest first, the month's views in each cell. It reads the yearly tables the `stats/post/{id}` endpoint already returns, so there is no new request shape.

Every row is a whole year. Months before the post was published and months still to come are filler cells, the ones the daily heatmap uses for days outside its range, and take no hover, tooltip or click. The exception is a rescheduled post: the endpoint keeps the views from before its new date, and those months draw and open like any other. A month inside the post's life with no views reads `0`, as the endpoint reports it.

The chart fills the tile and only its grid scrolls, so the scale stays under the table for a post with a long history.

### Picking a month

A click on a month applies it to the page as a custom range cut to the post's life: the publish month starts on the publish day, an earlier month the endpoint reports opens whole, and the current month ends today. It goes through the page's date-filter controller, so the other cards read over that month while this one stays all-time, and Back returns to the previous period. Enter and Space on the keyboard-selected cell do the same.

### The composition

The widget replaces `jpa/post-traffic-activity` in the fixed Post traffic composition. The old widget stays registered for now and goes in UNI-772, before inserting widgets is enabled again. A Post traffic tab rearranged from Customize keeps the cards it stored, so the new card shows there after Reset layout.

`formatMonth()` joins the formatters, reading month names from WordPress's translation tables the way `formatWeekday()` does.

### Left to the sub-tasks

The design's Totals column, centered month labels, and the Total views / Daily average switch need chart and toolkit pieces that are not on trunk yet. They follow in UNI-771 and UNI-770; removing the old widget is UNI-772.

## Related product discussion/links

* UNI-755 is the parent issue; UNI-769 (this change), UNI-770, UNI-771 and UNI-772 are its sub-tasks.
* WOOA7S-2046 files the same replacement; WOOA7S-2015 is the Insights counterpart that the chart pieces land with, and WOOA7S-2036 covers signaling the period change after a month is picked.

## Does this pull request change what data or activity we track or use?

No. The widget reads the `stats/post` endpoint the page already proxies, requesting yearly tables instead of daily rows.

## Testing instructions

Build the package with `jetpack build packages/premium-analytics`, open Stats v2 and go to the detail page of a post with some views, from All pages or the post list.

The last card is **All-time traffic**: one row per year since the post was published, months across. Months before the publish month and after the current one are faded filler; the others carry the month's views, `0` when there were none. Hovering a month shows its name and views.

Click a month with views: the period control switches to it (the publish month starts on the publish day, the current month ends today), the URL carries `preset=custom` with the range, and Highlights, Views performance, Likes, Comments, and UTM refetch for it.

The table itself does not change, and Back returns to the previous period. Tab to the grid, move with the arrow keys, and press Enter: the selected month applies the same way. Filler cells take no hover, tooltip, or click.

On a post with many years, or a short tile, the grid scrolls inside the card and the scale stays under it.

Unit tests, from the package: `pnpm run test -- widgets/post-all-time-traffic routes/post-detail packages/formatters`.

### Screenshots

**Before**

<img width="1532" height="438" alt="image" src="https://github.com/user-attachments/assets/1e508db7-3d8f-4dc5-a10e-d79838663583" />

**After**

<img width="1265" height="436" alt="image" src="https://github.com/user-attachments/assets/00c339b7-dd6d-4459-9d0b-3adedddc77bb" />

https://github.com/user-attachments/assets/780080bb-bdf9-4081-8ea6-9ed623c80497

## Follow-ups

- [ ] UNI-771: Totals column, centred and sticky month labels, chart-level cell click.
- [ ] UNI-770: Total views / Daily average metric field.
- [ ] WOOA7S-2036: highlight the period control after a month is picked.
- [ ] UNI-772: remove the `jpa/post-traffic-activity` widget.


