### PR TITLE
Plugins: add a WordPress.com Marketplace tab to the Add Plugins screen

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotpar-21-marketplace-tab
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotpar-21-marketplace-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Plugins: List WordPress.com partner and premium plugins as a Marketplace tab on the Add Plugins screen.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotpar-21-marketplace-tab
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotpar-21-marketplace-tab
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Plugins: List WordPress.com partner and premium plugins as a Marketplace tab on the Add Plugins screen.
+Plugins: add a Marketplace tab to the Add Plugins screen, listing WordPress.com partner and premium plugins. Behind the wpcom-plugins-marketplace-tab feature flag, off by default.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -461,6 +461,7 @@ class Jetpack_Mu_Wpcom {
 		require_once __DIR__ . '/features/wpcom-media/wpcom-export-media-files.php';
 		require_once __DIR__ . '/features/wpcom-options-general/options-general.php';
 		require_once __DIR__ . '/features/wpcom-plugins/wpcom-plugins.php';
+		require_once __DIR__ . '/features/wpcom-plugins/wpcom-marketplace-tab.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-link-to-wpcom.php';
 		require_once __DIR__ . '/features/wpcom-profile-settings/profile-settings-notices.php';
 		require_once __DIR__ . '/features/wpcom-sidebar-notice/wpcom-sidebar-notice.php';

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * The WordPress.com marketplace catalog, shaped for core's plugin browser.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Reads the plugins WordPress.com sells and normalizes them into the array shape
+ * `WP_Plugin_Install_List_Table` expects to get back from `plugins_api()`.
+ *
+ * Descriptions are most of the payload and are only read by the details modal, so
+ * they are dropped from the cached list and re-fetched per product when it opens.
+ */
+class Marketplace_Catalog {
+
+	/**
+	 * Transient holding the normalized product list.
+	 */
+	const LIST_CACHE_KEY = 'wpcom_marketplace_catalog';
+
+	/**
+	 * Transient prefix for a single product's full details.
+	 */
+	const PRODUCT_CACHE_PREFIX = 'wpcom_marketplace_product_';
+
+	/**
+	 * How long a successful read is cached for.
+	 */
+	const CACHE_TTL = 6 * HOUR_IN_SECONDS;
+
+	/**
+	 * How long a failed read is cached for. Short, but non-zero, so an outage does
+	 * not mean an outbound request per page load.
+	 */
+	const MISS_CACHE_TTL = 5 * MINUTE_IN_SECONDS;
+
+	/**
+	 * Every purchasable plugin, keyed by slug, in the order wpcom returns them.
+	 *
+	 * @return array<string, array> Normalized product data, empty when the catalog cannot be read.
+	 */
+	public static function get_products() {
+		$cached = get_transient( self::LIST_CACHE_KEY );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$response = self::request( '/marketplace/products?type=launched' );
+
+		if ( ! is_array( $response ) || ! is_array( $response['results'] ?? null ) ) {
+			set_transient( self::LIST_CACHE_KEY, array(), self::MISS_CACHE_TTL );
+			return array();
+		}
+
+		$products = self::to_catalog( $response['results'] );
+
+		set_transient( self::LIST_CACHE_KEY, $products, self::CACHE_TTL );
+
+		return $products;
+	}
+
+	/**
+	 * Turns an endpoint response into the catalog we list.
+	 *
+	 * @param array $results Products as the marketplace endpoint returns them.
+	 * @return array<string, array> Normalized products, keyed by slug.
+	 */
+	public static function to_catalog( array $results ) {
+		$products = array();
+
+		foreach ( $results as $product ) {
+			if ( ! is_array( $product ) || empty( $product['slug'] ) ) {
+				continue;
+			}
+
+			// Retired products stay available to existing subscribers but are no longer sold.
+			if ( ! empty( $product['is_retired'] ) || ! empty( $product['is_hidden'] ) ) {
+				continue;
+			}
+
+			$products[ $product['slug'] ] = self::to_card( $product );
+		}
+
+		return $products;
+	}
+
+	/**
+	 * Whether a slug belongs to the marketplace catalog.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return bool
+	 */
+	public static function has_product( $slug ) {
+		$products = self::get_products();
+
+		return isset( $products[ $slug ] );
+	}
+
+	/**
+	 * One product's card data, as it appears in the browse list.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return array|null Normalized product data, or null when the slug is not ours.
+	 */
+	public static function get_product( $slug ) {
+		$products = self::get_products();
+
+		return $products[ $slug ] ?? null;
+	}
+
+	/**
+	 * One product with the long-form fields the details modal renders.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return array|null Normalized product data, or null when the slug is not ours.
+	 */
+	public static function get_product_details( $slug ) {
+		if ( ! self::has_product( $slug ) ) {
+			return null;
+		}
+
+		$cache_key = self::PRODUCT_CACHE_PREFIX . $slug;
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$product = self::request( '/marketplace/products/' . rawurlencode( $slug ) );
+
+		// The card carries every field the modal needs except the long description.
+		if ( ! is_array( $product ) || empty( $product['slug'] ) ) {
+			return self::get_product( $slug );
+		}
+
+		$details = self::to_card( $product );
+
+		$description = is_string( $product['description'] ?? null ) ? $product['description'] : '';
+		if ( '' !== $description ) {
+			$details['sections']['description'] = $description;
+		}
+
+		set_transient( $cache_key, $details, self::CACHE_TTL );
+
+		return $details;
+	}
+
+	/**
+	 * Clears everything this class caches.
+	 *
+	 * @return void
+	 */
+	public static function flush_cache() {
+		$products = get_transient( self::LIST_CACHE_KEY );
+
+		delete_transient( self::LIST_CACHE_KEY );
+
+		foreach ( array_keys( is_array( $products ) ? $products : array() ) as $slug ) {
+			delete_transient( self::PRODUCT_CACHE_PREFIX . $slug );
+		}
+	}
+
+	/**
+	 * Reads a wpcom marketplace endpoint.
+	 *
+	 * @param string $path Path below `wpcom/v2`, query string included.
+	 * @return array|null Decoded response body, or null on any failure.
+	 */
+	private static function request( $path ) {
+		if ( ! method_exists( Client::class, 'wpcom_json_api_request_as_blog' ) ) {
+			return null;
+		}
+
+		$response = Client::wpcom_json_api_request_as_blog( $path, '2', array(), null, 'wpcom' );
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		return is_array( $body ) ? $body : null;
+	}
+
+	/**
+	 * Turns one wpcom product into the array a plugin card is rendered from.
+	 *
+	 * Core reads several of these keys without checking they exist, so every one it
+	 * touches is set here even when we have nothing to put in it.
+	 *
+	 * @param array $product Product data from the marketplace endpoint.
+	 * @return array
+	 */
+	public static function to_card( array $product ) {
+		$slug = (string) $product['slug'];
+		$icon = is_string( $product['icons'] ?? null ) ? $product['icons'] : '';
+
+		return array(
+			'name'              => (string) ( $product['name'] ?? '' ),
+			'slug'              => $slug,
+			'version'           => (string) ( $product['version'] ?? '' ),
+			// wpcom wraps the author name in a placeholder link that goes nowhere.
+			'author'            => wp_strip_all_tags( (string) ( $product['author'] ?? '' ) ),
+			'author_profile'    => '',
+			'contributors'      => array(),
+			'short_description' => (string) ( $product['short_description'] ?? '' ),
+			'sections'          => array( 'description' => (string) ( $product['short_description'] ?? '' ) ),
+			'icons'             => array(
+				'1x'      => $icon,
+				'2x'      => $icon,
+				'default' => $icon,
+			),
+			'banners'           => is_array( $product['banners'] ?? null ) ? $product['banners'] : array(),
+			// Already a 0-100 percentage, which is the scale wp_star_rating() wants.
+			'rating'            => (float) ( $product['rating'] ?? 0 ),
+			'num_ratings'       => 0,
+			'ratings'           => array(),
+			'active_installs'   => 0,
+			'downloaded'        => 0,
+			'last_updated'      => (string) ( $product['last_updated'] ?? '' ),
+			'added'             => '',
+			'homepage'          => self::product_url( $slug ),
+			'donate_link'       => '',
+			// No download link: these install through a purchase, and its absence is also
+			// what keeps core from offering an Install button in the details modal.
+			'download_link'     => '',
+			'requires'          => false,
+			'requires_php'      => false,
+			'tested'            => '',
+			'upgrade_notice'    => '',
+			// Suppresses core's "WordPress.org Plugin Page" link. These are not on .org.
+			'external'          => true,
+			'wpcom_marketplace' => true,
+		);
+	}
+
+	/**
+	 * The WordPress.com page a product is bought from.
+	 *
+	 * @param string $slug Plugin slug.
+	 * @return string
+	 */
+	public static function product_url( $slug ) {
+		$site_slug = wp_parse_url( home_url(), PHP_URL_HOST );
+
+		return sprintf(
+			'https://wordpress.com/plugins/%s/%s?ref=wpcom-marketplace-tab',
+			rawurlencode( $slug ),
+			rawurlencode( (string) $site_slug )
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
@@ -83,7 +83,9 @@ class Marketplace_Catalog {
 				continue;
 			}
 
-			$products[ $product['slug'] ] = self::to_card( $product );
+			$card = self::to_card( $product );
+
+			$products[ $card['slug'] ] = $card;
 		}
 
 		return $products;
@@ -120,7 +122,8 @@ class Marketplace_Catalog {
 	 * @return array|null Normalized product data, or null when the slug is not ours.
 	 */
 	public static function get_product_details( $slug ) {
-		if ( ! self::has_product( $slug ) ) {
+		$card = self::get_product( $slug );
+		if ( null === $card ) {
 			return null;
 		}
 
@@ -130,15 +133,11 @@ class Marketplace_Catalog {
 			return $cached;
 		}
 
-		$product = self::request( '/marketplace/products/' . rawurlencode( $slug ) );
+		$product = self::request( '/marketplace/products/' . rawurlencode( $card['wpcom_product_slug'] ?? $slug ) );
 
 		// The card carries every field the modal needs except the long description.
 		if ( ! is_array( $product ) || empty( $product['slug'] ) ) {
-			$card = self::get_product( $slug );
-
-			if ( null !== $card ) {
-				set_transient( $cache_key, $card, self::MISS_CACHE_TTL );
-			}
+			set_transient( $cache_key, $card, self::MISS_CACHE_TTL );
 
 			return $card;
 		}
@@ -153,21 +152,6 @@ class Marketplace_Catalog {
 		set_transient( $cache_key, $details, self::CACHE_TTL );
 
 		return $details;
-	}
-
-	/**
-	 * Clears everything this class caches.
-	 *
-	 * @return void
-	 */
-	public static function flush_cache() {
-		$products = get_transient( self::LIST_CACHE_KEY );
-
-		delete_transient( self::LIST_CACHE_KEY );
-
-		foreach ( array_keys( is_array( $products ) ? $products : array() ) as $slug ) {
-			delete_transient( self::PRODUCT_CACHE_PREFIX . $slug );
-		}
 	}
 
 	/**
@@ -202,45 +186,55 @@ class Marketplace_Catalog {
 	 * @return array
 	 */
 	public static function to_card( array $product ) {
-		$slug = (string) ( $product['slug'] ?? '' );
-		$icon = is_string( $product['icons'] ?? null ) ? $product['icons'] : '';
+		$product_slug = (string) ( $product['slug'] ?? '' );
+		$icon         = is_string( $product['icons'] ?? null ) ? $product['icons'] : '';
+
+		// Core resolves installed state from the plugin directory name, and
+		// Marketplace_Products_Updater keys its updates the same way, so the card has
+		// to carry the software slug. The two differ for a handful of products.
+		$slug = (string) ( $product['software_slug'] ?? '' );
+		if ( '' === $slug ) {
+			$slug = $product_slug;
+		}
 
 		return array(
-			'name'              => (string) ( $product['name'] ?? '' ),
-			'slug'              => $slug,
-			'version'           => (string) ( $product['version'] ?? '' ),
+			'name'               => (string) ( $product['name'] ?? '' ),
+			'slug'               => $slug,
+			'version'            => (string) ( $product['version'] ?? '' ),
 			// wpcom wraps the author name in a placeholder link that goes nowhere.
-			'author'            => wp_strip_all_tags( (string) ( $product['author'] ?? '' ) ),
-			'author_profile'    => '',
-			'contributors'      => array(),
-			'short_description' => (string) ( $product['short_description'] ?? '' ),
-			'sections'          => array( 'description' => (string) ( $product['short_description'] ?? '' ) ),
-			'icons'             => array(
+			'author'             => wp_strip_all_tags( (string) ( $product['author'] ?? '' ) ),
+			'author_profile'     => '',
+			'contributors'       => array(),
+			'short_description'  => (string) ( $product['short_description'] ?? '' ),
+			'sections'           => array( 'description' => (string) ( $product['short_description'] ?? '' ) ),
+			'icons'              => array(
 				'1x'      => $icon,
 				'2x'      => $icon,
 				'default' => $icon,
 			),
-			'banners'           => is_array( $product['banners'] ?? null ) ? $product['banners'] : array(),
-			// Already a 0-100 percentage, which is the scale wp_star_rating() wants.
-			'rating'            => (float) ( $product['rating'] ?? 0 ),
-			'num_ratings'       => 0,
-			'ratings'           => array(),
-			'active_installs'   => 0,
-			'downloaded'        => 0,
-			'last_updated'      => (string) ( $product['last_updated'] ?? '' ),
-			'added'             => '',
-			'homepage'          => self::product_url( $slug ),
-			'donate_link'       => '',
+			'banners'            => is_array( $product['banners'] ?? null ) ? $product['banners'] : array(),
+			// The payload has an average but no count, and core renders stars from the
+			// average alone, so showing one would mean "(based on 0 ratings)".
+			'rating'             => 0,
+			'num_ratings'        => 0,
+			'ratings'            => array(),
+			'active_installs'    => 0,
+			'downloaded'         => 0,
+			'last_updated'       => (string) ( $product['last_updated'] ?? '' ),
+			'added'              => '',
+			'homepage'           => self::product_url( $product_slug ),
+			'donate_link'        => '',
 			// No download link: these install through a purchase, and its absence is also
 			// what keeps core from offering an Install button in the details modal.
-			'download_link'     => '',
-			'requires'          => false,
-			'requires_php'      => false,
-			'tested'            => '',
-			'upgrade_notice'    => '',
+			'download_link'      => '',
+			'requires'           => false,
+			'requires_php'       => false,
+			'tested'             => '',
+			'upgrade_notice'     => '',
 			// Suppresses core's "WordPress.org Plugin Page" link. These are not on .org.
-			'external'          => true,
-			'wpcom_marketplace' => true,
+			'external'           => true,
+			'wpcom_marketplace'  => true,
+			'wpcom_product_slug' => $product_slug,
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
@@ -137,12 +137,14 @@ class Marketplace_Catalog {
 
 		// The card carries every field the modal needs except the long description.
 		if ( ! is_array( $product ) || empty( $product['slug'] ) ) {
-			set_transient( $cache_key, $card, self::MISS_CACHE_TTL );
+			$details = self::to_details( $card );
 
-			return $card;
+			set_transient( $cache_key, $details, self::MISS_CACHE_TTL );
+
+			return $details;
 		}
 
-		$details = self::to_card( $product );
+		$details = self::to_details( self::to_card( $product ) );
 
 		$description = is_string( $product['description'] ?? null ) ? $product['description'] : '';
 		if ( '' !== $description ) {
@@ -152,6 +154,22 @@ class Marketplace_Catalog {
 		set_transient( $cache_key, $details, self::CACHE_TTL );
 
 		return $details;
+	}
+
+	/**
+	 * Strips the fields that only exist to satisfy the browse list.
+	 *
+	 * The list table reads active_installs unguarded, so a card has to carry it, but
+	 * the details modal guards on isset() and renders 0 as "Less Than 10", which we
+	 * would be stating as fact about a plugin we have no install count for.
+	 *
+	 * @param array $card Normalized card data.
+	 * @return array
+	 */
+	private static function to_details( array $card ) {
+		unset( $card['active_installs'], $card['downloaded'] );
+
+		return $card;
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/class-marketplace-catalog.php
@@ -134,7 +134,13 @@ class Marketplace_Catalog {
 
 		// The card carries every field the modal needs except the long description.
 		if ( ! is_array( $product ) || empty( $product['slug'] ) ) {
-			return self::get_product( $slug );
+			$card = self::get_product( $slug );
+
+			if ( null !== $card ) {
+				set_transient( $cache_key, $card, self::MISS_CACHE_TTL );
+			}
+
+			return $card;
 		}
 
 		$details = self::to_card( $product );
@@ -196,7 +202,7 @@ class Marketplace_Catalog {
 	 * @return array
 	 */
 	public static function to_card( array $product ) {
-		$slug = (string) $product['slug'];
+		$slug = (string) ( $product['slug'] ?? '' );
 		$icon = is_string( $product['icons'] ?? null ) ? $product['icons'] : '';
 
 		return array(

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/css/marketplace-tab.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/css/marketplace-tab.css
@@ -1,0 +1,34 @@
+/**
+ * Marketplace tab on the Add Plugins screen.
+ *
+ * Partner plugins carry no install count and no WordPress.org ratings, and core
+ * renders a missing count as "Less Than 10 Active Installations" and a missing
+ * rating as zero stars. Both would be wrong, so those two cells are dropped.
+ */
+
+.wpcom-marketplace-tab .plugin-card .column-rating,
+.wpcom-marketplace-tab .plugin-card .column-downloaded {
+	display: none;
+}
+
+.wpcom-marketplace-tab .plugin-card-bottom {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px 20px;
+}
+
+.wpcom-marketplace-tab .plugin-card .column-updated,
+.wpcom-marketplace-tab .plugin-card .column-compatibility {
+	float: none;
+	clear: none;
+	width: auto;
+	margin-block-end: 0;
+	text-align: start;
+}
+
+.wpcom-marketplace-tab .wpcom-marketplace-intro {
+	max-inline-size: 60em;
+	margin-block: 0 1em;
+	margin-inline: 0;
+	color: #50575e;
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/css/marketplace-tab.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/css/marketplace-tab.css
@@ -1,13 +1,14 @@
 /**
  * Marketplace tab on the Add Plugins screen.
  *
- * Partner plugins carry no install count and no WordPress.org ratings, and core
- * renders a missing count as "Less Than 10 Active Installations" and a missing
- * rating as zero stars. Both would be wrong, so those two cells are dropped.
+ * The catalog carries no install count, rating count or tested-up-to
+ * version, and core states each as fact when it has nothing, so those
+ * cells are dropped.
  */
 
 .wpcom-marketplace-tab .plugin-card .column-rating,
-.wpcom-marketplace-tab .plugin-card .column-downloaded {
+.wpcom-marketplace-tab .plugin-card .column-downloaded,
+.wpcom-marketplace-tab .plugin-card .column-compatibility {
 	display: none;
 }
 
@@ -17,8 +18,7 @@
 	gap: 4px 20px;
 }
 
-.wpcom-marketplace-tab .plugin-card .column-updated,
-.wpcom-marketplace-tab .plugin-card .column-compatibility {
+.wpcom-marketplace-tab .plugin-card .column-updated {
 	float: none;
 	clear: none;
 	width: auto;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Lists the plugins WordPress.com sells as a tab on the core Add Plugins screen.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Feature_Flags\Feature_Flags;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Marketplace_Catalog;
+
+/**
+ * The tab's slug, which is also its `?tab=` value.
+ */
+const WPCOM_MARKETPLACE_TAB = 'wpcom-marketplace';
+
+/**
+ * Feature flag gating the tab.
+ */
+const WPCOM_MARKETPLACE_TAB_FLAG = 'wpcom-plugins-marketplace-tab';
+
+/**
+ * Registers the feature flag.
+ *
+ * Runs on every request so the flag stays visible wherever flags are listed or toggled.
+ *
+ * @return void
+ */
+function wpcom_marketplace_register_flag() {
+	Feature_Flags::register(
+		WPCOM_MARKETPLACE_TAB_FLAG,
+		array(
+			'default'     => false,
+			'description' => 'Show WordPress.com partner and premium plugins as a Marketplace tab on the Add Plugins screen.',
+			'owner'       => 'jetpack-mu-wpcom',
+		)
+	);
+}
+wpcom_marketplace_register_flag();
+
+/**
+ * Whether to show the tab on this site.
+ *
+ * @return bool
+ */
+function wpcom_marketplace_tab_enabled() {
+	return Feature_Flags::is_enabled( WPCOM_MARKETPLACE_TAB_FLAG );
+}
+
+/**
+ * Adds the tab to the Add Plugins screen, after Featured.
+ *
+ * Not first: core lands on whichever tab comes first here when none is requested.
+ *
+ * @param string[] $tabs Tabs shown on the Add Plugins screen.
+ * @return string[]
+ */
+function wpcom_marketplace_add_tab( $tabs ) {
+	if ( ! wpcom_marketplace_tab_enabled() || ! is_array( $tabs ) ) {
+		return $tabs;
+	}
+
+	$label = _x( 'Marketplace', 'Plugin Installer', 'jetpack-mu-wpcom' );
+
+	$position = array_search( 'featured', array_keys( $tabs ), true );
+	if ( false === $position ) {
+		$tabs[ WPCOM_MARKETPLACE_TAB ] = $label;
+		return $tabs;
+	}
+
+	return array_merge(
+		array_slice( $tabs, 0, $position + 1, true ),
+		array( WPCOM_MARKETPLACE_TAB => $label ),
+		array_slice( $tabs, $position + 1, null, true )
+	);
+}
+add_filter( 'install_plugins_tabs', 'wpcom_marketplace_add_tab' );
+
+/**
+ * Restores and tags the list table's API request.
+ *
+ * Core sets `$args` to false for a tab it does not know, skipping the query entirely.
+ *
+ * @param array|false $args Plugin install API arguments.
+ * @return array|false
+ */
+function wpcom_marketplace_tab_api_args( $args ) {
+	if ( ! wpcom_marketplace_tab_enabled() ) {
+		return $args;
+	}
+
+	$args = is_array( $args ) ? $args : array();
+
+	$args['wpcom_marketplace'] = true;
+
+	return $args;
+}
+add_filter( 'install_plugins_table_api_args_' . WPCOM_MARKETPLACE_TAB, 'wpcom_marketplace_tab_api_args' );
+
+/**
+ * Answers the plugin API with marketplace products.
+ *
+ * Handles the tab's listing and a details lookup for any slug in the catalog.
+ *
+ * @param false|object|WP_Error $result The result object or array. Default false.
+ * @param string                $action The type of information being requested.
+ * @param object                $args   Plugin API arguments.
+ * @return false|object|WP_Error
+ */
+function wpcom_marketplace_serve_plugins_api( $result, $action, $args ) {
+	if ( false !== $result || ! wpcom_marketplace_tab_enabled() ) {
+		return $result;
+	}
+
+	if ( 'query_plugins' === $action && ! empty( $args->wpcom_marketplace ) ) {
+		$products = array_values( Marketplace_Catalog::get_products() );
+
+		return (object) array(
+			'info'    => array(
+				'page'    => 1,
+				'pages'   => 1,
+				'results' => count( $products ),
+			),
+			'plugins' => $products,
+		);
+	}
+
+	if ( 'plugin_information' === $action && ! empty( $args->slug ) ) {
+		$product = Marketplace_Catalog::get_product_details( (string) $args->slug );
+
+		if ( null !== $product ) {
+			return (object) $product;
+		}
+	}
+
+	return $result;
+}
+add_filter( 'plugins_api', 'wpcom_marketplace_serve_plugins_api', 10, 3 );
+
+/**
+ * Replaces "Install Now" with a link to the product's page on WordPress.com.
+ *
+ * Installed products keep core's button: Marketplace_Products_Updater already gives
+ * core the right package URL, so Activate, Update and Active all behave.
+ *
+ * @param string[] $action_links Plugin action links. Install and Details by default.
+ * @param array    $plugin       Plugin data as returned by plugins_api().
+ * @return string[]
+ */
+function wpcom_marketplace_action_links( $action_links, $plugin ) {
+	if ( empty( $plugin['wpcom_marketplace'] ) || empty( $plugin['slug'] ) ) {
+		return $action_links;
+	}
+
+	$status = install_plugin_install_status( $plugin );
+	if ( 'install' !== $status['status'] ) {
+		return $action_links;
+	}
+
+	$action_links[0] = sprintf(
+		'<a class="button" href="%s" aria-label="%s" target="_blank" rel="noopener">%s</a>',
+		esc_url( Marketplace_Catalog::product_url( $plugin['slug'] ) ),
+		/* translators: %s: Plugin name. */
+		esc_attr( sprintf( __( 'Get started with %s', 'jetpack-mu-wpcom' ), $plugin['name'] ?? $plugin['slug'] ) ),
+		esc_html__( 'Get started', 'jetpack-mu-wpcom' )
+	);
+
+	return $action_links;
+}
+add_filter( 'plugin_install_action_links', 'wpcom_marketplace_action_links', 10, 2 );
+
+/**
+ * Loads the tab's styles.
+ *
+ * @return void
+ */
+function wpcom_marketplace_render_tab() {
+	add_filter( 'admin_body_class', 'wpcom_marketplace_body_class' );
+
+	wp_enqueue_style(
+		'wpcom-marketplace-tab',
+		plugins_url( 'css/marketplace-tab.css', __FILE__ ),
+		array(),
+		\Automattic\Jetpack\Jetpack_Mu_Wpcom::PACKAGE_VERSION
+	);
+}
+add_action( 'install_plugins_pre_' . WPCOM_MARKETPLACE_TAB, 'wpcom_marketplace_render_tab' );
+
+/**
+ * Flags the screen so the stylesheet can scope itself to this tab.
+ *
+ * @param string $classes Space-separated admin body classes.
+ * @return string
+ */
+function wpcom_marketplace_body_class( $classes ) {
+	return $classes . ' wpcom-marketplace-tab ';
+}
+
+/**
+ * Says what these plugins are, above the cards.
+ *
+ * @return void
+ */
+function wpcom_marketplace_intro() {
+	printf(
+		'<p class="wpcom-marketplace-intro">%s</p>',
+		esc_html__( 'Premium plugins from WordPress.com and our partners. Each one comes with a subscription, and is installed, updated, and supported for you.', 'jetpack-mu-wpcom' )
+	);
+}
+
+add_action( 'install_plugins_' . WPCOM_MARKETPLACE_TAB, 'wpcom_marketplace_intro', 9 );
+add_action( 'install_plugins_' . WPCOM_MARKETPLACE_TAB, 'display_plugins_table' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
@@ -207,6 +207,24 @@ function wpcom_marketplace_render_tab() {
 add_action( 'install_plugins_pre_' . WPCOM_MARKETPLACE_TAB, 'wpcom_marketplace_render_tab' );
 
 /**
+ * Hides the Calypso marketplace banner on this tab.
+ *
+ * The banner points at the marketplace this tab replaces. Priority 9 because
+ * `load-plugin-install.php` fires long before the tab's own render hook.
+ *
+ * @return void
+ */
+function wpcom_marketplace_hide_banner() {
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$tab = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : '';
+
+	if ( WPCOM_MARKETPLACE_TAB === $tab && wpcom_marketplace_tab_enabled() ) {
+		remove_action( 'load-plugin-install.php', 'wpcom_plugins_show_banner' );
+	}
+}
+add_action( 'load-plugin-install.php', 'wpcom_marketplace_hide_banner', 9 );
+
+/**
  * Flags the screen so the stylesheet can scope itself to this tab.
  *
  * @param string $classes Space-separated admin body classes.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
@@ -21,7 +21,7 @@ const WPCOM_MARKETPLACE_TAB_FLAG = 'wpcom-plugins-marketplace-tab';
 /**
  * Registers the feature flag.
  *
- * Runs on every request so the flag stays visible wherever flags are listed or toggled.
+ * Runs as this file loads, so the flag is listed wherever flags are read or toggled.
  *
  * @return void
  */

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
@@ -78,7 +78,9 @@ add_filter( 'install_plugins_tabs', 'wpcom_marketplace_add_tab' );
 /**
  * Restores and tags the list table's API request.
  *
- * Core sets `$args` to false for a tab it does not know, skipping the query entirely.
+ * Core sets `$args` to false for a tab it does not know, which both skips the query
+ * and discards the page, per_page and locale it had already put there. It reads
+ * per_page back unguarded after the query, so they have to be restored here.
  *
  * @param array|false $args Plugin install API arguments.
  * @return array|false
@@ -90,9 +92,16 @@ function wpcom_marketplace_tab_api_args( $args ) {
 
 	$args = is_array( $args ) ? $args : array();
 
-	$args['wpcom_marketplace'] = true;
-
-	return $args;
+	// The catalog comes back whole, so per_page only exists to keep core's pagination happy.
+	return array_merge(
+		array(
+			'page'     => 1,
+			'per_page' => 100,
+			'locale'   => get_user_locale(),
+		),
+		$args,
+		array( 'wpcom_marketplace' => true )
+	);
 }
 add_filter( 'install_plugins_table_api_args_' . WPCOM_MARKETPLACE_TAB, 'wpcom_marketplace_tab_api_args' );
 
@@ -124,7 +133,9 @@ function wpcom_marketplace_serve_plugins_api( $result, $action, $args ) {
 		);
 	}
 
-	if ( 'plugin_information' === $action && ! empty( $args->slug ) ) {
+	// Only answered from a warm cache: plugins_api( 'plugin_information' ) is called
+	// from unrelated screens, and none of them should pay for a catalog fetch.
+	if ( 'plugin_information' === $action && ! empty( $args->slug ) && false !== get_transient( Marketplace_Catalog::LIST_CACHE_KEY ) ) {
 		$product = Marketplace_Catalog::get_product_details( (string) $args->slug );
 
 		if ( null !== $product ) {
@@ -156,13 +167,23 @@ function wpcom_marketplace_action_links( $action_links, $plugin ) {
 		return $action_links;
 	}
 
-	$action_links[0] = sprintf(
+	$button = sprintf(
 		'<a class="button" href="%s" aria-label="%s" target="_blank" rel="noopener">%s</a>',
-		esc_url( Marketplace_Catalog::product_url( $plugin['slug'] ) ),
+		esc_url( Marketplace_Catalog::product_url( $plugin['wpcom_product_slug'] ?? $plugin['slug'] ) ),
 		/* translators: %s: Plugin name. */
 		esc_attr( sprintf( __( 'Get started with %s', 'jetpack-mu-wpcom' ), $plugin['name'] ?? $plugin['slug'] ) ),
 		esc_html__( 'Get started', 'jetpack-mu-wpcom' )
 	);
+
+	// Replace core's install button wherever it ended up, rather than assuming index 0.
+	foreach ( $action_links as $index => $link ) {
+		if ( str_contains( $link, 'install-now' ) ) {
+			$action_links[ $index ] = $button;
+			return $action_links;
+		}
+	}
+
+	array_unshift( $action_links, $button );
 
 	return $action_links;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-plugins/wpcom-marketplace-tab.php
@@ -167,8 +167,9 @@ function wpcom_marketplace_action_links( $action_links, $plugin ) {
 		return $action_links;
 	}
 
+	// Same tab, like every other button on this screen.
 	$button = sprintf(
-		'<a class="button" href="%s" aria-label="%s" target="_blank" rel="noopener">%s</a>',
+		'<a class="button" href="%s" aria-label="%s">%s</a>',
 		esc_url( Marketplace_Catalog::product_url( $plugin['wpcom_product_slug'] ?? $plugin['slug'] ) ),
 		/* translators: %s: Plugin name. */
 		esc_attr( sprintf( __( 'Get started with %s', 'jetpack-mu-wpcom' ), $plugin['name'] ?? $plugin['slug'] ) ),

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
@@ -117,14 +117,12 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'https://example.com/icon.png', $card['icons']['1x'] );
 		$this->assertSame( 'https://example.com/icon.png', $card['icons']['default'] );
 
-		// The rating is already a percentage, and has to be numeric for wp_star_rating().
-		$this->assertSame( 53.4, $card['rating'] );
+		$this->assertSame( 0, $card['rating'] );
+		$this->assertSame( 0, $card['num_ratings'] );
 
 		// The author arrives wrapped in a link that goes nowhere.
 		$this->assertSame( 'Gravity Forms', $card['author'] );
 
-		// No download link, which is also what stops core offering an Install
-		// button inside the details modal.
 		$this->assertSame( '', $card['download_link'] );
 
 		$this->assertTrue( $card['wpcom_marketplace'] );
@@ -173,8 +171,7 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The tab sits after Featured, so the screen's default view does not change:
-	 * core lands on whichever tab comes first when none is requested.
+	 * The tab sits after Featured, leaving the screen's default view unchanged.
 	 */
 	public function test_tab_is_registered_after_featured() {
 		$this->enable_tab();
@@ -197,13 +194,26 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * With the flag off nothing about the screen changes.
 	 */
+	public function test_tab_is_absent_by_default() {
+		$this->assertSame(
+			array( 'featured' ),
+			array_keys( wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) ) )
+		);
+	}
+
+	/**
+	 * Turning the flag off beats the registered default, whatever that becomes.
+	 */
 	public function test_tab_is_absent_when_flag_is_off() {
+		add_filter( self::FLAG_FILTER, '__return_true' );
+		$this->assertContains( WPCOM_MARKETPLACE_TAB, array_keys( wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) ) ) );
+		remove_filter( self::FLAG_FILTER, '__return_true' );
+
 		add_filter( self::FLAG_FILTER, '__return_false' );
-
-		$tabs = wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) );
-
-		$this->assertSame( array( 'featured' ), array_keys( $tabs ) );
-
+		$this->assertSame(
+			array( 'featured' ),
+			array_keys( wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) ) )
+		);
 		remove_filter( self::FLAG_FILTER, '__return_false' );
 	}
 
@@ -217,6 +227,10 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertIsArray( $args );
 		$this->assertTrue( $args['wpcom_marketplace'] );
+
+		// prepare_items() reads these back after the query without guarding them.
+		$this->assertArrayHasKey( 'per_page', $args );
+		$this->assertArrayHasKey( 'page', $args );
 	}
 
 	/**
@@ -261,6 +275,75 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 			$existing,
 			wpcom_marketplace_serve_plugins_api( $existing, 'query_plugins', (object) array( 'wpcom_marketplace' => true ) )
 		);
+	}
+
+	/**
+	 * Core resolves installed state from the directory name, so the card's slug has to
+	 * be the software slug. Three products in the live catalog differ from their own.
+	 */
+	public function test_card_uses_the_software_slug() {
+		$card = Marketplace_Catalog::to_card(
+			array_merge(
+				self::PRODUCT,
+				array(
+					'slug'          => 'mailpoet-business',
+					'software_slug' => 'mailpoet-premium',
+				)
+			)
+		);
+
+		$this->assertSame( 'mailpoet-premium', $card['slug'] );
+		$this->assertSame( 'mailpoet-business', $card['wpcom_product_slug'] );
+
+		// The purchase link still needs the product slug.
+		$this->assertStringContainsString( 'wordpress.com/plugins/mailpoet-business/', $card['homepage'] );
+	}
+
+	/**
+	 * One product in the live catalog has no software slug at all.
+	 */
+	public function test_card_falls_back_to_the_product_slug() {
+		$product = self::PRODUCT;
+		unset( $product['software_slug'] );
+
+		$this->assertSame( 'gravityforms', Marketplace_Catalog::to_card( $product )['slug'] );
+	}
+
+	/**
+	 * The catalog is keyed by the slug core will ask for.
+	 */
+	public function test_catalog_is_keyed_by_software_slug() {
+		$catalog = Marketplace_Catalog::to_catalog(
+			array(
+				array_merge(
+					self::PRODUCT,
+					array(
+						'slug'          => 'js-composer',
+						'software_slug' => 'js_composer',
+					)
+				),
+			)
+		);
+
+		$this->assertSame( array( 'js_composer' ), array_keys( $catalog ) );
+	}
+
+	/**
+	 * An unexpected payload shape produces a usable card rather than a warning.
+	 */
+	public function test_card_survives_unexpected_shapes() {
+		$card = Marketplace_Catalog::to_card(
+			array(
+				'slug'    => 'odd-one',
+				'icons'   => array( '1x' => 'https://example.com/a.png' ),
+				'banners' => null,
+			)
+		);
+
+		$this->assertSame( '', $card['version'] );
+		$this->assertSame( '', $card['icons']['default'] );
+		$this->assertSame( array(), $card['banners'] );
+		$this->assertSame( '', $card['last_updated'] );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
@@ -376,6 +376,7 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 		);
 
 		$this->assertStringContainsString( 'Get started', $links[0] );
+		$this->assertStringNotContainsString( 'target=', $links[0] );
 		$this->assertStringContainsString( 'wordpress.com/plugins/gravityforms/', $links[0] );
 		$this->assertStringNotContainsString( 'install-now', $links[0] );
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
@@ -16,6 +16,13 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-plugins/wpcom-marke
 class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 
 	/**
+	 * Per-flag filter, so toggling ours leaves every other flag alone.
+	 *
+	 * @var string
+	 */
+	private const FLAG_FILTER = 'jetpack_feature_flag_enabled_' . WPCOM_MARKETPLACE_TAB_FLAG;
+
+	/**
 	 * A product as the marketplace endpoint returns it.
 	 *
 	 * @var array
@@ -41,7 +48,7 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	 * @return void
 	 */
 	private function enable_tab() {
-		add_filter( 'jetpack_feature_flag_enabled', '__return_true' );
+		add_filter( self::FLAG_FILTER, '__return_true' );
 	}
 
 	/**
@@ -61,7 +68,7 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function tear_down() {
 		delete_transient( Marketplace_Catalog::LIST_CACHE_KEY );
-		remove_filter( 'jetpack_feature_flag_enabled', '__return_true' );
+		remove_filter( self::FLAG_FILTER, '__return_true' );
 
 		parent::tear_down();
 	}
@@ -191,13 +198,13 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	 * With the flag off nothing about the screen changes.
 	 */
 	public function test_tab_is_absent_when_flag_is_off() {
-		add_filter( 'jetpack_feature_flag_enabled', '__return_false' );
+		add_filter( self::FLAG_FILTER, '__return_false' );
 
 		$tabs = wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) );
 
 		$this->assertSame( array( 'featured' ), array_keys( $tabs ) );
 
-		remove_filter( 'jetpack_feature_flag_enabled', '__return_false' );
+		remove_filter( self::FLAG_FILTER, '__return_false' );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
@@ -347,6 +347,23 @@ class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Core's details modal guards active_installs on isset(), so a zero would be
+	 * rendered as the claim "Less Than 10 Active Installations".
+	 */
+	public function test_details_drop_the_browse_only_fields() {
+		$this->enable_tab();
+		$this->seed_catalog( array( 'gravityforms' => Marketplace_Catalog::to_card( self::PRODUCT ) ) );
+
+		$details = Marketplace_Catalog::get_product_details( 'gravityforms' );
+
+		$this->assertArrayNotHasKey( 'active_installs', $details );
+		$this->assertArrayNotHasKey( 'downloaded', $details );
+
+		// The list table does read it unguarded, so the card keeps it.
+		$this->assertArrayHasKey( 'active_installs', Marketplace_Catalog::to_card( self::PRODUCT ) );
+	}
+
+	/**
 	 * A product that is not installed is bought, not downloaded.
 	 */
 	public function test_install_button_is_replaced_for_our_products() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-plugins/Wpcom_Marketplace_Tab_Test.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Tests for the Marketplace tab on the Add Plugins screen.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Marketplace_Catalog;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-plugins/wpcom-marketplace-tab.php';
+
+/**
+ * Class Wpcom_Marketplace_Tab_Test
+ */
+class Wpcom_Marketplace_Tab_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * A product as the marketplace endpoint returns it.
+	 *
+	 * @var array
+	 */
+	private const PRODUCT = array(
+		'id'                => 2509,
+		'name'              => 'Gravity Forms',
+		'slug'              => 'gravityforms',
+		'software_slug'     => 'gravityforms',
+		'short_description' => 'Build custom forms for any project.',
+		'description'       => '<p>The long one.</p>',
+		'icons'             => 'https://example.com/icon.png',
+		'rating'            => '53.4',
+		'author'            => '<a href="#">Gravity Forms</a>',
+		'version'           => '3.1.1',
+		'last_updated'      => '2026-09-03',
+		'banners'           => null,
+	);
+
+	/**
+	 * Turn the tab on for the duration of a test.
+	 *
+	 * @return void
+	 */
+	private function enable_tab() {
+		add_filter( 'jetpack_feature_flag_enabled', '__return_true' );
+	}
+
+	/**
+	 * Put a catalog in place without going near the network.
+	 *
+	 * @param array $products Products keyed by slug.
+	 * @return void
+	 */
+	private function seed_catalog( array $products ) {
+		set_transient( Marketplace_Catalog::LIST_CACHE_KEY, $products, HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Clean up.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		delete_transient( Marketplace_Catalog::LIST_CACHE_KEY );
+		remove_filter( 'jetpack_feature_flag_enabled', '__return_true' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Every key core reads without an isset() guard has to be present, or the
+	 * plugin card renders warnings.
+	 */
+	public function test_card_sets_every_field_core_reads_unguarded() {
+		$card = Marketplace_Catalog::to_card( self::PRODUCT );
+
+		$required = array(
+			'name',
+			'slug',
+			'version',
+			'author',
+			'short_description',
+			'sections',
+			'icons',
+			'rating',
+			'num_ratings',
+			'ratings',
+			'active_installs',
+			'downloaded',
+			'last_updated',
+			'homepage',
+			'download_link',
+			'contributors',
+		);
+
+		foreach ( $required as $key ) {
+			$this->assertArrayHasKey( $key, $card, "Missing '$key', which core reads unguarded." );
+		}
+
+		// Core falls back to icons['default'] with no guard of its own.
+		$this->assertArrayHasKey( 'default', $card['icons'] );
+	}
+
+	/**
+	 * The wpcom shapes that core would choke on are converted, not passed through.
+	 */
+	public function test_card_normalizes_wpcom_shapes() {
+		$card = Marketplace_Catalog::to_card( self::PRODUCT );
+
+		// Icons arrive as a bare URL string, core wants the sized array.
+		$this->assertSame( 'https://example.com/icon.png', $card['icons']['1x'] );
+		$this->assertSame( 'https://example.com/icon.png', $card['icons']['default'] );
+
+		// The rating is already a percentage, and has to be numeric for wp_star_rating().
+		$this->assertSame( 53.4, $card['rating'] );
+
+		// The author arrives wrapped in a link that goes nowhere.
+		$this->assertSame( 'Gravity Forms', $card['author'] );
+
+		// No download link, which is also what stops core offering an Install
+		// button inside the details modal.
+		$this->assertSame( '', $card['download_link'] );
+
+		$this->assertTrue( $card['wpcom_marketplace'] );
+	}
+
+	/**
+	 * Retired and hidden products are not on offer and must not be listed.
+	 */
+	public function test_retired_and_hidden_products_are_not_listed() {
+		$catalog = Marketplace_Catalog::to_catalog(
+			array(
+				self::PRODUCT,
+				array_merge(
+					self::PRODUCT,
+					array(
+						'slug'       => 'retired-one',
+						'is_retired' => true,
+					)
+				),
+				array_merge(
+					self::PRODUCT,
+					array(
+						'slug'      => 'hidden-one',
+						'is_hidden' => true,
+					)
+				),
+			)
+		);
+
+		$this->assertSame( array( 'gravityforms' ), array_keys( $catalog ) );
+	}
+
+	/**
+	 * A malformed entry is skipped rather than taking the whole catalog down.
+	 */
+	public function test_malformed_products_are_skipped() {
+		$catalog = Marketplace_Catalog::to_catalog(
+			array(
+				'not an array',
+				array( 'name' => 'No slug' ),
+				self::PRODUCT,
+			)
+		);
+
+		$this->assertSame( array( 'gravityforms' ), array_keys( $catalog ) );
+	}
+
+	/**
+	 * The tab sits after Featured, so the screen's default view does not change:
+	 * core lands on whichever tab comes first when none is requested.
+	 */
+	public function test_tab_is_registered_after_featured() {
+		$this->enable_tab();
+
+		$tabs = wpcom_marketplace_add_tab(
+			array(
+				'featured'    => 'Featured',
+				'popular'     => 'Popular',
+				'recommended' => 'Recommended',
+			)
+		);
+
+		$this->assertSame(
+			array( 'featured', WPCOM_MARKETPLACE_TAB, 'popular', 'recommended' ),
+			array_keys( $tabs )
+		);
+		$this->assertSame( 'featured', array_key_first( $tabs ) );
+	}
+
+	/**
+	 * With the flag off nothing about the screen changes.
+	 */
+	public function test_tab_is_absent_when_flag_is_off() {
+		add_filter( 'jetpack_feature_flag_enabled', '__return_false' );
+
+		$tabs = wpcom_marketplace_add_tab( array( 'featured' => 'Featured' ) );
+
+		$this->assertSame( array( 'featured' ), array_keys( $tabs ) );
+
+		remove_filter( 'jetpack_feature_flag_enabled', '__return_false' );
+	}
+
+	/**
+	 * Core skips the query for a tab it does not recognise unless the args say otherwise.
+	 */
+	public function test_api_args_restore_and_tag_the_query() {
+		$this->enable_tab();
+
+		$args = wpcom_marketplace_tab_api_args( false );
+
+		$this->assertIsArray( $args );
+		$this->assertTrue( $args['wpcom_marketplace'] );
+	}
+
+	/**
+	 * The tab's listing comes back in the envelope the list table reads.
+	 */
+	public function test_plugins_api_returns_the_catalog_for_our_tab() {
+		$this->enable_tab();
+		$this->seed_catalog( array( 'gravityforms' => Marketplace_Catalog::to_card( self::PRODUCT ) ) );
+
+		$response = wpcom_marketplace_serve_plugins_api( false, 'query_plugins', (object) array( 'wpcom_marketplace' => true ) );
+
+		$this->assertIsObject( $response );
+		$this->assertSame( 1, $response->info['results'] );
+		$this->assertSame( 'gravityforms', $response->plugins[0]['slug'] );
+	}
+
+	/**
+	 * A .org query is left for WordPress.org to answer.
+	 */
+	public function test_plugins_api_ignores_other_queries() {
+		$this->enable_tab();
+		$this->seed_catalog( array( 'gravityforms' => Marketplace_Catalog::to_card( self::PRODUCT ) ) );
+
+		$this->assertFalse(
+			wpcom_marketplace_serve_plugins_api( false, 'query_plugins', (object) array( 'browse' => 'popular' ) )
+		);
+
+		$this->assertFalse(
+			wpcom_marketplace_serve_plugins_api( false, 'plugin_information', (object) array( 'slug' => 'akismet' ) )
+		);
+	}
+
+	/**
+	 * Another filter having already answered wins.
+	 */
+	public function test_plugins_api_does_not_override_an_earlier_result() {
+		$this->enable_tab();
+
+		$existing = (object) array( 'plugins' => array() );
+
+		$this->assertSame(
+			$existing,
+			wpcom_marketplace_serve_plugins_api( $existing, 'query_plugins', (object) array( 'wpcom_marketplace' => true ) )
+		);
+	}
+
+	/**
+	 * A product that is not installed is bought, not downloaded.
+	 */
+	public function test_install_button_is_replaced_for_our_products() {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		$links = wpcom_marketplace_action_links(
+			array( '<a class="install-now">Install Now</a>', '<a>More Details</a>' ),
+			Marketplace_Catalog::to_card( self::PRODUCT )
+		);
+
+		$this->assertStringContainsString( 'Get started', $links[0] );
+		$this->assertStringContainsString( 'wordpress.com/plugins/gravityforms/', $links[0] );
+		$this->assertStringNotContainsString( 'install-now', $links[0] );
+
+		// The Details link is left alone.
+		$this->assertStringContainsString( 'More Details', $links[1] );
+	}
+
+	/**
+	 * WordPress.org plugins keep core's button.
+	 */
+	public function test_install_button_is_untouched_for_org_plugins() {
+		$original = array( '<a class="install-now">Install Now</a>' );
+
+		$this->assertSame(
+			$original,
+			wpcom_marketplace_action_links(
+				$original,
+				array(
+					'slug' => 'akismet',
+					'name' => 'Akismet',
+				)
+			)
+		);
+	}
+}


### PR DESCRIPTION
Fixes DOTPAR-21

## Proposed changes

WordPress.com sells around 55 partner and premium plugins that are not on WordPress.org, so core's plugin browser cannot find them. Today the only route to them from wp-admin is a full-width banner that sends people out to the Calypso marketplace.

This adds them as one more tab on the core Add Plugins screen instead, rendered by core's own `WP_Plugin_Install_List_Table`. It is the first piece of the "reintroduce the marketplace into the core pages" half of the plugins project, and it is Atomic-only in practice: Simple sites never reach `plugin-install.php`, because core redirects multisite subsites to network admin.

* `Marketplace_Catalog` reads `wpcom/v2/marketplace/products` and normalizes each product into the array shape `plugins_api()` returns. Core reads about a dozen of those keys without checking they exist, so all of them are set. Retired and hidden products are dropped.
* The list is cached for 6 hours, failures for 5 minutes. Descriptions are most of the payload and are only read by the details modal, so they are dropped from the cached list and re-fetched one product at a time when that modal opens.
* The tab is registered through `install_plugins_tabs`, populated through `install_plugins_table_api_args_{tab}` plus a `plugins_api` short-circuit, and rendered by core's `display_plugins_table()`.
* `plugin_install_action_links` swaps "Install Now" for a "Get started" link to the product's page on WordPress.com, but only while the product is not installed. Once it is, core's Activate / Update / Active buttons are already correct, and `Marketplace_Products_Updater` already gives core the right package URL for updates.
* The details modal is served from the same catalog, so "More Details" opens real product information rather than a WordPress.org 404. These products have no `download_link`, which is also what stops core offering an Install button inside that modal.
* Two card cells are hidden on this tab: partner plugins carry no install count and no WordPress.org ratings, and core renders a missing count as "Less Than 10 Active Installations" and a missing rating as zero stars.

On placement and naming:

* **The tab comes first, and is the screen's default view.** Those are the same change: core lands on whichever tab comes first when none is requested. It sits immediately before Featured rather than at the very front, so core's own Search Results and Beta Testing tabs still lead on the screens that add them.
* **"Marketplace" is the label.** It matches the existing Plugins submenu. The name is still open, and worth revisiting: WooCommerce already registers its own "WooCommerce Marketplace" tab on this screen, so there are now two tabs with the word in them. It is a one-line change.

Behind the `wpcom-plugins-marketplace-tab` feature flag, off by default.

Not in this PR, and worth knowing before reviewing: weighting the ordinary plugin search toward our products, injecting partner matches into search results, and removing the existing marketplace banner. Those all build on this and are easier to reason about separately.

## Related product discussion/links

* Linear: DOTPAR-21, part of the "Simplify choosing and installing plugins for logged-in WordPress users" project
* p58i-rpz-p2 and the plugins and themes marketplace design post on the Dotcom Design P2, where the decision to use core hooks rather than a separate fullscreen marketplace was made

## Does this pull request change what data or activity we track or use?

No. No new tracking. The catalog request is a blog-authenticated read of an endpoint the marketplace already exposes, and the outbound "Get started" link carries the same kind of `ref` parameter the existing banner does.

## Testing instructions

You need a site where mu-wpcom loads its WordPress.com user features, so an Atomic (WoA) site, a Simple site, or a Jurassic Ninja site with Jetpack connected as a WordPress.com user.

1. Turn the flag on at **Tools > Feature Flags** (Automatticians only): set `wpcom-plugins-marketplace-tab` to enabled.
2. Go to **Plugins > Add New Plugin**.
3. **Marketplace** should be the first tab, and the tab you land on with no `?tab=` in the URL.
4. Open it. You should see the partner catalog rendered as ordinary plugin cards, with a short line of explanation above them.
5. Each card's primary button should read **Get started** and open that plugin's page on WordPress.com in a new tab. No card should offer "Install Now".
6. Click **More Details** on a card. The modal should show the product's own name, version, author and description, with no Install button in its footer.
7. The card footers should show Last Updated and compatibility, and no star rating or install count.
8. If you have a marketplace plugin already installed on the site, its card should show core's normal button (Active, or Activate) rather than Get started.
9. Turn the flag back off and confirm the screen is exactly as it was: no tab, no stylesheet, no change to any other tab.

To check the failure path, block outbound requests to `public-api.wordpress.com` (or set the transient by hand) and reload the tab. It should show core's empty state rather than an error, and should not retry on every page load for the next five minutes.

