### PR TITLE
Map block: record the WordPress.com load event under the jetpack source

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-map-block-tracks-source-prefix
+++ b/projects/plugins/jetpack/changelog/fix-map-block-tracks-source-prefix
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Map block: record the WordPress.com Mapbox key load event under the jetpack source so it is not rejected at ingest.
+Map block: Ensure the WordPress.com Mapbox key load tracking event is recorded on Simple sites.

--- a/projects/plugins/jetpack/changelog/fix-map-block-tracks-source-prefix
+++ b/projects/plugins/jetpack/changelog/fix-map-block-tracks-source-prefix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Map block: record the WordPress.com Mapbox key load event under the jetpack source so it is not rejected at ingest.

--- a/projects/plugins/jetpack/extensions/blocks/map/map.php
+++ b/projects/plugins/jetpack/extensions/blocks/map/map.php
@@ -52,7 +52,8 @@ function wpcom_load_event( $access_token_source ) {
 	$event_name = 'map_block_mapbox_wpcom_key_load';
 	if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 		require_lib( 'tracks/client' );
-		tracks_record_event( wp_get_current_user(), $event_name );
+		// Tracking::record_user_event() prefixes the source itself; tracks_record_event() does not.
+		tracks_record_event( wp_get_current_user(), 'jetpack_' . $event_name );
 	} elseif ( ( new Host() )->is_woa_site() && Jetpack::is_connection_ready() ) {
 		$tracking = new Tracking();
 		$tracking->record_user_event( $event_name );


### PR DESCRIPTION
## Proposed changes

**The Map block's WordPress.com load event is rejected at Tracks ingest on Simple sites, because it is sent without a source prefix.**

* On Atomic, `Tracking::record_user_event()` prepends the product name, so the event arrives as `jetpack_map_block_mapbox_wpcom_key_load` and is accepted.
* On Simple, `tracks_record_event()` sends the name verbatim, so Tracks reads the source as `map`, which is not a registered source, and drops the event.
* Prefixing at the call site rather than renaming `$event_name`, so the Atomic path does not end up double-prefixed.

## Related product discussion/links

* Linear: DOTCOM-18366
* The matching registration for `jetpack_map_block_mapbox_wpcom_key_load` is already merged in `tracks-events-registration`.

## Does this pull request change what data or activity we track or use?

No new data is collected. The same event, with the same properties, is sent under the name it is already registered under, so that it stops being discarded at ingest on Simple sites.

## Testing instructions

1. On a WordPress.com Simple site, add a Map block to a post and publish it.
2. Load the post on the front end (the map must use the WordPress.com Mapbox key, not a site-supplied one).
3. Confirm a `jetpack_map_block_mapbox_wpcom_key_load` event is recorded, and that no `map_block_mapbox_wpcom_key_load` is emitted.
4. Repeat on an Atomic site: the event name should be unchanged from before this PR.
