### PR TITLE
My Jetpack: restore the stats card's link to the Stats page

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -112,6 +112,7 @@ const getDynamicTitle = metric => {
  * @param {number}   props.headingLevel         - Heading level between 1 and 6.
  * @param {Array}    props.chartData            - Chart data for the bar chart visualization.
  * @param {boolean}  props.isLoading            - Whether the data is loading.
+ * @param {string}   props.detailedStatsHref    - Destination of the detailed stats link.
  * @param {Function} props.onDetailedStatsClick - Function to handle detailed stats click.
  *
  * @return {object} StatsCards React component.
@@ -122,6 +123,7 @@ const StatsCards = ( {
 	headingLevel,
 	chartData,
 	isLoading,
+	detailedStatsHref,
 	onDetailedStatsClick,
 } ) => {
 	const Heading = `h${ headingLevel >= 1 && headingLevel <= 6 ? headingLevel : 3 }`;
@@ -155,15 +157,6 @@ const StatsCards = ( {
 		[ handleMetricSelect ]
 	);
 
-	const handleKeyDown = useCallback(
-		e => {
-			if ( e.key === 'Enter' || e.key === ' ' ) {
-				onDetailedStatsClick();
-			}
-		},
-		[ onDetailedStatsClick ]
-	);
-
 	// Get icon for selected metric
 	const getMetricIcon = useCallback( metric => {
 		const icons = {
@@ -177,12 +170,10 @@ const StatsCards = ( {
 
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
-			<div
+			<a
 				className={ styles[ 'section-title-container' ] }
+				href={ detailedStatsHref }
 				onClick={ onDetailedStatsClick }
-				role="button"
-				tabIndex={ 0 }
-				onKeyDown={ handleKeyDown }
 			>
 				<Heading className={ styles[ 'section-title' ] }>
 					<span>{ getDynamicTitle( selectedMetric ) }</span>
@@ -190,13 +181,13 @@ const StatsCards = ( {
 				<div>
 					<Icon icon={ chevronRight } />
 				</div>
-			</div>
+			</a>
 
 			<StatsChart
 				data={ transformedChartData }
 				isLoading={ isLoading }
+				href={ detailedStatsHref }
 				onClick={ onDetailedStatsClick }
-				onKeyDown={ handleKeyDown }
 				selectedMetric={ selectedMetric }
 				metricIcon={ getMetricIcon( selectedMetric ) }
 			/>

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -1,5 +1,6 @@
 import { sprintf, __, _n } from '@wordpress/i18n';
 import { Icon, commentContent, people, starEmpty, chevronRight } from '@wordpress/icons';
+import { Link } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useState, useCallback } from 'react';
 import formatNumber from '../../utils/format-number';
@@ -170,7 +171,8 @@ const StatsCards = ( {
 
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
-			<a
+			<Link
+				variant="unstyled"
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
 				onClick={ onDetailedStatsClick }
@@ -181,7 +183,7 @@ const StatsCards = ( {
 				<div>
 					<Icon icon={ chevronRight } />
 				</div>
-			</a>
+			</Link>
 
 			<StatsChart
 				data={ transformedChartData }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -172,7 +172,6 @@ const StatsCards = ( {
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
 			<Link
-				variant="unstyled"
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
 				onClick={ detailedStatsHref ? onDetailedStatsClick : undefined }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -175,7 +175,7 @@ const StatsCards = ( {
 				variant="unstyled"
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
-				onClick={ onDetailedStatsClick }
+				onClick={ detailedStatsHref ? onDetailedStatsClick : undefined }
 			>
 				<Heading className={ styles[ 'section-title' ] }>
 					<span>{ getDynamicTitle( selectedMetric ) }</span>

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -172,6 +172,7 @@ const StatsCards = ( {
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
 			<Link
+				variant={ detailedStatsHref ? 'default' : 'unstyled' }
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
 				onClick={ detailedStatsHref ? onDetailedStatsClick : undefined }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -172,7 +172,7 @@ const StatsCards = ( {
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
 			<Link
-				variant={ detailedStatsHref ? 'default' : 'unstyled' }
+				variant="unstyled"
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
 				onClick={ detailedStatsHref ? onDetailedStatsClick : undefined }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/cards.jsx
@@ -172,7 +172,7 @@ const StatsCards = ( {
 	return (
 		<div className={ styles[ 'section-stats-highlights' ] }>
 			<Link
-				variant="unstyled"
+				tone="neutral"
 				className={ styles[ 'section-title-container' ] }
 				href={ detailedStatsHref }
 				onClick={ detailedStatsHref ? onDetailedStatsClick : undefined }

--- a/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/index.jsx
@@ -204,6 +204,7 @@ const StatsSection = () => {
 				headingLevel={ 3 }
 				chartData={ chartData }
 				isLoading={ isVisitsDataLoading }
+				detailedStatsHref={ viewStatsHref }
 				onDetailedStatsClick={ onDetailedStatsClick }
 			/>
 		</ProductCard>

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
@@ -10,7 +10,7 @@
 	box-sizing: border-box;
 
 	&[href] {
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 	}
 
 	.chart-empty {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
@@ -9,8 +9,6 @@
 	position: relative;
 	box-sizing: border-box;
 	cursor: pointer;
-	color: inherit;
-	text-decoration: none;
 
 	.chart-empty {
 		align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
@@ -8,7 +8,10 @@
 	display: block;
 	position: relative;
 	box-sizing: border-box;
-	cursor: pointer;
+
+	&[href] {
+		cursor: pointer;
+	}
 
 	.chart-empty {
 		align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
@@ -5,9 +5,12 @@
 }
 
 .chart-container {
+	display: block;
 	position: relative;
 	box-sizing: border-box;
 	cursor: pointer;
+	color: inherit;
+	text-decoration: none;
 
 	.chart-empty {
 		align-items: center;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
@@ -5,7 +5,7 @@ import { Suspense, useCallback, useMemo } from 'react';
 import LoadingBlock from '../loading-block';
 import StatsChartTooltip from './stats-chart-tooltip';
 import styles from './stats-chart.module.scss';
-import type { ReactElement, KeyboardEvent, FC } from 'react';
+import type { ReactElement, FC } from 'react';
 
 interface ChartDataPoint {
 	date: Date;
@@ -23,8 +23,8 @@ interface ChartSeries {
 interface StatsChartProps {
 	data: ChartSeries[];
 	isLoading: boolean;
+	href?: string;
 	onClick: () => void;
-	onKeyDown: ( e: KeyboardEvent< HTMLDivElement > ) => void;
 	selectedMetric: string;
 	metricIcon: ReactElement;
 }
@@ -34,18 +34,12 @@ interface StatsChartProps {
  * @param {object}   props            - Component props.
  * @param {object}   props.data       - Chart data.
  * @param {boolean}  props.isLoading  - Whether the chart is loading.
+ * @param {string}   props.href       - Destination of the detailed stats link.
  * @param {Function} props.onClick    - Click handler.
- * @param {Function} props.onKeyDown  - Keydown handler.
  * @param {object}   props.metricIcon - The icon JSX element for the selected metric.
  * @return {object} StatsChart React component.
  */
-const StatsChart: FC< StatsChartProps > = ( {
-	data,
-	isLoading,
-	onClick,
-	onKeyDown,
-	metricIcon,
-} ) => {
+const StatsChart: FC< StatsChartProps > = ( { data, isLoading, href, onClick, metricIcon } ) => {
 	// Check if there's data for the selected metric specifically
 	const isEmpty = useMemo( () => {
 		return ! isLoading && data?.[ 0 ]?.data?.every( item => item.value === 0 );
@@ -81,13 +75,7 @@ const StatsChart: FC< StatsChartProps > = ( {
 	);
 
 	return (
-		<div
-			className={ styles[ 'chart-container' ] }
-			onClick={ onClick }
-			role="button"
-			tabIndex={ 0 }
-			onKeyDown={ onKeyDown }
-		>
+		<a className={ styles[ 'chart-container' ] } href={ href } onClick={ onClick }>
 			{ isEmpty && (
 				<div className={ styles[ 'chart-empty' ] }>
 					<div
@@ -163,7 +151,7 @@ const StatsChart: FC< StatsChartProps > = ( {
 					/>
 				</Suspense>
 			) }
-		</div>
+		</a>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
@@ -1,6 +1,7 @@
 import { BarChart, DataPointDate } from '@automattic/charts';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
+import { Link } from '@wordpress/ui';
 import { Suspense, useCallback, useMemo } from 'react';
 import LoadingBlock from '../loading-block';
 import StatsChartTooltip from './stats-chart-tooltip';
@@ -75,7 +76,12 @@ const StatsChart: FC< StatsChartProps > = ( { data, isLoading, href, onClick, me
 	);
 
 	return (
-		<a className={ styles[ 'chart-container' ] } href={ href } onClick={ onClick }>
+		<Link
+			variant="unstyled"
+			className={ styles[ 'chart-container' ] }
+			href={ href }
+			onClick={ onClick }
+		>
 			{ isEmpty && (
 				<div className={ styles[ 'chart-empty' ] }>
 					<div
@@ -151,7 +157,7 @@ const StatsChart: FC< StatsChartProps > = ( { data, isLoading, href, onClick, me
 					/>
 				</Suspense>
 			) }
-		</a>
+		</Link>
 	);
 };
 

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
@@ -80,7 +80,7 @@ const StatsChart: FC< StatsChartProps > = ( { data, isLoading, href, onClick, me
 			variant="unstyled"
 			className={ styles[ 'chart-container' ] }
 			href={ href }
-			onClick={ onClick }
+			onClick={ href ? onClick : undefined }
 			aria-label={ __( 'View detailed stats', 'jetpack-my-jetpack' ) }
 		>
 			{ isEmpty && (

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.tsx
@@ -81,6 +81,7 @@ const StatsChart: FC< StatsChartProps > = ( { data, isLoading, href, onClick, me
 			className={ styles[ 'chart-container' ] }
 			href={ href }
 			onClick={ onClick }
+			aria-label={ __( 'View detailed stats', 'jetpack-my-jetpack' ) }
 		>
 			{ isEmpty && (
 				<div className={ styles[ 'chart-empty' ] }>

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -30,7 +30,6 @@ $min-card-width: 155px;
 .section-title {
 	display: flex;
 	align-items: center;
-	color: inherit;
 	font-weight: 500;
 	margin-bottom: 0;
 	margin-top: 0;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -30,6 +30,7 @@ $min-card-width: 155px;
 .section-title {
 	display: flex;
 	align-items: center;
+	color: inherit;
 	font-weight: 500;
 	margin-bottom: 0;
 	margin-top: 0;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -23,7 +23,7 @@ $min-card-width: 155px;
 	margin-bottom: $spacing-vertical;
 
 	&[href] {
-		cursor: pointer;
+		cursor: var(--wpds-cursor-control);
 	}
 }
 

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -22,14 +22,6 @@ $min-card-width: 155px;
 	border-bottom: 1px solid var(--jp-gray-5);
 	cursor: pointer;
 	margin-bottom: $spacing-vertical;
-	color: inherit;
-	text-decoration: none;
-
-	&:hover,
-	&:focus {
-		color: inherit;
-		text-decoration: none;
-	}
 }
 
 .section-title {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -20,8 +20,11 @@ $min-card-width: 155px;
 	justify-content: space-between;
 	padding: $spacing-vertical $spacing-horizontal;
 	border-bottom: 1px solid var(--jp-gray-5);
-	cursor: pointer;
 	margin-bottom: $spacing-vertical;
+
+	&[href] {
+		cursor: pointer;
+	}
 }
 
 .section-title {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/style.module.scss
@@ -22,10 +22,14 @@ $min-card-width: 155px;
 	border-bottom: 1px solid var(--jp-gray-5);
 	cursor: pointer;
 	margin-bottom: $spacing-vertical;
+	color: inherit;
+	text-decoration: none;
 
-	// &:hover,
-	// &:focus {
-
+	&:hover,
+	&:focus {
+		color: inherit;
+		text-decoration: none;
+	}
 }
 
 .section-title {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import StatsCards from '../cards.jsx';
 
 const HREF = 'admin.php?page=stats&force_refresh=1';
@@ -41,9 +42,14 @@ describe( 'StatsCards detailed stats link', () => {
 
 	// The card is inside a "slim" ProductCard, which renders no action buttons, so these
 	// links are the only route to the Stats page.
-	it( 'leaves no link behind when the product has no manage URL', () => {
-		renderCards( { detailedStatsHref: undefined } );
+	it( 'leaves nothing clickable when the product has no manage URL', async () => {
+		const onDetailedStatsClick = jest.fn();
+		renderCards( { detailedStatsHref: undefined, onDetailedStatsClick } );
 
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByRole( 'heading', { name: /Views in the last 7 days/ } ) );
+
+		expect( onDetailedStatsClick ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import StatsCards from '../cards.jsx';
+
+const HREF = 'admin.php?page=stats&force_refresh=1';
+
+const noop = () => {};
+
+const renderCards = ( props = {} ) =>
+	render(
+		<StatsCards
+			counts={ { views: 10, visitors: 5, likes: 2, comments: 1 } }
+			previousCounts={ { views: 8, visitors: 4, likes: 1, comments: 1 } }
+			headingLevel={ 3 }
+			chartData={ null }
+			isLoading={ false }
+			detailedStatsHref={ HREF }
+			onDetailedStatsClick={ noop }
+			{ ...props }
+		/>
+	);
+
+describe( 'StatsCards detailed stats link', () => {
+	it( 'points the heading at the detailed stats page', () => {
+		renderCards();
+
+		expect( screen.getByRole( 'link', { name: /Views in the last 7 days/ } ) ).toHaveAttribute(
+			'href',
+			HREF
+		);
+	} );
+
+	// The card is inside a "slim" ProductCard, which renders no action buttons, so these
+	// links are the only route to the Stats page.
+	it( 'leaves no link behind when the product has no manage URL', () => {
+		renderCards( { detailedStatsHref: undefined } );
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/test/cards.test.jsx
@@ -29,6 +29,16 @@ describe( 'StatsCards detailed stats link', () => {
 		);
 	} );
 
+	// Without a label the link is named by its content: the empty-state copy or the axis ticks.
+	it( 'names the chart link by its destination', () => {
+		renderCards();
+
+		expect( screen.getByRole( 'link', { name: 'View detailed stats' } ) ).toHaveAttribute(
+			'href',
+			HREF
+		);
+	} );
+
 	// The card is inside a "slim" ProductCard, which renders no action buttons, so these
 	// links are the only route to the Stats page.
 	it( 'leaves no link behind when the product has no manage URL', () => {

--- a/projects/packages/my-jetpack/changelog/my-jetpack-stats-card-header-link
+++ b/projects/packages/my-jetpack/changelog/my-jetpack-stats-card-header-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: Restore the link from the stats card heading and chart to the Stats page.

--- a/projects/plugins/jetpack/changelog/my-jetpack-stats-card-header-link
+++ b/projects/plugins/jetpack/changelog/my-jetpack-stats-card-header-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+My Jetpack: Restore the link from the stats card heading and chart to the Stats page.


### PR DESCRIPTION
Fixes MYJP-341

## Proposed changes

* The Stats card on the My Jetpack overview has no working route to the Stats page: clicking the "Views in the last 7 days" heading, or the chart under it, does nothing. Both are `div` elements with `role="button"` sharing one click handler, and #51557 moved that handler's navigation onto the "View detailed stats" button's `href`, leaving the handler recording only the Tracks event. That is correct for the button, which is a real link now, but the heading and the chart have no anchor of their own. The card also uses the `slim` ProductCard variant, which renders no action buttons, so nothing else on the card reaches Stats either, and the admin sidebar item is the only link left on the page.
* Render both as `Link` from `@wordpress/ui`, carrying the `href` the button already computes, `force_refresh` hint included. This follows where #51557 was heading rather than putting `window.location.href` back in the handler. Keyboard access comes from the anchor, so the hand-rolled Enter and Space handler is gone; middle-click and right-click work, which they never did on a `div`; and a product with no manage URL leaves an inert element: an anchor without an `href`, no click handler and no pointer cursor, instead of a button that fires tracking and goes nowhere. Not `LinkButton`, which is a link shaped like a button: neither a card heading nor a chart is a button, and its own guidance points at `Link` for navigation.
* The heading uses `tone="neutral"`: its text keeps its colour and gains a grey underline, which marks it as a link without the brand blue of the default tone. The chart uses `variant="unstyled"`, because its only HTML text is the empty-state copy and the axis labels are SVG, so a tone would have nothing to mark. Both variants keep the design system's focus ring and its guard against wp-admin's own anchor styles. The chart container gets `display: block` so its layout is unchanged. The bar chart from `@automattic/charts` keeps its own focusable `role="grid"` for arrow-key tooltip navigation, so the chart anchor still contains a focusable child, as the `role="button"` container on trunk did; that `tabIndex` belongs to the charts package, so it stays. The chart anchor gets an `aria-label` of "View detailed stats", because its own content is the empty-state copy or the axis tick labels, neither of which says where the link goes.

## Related product discussion/links

* Broke in #51557
* MYJP-341

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Get the branch onto a site with a Jurassic Ninja instance synced to it, or with the Jetpack Beta Tester plugin pointed at this branch. The Jetpack plugin has to be active, the Stats module on, and the Stats status active or can_upgrade, because the large card hides itself otherwise.

* Go to **Jetpack → My Jetpack** and find the Stats card, the one with the bar chart.
* Click the "Views in the last 7 days" heading. You land on **Jetpack → Stats**.
* Go back, then click anywhere on the chart. Same destination.
* Tab to the heading and press Enter. Same destination.
* Middle-click the heading. Stats opens in a new tab.
* Confirm the heading text keeps its colour with a grey underline, and that the chart has not moved.
* In the browser's accessibility tree, or with a screen reader, the chart is a link named "View detailed stats".

On trunk every one of those clicks does nothing.

| Before (trunk) | After |
| --- | --- |
| ![Stats card heading on trunk](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/my-jetpack-stats-card-header-link/trunk-no-link.png) | ![Stats card heading with the neutral link](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/my-jetpack-stats-card-header-link/neutral.png) |

I confirmed the fix on a local site: both elements render as anchors pointing at `admin.php?page=stats&force_refresh=1`, and clicking the heading lands on the Stats page.





