### PR TITLE
Premium Analytics: add the Total views / Daily average switch to the All-time traffic card

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-metric
+++ b/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-metric
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post detail: Add a Total views / Daily average switch to the All-time traffic card.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-view-count.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-view-count.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { formatDailyViewCount, formatViewCount } from '../format-view-count';
+
+describe( 'formatViewCount', () => {
+	it( 'pluralises the unit', () => {
+		expect( formatViewCount( 1 ) ).toBe( '1 view' );
+		expect( formatViewCount( 2 ) ).toBe( '2 views' );
+	} );
+} );
+
+describe( 'formatDailyViewCount', () => {
+	it( 'pluralises the daily rate', () => {
+		expect( formatDailyViewCount( 0 ) ).toBe( '0 views per day' );
+		expect( formatDailyViewCount( 1 ) ).toBe( '1 view per day' );
+		expect( formatDailyViewCount( 2 ) ).toBe( '2 views per day' );
+	} );
+
+	it( 'rounds a fractional rate before choosing the plural', () => {
+		expect( formatDailyViewCount( 1.39 ) ).toBe( '1 view per day' );
+		expect( formatDailyViewCount( 1.5 ) ).toBe( '2 views per day' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-view-count.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-view-count.ts
@@ -23,9 +23,13 @@ export function formatViewCount( count: number ): string {
  * than a total. Kept beside `formatViewCount` so the two plural sets stay together.
  */
 export function formatDailyViewCount( count: number ): string {
+	// Rounded once for both the plural and the figure, so a fractional rate
+	// cannot read "1 views per day".
+	const views = Math.round( count );
+
 	return sprintf(
 		/* translators: %s: average number of views per day, e.g. "2,033". */
-		_n( '%s view per day', '%s views per day', count, 'jetpack-premium-analytics-pkg' ),
-		formatMetricValue( count, 'number', { decimals: 0 } )
+		_n( '%s view per day', '%s views per day', views, 'jetpack-premium-analytics-pkg' ),
+		formatMetricValue( views, 'number', { decimals: 0 } )
 	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-view-count.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-view-count.ts
@@ -17,3 +17,15 @@ export function formatViewCount( count: number ): string {
 		formatMetricValue( count, 'number', { decimals: 0 } )
 	);
 }
+
+/**
+ * The same count as a daily rate, for a cell that reports an average rather
+ * than a total. Kept beside `formatViewCount` so the two plural sets stay together.
+ */
+export function formatDailyViewCount( count: number ): string {
+	return sprintf(
+		/* translators: %s: average number of views per day, e.g. "2,033". */
+		_n( '%s view per day', '%s views per day', count, 'jetpack-premium-analytics-pkg' ),
+		formatMetricValue( count, 'number', { decimals: 0 } )
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -79,7 +79,7 @@ export {
 	type CalendarHeatmapLayoutInput,
 	type FitWeekColumnsInput,
 } from './calendar-heatmap-layout';
-export { formatViewCount } from './format-view-count';
+export { formatDailyViewCount, formatViewCount } from './format-view-count';
 export { siteChartFormatting } from './site-chart-formatting';
 export { formatComparisonSeriesLabel } from './format-comparison-series-label';
 export { formatTooltipSeriesLabel } from './format-tooltip-series-label';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -214,6 +214,7 @@ export {
 	CALENDAR_HEATMAP_HEADER_HEIGHT,
 	computeCalendarHeatmapLayout,
 	fitWeekColumns,
+	formatDailyViewCount,
 	formatViewCount,
 	buildDenseDaySeries,
 	resolveCalendarHeatmapGridStart,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/stats-post.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/stats-post.ts
@@ -33,11 +33,13 @@ const mockPostDailyViews: Array< [ string, number ] > = Array.from(
 type YearTable = { total: number; months: Record< string, number > };
 
 /**
- * The endpoint's per-year tables, rolled up from the daily series: each
- * month's views and the year's total. Months are keyed `1`-`12`.
+ * The endpoint's per-year tables, rolled up from the daily series: `years`
+ * carries each month's views and the year's total, `averages` the views per
+ * day of each month with the year under `overall`. Months are keyed `1`-`12`.
  */
 function rollUpYears( series: Array< [ string, number ] > ) {
 	const years: Record< string, YearTable > = {};
+	const days: Record< string, Record< string, number > > = {};
 
 	series.forEach( ( [ date, views ] ) => {
 		const year = date.slice( 0, 4 );
@@ -46,9 +48,31 @@ function rollUpYears( series: Array< [ string, number ] > ) {
 		years[ year ] = years[ year ] ?? { total: 0, months: {} };
 		years[ year ].months[ month ] = ( years[ year ].months[ month ] ?? 0 ) + views;
 		years[ year ].total += views;
+
+		days[ year ] = days[ year ] ?? {};
+		days[ year ][ month ] = ( days[ year ][ month ] ?? 0 ) + 1;
 	} );
 
-	return { years };
+	const averages = Object.fromEntries(
+		Object.entries( years ).map( ( [ year, { total, months } ] ) => {
+			const yearDays = Object.values( days[ year ] ).reduce( ( sum, count ) => sum + count, 0 );
+
+			return [
+				year,
+				{
+					overall: Math.round( total / yearDays ),
+					months: Object.fromEntries(
+						Object.entries( months ).map( ( [ month, views ] ) => [
+							month,
+							Math.round( views / days[ year ][ month ] ),
+						] )
+					),
+				},
+			];
+		} )
+	);
+
+	return { years, averages };
 }
 
 // Published on the series' first day, so the post's life and its stats agree.

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { buildAllTimeTrafficRows } from '../build-all-time-traffic-rows';
+import { buildAllTimeTrafficRows, resolveMetric } from '../build-all-time-traffic-rows';
 import type { StatsPostResponse } from '@jetpack-premium-analytics/data';
 
 // The endpoint keys months `1`-`12` and leaves out months without views.
@@ -10,19 +10,23 @@ const RESPONSE: StatsPostResponse = {
 		'2025': { total: 30, months: { '11': 10, '12': 20 } },
 		'2026': { total: 45, months: { '1': 5, '3': 40 } },
 	},
+	averages: {
+		'2025': { overall: 1, months: { '11': 1, '12': 2 } },
+		'2026': { overall: 3, months: { '1': 1, '3': 8 } },
+	},
 };
 
 const TODAY = { year: 2026, month: 2 };
 
 describe( 'buildAllTimeTrafficRows', () => {
 	it( 'returns one row per year of the post, newest first', () => {
-		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY );
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'total', TODAY );
 
 		expect( rows.map( row => row.year ) ).toEqual( [ 2026, 2025 ] );
 	} );
 
 	it( 'draws every month of the post life, zeroing the ones the endpoint left out', () => {
-		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY );
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'total', TODAY );
 
 		expect( rows[ 1 ].months ).toEqual( [
 			'before',
@@ -56,26 +60,42 @@ describe( 'buildAllTimeTrafficRows', () => {
 	} );
 
 	it( 'starts the life at the publish month when that is earlier than the first stats', () => {
-		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY, { year: 2025, month: 8 } );
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'total', TODAY, { year: 2025, month: 8 } );
 
 		expect( rows[ 1 ].months.slice( 7, 11 ) ).toEqual( [ 'before', 0, 0, 10 ] );
 	} );
 
 	it( 'keeps stats from before the publish month', () => {
-		const rows = buildAllTimeTrafficRows( RESPONSE, TODAY, { year: 2026, month: 0 } );
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'total', TODAY, { year: 2026, month: 0 } );
 
 		expect( rows[ 1 ].months.slice( 10 ) ).toEqual( [ 10, 20 ] );
 	} );
 
 	it( 'keeps the table open through the current month when the endpoint runs behind', () => {
-		const rows = buildAllTimeTrafficRows( RESPONSE, { year: 2026, month: 5 } );
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'total', { year: 2026, month: 5 } );
 
 		expect( rows[ 0 ].months[ 5 ] ).toBe( 0 );
 		expect( rows[ 0 ].months[ 6 ] ).toBe( 'after' );
 	} );
 
+	it( 'reads the per-day averages under the average metric, over the months years reports', () => {
+		const rows = buildAllTimeTrafficRows( RESPONSE, 'average', TODAY );
+
+		expect( rows[ 0 ].months.slice( 0, 3 ) ).toEqual( [ 1, 0, 8 ] );
+		expect( rows[ 1 ].months.slice( 10 ) ).toEqual( [ 1, 2 ] );
+	} );
+
 	it( 'returns no rows without yearly stats', () => {
-		expect( buildAllTimeTrafficRows( undefined, TODAY ) ).toEqual( [] );
-		expect( buildAllTimeTrafficRows( { years: {} }, TODAY ) ).toEqual( [] );
+		expect( buildAllTimeTrafficRows( undefined, 'total', TODAY ) ).toEqual( [] );
+		expect( buildAllTimeTrafficRows( { years: {} }, 'total', TODAY ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'resolveMetric', () => {
+	it( 'reads a stored metric and falls back to total views', () => {
+		expect( resolveMetric( 'average' ) ).toBe( 'average' );
+		expect( resolveMetric( 'total' ) ).toBe( 'total' );
+		expect( resolveMetric( undefined ) ).toBe( 'total' );
+		expect( resolveMetric( 'views' ) ).toBe( 'total' );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
@@ -85,6 +85,10 @@ describe( 'buildAllTimeTrafficRows', () => {
 		expect( rows[ 1 ].months.slice( 10 ) ).toEqual( [ 1, 2 ] );
 	} );
 
+	it( 'returns no rows under the average metric without its table', () => {
+		expect( buildAllTimeTrafficRows( { years: RESPONSE.years }, 'average', TODAY ) ).toEqual( [] );
+	} );
+
 	it( 'returns no rows without yearly stats', () => {
 		expect( buildAllTimeTrafficRows( undefined, 'total', TODAY ) ).toEqual( [] );
 		expect( buildAllTimeTrafficRows( { years: {} }, 'total', TODAY ) ).toEqual( [] );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -118,6 +118,10 @@ const RESPONSE = {
 		'2025': { total: 30, months: { '11': 10, '12': 20 } },
 		'2026': { total: 45, months: { '1': 5, '3': 40 } },
 	},
+	averages: {
+		'2025': { overall: 1, months: { '11': 1, '12': 2 } },
+		'2026': { overall: 3, months: { '1': 1, '3': 8 } },
+	},
 	post: { ID: 779, post_date: '2025-11-10 16:27:32' },
 };
 
@@ -130,10 +134,11 @@ const NOVEMBER_2025 = {
 const NOW = new Date( '2026-03-15T12:00:00.000Z' );
 
 // `null` renders the widget without a post scope.
-function renderWidget( postId: number | null = 779 ) {
+function renderWidget( postId: number | null = 779, attributes: Record< string, unknown > = {} ) {
 	return render(
 		<PostAllTimeTrafficRender
 			attributes={ {
+				...attributes,
 				reportParams: {
 					from: '2026-01-01T00:00:00.000+00:00',
 					to: '2026-01-31T23:59:59.999+00:00',
@@ -174,6 +179,16 @@ describe( 'PostAllTimeTraffic widget', () => {
 		// Published in November: the months before it are filler.
 		expect( rows[ 1 ] ).toBe( '.,.,.,.,.,.,.,.,.,.,10,20' );
 		expect( screen.getByTestId( 'legend' ) ).toHaveTextContent( 'Fewer views/More views' );
+	} );
+
+	it( 'draws views per day under the average metric', () => {
+		renderWidget( 779, { metric: 'average' } );
+
+		const heatmap = screen.getByTestId( 'heatmap' );
+		expect( heatmap.dataset.rows?.split( '|' )[ 0 ]?.startsWith( '1,0,8' ) ).toBe( true );
+		expect( screen.getByTestId( 'legend' ) ).toHaveTextContent(
+			'Fewer views per day/More views per day'
+		);
 	} );
 
 	it( 'applies a clicked month to the page as a custom range cut to the post life', async () => {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/use-post-all-time-traffic.test.tsx
@@ -16,6 +16,7 @@ const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 
 const STATS_POST_RESPONSE = {
 	years: { '2026': { total: 45, months: { '1': 5, '3': 40 } } },
+	averages: { '2026': { overall: 3, months: { '1': 1, '3': 8 } } },
 	post: { ID: 779, post_date: '2026-01-10 16:27:32' },
 };
 
@@ -36,13 +37,13 @@ describe( 'usePostAllTimeTraffic', () => {
 	} );
 
 	it( 'requests the yearly tables and the post row, and builds the rows from them', async () => {
-		const { result } = renderHook( () => usePostAllTimeTraffic( 779 ), { wrapper } );
+		const { result } = renderHook( () => usePostAllTimeTraffic( 779, 'total' ), { wrapper } );
 
 		await waitFor( () => expect( result.current.rows ).toHaveLength( 1 ) );
 
 		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( String( mockApiFetch.mock.calls[ 0 ][ 0 ].path ) ).toMatch(
-			/stats\/post\/779.*fields=years(%2C|,)post/
+			/stats\/post\/779.*fields=years(%2C|,)averages(%2C|,)post/
 		);
 
 		expect( result.current.rows[ 0 ].year ).toBe( 2026 );
@@ -55,15 +56,29 @@ describe( 'usePostAllTimeTraffic', () => {
 			...STATS_POST_RESPONSE,
 			post: { ID: 779, post_date: '2026-03-05 10:00:00' },
 		} );
-		const { result } = renderHook( () => usePostAllTimeTraffic( 779 ), { wrapper } );
+		const { result } = renderHook( () => usePostAllTimeTraffic( 779, 'total' ), { wrapper } );
 
 		await waitFor( () => expect( result.current.rows ).toHaveLength( 1 ) );
 
 		expect( result.current.lifeStartsAt?.toISOString() ).toBe( '2026-01-01T00:00:00.000Z' );
 	} );
 
+	it( 'switches to the per-day averages without refetching', async () => {
+		const { result, rerender } = renderHook(
+			( { metric }: { metric: 'total' | 'average' } ) => usePostAllTimeTraffic( 779, metric ),
+			{ wrapper, initialProps: { metric: 'total' } }
+		);
+
+		await waitFor( () => expect( result.current.rows ).toHaveLength( 1 ) );
+
+		rerender( { metric: 'average' } );
+
+		expect( result.current.rows[ 0 ].months.slice( 0, 3 ) ).toEqual( [ 1, 0, 8 ] );
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'never requests without a post scope', () => {
-		const { result } = renderHook( () => usePostAllTimeTraffic( 0 ), { wrapper } );
+		const { result } = renderHook( () => usePostAllTimeTraffic( 0, 'total' ), { wrapper } );
 
 		expect( mockApiFetch ).not.toHaveBeenCalled();
 		expect( result.current.rows ).toEqual( [] );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
@@ -5,6 +5,21 @@ import type { StatsPostResponse, StatsPostYear } from '@jetpack-premium-analytic
 
 export const MONTHS_IN_YEAR = 12;
 
+/** Which number each cell reports: the month's views, or its views per day. */
+export type AllTimeTrafficMetric = 'total' | 'average';
+
+export const DEFAULT_METRIC: AllTimeTrafficMetric = 'total';
+
+/**
+ * The metric a stored instance names; anything that is not one reads as the default.
+ *
+ * @param value - The raw `metric` attribute.
+ * @return The metric to draw.
+ */
+export function resolveMetric( value: unknown ): AllTimeTrafficMetric {
+	return value === 'average' ? 'average' : DEFAULT_METRIC;
+}
+
 /** A calendar month; `month` is zero-based, as `Date` counts it. */
 export type MonthKey = { year: number; month: number };
 
@@ -34,11 +49,13 @@ function reportedMonths( years: Record< string, StatsPostYear > ): number[] {
 /**
  * Turns the endpoint's per-year tables into one row per year, newest first.
  *
- * `years` carries each month's views. A month the endpoint leaves out inside
- * the post's life is a zero, so the grid stays complete, the way the daily
- * heatmap draws every day of its range.
+ * `years` carries each month's views and `averages` its views per day; the
+ * months reported come from `years` under both metrics. A month the endpoint
+ * leaves out inside the post's life is a zero, so the grid stays complete, the
+ * way the daily heatmap draws every day of its range.
  *
  * @param response  - The sanitized `stats/post` response.
+ * @param metric    - Which number each cell reports.
  * @param today     - The site's current month, which closes the last row.
  * @param published - The month the post was published; defaults to the first
  *                  reported month.
@@ -46,6 +63,7 @@ function reportedMonths( years: Record< string, StatsPostYear > ): number[] {
  */
 export function buildAllTimeTrafficRows(
 	response: StatsPostResponse | undefined,
+	metric: AllTimeTrafficMetric,
 	today: MonthKey,
 	published?: MonthKey
 ): AllTimeTrafficRow[] {
@@ -56,6 +74,7 @@ export function buildAllTimeTrafficRows(
 		return [];
 	}
 
+	const source = metric === 'average' ? response?.averages ?? {} : years;
 	// A post can carry stats from before its publish date (a rescheduled one),
 	// so its life starts at whichever comes first.
 	const firstOrder = Math.min( ...reported, published ? monthOrder( published ) : Infinity );
@@ -65,7 +84,7 @@ export function buildAllTimeTrafficRows(
 	const rows: AllTimeTrafficRow[] = [];
 
 	for ( let year = lastYear; year >= firstYear; year-- ) {
-		const stats = years[ String( year ) ];
+		const stats = source[ String( year ) ];
 		const months = Array.from(
 			{ length: MONTHS_IN_YEAR },
 			( _month, month ): AllTimeTrafficMonth => {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
@@ -70,11 +70,13 @@ export function buildAllTimeTrafficRows(
 	const years = response?.years ?? {};
 	const reported = reportedMonths( years );
 
-	if ( reported.length === 0 ) {
+	// Without its table the average view has nothing to draw: a grid of zeros
+	// built from `years` alone would read as a real measurement.
+	if ( reported.length === 0 || ( metric === 'average' && ! response?.averages ) ) {
 		return [];
 	}
 
-	const source = metric === 'average' ? response?.averages ?? {} : years;
+	const source = metric === 'average' ? response.averages : years;
 	// A post can carry stats from before its publish date (a rescheduled one),
 	// so its life starts at whichever comes first.
 	const firstOrder = Math.min( ...reported, published ? monthOrder( published ) : Infinity );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/package.json
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/package.json
@@ -7,6 +7,7 @@
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
 		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
+		"@jetpack-premium-analytics/fields": "link:../../packages/fields",
 		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/routing": "link:../../packages/routing",

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -14,6 +14,7 @@ import {
 	WidgetRoot,
 	WidgetState,
 	describeError,
+	formatDailyViewCount,
 	formatViewCount,
 	useWidgetRootContext,
 	type HeatmapColumn,
@@ -25,7 +26,11 @@ import { useCallback, useMemo, type KeyboardEvent, type MouseEvent } from 'react
 /**
  * Internal dependencies
  */
-import { MONTHS_IN_YEAR } from './build-all-time-traffic-rows';
+import {
+	MONTHS_IN_YEAR,
+	resolveMetric,
+	type AllTimeTrafficMetric,
+} from './build-all-time-traffic-rows';
 import { monthRange } from './period-range';
 import styles from './style.module.css';
 import usePostAllTimeTraffic from './use-post-all-time-traffic';
@@ -45,12 +50,12 @@ const MAX_CELL_HEIGHT = 40;
 // The chart's own cell markup, which a click or the keyboard selection lands on.
 const CELL_SELECTOR = '[role="gridcell"][data-column][data-row]';
 
-function PostAllTimeTrafficInner() {
+function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } ) {
 	const { reportParams } = useWidgetRootContext();
 	const postId = toPostId( reportParams.post_id );
 
 	const { rows, lifeStartsAt, isLoading, isFetching, isError, error, refetch } =
-		usePostAllTimeTraffic( postId );
+		usePostAllTimeTraffic( postId, metric );
 
 	// Bound to the route hosting the widget: a month picked here becomes the
 	// page's period, read over by the other cards while this one stays all-time.
@@ -143,10 +148,10 @@ function PostAllTimeTrafficInner() {
 				// screen reader: "Aug 2026".
 				cellLabel={ `${ columnLabel ?? '' } ${ rowLabel ?? '' }`.trim() }
 				emptyLabel={ __( 'No views', 'jetpack-premium-analytics-pkg' ) }
-				formatValue={ formatViewCount }
+				formatValue={ metric === 'average' ? formatDailyViewCount : formatViewCount }
 			/>
 		),
-		[]
+		[ metric ]
 	);
 
 	return (
@@ -197,8 +202,16 @@ function PostAllTimeTrafficInner() {
 					{ /* Wrapped so the scale sits centred: the chart lays its trailing content out full width. */ }
 					<Stack direction="row" justify="center">
 						<HeatmapChart.Legend
-							lessLabel={ __( 'Fewer views', 'jetpack-premium-analytics-pkg' ) }
-							moreLabel={ __( 'More views', 'jetpack-premium-analytics-pkg' ) }
+							lessLabel={
+								metric === 'average'
+									? __( 'Fewer views per day', 'jetpack-premium-analytics-pkg' )
+									: __( 'Fewer views', 'jetpack-premium-analytics-pkg' )
+							}
+							moreLabel={
+								metric === 'average'
+									? __( 'More views per day', 'jetpack-premium-analytics-pkg' )
+									: __( 'More views', 'jetpack-premium-analytics-pkg' )
+							}
 						/>
 					</Stack>
 				</HeatmapChart>
@@ -210,7 +223,7 @@ function PostAllTimeTrafficInner() {
 export default function PostAllTimeTraffic( { attributes = {} }: PostAllTimeTrafficWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<PostAllTimeTrafficInner />
+			<PostAllTimeTrafficInner metric={ resolveMetric( attributes.metric ) } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
@@ -1,8 +1,9 @@
 /**
  * The All-time traffic widget is the post detail Traffic view's history card:
- * every month of the scoped post's views, one row per year. It reads the
- * post's whole life regardless of the page period, and picking a month
- * applies that month to the page. The post scope arrives through
+ * every month of the scoped post's views, one row per year, as total views or
+ * views per day (the `metric` attribute, which the framed host offers in the
+ * header). It reads the post's whole life regardless of the page period, and
+ * picking a month applies that month to the page. The post scope arrives through
  * `reportParams.post_id` (seeded from the detail page URL in product); the
  * `hasPostScope` control toggles it to exercise the scopeless empty state.
  *
@@ -49,13 +50,15 @@ const POST_STATS_REQUEST_PATH = `stats/post/${ MOCK_POST_ID }`;
 
 interface PostAllTimeTrafficStoryControls {
 	hasPostScope: boolean;
+	metric: 'total' | 'average';
 }
 
 function getPostAllTimeTrafficAttributes(
-	{ hasPostScope }: PostAllTimeTrafficStoryControls,
+	{ hasPostScope, metric }: PostAllTimeTrafficStoryControls,
 	withComparison = false
 ): ComponentProps< typeof PostAllTimeTrafficRender >[ 'attributes' ] {
 	return {
+		metric,
 		reportParams: {
 			...getDefaultQueryParams( withComparison ),
 			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
@@ -72,6 +75,12 @@ const hasPostScopeArgType = {
 	description: 'Include the `post_id` report param the post detail page seeds from its URL.',
 } as const;
 
+const metricArgType = {
+	control: 'radio',
+	options: [ 'total', 'average' ],
+	description: "The `metric` attribute: the month's views, or its views per day.",
+} as const;
+
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostAllTimeTraffic',
 	component: PostAllTimeTrafficRender,
@@ -81,12 +90,13 @@ const meta = {
 	decorators: [ withStoryRouter ],
 	argTypes: {
 		hasPostScope: hasPostScopeArgType,
+		metric: metricArgType,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "All-time traffic" widget: every month of the scoped post\'s views, one row per year. It always covers the post\'s whole life, whatever period the page shows, and picking a month applies that month to the page. Without a post scope the widget renders a scopeless empty state.',
+					"The \"All-time traffic\" widget: every month of the scoped post's views, one row per year, as total views or views per day. The `metric` attribute has `relevance: 'high'`, so the framed host renders its select in the header; the close-up stories set it as an arg. It always covers the post's whole life, whatever period the page shows, and picking a month applies that month to the page. Without a post scope the widget renders a scopeless empty state.",
 			},
 		},
 	},
@@ -103,7 +113,17 @@ type Story = StoryObj< PostAllTimeTrafficStoryControls >;
  */
 export const Default: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, metric: 'total' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * DailyAverage — the same table under the Daily average metric: each cell is
+ * the month's views per day, and the scale and tooltips say so.
+ */
+export const DailyAverage: Story = {
+	render: renderPostAllTimeTraffic,
+	args: { hasPostScope: true, metric: 'average' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -114,7 +134,7 @@ export const Default: Story = {
  */
 export const NoPostScope: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: false },
+	args: { hasPostScope: false, metric: 'total' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -124,7 +144,7 @@ export const NoPostScope: Story = {
  */
 export const Loading: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, metric: 'total' },
 	// Off the shared autodocs page — path-keyed override; see setReportMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -139,7 +159,7 @@ export const Loading: Story = {
  */
 export const Error: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, metric: 'total' },
 	// Off the shared autodocs page — path-keyed override; see setReportMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -155,7 +175,7 @@ export const Error: Story = {
  */
 export const ErrorRetryable: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, metric: 'total' },
 	// Off the shared autodocs page — path-keyed override; see setReportMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -170,7 +190,7 @@ export const ErrorRetryable: Story = {
  */
 export const Empty: Story = {
 	render: renderPostAllTimeTraffic,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, metric: 'total' },
 	// Off the shared autodocs page — path-keyed override; see setReportMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -190,6 +210,7 @@ interface PostAllTimeTrafficDashboardStoryProps
  */
 function PostAllTimeTrafficDashboardStory( {
 	hasPostScope,
+	metric,
 	...dashboardArgs
 }: PostAllTimeTrafficDashboardStoryProps ) {
 	return (
@@ -198,7 +219,7 @@ function PostAllTimeTrafficDashboardStory( {
 			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_ALL_TIME_TRAFFIC_RENDER_MODULE }
 			renderComponent={ PostAllTimeTrafficRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ getPostAllTimeTrafficAttributes( { hasPostScope }, true ) }
+			attributes={ getPostAllTimeTrafficAttributes( { hasPostScope, metric }, true ) }
 		/>
 	);
 }
@@ -213,9 +234,11 @@ export const WidgetDashboardWithWidget: StoryObj< PostAllTimeTrafficDashboardSto
 		widgetWidth: 3,
 		widgetHeight: 2,
 		hasPostScope: true,
+		metric: 'total',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		hasPostScope: hasPostScopeArgType,
+		metric: metricArgType,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/use-post-all-time-traffic.ts
@@ -14,6 +14,7 @@ import { useMemo } from 'react';
  */
 import {
 	buildAllTimeTrafficRows,
+	type AllTimeTrafficMetric,
 	type AllTimeTrafficRow,
 	type MonthKey,
 } from './build-all-time-traffic-rows';
@@ -60,12 +61,16 @@ function lifeStart(
  * A `postId` of 0 disables the request.
  *
  * @param postId - The post the page is scoped to.
+ * @param metric - Which number each cell reports.
  * @return The rows and the request's state.
  */
-export default function usePostAllTimeTraffic( postId: number ): PostAllTimeTrafficState {
+export default function usePostAllTimeTraffic(
+	postId: number,
+	metric: AllTimeTrafficMetric
+): PostAllTimeTrafficState {
 	const { data, isLoading, isFetching, isError, error, refetch } = useStatsPost( {
 		postId,
-		fields: [ 'years', 'post' ],
+		fields: [ 'years', 'averages', 'post' ],
 	} );
 
 	// Same reading as the page header: a site-local wall time, or the GMT stamp
@@ -88,12 +93,13 @@ export default function usePostAllTimeTraffic( postId: number ): PostAllTimeTraf
 		};
 		const built = buildAllTimeTrafficRows(
 			data,
+			metric,
 			{ year: today.getFullYear(), month: today.getMonth() },
 			publishedMonth
 		);
 
 		return { rows: built, lifeStartsAt: lifeStart( built, publishedAt, publishedMonth ) };
-	}, [ data, publishedAt ] );
+	}, [ data, metric, publishedAt ] );
 
 	return {
 		rows,

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.json
@@ -3,7 +3,7 @@
 	"title": "All-time traffic",
 	"description": "Every month of views for the post or page being viewed, across its whole life.",
 	"help": {
-		"content": "Every month of views for the post or page being viewed, shaded by how it compares to the rest. Always the full history: the period above doesn't narrow it. Pick a month to read the rest of the page over it."
+		"content": "Every month of views for the post or page being viewed, shaded by how it compares to the rest. Always the full history: the period above doesn't narrow it. Pick a month to read the rest of the page over it. Daily average leaves the current day out, as the classic Stats table does."
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/widget.ts
@@ -1,20 +1,38 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
+import { SelectField } from '@jetpack-premium-analytics/fields';
+import { __, _x } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import type { AllTimeTrafficMetric } from './build-all-time-traffic-rows';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
-/**
- * No configurable attributes: the widget always shows the post the page is
- * scoped to (via `reportParams.post_id`). `Record< never, never >` so the
- * render-only type can compose host fields such as `reportParams`.
- */
-export type PostAllTimeTrafficAttributes = Record< never, never >;
+export type PostAllTimeTrafficAttributes = {
+	/** Which number each cell reports; total views when unset. */
+	metric?: AllTimeTrafficMetric;
+};
 
+// `relevance: 'high'`: the framed host draws the select in the widget header,
+// where the design puts the Total views / Daily average switch.
 export default {
 	icon: calendar,
-	attributes: [] as WidgetAttributeField< PostAllTimeTrafficAttributes >[],
+	attributes: [
+		{
+			id: 'metric',
+			label: _x( 'Metric', 'label for the views metric selector', 'jetpack-premium-analytics-pkg' ),
+			type: 'text',
+			relevance: 'high',
+			Edit: SelectField,
+			elements: [
+				{ value: 'total', label: __( 'Total views', 'jetpack-premium-analytics-pkg' ) },
+				{ value: 'average', label: __( 'Daily average', 'jetpack-premium-analytics-pkg' ) },
+			],
+		},
+	] as WidgetAttributeField< PostAllTimeTrafficAttributes >[],
 	example: {
-		attributes: {},
+		attributes: { metric: 'total' },
 	},
 };

--- a/projects/plugins/jetpack/changelog/update-post-all-time-traffic-metric
+++ b/projects/plugins/jetpack/changelog/update-post-all-time-traffic-metric
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Add a Total views / Daily average switch to the post detail All-time traffic card.

--- a/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-metric
+++ b/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-metric
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post detail: Add a Total views / Daily average switch to the All-time traffic card.

--- a/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-metric
+++ b/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-metric
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: Add a Total views / Daily average switch to the post detail All-time traffic card.


### PR DESCRIPTION
Fixes UNI-770. Part of UNI-755. Stacked on #52118, which adds the card; this PR carries only the metric change and is retargeted to trunk once that one lands.

## Proposed changes

The All-time traffic card on the post and page detail Traffic tab reports each month's total views. The design puts a switch on its title line, Total views or Daily average, the same pair the classic Stats table offers as "Months and years" and "Average per day".

### The metric attribute

The widget declares a `metric` attribute (`total` or `average`) with `relevance: 'high'` and the shared `SelectField`, the way the Year in review widget declares its year. The framed host renders a high-relevance field in the widget header, which is where the design places the switch, so the widget body draws nothing for it. An instance that never picked one reads as total views, and so does any stored value that is not a metric.

### What changes with the metric

Under Daily average the cells read the endpoint's `averages` tables: each month's views per day, over the same months the `years` tables report. The request asks for `averages` alongside `years`, so switching is a client-side row pick with no new fetch. The tooltip says "views per day" and the scale reads "Fewer views per day" to "More views per day"; under Total views nothing changes.

`formatDailyViewCount()` joins `formatViewCount()` in the widgets toolkit, so the two plural sets stay together.

## Related product discussion/links

* UNI-755 is the parent issue; UNI-769 (#52118), UNI-770 (this change), UNI-771 and UNI-772 are its sub-tasks.
* WOOA7S-2046 files the same replacement; WOOA7S-2015 is the Insights counterpart.

## Does this pull request change what data or activity we track or use?

No. The widget reads the `stats/post` endpoint the page already proxies, adding its `averages` tables to the fields it asks for.

## Testing instructions

Build the package with `jetpack build packages/premium-analytics`, open Stats v2 and go to the detail page of a post with some views.

The All-time traffic card header carries a select reading **Total views**. Pick **Daily average**: the cells switch to each month's views per day with no new request (the Network panel shows none), the tooltip on a month reads "N views per day", and the scale reads "Fewer views per day" to "More views per day". Months outside the post's life stay filler; a month with views but no full day behind it yet reads `0`.

Pick **Total views** again: the previous numbers and copy return. Reload the page: the choice persists with the card's stored arrangement.

In Storybook, the `DailyAverage` story shows the average view and the `WidgetDashboardWithWidget` story renders the real header select.

Unit tests, from the package: `pnpm run test -- widgets/post-all-time-traffic packages/widgets-toolkit/src/helpers`.

### Screenshots

The select the framed host renders in the card header, open on Total views:

![The All-time traffic card with its header select open, listing Total views and Daily average](https://github.com/Automattic/jetpack/raw/screenshots/update/post-all-time-traffic-metric/after-metric-select.png)

A month under Total views:

![The table under Total views, with the tooltip on August 2026 reading 6,149 views](https://github.com/Automattic/jetpack/raw/screenshots/update/post-all-time-traffic-metric/after-total-views-tooltip.png)

The same post under Daily average:

![The table under Daily average, with the tooltip on July 2026 reading 209 views per day](https://github.com/Automattic/jetpack/raw/screenshots/update/post-all-time-traffic-metric/after-daily-average.png)

## Follow-ups

- [ ] UNI-771: Totals column, centred and sticky month labels, chart-level cell click.
- [ ] UNI-772: remove the `jpa/post-traffic-activity` widget.
