### PR TITLE
Security policy: add Jetpack Stats to the HackerOne plugin list

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,7 @@ Our HackerOne program covers the below plugin software, as well as a variety of 
 * Jetpack Protect
 * Jetpack Search
 * Jetpack Social
+* Jetpack Stats
 * Jetpack VideoPress
 
 **For responsible disclosure of security issues and to be eligible for our bug bounty program, please submit your report via the [HackerOne](https://hackerone.com/automattic) portal.**


### PR DESCRIPTION
Fixes N/A

## Proposed changes
* Add Jetpack Stats to the list of plugins covered by the Automattic HackerOne program in `SECURITY.md`. The standalone plugin passed the WordPress.org review on 8 September and is about to get its first release under the `jetpack-stats` slug. The other standalone plugins are listed here already, so security reports for the new plugin should go through the same channel.

Kept as a draft on purpose. I will merge it when the plugin goes live on WordPress.org, so the policy does not name a plugin nobody can install yet.

## Related product discussion/links
* STATS-343
* Review history is on the Jetpack Stats P2, "Jetpack Stats standalone plugin — WordPress.org review"

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Read `SECURITY.md` and confirm Jetpack Stats sits in the plugin list in alphabetical order.
