### PR TITLE
Boost: add the modern dashboard's mode detection and URL rules

### DIFF
--- a/projects/plugins/boost/_inc/components/boost-page.tsx
+++ b/projects/plugins/boost/_inc/components/boost-page.tsx
@@ -4,11 +4,10 @@ import { Tabs } from '@wordpress/ui';
 import clsx from 'clsx';
 import './boost-page.scss';
 import type { ReactNode } from 'react';
-
-export type BoostTab = 'overview' | 'settings';
+import type { Tab } from '../runtime-contract';
 
 type Props = {
-	activeTab: BoostTab;
+	activeTab: Tab;
 	isSubpage: boolean;
 	onTabChange: ( tab: string | null ) => void;
 	children: ReactNode;

--- a/projects/plugins/boost/_inc/runtime-contract.test.ts
+++ b/projects/plugins/boost/_inc/runtime-contract.test.ts
@@ -1,0 +1,37 @@
+import { getSubpage, splitHash, SUBPAGES } from './runtime-contract';
+
+describe( 'getSubpage', () => {
+	it.each( SUBPAGES )( 'matches %s', subpage => {
+		expect( getSubpage( `#/${ subpage }` ) ).toBe( subpage );
+	} );
+
+	it( 'tolerates a trailing slash', () => {
+		expect( getSubpage( '#/getting-started/' ) ).toBe( 'getting-started' );
+	} );
+
+	it( 'ignores a hash query when matching', () => {
+		expect( getSubpage( '#/cache-debug-log?x=1' ) ).toBe( 'cache-debug-log' );
+	} );
+
+	it.each( [ '', '#', '#/' ] )( 'returns null for the root (%p)', hash => {
+		expect( getSubpage( hash ) ).toBeNull();
+	} );
+
+	it( 'returns null for an unrecognised path', () => {
+		expect( getSubpage( '#/nope' ) ).toBeNull();
+	} );
+} );
+
+describe( 'splitHash', () => {
+	it( 'separates the path from the hash query', () => {
+		const { path, query } = splitHash( '#/cache-debug-log?x=1&y=2' );
+
+		expect( path ).toBe( 'cache-debug-log' );
+		expect( query.get( 'x' ) ).toBe( '1' );
+		expect( query.get( 'y' ) ).toBe( '2' );
+	} );
+
+	it( 'gives an empty query when the hash carries none', () => {
+		expect( splitHash( '#/getting-started' ).query.toString() ).toBe( '' );
+	} );
+} );

--- a/projects/plugins/boost/_inc/runtime-contract.ts
+++ b/projects/plugins/boost/_inc/runtime-contract.ts
@@ -1,0 +1,52 @@
+/**
+ * The values and hash rules both dashboard runtimes must agree on.
+ *
+ * Imported by the wp-build chassis and by the webpack app, so the two cannot
+ * drift from each other while both are live.
+ */
+
+export const SUBPAGES = [
+	'cache-debug-log',
+	'critical-css-advanced',
+	'getting-started',
+	'purchase-successful',
+] as const;
+
+export type Subpage = ( typeof SUBPAGES )[ number ];
+
+export type Tab = 'overview' | 'settings';
+
+export const LOCATION_CHANGE_EVENT = 'jetpack-boost:location-change';
+
+/** Everything that means the location changed; the chassis dispatches the custom one. */
+export const LOCATION_EVENTS = [ 'hashchange', 'popstate', LOCATION_CHANGE_EVENT ];
+
+export const SETTINGS_SLOT_ID = 'jb-settings-tab-mount';
+export const SUBPAGE_SLOT_ID = 'jb-subpage-mount';
+
+/**
+ * Split a hash into its path and query, tolerating `#`, `#/` and trailing slashes.
+ *
+ * @param hash - Location hash, with or without the leading `#`.
+ * @return The bare path and its parsed query.
+ */
+export function splitHash( hash: string ): { path: string; query: URLSearchParams } {
+	const [ path, query = '' ] = hash.replace( /^#/, '' ).split( '?' );
+
+	return {
+		path: path.replace( /^\//, '' ).replace( /\/$/, '' ),
+		query: new URLSearchParams( query ),
+	};
+}
+
+/**
+ * Read the sub-page out of a hash.
+ *
+ * @param hash - Location hash.
+ * @return The sub-page, or null for the root.
+ */
+export function getSubpage( hash: string ): Subpage | null {
+	const { path } = splitHash( hash );
+
+	return SUBPAGES.find( subpage => subpage === path ) ?? null;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/mode.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/mode.test.ts
@@ -1,0 +1,75 @@
+import { SETTINGS_SLOT_ID, SUBPAGE_SLOT_ID } from '../../../../../../_inc/runtime-contract';
+import { detectMode, LEGACY_ROOT_ID, MODERN_ROOT_ID, waitForSlots } from './mode';
+
+const addRoot = ( id: string ) => {
+	const root = document.createElement( 'div' );
+	root.id = id;
+	document.body.appendChild( root );
+
+	return root;
+};
+
+describe( 'detectMode', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'reads legacy from the legacy root', () => {
+		addRoot( LEGACY_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'legacy' );
+	} );
+
+	it( 'reads modern from the chassis root', () => {
+		addRoot( MODERN_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'modern' );
+	} );
+
+	it( 'returns null when neither root is present', () => {
+		expect( detectMode() ).toBeNull();
+	} );
+
+	it( 'prefers legacy when both roots are present', () => {
+		addRoot( MODERN_ROOT_ID );
+		addRoot( LEGACY_ROOT_ID );
+
+		expect( detectMode() ).toBe( 'legacy' );
+	} );
+} );
+
+describe( 'waitForSlots', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'resolves immediately when both slots already exist', async () => {
+		const settings = addRoot( SETTINGS_SLOT_ID );
+		const subpage = addRoot( SUBPAGE_SLOT_ID );
+
+		await expect( waitForSlots() ).resolves.toEqual( { settings, subpage } );
+	} );
+
+	it( 'waits for slots the chassis has not rendered yet', async () => {
+		const pending = waitForSlots();
+		addRoot( SETTINGS_SLOT_ID );
+		const subpage = addRoot( SUBPAGE_SLOT_ID );
+
+		await expect( pending ).resolves.toEqual( {
+			settings: document.getElementById( SETTINGS_SLOT_ID ),
+			subpage,
+		} );
+	} );
+
+	it( 'stays pending while only one slot exists', async () => {
+		let settled = false;
+		waitForSlots().then( () => {
+			settled = true;
+		} );
+		addRoot( SETTINGS_SLOT_ID );
+
+		await Promise.resolve();
+
+		expect( settled ).toBe( false );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/mode.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/mode.ts
@@ -1,0 +1,79 @@
+/**
+ * Runtime boundary between today's dashboard and the modern wp-build chassis.
+ *
+ * PHP resolves `rsm_jetpack_ui_modernization_boost` once per request and renders
+ * exactly one root. Which root exists is the mode signal.
+ */
+
+import { SETTINGS_SLOT_ID, SUBPAGE_SLOT_ID } from '../../../../../../_inc/runtime-contract';
+
+export const LEGACY_ROOT_ID = 'jb-admin-settings';
+export const MODERN_ROOT_ID = 'jetpack-boost-dashboard-wp-admin-app';
+
+export type DashboardMode = 'legacy' | 'modern';
+
+export type ModernSlots = {
+	settings: HTMLElement;
+	subpage: HTMLElement;
+};
+
+/**
+ * Detect which dashboard PHP rendered.
+ *
+ * @param doc - Document to inspect. Defaults to the live document.
+ * @return The mode, or null when neither root is present.
+ */
+export function detectMode( doc: Document = document ): DashboardMode | null {
+	// Legacy wins if both are somehow present, so a chassis bug can't take today's dashboard away.
+	if ( doc.getElementById( LEGACY_ROOT_ID ) ) {
+		return 'legacy';
+	}
+
+	if ( doc.getElementById( MODERN_ROOT_ID ) ) {
+		return 'modern';
+	}
+
+	return null;
+}
+
+/**
+ * Find both chassis slots, if they are already rendered.
+ *
+ * @param doc - Document to inspect.
+ * @return Both slots, or null while either is missing.
+ */
+function findSlots( doc: Document ): ModernSlots | null {
+	const settings = doc.getElementById( SETTINGS_SLOT_ID );
+	const subpage = doc.getElementById( SUBPAGE_SLOT_ID );
+
+	return settings && subpage ? { settings, subpage } : null;
+}
+
+/**
+ * Resolve once the chassis has created both slots.
+ *
+ * This app can boot before the chassis renders, so the modern mount waits rather
+ * than assuming the slots exist. There is deliberately no timeout: without a
+ * chassis there is no tab shell to render into either.
+ *
+ * @param doc - Document to observe.
+ * @return Both slots.
+ */
+export function waitForSlots( doc: Document = document ): Promise< ModernSlots > {
+	const present = findSlots( doc );
+	if ( present ) {
+		return Promise.resolve( present );
+	}
+
+	return new Promise( resolve => {
+		const observer = new MutationObserver( () => {
+			const slots = findSlots( doc );
+			if ( slots ) {
+				observer.disconnect();
+				resolve( slots );
+			}
+		} );
+
+		observer.observe( doc.body, { childList: true, subtree: true } );
+	} );
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
@@ -1,0 +1,98 @@
+import { LOCATION_CHANGE_EVENT } from '../../../../../../_inc/runtime-contract';
+import { navigateTo, resolveRoute, settingsUrl, subpageHref, subpageUrl } from './routes';
+
+const url = ( suffix: string ) =>
+	`http://localhost/wp-admin/admin.php?page=jetpack-boost${ suffix }`;
+
+describe( 'resolveRoute', () => {
+	it.each( [ '', '#', '#/' ] )( 'treats %p as the Overview root', suffix => {
+		expect( resolveRoute( url( suffix ) ).route ).toEqual( { subpage: null, tab: 'overview' } );
+	} );
+
+	it( 'reads the tab from the outer query', () => {
+		expect( resolveRoute( url( '&tab=settings' ) ).route ).toEqual( {
+			subpage: null,
+			tab: 'settings',
+		} );
+	} );
+
+	it( 'promotes a tab carried in the hash to the outer query', () => {
+		const { route, normalizedUrl } = resolveRoute( url( '#/?tab=settings' ) );
+
+		expect( route ).toEqual( { subpage: null, tab: 'settings' } );
+		expect( normalizedUrl ).toBe( url( '&tab=settings' ) );
+	} );
+
+	it( 'parses the hash query before matching a sub-page', () => {
+		expect( resolveRoute( url( '#/cache-debug-log?x=1' ) ).route.subpage ).toBe(
+			'cache-debug-log'
+		);
+	} );
+
+	it( 'lets a recognised hash win over the tab', () => {
+		expect( resolveRoute( url( '&tab=settings#/critical-css-advanced' ) ).route.subpage ).toBe(
+			'critical-css-advanced'
+		);
+	} );
+
+	it( 'falls back to the root for an unrecognised hash', () => {
+		expect( resolveRoute( url( '#/nope' ) ).route ).toEqual( { subpage: null, tab: 'overview' } );
+	} );
+
+	it( 'normalizes nothing for a plain URL', () => {
+		expect( resolveRoute( url( '&tab=settings' ) ).normalizedUrl ).toBeNull();
+	} );
+} );
+
+describe( 'settingsUrl', () => {
+	it( 'clears the hash and sets the tab', () => {
+		expect( settingsUrl( url( '#/cache-debug-log' ) ) ).toBe( url( '&tab=settings' ) );
+	} );
+
+	it( 'leaves an existing settings tab alone', () => {
+		expect( settingsUrl( url( '&tab=settings' ) ) ).toBe( url( '&tab=settings' ) );
+	} );
+} );
+
+describe( 'subpageUrl', () => {
+	it( 'keeps the outer query', () => {
+		expect( subpageUrl( 'getting-started', url( '&tab=settings' ) ) ).toBe(
+			url( '&tab=settings#/getting-started' )
+		);
+	} );
+
+	it( 'builds the same hash in both modes', () => {
+		expect( subpageHref( 'purchase-successful' ) ).toBe( '#/purchase-successful' );
+	} );
+} );
+
+describe( 'navigateTo', () => {
+	const BASE = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
+
+	beforeEach( () => {
+		window.history.replaceState( null, '', BASE );
+	} );
+
+	it( 'pushes an entry and announces the change', () => {
+		const listener = jest.fn();
+		window.addEventListener( LOCATION_CHANGE_EVENT, listener );
+		const before = window.history.length;
+
+		navigateTo( `${ BASE }&tab=settings` );
+
+		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( window.history ).toHaveLength( before + 1 );
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+
+		window.removeEventListener( LOCATION_CHANGE_EVENT, listener );
+	} );
+
+	it( 'replaces the entry when asked, so a redirect leaves no history stop', () => {
+		const before = window.history.length;
+
+		navigateTo( `${ BASE }#/getting-started`, { replace: true } );
+
+		expect( window.location.hash ).toBe( '#/getting-started' );
+		expect( window.history ).toHaveLength( before );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
@@ -1,0 +1,125 @@
+/**
+ * URL rules for the modern chassis.
+ *
+ * The wp-build route is `/` with `?tab=overview|settings` in the outer query,
+ * owned by the chassis. Sub-pages keep today's hashes, and a recognised hash
+ * wins over the tab.
+ */
+
+import {
+	getSubpage,
+	LOCATION_CHANGE_EVENT,
+	splitHash,
+} from '../../../../../../_inc/runtime-contract';
+import type { Subpage, Tab } from '../../../../../../_inc/runtime-contract';
+
+export type ModernRoute = {
+	subpage: Subpage | null;
+	tab: Tab;
+};
+
+export type ResolvedRoute = {
+	route: ModernRoute;
+	/** Tidied URL to replaceState onto when a tab was carried in the hash. */
+	normalizedUrl: string | null;
+};
+
+/**
+ * Resolve a URL to the route it shows.
+ *
+ * @param href - URL to resolve. Defaults to the current location.
+ * @return The route, plus a normalized URL when the hash carried a tab.
+ */
+export function resolveRoute( href: string = window.location.href ): ResolvedRoute {
+	const url = new URL( href );
+	const subpage = getSubpage( url.hash );
+
+	if ( subpage ) {
+		return { route: { subpage, tab: readTab( url.searchParams ) }, normalizedUrl: null };
+	}
+
+	const hashTab = readTab( splitHash( url.hash ).query );
+	if ( hashTab === 'settings' ) {
+		return {
+			route: { subpage: null, tab: 'settings' },
+			normalizedUrl: settingsUrl( url.toString() ),
+		};
+	}
+
+	return { route: { subpage: null, tab: readTab( url.searchParams ) }, normalizedUrl: null };
+}
+
+/**
+ * Read the tab out of a query, defaulting to Overview.
+ *
+ * @param query - Query to read.
+ * @return The tab.
+ */
+function readTab( query: URLSearchParams ): Tab {
+	return query.get( 'tab' ) === 'settings' ? 'settings' : 'overview';
+}
+
+/**
+ * Build the URL for Settings: the hash cleared, the tab set.
+ *
+ * @param href - URL to derive from. Defaults to the current location.
+ * @return The Settings URL.
+ */
+export function settingsUrl( href: string = window.location.href ): string {
+	const url = new URL( href );
+	url.hash = '';
+	url.searchParams.set( 'tab', 'settings' );
+
+	return url.toString();
+}
+
+/**
+ * Build the hash that links to a sub-page. Identical in both modes.
+ *
+ * @param subpage - Sub-page to link to.
+ * @return The hash href.
+ */
+export function subpageHref( subpage: Subpage ): string {
+	return `#/${ subpage }`;
+}
+
+/**
+ * Build the URL for a sub-page, keeping the outer query.
+ *
+ * @param subpage - Sub-page to link to.
+ * @param href    - URL to derive from. Defaults to the current location.
+ * @return The sub-page URL.
+ */
+export function subpageUrl( subpage: Subpage, href: string = window.location.href ): string {
+	const url = new URL( href );
+	url.hash = subpageHref( subpage );
+
+	return url.toString();
+}
+
+/**
+ * Tell every listener the URL changed.
+ *
+ * The chassis wraps `history` and dispatches this too, so a handler may run
+ * twice for one navigation and must be idempotent.
+ */
+export function notifyLocationChange(): void {
+	window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+}
+
+/**
+ * Navigate to a URL without a reload.
+ *
+ * @param url             - Destination.
+ * @param options         - Navigation options.
+ * @param options.replace - Replace the current entry instead of pushing one.
+ */
+export function navigateTo( url: string, options: { replace?: boolean } = {} ): void {
+	if ( options.replace ) {
+		window.history.replaceState( null, '', url );
+	} else {
+		window.history.pushState( null, '', url );
+	}
+
+	notifyLocationChange();
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from '@testing-library/react';
+import { LOCATION_CHANGE_EVENT } from '../../../../../../_inc/runtime-contract';
+import { useModernRoute } from './use-modern-route';
+
+const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
+
+const goTo = ( suffix: string, event = LOCATION_CHANGE_EVENT ) => {
+	act( () => {
+		window.history.replaceState( null, '', `${ BASE_URL }${ suffix }` );
+		window.dispatchEvent( new Event( event ) );
+	} );
+};
+
+describe( 'useModernRoute', () => {
+	beforeEach( () => {
+		window.history.replaceState( null, '', BASE_URL );
+	} );
+
+	it( 'starts from the current URL', () => {
+		window.history.replaceState( null, '', `${ BASE_URL }#/cache-debug-log` );
+
+		expect( renderHook( () => useModernRoute() ).result.current ).toEqual( {
+			subpage: 'cache-debug-log',
+			tab: 'overview',
+		} );
+	} );
+
+	it( 'follows a hash change', () => {
+		const { result } = renderHook( () => useModernRoute() );
+
+		goTo( '#/critical-css-advanced', 'hashchange' );
+
+		expect( result.current.subpage ).toBe( 'critical-css-advanced' );
+	} );
+
+	it( 'follows the chassis location event and history navigation', () => {
+		const { result } = renderHook( () => useModernRoute() );
+
+		goTo( '&tab=settings' );
+		expect( result.current.tab ).toBe( 'settings' );
+
+		goTo( '', 'popstate' );
+		expect( result.current.tab ).toBe( 'overview' );
+	} );
+
+	it( 'rewrites a tab carried in the hash', () => {
+		const { result } = renderHook( () => useModernRoute() );
+
+		goTo( '#/?tab=settings' );
+
+		expect( window.location.hash ).toBe( '' );
+		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( result.current ).toEqual( { subpage: null, tab: 'settings' } );
+	} );
+
+	it( 'keeps the same route object when the URL has not changed', () => {
+		const { result } = renderHook( () => useModernRoute() );
+		const first = result.current;
+
+		goTo( '' );
+
+		expect( result.current ).toBe( first );
+	} );
+
+	it( 'stops listening once unmounted', () => {
+		const { result, unmount } = renderHook( () => useModernRoute() );
+		const last = result.current;
+
+		unmount();
+		goTo( '#/getting-started' );
+
+		expect( result.current ).toBe( last );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { LOCATION_EVENTS } from '../../../../../../_inc/runtime-contract';
+import { resolveRoute } from './routes';
+import type { ModernRoute } from './routes';
+
+/**
+ * Serialize a route so an unchanged URL doesn't re-render the app. The chassis
+ * dispatches its own location event alongside ours, so handlers run twice.
+ *
+ * @param route - Route to key.
+ * @return Stable key for the route.
+ */
+function routeKey( route: ModernRoute ): string {
+	return `${ route.subpage ?? '' }:${ route.tab }`;
+}
+
+/**
+ * Track the route the modern chassis is showing, normalizing the URL as it goes.
+ *
+ * @return The current route.
+ */
+export function useModernRoute(): ModernRoute {
+	const [ route, setRoute ] = useState< ModernRoute >( () => resolveRoute().route );
+
+	useEffect( () => {
+		const onLocationChange = () => {
+			const { route: next, normalizedUrl } = resolveRoute();
+
+			if ( normalizedUrl ) {
+				window.history.replaceState( null, '', normalizedUrl );
+			}
+
+			setRoute( current => ( routeKey( current ) === routeKey( next ) ? current : next ) );
+		};
+
+		LOCATION_EVENTS.forEach( event => window.addEventListener( event, onLocationChange ) );
+		onLocationChange();
+
+		return () =>
+			LOCATION_EVENTS.forEach( event => window.removeEventListener( event, onLocationChange ) );
+	}, [] );
+
+	return route;
+}

--- a/projects/plugins/boost/changelog/cycle-one-modern-primitives
+++ b/projects/plugins/boost/changelog/cycle-one-modern-primitives
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Add the mode detection and URL rules the modernized dashboard will mount against. Inert until it is wired up.
+
+

--- a/projects/plugins/boost/routes/dashboard/stage.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.tsx
@@ -2,19 +2,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
-import BoostPage, { type BoostTab } from '../../_inc/components/boost-page';
+import BoostPage from '../../_inc/components/boost-page';
+import {
+	getSubpage,
+	LOCATION_CHANGE_EVENT,
+	LOCATION_EVENTS,
+	SETTINGS_SLOT_ID,
+	SUBPAGE_SLOT_ID,
+} from '../../_inc/runtime-contract';
+import type { Tab } from '../../_inc/runtime-contract';
 import './route.scss';
 
-const SUBPAGES = [
-	'cache-debug-log',
-	'critical-css-advanced',
-	'getting-started',
-	'purchase-successful',
-] as const;
-
-type Subpage = ( typeof SUBPAGES )[ number ];
-
-const LOCATION_CHANGE_EVENT = 'jetpack-boost:location-change';
 const HISTORY_WRAPPED_KEY = '__jetpackBoostLocationChangeWrapped';
 
 // Leave the wrapper installed for the page lifetime so later subscriptions reuse it.
@@ -39,14 +37,8 @@ function wrapHistoryOnce() {
 
 function subscribeToLocationChange( listener: () => void ) {
 	wrapHistoryOnce();
-	const events = [ 'hashchange', 'popstate', LOCATION_CHANGE_EVENT ];
-	events.forEach( event => window.addEventListener( event, listener ) );
-	return () => events.forEach( event => window.removeEventListener( event, listener ) );
-}
-
-function getSubpage( hash: string ): Subpage | null {
-	const path = hash.replace( /^#\/?/, '' ).split( '?' )[ 0 ].replace( /\/$/, '' );
-	return SUBPAGES.find( subpage => subpage === path ) ?? null;
+	LOCATION_EVENTS.forEach( event => window.addEventListener( event, listener ) );
+	return () => LOCATION_EVENTS.forEach( event => window.removeEventListener( event, listener ) );
 }
 
 function Stage() {
@@ -55,9 +47,9 @@ function Stage() {
 	const [ queryClient ] = useState( () => new QueryClient() );
 	const [ subpage, setSubpage ] = useState( () => getSubpage( window.location.hash ) );
 	const lastSubpage = useRef( subpage );
-	const activeTab: BoostTab = search.tab === 'settings' ? 'settings' : 'overview';
+	const activeTab: Tab = search.tab === 'settings' ? 'settings' : 'overview';
 	const goToTab = useCallback(
-		( next: BoostTab, replace = false ) => {
+		( next: Tab, replace = false ) => {
 			navigate( {
 				search: { tab: next === 'settings' ? 'settings' : undefined },
 				replace,
@@ -94,13 +86,13 @@ function Stage() {
 			activeTab={ activeTab }
 			isSubpage={ subpage !== null }
 			onTabChange={ onTabChange }
-			subpage={ <div id="jb-subpage-mount" hidden={ subpage === null } /> }
+			subpage={ <div id={ SUBPAGE_SLOT_ID } hidden={ subpage === null } /> }
 		>
 			<Tabs.Panel value="overview">
 				<QueryClientProvider client={ queryClient }>{ null }</QueryClientProvider>
 			</Tabs.Panel>
 			<Tabs.Panel value="settings" keepMounted>
-				<div id="jb-settings-tab-mount" />
+				<div id={ SETTINGS_SLOT_ID } />
 			</Tabs.Panel>
 		</BoostPage>
 	);


### PR DESCRIPTION
Part of BOOST-670. Second of three, on trunk now that #52132 has merged.

## Proposed changes

Boost's dashboard is gaining a second runtime, so a request resolves to one of two **modes**: **legacy**, today's dashboard on `#jb-admin-settings`, or **modern**, the same app inside the wp-build chassis from #52037. PHP resolves the default-off `rsm_jetpack_ui_modernization_boost` filter once per request and renders exactly one root; per BOOST-665 the JS infers its mode from which root is in the DOM rather than taking a second flag.

This adds that inference and the URL rules the modern side needs. Nothing renders differently in either mode.

* `detectMode()` reads which root PHP rendered. Legacy wins if both are ever present, so a chassis bug cannot take today's dashboard away.
* `waitForSlots()` waits for the chassis mounts, since this app can boot first. No timeout by design — without a chassis there is no tab shell to render into either.
* `resolveRoute()` implements navigation rules 1–3: `#`, `#/` and the empty hash are all the root; hash queries parse before matching (`#/cache-debug-log?x=1`); a recognised hash beats the tab; a tab inside the hash is promoted to the outer query.
* `useModernRoute()` follows `hashchange`, `popstate` and the chassis's location event, recomputing idempotently because the chassis dispatches that event too.

### One source for the values both runtimes share

Both sides must agree on the sub-page slugs, tab names, mount ids and location events — and each carried its own copy, the chassis's mount ids existing only as string literals inline in JSX. A rename on one side silently orphaned the other's mount, invisible to both test suites.

`_inc/runtime-contract.ts` now holds those values and the hash parsing that derives a sub-page from them, with no imports of its own, and both trees import it. It sits in the wp-build tree so the runtime Cycle One eventually deletes depends on the one that survives, not the reverse. `stage.tsx` and `boost-page.tsx` drop their copies — `BoostTab` becomes the shared `Tab` — with their 16 tests passing untouched, and a production build confirms both bundlers resolve it.

## Related product discussion/links

* Contract: BOOST-665 — § Mounts and navigation rules 1–3
* Parent: BOOST-633
* Reference PR this was split out of: #52092

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `pnpm --dir projects/plugins/boost test` — 152 tests, 36 new here.
2. Read the new tests against BOOST-665's § Mounts and navigation rules 1–3; each rule is asserted directly.
3. Confirm the dashboard is unchanged in both modes: the chassis change is a pure refactor, and `mode.ts` / `routes.ts` have no consumers yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzGT9kxxs229BAH6yUMoJ3
