### PR TITLE
Boost: route dashboard navigation through a shared helper

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/ui/back-button/back-button.tsx
@@ -1,23 +1,19 @@
 import { __ } from '@wordpress/i18n';
 import LeftArrow from '$svg/left-arrow';
-import { useNavigate } from 'react-router';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { Button } from '@automattic/jetpack-components';
 import styles from './back-button.module.scss';
 import type { FC } from 'react';
 
-type BackButtonProps = {
-	route?: string;
-};
-
-const BackButton: FC< BackButtonProps > = ( { route = '/' } ) => {
-	const navigate = useNavigate();
+const BackButton: FC = () => {
+	const { returnToSettings } = useBoostNavigation();
 	const handleBack = () => {
 		recordBoostEvent( 'back_button_clicked', {
 			current_page: window.location.href.replace( window.location.origin, '' ),
-			destination: route,
+			destination: '/',
 		} );
-		navigate( route );
+		returnToSettings();
 	};
 
 	return (

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react';
+import { LegacyNavigationProvider, useBoostNavigation } from './navigation-context';
+
+const mockNavigate = jest.fn();
+
+jest.mock( 'react-router', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
+
+describe( 'useBoostNavigation', () => {
+	beforeEach( () => {
+		mockNavigate.mockClear();
+	} );
+
+	it( 'throws outside a provider, rather than navigating nowhere', () => {
+		const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+		expect( () => renderHook( () => useBoostNavigation() ) ).toThrow(
+			'useBoostNavigation must be used inside a Boost navigation provider.'
+		);
+
+		consoleError.mockRestore();
+	} );
+} );
+
+describe( 'LegacyNavigationProvider', () => {
+	beforeEach( () => {
+		mockNavigate.mockClear();
+	} );
+
+	const renderNavigation = () =>
+		renderHook( () => useBoostNavigation(), { wrapper: LegacyNavigationProvider } );
+
+	it( 'sends returnToSettings to the router root', () => {
+		renderNavigation().result.current.returnToSettings();
+
+		expect( mockNavigate ).toHaveBeenCalledWith( '/', undefined );
+	} );
+
+	it( 'passes navigation options through', () => {
+		renderNavigation().result.current.returnToSettings( { replace: true } );
+
+		expect( mockNavigate ).toHaveBeenCalledWith( '/', { replace: true } );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useMemo } from 'react';
+import { useNavigate } from 'react-router';
+import type { ReactNode } from 'react';
+
+type NavigateOptions = {
+	replace?: boolean;
+};
+
+type BoostNavigation = {
+	returnToSettings: ( options?: NavigateOptions ) => void;
+};
+
+const NavigationContext = createContext< BoostNavigation | null >( null );
+
+export function useBoostNavigation(): BoostNavigation {
+	const navigation = useContext( NavigationContext );
+
+	if ( ! navigation ) {
+		throw new Error( 'useBoostNavigation must be used inside a Boost navigation provider.' );
+	}
+
+	return navigation;
+}
+
+/**
+ * Navigation for the legacy hash router. Must render inside the router.
+ *
+ * @param props          - Component props.
+ * @param props.children - Tree to provide navigation to.
+ */
+export function LegacyNavigationProvider( { children }: { children: ReactNode } ) {
+	const navigate = useNavigate();
+	const navigation = useMemo< BoostNavigation >(
+		() => ( { returnToSettings: options => navigate( '/', options ) } ),
+		[ navigate ]
+	);
+
+	return <NavigationContext.Provider value={ navigation }>{ children }</NavigationContext.Provider>;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/get-critical-css-error-set-interpolate-vars.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import actionLinkInterpolateVar from '$lib/utils/action-link-interpolate-var';
 import { InterpolateVars } from '$lib/utils/interplate-vars-types';
 import supportLinkInterpolateVar from '$lib/utils/support-link-interpolate-var';
@@ -10,11 +10,11 @@ import { Link } from '@wordpress/ui';
 
 function getCriticalCssErrorSetInterpolateVars( errorSet: ErrorSet ) {
 	const regenerateAction = useRegenerateCriticalCssAction();
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	function retry() {
 		regenerateAction.mutate();
-		navigate( '/' );
+		returnToSettings();
 	}
 
 	const interpolateVars: InterpolateVars = {

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -8,6 +8,7 @@ import SettingsPage from '$layout/settings-page/settings-page';
 import { useEffect, StrictMode } from 'react';
 import type { JSX } from 'react';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import { LegacyNavigationProvider } from '$lib/navigation/navigation-context';
 import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
 import { useGettingStarted } from '$lib/stores/getting-started';
 import '../css/admin-style.scss';
@@ -29,9 +30,9 @@ const useBoostRouter = () => {
 			loader: checkForGettingStarted,
 			element: (
 				<SettingsPage>
-					<Tracks>
+					<LegacyRouteFrame>
 						<Index />
-					</Tracks>
+					</LegacyRouteFrame>
 				</SettingsPage>
 			),
 		},
@@ -39,9 +40,9 @@ const useBoostRouter = () => {
 			path: '/cache-debug-log',
 			loader: checkForGettingStarted,
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<CacheDebugLog />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 		{
@@ -49,26 +50,26 @@ const useBoostRouter = () => {
 			loader: checkForGettingStarted,
 			element: (
 				<SettingsPage>
-					<Tracks>
+					<LegacyRouteFrame>
 						<AdvancedCriticalCss />
-					</Tracks>
+					</LegacyRouteFrame>
 				</SettingsPage>
 			),
 		},
 		{
 			path: '/getting-started',
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<GettingStarted />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 		{
 			path: '/purchase-successful',
 			element: (
-				<Tracks>
+				<LegacyRouteFrame>
 					<PurchaseSuccess />
-				</Tracks>
+				</LegacyRouteFrame>
 			),
 		},
 	] );
@@ -80,12 +81,12 @@ function Main() {
 }
 
 /**
- * Track the page view.
+ * Record the page view and provide navigation for a legacy route.
  *
  * @param props
  * @param props.children - The actual page to render
  */
-const Tracks = ( { children }: { children: JSX.Element } ) => {
+const LegacyRouteFrame = ( { children }: { children: JSX.Element } ) => {
 	const location = useLocation();
 
 	useEffect( () => {
@@ -99,7 +100,7 @@ const Tracks = ( { children }: { children: JSX.Element } ) => {
 		} );
 	}, [ location ] );
 
-	return children;
+	return <LegacyNavigationProvider>{ children }</LegacyNavigationProvider>;
 };
 
 export default () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -3,16 +3,16 @@ import { check, copy } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate } from 'react-router';
 import clsx from 'clsx';
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
 import { useDebugLog } from '$features/page-cache/lib/stores';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { recordBoostEvent } from '$lib/utils/analytics';
 import styles from './cache-debug-log.module.scss';
 
 const CacheDebugLog = () => {
 	const [ { data: debugLog } ] = useDebugLog();
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 	const [ hasCopied, setHasCopied ] = useState( false );
 	const copyTimer = useRef< ReturnType< typeof setTimeout > | undefined >();
 
@@ -31,7 +31,7 @@ const CacheDebugLog = () => {
 			current_page: window.location.href.replace( window.location.origin, '' ),
 			destination: '/',
 		} );
-		navigate( '/' );
+		returnToSettings();
 	};
 
 	const handleCopy = () => {

--- a/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/critical-css-advanced/critical-css-advanced.tsx
@@ -11,11 +11,11 @@ import {
 	groupRecommendationsByStatus,
 } from '$features/critical-css/lib/critical-css-errors';
 import { BackButton, CloseButton } from '$features/ui';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import CriticalCssErrorDescription from '$features/critical-css/error-description/error-description';
 import InfoIcon from '$svg/info';
 import styles from './critical-css-advanced.module.scss';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 import clsx from 'clsx';
 import { Button } from '@automattic/jetpack-components';
 import {
@@ -51,12 +51,12 @@ export default function AdvancedCriticalCss() {
 	}
 
 	// If there are no issues at all, redirect to the main page.
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 	useEffect( () => {
 		if ( providersWithIssues.length === 0 ) {
-			navigate( '/' );
+			returnToSettings();
 		}
-	}, [ providersWithIssues, navigate ] );
+	}, [ providersWithIssues, returnToSettings ] );
 	const heading =
 		activeRecommendations.length === 0
 			? __( 'Congratulations, you have dealt with all the recommendations.', 'jetpack-boost' )

--- a/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/getting-started/getting-started.tsx
@@ -6,7 +6,7 @@ import { BoostPricingTable } from '$features/boost-pricing-table/boost-pricing-t
 import BoostAdminPage from '$layout/boost-admin-page/boost-admin-page';
 import styles from './getting-started.module.scss';
 import { useGettingStarted } from '$lib/stores/getting-started';
-import { useNavigate } from 'react-router';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import { __ } from '@wordpress/i18n';
 import { usePremiumFeatures } from '$lib/stores/premium-features';
 import { useSingleModuleState } from '$features/module/lib/stores';
@@ -15,7 +15,7 @@ import type { FC } from 'react';
 const GettingStarted: FC = () => {
 	const [ selectedPlan, setSelectedPlan ] = useState< 'free' | 'premium' | false >( false );
 	const [ snackbarMessage, setSnackbarMessage ] = useState< string >( '' );
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	const {
 		site: { domain },
@@ -42,13 +42,13 @@ const GettingStarted: FC = () => {
 				if ( ! isPremium ) {
 					setCriticalCssState( true );
 				}
-				navigate( '/', { replace: true } );
+				returnToSettings( { replace: true } );
 			}
 		}
 	}, [
 		domain,
 		isPremium,
-		navigate,
+		returnToSettings,
 		selectedPlan,
 		setCriticalCssState,
 		shouldGetStarted,

--- a/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/purchase-success/purchase-success.tsx
@@ -3,15 +3,15 @@ import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { useSingleModuleState } from '$features/module/lib/stores';
-import { useNavigate } from 'react-router';
 import CardPage from '$layout/card-page/card-page';
+import { useBoostNavigation } from '$lib/navigation/navigation-context';
 import styles from './purchase-success.module.scss';
 import { isWoaHosting } from '$lib/utils/hosting';
 import type { FC } from 'react';
 
 const PurchaseSuccess: FC = () => {
 	const [ , setCloudCssState ] = useSingleModuleState( 'cloud_css' );
-	const navigate = useNavigate();
+	const { returnToSettings } = useBoostNavigation();
 
 	useEffect( () => {
 		setCloudCssState( true );
@@ -101,7 +101,7 @@ const PurchaseSuccess: FC = () => {
 			<Button
 				label={ __( 'Continue', 'jetpack-boost' ) }
 				variant="primary"
-				onClick={ () => navigate( '/' ) }
+				onClick={ () => returnToSettings() }
 				className="mt-3"
 			>
 				{ __( 'Continue', 'jetpack-boost' ) }

--- a/projects/plugins/boost/changelog/cycle-one-nav-mode-agnostic
+++ b/projects/plugins/boost/changelog/cycle-one-nav-mode-agnostic
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Route dashboard navigation through a shared helper so the destination can vary by dashboard mode.
+
+


### PR DESCRIPTION
Part of BOOST-670. First of three; supersedes the single PR in #52092, which stays open as a draft reference.

## Proposed changes

Every "go back to the main page" in the dashboard called `navigate( '/' )` directly, tying the destination to the legacy hash router. This routes them through a `returnToSettings()` helper from a navigation context, so a second dashboard runtime can supply its own destination without touching these call sites again.

* Add `useBoostNavigation()` and `LegacyNavigationProvider`; the legacy provider resolves `returnToSettings()` to `navigate( '/' )`.
* Move the six `navigate( '/' )` call sites onto it — Cache Log Back, the Critical CSS no-issues redirect, the Critical CSS retry link, Getting Started completion, Purchase Success Continue, and `BackButton`.
* Drop `BackButton`'s `route` prop, which no caller passed.

No behaviour or markup changes. `Tracks` is renamed `LegacyRouteFrame` because it now provides navigation as well as recording the page view.

## Related product discussion/links

* Contract: BOOST-665
* Parent: BOOST-633
* Reference PR this was split out of: #52092

## Does this pull request change what data or activity we track or use?

No.

## Real-screen before / after

Captured on one Jurassic Ninja site at 1440×900, same site and same data for both passes. **Before** is the `trunk` build of Boost, **after** is this branch, both installed via Jetpack Beta Tester so only the plugin build differs. The modernization filter is absent in both, which is the state this PR ships in.

Settings — `admin.php?page=jetpack-boost`

| Before (trunk) | After (this branch) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-nav-mode-agnostic/before-settings.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-nav-mode-agnostic/after-settings.jpg) |

Critical CSS Advanced — `#/critical-css-advanced`, which renders `BackButton` and the error descriptions this PR touches

| Before (trunk) | After (this branch) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-nav-mode-agnostic/before-critical-css-advanced.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-nav-mode-agnostic/after-critical-css-advanced.jpg) |

The bundle under test really was the branch: `returnToSettings` appears 7× in the served `jetpack-boost.js` after the swap and 0× before it.

Screenshots can only show the rendered state, so the navigation itself was exercised by hand on the after build: clicking **Go back** on Critical CSS Advanced lands on `#/`, the Settings root, exactly as on trunk.

## Testing instructions

1. Build Boost: `pnpm jetpack build plugins/boost --no-pnpm-install --production`.
2. Open **Jetpack → Boost** and confirm Settings renders as it does on trunk.
3. Visit `#/cache-debug-log` and click **Go back** — you should land on Settings.
4. Visit `#/critical-css-advanced` on a site with **no** Critical CSS issues and confirm it redirects to Settings on its own.
5. On a site that **does** have Critical CSS issues, reach that page from the "advanced recommendations" link in the Critical CSS status and click **Go back**. This is the only place `BackButton` renders today — `CardPage`'s copy is disabled by its one consumer, Purchase Success.
6. Run through Getting Started and confirm completion lands on Settings.
7. `pnpm --dir projects/plugins/boost test` — 110 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzGT9kxxs229BAH6yUMoJ3





