### PR TITLE
Charts: flip the tooltip to the side that stays inside the chart wrapper

### DIFF
--- a/projects/js-packages/charts/changelog/charts-269-tooltip-flips-inside-wrapper
+++ b/projects/js-packages/charts/changelog/charts-269-tooltip-flips-inside-wrapper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Flip the tooltip to the side of the anchor that stays inside the chart wrapper, so a box that fits in the chart no longer reaches past it into page content that paints over it.

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -498,7 +498,7 @@ hourly data. A custom `renderTooltip` is handed the same classification as
 	/>` }
 />
 
-Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. `detectBounds` flips the box to the side of the anchor that overflows the wrapper less, so it stays inside the chart whenever it fits there, then clamps it inside the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), or inside the viewport when nothing clips. A box larger than the wrapper may reach past it into that ancestor, where siblings later in the DOM can paint over it. Only an ancestor smaller than the box itself can still cut it off.
+Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. `detectBounds` flips the box to the side of the anchor that overflows less, measured against both the wrapper and the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), so it stays inside the chart whenever it fits there; then it clamps the box inside that ancestor, or inside the viewport when nothing clips. A box larger than the wrapper may reach past it into that ancestor, where siblings later in the DOM can paint over it. Only an ancestor smaller than the box itself can still cut it off.
 
 ### Pointer Events
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -498,7 +498,7 @@ hourly data. A custom `renderTooltip` is handed the same classification as
 	/>` }
 />
 
-Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. `detectBounds` keeps the box inside the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), or inside the viewport when nothing clips, flipping and then clamping it; it may reach past the chart wrapper into that ancestor. Only an ancestor smaller than the box itself can still cut it off.
+Tooltips render inside the chart's own wrapper, not in a `document.body` portal, so they stack with the page like any other element and a sticky or fixed header paints over them. `detectBounds` flips the box to the side of the anchor that overflows the wrapper less, so it stays inside the chart whenever it fits there, then clamps it inside the nearest ancestor that clips its overflow (`overflow: hidden`, `clip`, `auto` or `scroll`), or inside the viewport when nothing clips. A box larger than the wrapper may reach past it into that ancestor, where siblings later in the DOM can paint over it. Only an ancestor smaller than the box itself can still cut it off.
 
 ### Pointer Events
 

--- a/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
@@ -34,16 +34,21 @@ const findClippingAncestor = ( wrapper: Element ): Element | null => {
 
 /**
  * Where the box goes, in wrapper coordinates. Below and to the right of the
- * anchor; flipped to the other side when that side clips less, as visx's
+ * anchor; flipped to the other side when that side overflows less, as visx's
  * `TooltipWithBounds` decides it; then clamped so the box stays inside
  * `bounds` whenever it fits at all.
  *
- * @param params            - Anchor, offsets, the box size and the bounds to keep inside.
+ * The flip measures against the wrapper as well as `bounds`. Only the clamp
+ * is bound by the page: a box that fits inside the chart on one side stays
+ * there, so it does not reach past the chart into siblings that paint over it.
+ *
+ * @param params            - Anchor, offsets, the box size and the rects to keep inside.
  * @param params.left       - Anchor x, in wrapper coordinates.
  * @param params.top        - Anchor y, in wrapper coordinates.
  * @param params.offsetLeft - Gap between the anchor and the box, horizontally.
  * @param params.offsetTop  - Gap between the anchor and the box, vertically.
  * @param params.box        - Rendered size of the box.
+ * @param params.wrapper    - The wrapper's own edges, in wrapper coordinates.
  * @param params.bounds     - Edges the box must keep inside, in wrapper coordinates.
  * @return The box's top-left corner, rounded to whole pixels.
  */
@@ -53,6 +58,7 @@ export const getBoundedPosition = ( {
 	offsetLeft,
 	offsetTop,
 	box,
+	wrapper,
 	bounds,
 }: {
 	left: number;
@@ -60,18 +66,25 @@ export const getBoundedPosition = ( {
 	offsetLeft: number;
 	offsetTop: number;
 	box: Size;
+	wrapper: Bounds;
 	bounds: Bounds;
 } ) => {
 	const rightX = left + offsetLeft;
 	const leftX = left - offsetLeft - box.width;
-	const rightOverflow = rightX + box.width - bounds.right;
-	const leftOverflow = bounds.left - leftX;
+	const rightOverflow = Math.max(
+		rightX + box.width - wrapper.right,
+		rightX + box.width - bounds.right
+	);
+	const leftOverflow = Math.max( wrapper.left - leftX, bounds.left - leftX );
 	let x = rightOverflow > 0 && rightOverflow > leftOverflow ? leftX : rightX;
 
 	const downY = top + offsetTop;
 	const upY = top - offsetTop - box.height;
-	const downOverflow = downY + box.height - bounds.bottom;
-	const upOverflow = bounds.top - upY;
+	const downOverflow = Math.max(
+		downY + box.height - wrapper.bottom,
+		downY + box.height - bounds.bottom
+	);
+	const upOverflow = Math.max( wrapper.top - upY, bounds.top - upY );
 	let y = downOverflow > 0 && downOverflow > upOverflow ? upY : downY;
 
 	x = Math.min( Math.max( x, bounds.left ), Math.max( bounds.left, bounds.right - box.width ) );
@@ -81,11 +94,11 @@ export const getBoundedPosition = ( {
 };
 
 /**
- * visx's `Tooltip`, positioned like its `TooltipWithBounds` but kept inside the
- * nearest clipping ancestor — or the viewport when there is none — rather than
- * inside its own parent. Rendered in-tree, a tooltip's parent is the chart
- * wrapper, which is often narrower than the box; measuring against the parent
- * alone would let the box spill into an `overflow: hidden` card and be cut off.
+ * visx's `Tooltip`, positioned like its `TooltipWithBounds` but clamped inside
+ * the nearest clipping ancestor — or the viewport when there is none — rather
+ * than inside its own parent. Rendered in-tree, a tooltip's parent is the chart
+ * wrapper, which is often narrower than the box; clamping to the parent alone
+ * would let the box spill into an `overflow: hidden` card and be cut off.
  *
  * Re-measures on every render, so a box whose content changes width between
  * two hovers is placed for its current size.
@@ -137,6 +150,7 @@ export const BoundedTooltip = ( {
 			offsetLeft,
 			offsetTop,
 			box: { width: own.width, height: own.height },
+			wrapper: { left: 0, top: 0, right: wrapperRect.width, bottom: wrapperRect.height },
 			bounds: {
 				left: clipRect.left - wrapperRect.left,
 				top: clipRect.top - wrapperRect.top,

--- a/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/private/bounded-tooltip.tsx
@@ -38,9 +38,10 @@ const findClippingAncestor = ( wrapper: Element ): Element | null => {
  * `TooltipWithBounds` decides it; then clamped so the box stays inside
  * `bounds` whenever it fits at all.
  *
- * The flip measures against the wrapper as well as `bounds`. Only the clamp
- * is bound by the page: a box that fits inside the chart on one side stays
- * there, so it does not reach past the chart into siblings that paint over it.
+ * The flip measures against the visible part of the wrapper, its intersection
+ * with `bounds`. Only the clamp is bound by the page: a box that fits inside the
+ * chart on one side stays there, so it does not reach past the chart into
+ * siblings that paint over it.
  *
  * @param params            - Anchor, offsets, the box size and the rects to keep inside.
  * @param params.left       - Anchor x, in wrapper coordinates.
@@ -69,22 +70,24 @@ export const getBoundedPosition = ( {
 	wrapper: Bounds;
 	bounds: Bounds;
 } ) => {
+	// The part of the wrapper that is not cut off: the flip keeps the box inside it.
+	const fit = {
+		left: Math.max( wrapper.left, bounds.left ),
+		top: Math.max( wrapper.top, bounds.top ),
+		right: Math.min( wrapper.right, bounds.right ),
+		bottom: Math.min( wrapper.bottom, bounds.bottom ),
+	};
+
 	const rightX = left + offsetLeft;
 	const leftX = left - offsetLeft - box.width;
-	const rightOverflow = Math.max(
-		rightX + box.width - wrapper.right,
-		rightX + box.width - bounds.right
-	);
-	const leftOverflow = Math.max( wrapper.left - leftX, bounds.left - leftX );
+	const rightOverflow = rightX + box.width - fit.right;
+	const leftOverflow = fit.left - leftX;
 	let x = rightOverflow > 0 && rightOverflow > leftOverflow ? leftX : rightX;
 
 	const downY = top + offsetTop;
 	const upY = top - offsetTop - box.height;
-	const downOverflow = Math.max(
-		downY + box.height - wrapper.bottom,
-		downY + box.height - bounds.bottom
-	);
-	const upOverflow = Math.max( wrapper.top - upY, bounds.top - upY );
+	const downOverflow = downY + box.height - fit.bottom;
+	const upOverflow = fit.top - upY;
 	let y = downOverflow > 0 && downOverflow > upOverflow ? upY : downY;
 
 	x = Math.min( Math.max( x, bounds.left ), Math.max( bounds.left, bounds.right - box.width ) );

--- a/projects/js-packages/charts/src/components/tooltip/test/bounded-tooltip.test.tsx
+++ b/projects/js-packages/charts/src/components/tooltip/test/bounded-tooltip.test.tsx
@@ -12,6 +12,7 @@ describe( 'getBoundedPosition', () => {
 				top: 20,
 				...OFFSETS,
 				box: BOX,
+				wrapper: { left: 0, top: 0, right: 600, bottom: 300 },
 				bounds: { left: 0, top: 0, right: 600, bottom: 300 },
 			} )
 		).toEqual( { x: 50, y: 30 } );
@@ -24,6 +25,7 @@ describe( 'getBoundedPosition', () => {
 				top: 280,
 				...OFFSETS,
 				box: BOX,
+				wrapper: { left: 0, top: 0, right: 600, bottom: 300 },
 				bounds: { left: 0, top: 0, right: 600, bottom: 300 },
 			} )
 		).toEqual( { x: 282, y: 234 } );
@@ -38,23 +40,54 @@ describe( 'getBoundedPosition', () => {
 				top: 50,
 				...OFFSETS,
 				box: BOX,
+				wrapper: { left: 0, top: 0, right: 346, bottom: 200 },
 				bounds: { left: 0, top: 0, right: 346, bottom: 200 },
 			} )
 		).toEqual( { x: 138, y: 60 } );
 	} );
 
 	test( 'may leave the wrapper as long as it stays inside the clipping ancestor', () => {
-		// The wrapper starts 40px inside its clipping card, so the box can reach
-		// 40px past the wrapper's left edge, and stops there.
+		// Neither side fits the 346px wrapper, and the clipping card ends 14px
+		// past its right edge, so the box keeps the near side and stops there.
 		expect(
 			getBoundedPosition( {
 				left: 173,
 				top: 50,
 				...OFFSETS,
 				box: BOX,
+				wrapper: { left: 0, top: 0, right: 346, bottom: 200 },
 				bounds: { left: -40, top: -60, right: 360, bottom: 200 },
 			} )
-		).toEqual( { x: -40, y: 60 } );
+		).toEqual( { x: 152, y: 60 } );
+	} );
+
+	test( 'flips up to stay inside the wrapper even when the page below has room', () => {
+		// The box fits above the anchor inside the 200px wrapper, so it goes
+		// there rather than below the chart, where the page would cover it.
+		expect(
+			getBoundedPosition( {
+				left: 40,
+				top: 180,
+				...OFFSETS,
+				box: BOX,
+				wrapper: { left: 0, top: 0, right: 600, bottom: 200 },
+				bounds: { left: 0, top: 0, right: 1024, bottom: 768 },
+			} )
+		).toEqual( { x: 50, y: 134 } );
+	} );
+
+	test( 'flips up when the wrapper fits below but the clipping ancestor does not', () => {
+		// A scrolled container cuts the wrapper off 20px under the anchor.
+		expect(
+			getBoundedPosition( {
+				left: 40,
+				top: 100,
+				...OFFSETS,
+				box: BOX,
+				wrapper: { left: 0, top: 0, right: 600, bottom: 300 },
+				bounds: { left: 0, top: -50, right: 600, bottom: 120 },
+			} )
+		).toEqual( { x: 50, y: 54 } );
 	} );
 } );
 
@@ -100,9 +133,31 @@ describe( 'BoundedTooltip', () => {
 			</div>
 		);
 
-		// Neither side of the anchor fits inside the card, so the box stops at
-		// the card's left edge, 40px outside the wrapper.
-		expect( screen.getByTestId( 'box' ) ).toHaveStyle( { transform: 'translate(-40px, 60px)' } );
+		// Neither side of the anchor fits the wrapper, so the box keeps the near
+		// side and stops at the card's right edge, 14px outside the wrapper.
+		expect( screen.getByTestId( 'box' ) ).toHaveStyle( { transform: 'translate(152px, 60px)' } );
+	} );
+
+	test( 'keeps the box inside the wrapper when nothing clips and the anchor sits low', () => {
+		jest.spyOn( Element.prototype, 'getBoundingClientRect' ).mockImplementation( function (
+			this: Element
+		) {
+			return this.classList.contains( 'visx-tooltip' )
+				? rect( 0, 0, 150, 100 )
+				: rect( 100, 100, 600, 200 );
+		} );
+
+		render(
+			<div style={ { position: 'relative' } }>
+				<BoundedTooltip left={ 300 } top={ 180 } data-testid="box">
+					content
+				</BoundedTooltip>
+			</div>
+		);
+
+		// The viewport has room below the wrapper, but that is where the page's
+		// own content paints over the box; above the anchor it fits in the chart.
+		expect( screen.getByTestId( 'box' ) ).toHaveStyle( { transform: 'translate(310px, 70px)' } );
 	} );
 
 	test( 'falls back to the viewport when nothing clips', () => {


### PR DESCRIPTION
Fixes CHARTS-269

## Proposed changes

* #51640 moved chart tooltips in-tree and replaced visx's `TooltipWithBounds` with `BoundedTooltip`, which flips the box only when it would leave the nearest clipping ancestor, or the viewport when nothing clips. That dropped the chart wrapper out of the flip decision. On a page with no clipping ancestor, the My Jetpack overview for one, a datum near the bottom of the chart sends the box past the x axis into the summary cards below, and because the box lives inside the chart's own stacking context the cards paint over it. The bar chart snaps the tooltip to the datum, so every zero-view day triggers it.
* The flip now measures each side's overflow against the wrapper as well as the clipping ancestor and takes the larger, so a box that fits inside the chart on one side stays there. The clamp is unchanged and still uses the clipping ancestor, which keeps the case #51640 fixed: a wrapper narrower than the box does not cut it off.
* When neither side fits the wrapper, the box keeps the near side and parks at the clamp edge instead of jumping to the far side. Two existing tests encoded the old tie-break and now expect that.
* Docs: the tooltip paragraph in the line chart story describes the new rule.

## Related product discussion/links

* CHARTS-269, follow-up to STATS-457
* p1787783459070569-slack-C081YUPEVDF

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Route: a Jurassic Ninja site with `plugins/jetpack` from this branch rsynced in, or the Jetpack Beta Tester plugin pointed at this branch. The site needs a few views in the last 7 days and at least one day with none; a fresh JN site gets there by loading the front page a few times and waiting a minute.

* Go to My Jetpack, Overview.
* Hover a day with zero views in "Views in the last 7 days". The tooltip stays inside the chart, above the baseline.
* Hover the bottom of a day with views. Same.
* Hover the top of the tallest bar. The tooltip still opens below the datum, as before.
* Stats v2: hover a few points on the Traffic chart near the bottom and the right edge. The box stays inside the chart and never crosses the sticky section header.

I tested the My Jetpack chart on a JN site with this branch. I did not test Stats v2 or the pie, funnel and heatmap charts by hand; they share `BoundedTooltip` and are covered by the unit tests.

| Before | After |
|---|---|
| ![The tooltip for an empty day drops below the axis and the Comments card covers it](https://github.com/user-attachments/assets/ce4da155-f9c0-475c-967a-19f50644e63d) | ![The same hover keeps the tooltip inside the chart, above the baseline](https://github.com/user-attachments/assets/7ea7126f-2d95-4dc9-ac60-412dd165e804) |
| Trunk: the tooltip for Sep 8 opens below the chart and the Comments card paints over it. | This branch: the same hover flips the tooltip up, inside the chart. |
