### PR TITLE
Boost: mount the dashboard inside the modernization chassis

### DIFF
--- a/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
+++ b/projects/plugins/boost/app/assets/src/css/main/wp-admin.scss
@@ -1,7 +1,8 @@
 @use "variables";
 
 // Style everything with border box turned on
-#jb-dashboard * {
+#jb-dashboard *,
+.jb-modern-settings * {
 	box-sizing: border-box;
 }
 
@@ -9,8 +10,10 @@ p {
 	font-size: 16px;
 	color: variables.$gray_80;
 }
-// Override WordPress component styles
-.jb-dashboard {
+// The type scale, tokens and component overrides the settings controls rely on.
+// Shared, because both dashboards render those same controls. The page frame
+// below is not: the modern chassis supplies its own.
+@mixin settings-content {
 	--font-headline-medium: 48px;
 	--font-title-medium: 24px;
 	--font-body-small: 14px;
@@ -21,17 +24,6 @@ p {
 	--spacing-base: 8px;
 
 	font-size: 16px;
-	min-height: calc(100vh - 60px);
-	display: flex;
-	flex-direction: column;
-	position: relative;
-	background-color: #f9f9f6;
-	clear: both;
-
-
-	&--main {
-		background-color: variables.$primary-white;
-	}
 
 	a {
 		color: var(--wp-admin-theme-link-color);
@@ -80,6 +72,28 @@ p {
 		border-radius: inherit;
 		box-shadow: none;
 	}
+}
+
+// Override WordPress component styles
+.jb-dashboard {
+	min-height: calc(100vh - 60px);
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	background-color: #f9f9f6;
+	clear: both;
+
+	@include settings-content;
+
+	&--main {
+		background-color: variables.$primary-white;
+	}
+}
+
+// Settings inside the modern chassis, which frames the page itself.
+.jb-modern-settings {
+
+	@include settings-content;
 }
 
 // Reset WP-Admin styles for boost dashboard

--- a/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/critical-css/status/status.tsx
@@ -5,13 +5,13 @@ import TimeAgo from '../time-ago/time-ago';
 import InfoIcon from '$svg/info';
 import RefreshIcon from '$svg/refresh';
 import { createInterpolateElement } from '@wordpress/element';
-import { Link } from 'react-router';
 import { useRegenerateCriticalCssAction } from '../lib/stores/critical-css-state';
 import { getProvidersWithErrors } from '../lib/critical-css-errors';
 import ShowStopperError from '../show-stopper-error/show-stopper-error';
 import { Button } from '@automattic/jetpack-components';
 import styles from './status.module.scss';
 import { recordBoostEvent } from '$lib/utils/analytics';
+import { subpageHref } from '$lib/modern/routes';
 import type { FC } from 'react';
 
 type StatusTypes = {
@@ -96,7 +96,13 @@ const Status: FC< StatusTypes > = ( {
 									providersWithErrors.length
 								),
 								{
-									advanced: <Link to="/critical-css-advanced" onClick={ handleAdvancedClick } />,
+									advanced: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content -- createInterpolateElement supplies the content.
+										<a
+											href={ subpageHref( 'critical-css-advanced' ) }
+											onClick={ handleAdvancedClick }
+										/>
+									),
 								}
 							) }
 						</>

--- a/projects/plugins/boost/app/assets/src/js/index.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/index.test.tsx
@@ -1,0 +1,76 @@
+import { SETTINGS_SLOT_ID, SUBPAGE_SLOT_ID } from '../../../../_inc/runtime-contract';
+import { LEGACY_ROOT_ID, MODERN_ROOT_ID } from '$lib/modern/mode';
+
+const mockRender = jest.fn();
+const mockCreateRoot = jest.fn( ( _container: HTMLElement ) => ( { render: mockRender } ) );
+
+jest.mock( '@wordpress/element', () => ( {
+	createRoot: ( container: HTMLElement ) => mockCreateRoot( container ),
+} ) );
+jest.mock( './main', () => ( { __esModule: true, default: () => null } ) );
+jest.mock( '$layout/modern/modern-app', () => ( { __esModule: true, default: () => null } ) );
+
+const addRoot = ( id: string ) => {
+	const root = document.createElement( 'div' );
+	root.id = id;
+	document.body.appendChild( root );
+
+	return root;
+};
+
+const boot = async () => {
+	jest.isolateModules( () => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- the entry mounts on import, so each case needs a fresh one.
+		require( './index' );
+	} );
+	// The modern path awaits the chassis slots before it mounts.
+	await Promise.resolve();
+	await Promise.resolve();
+};
+
+describe( 'dashboard boot', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		mockCreateRoot.mockClear();
+		mockRender.mockClear();
+	} );
+
+	it( 'mounts today’s dashboard into the root PHP renders for it', async () => {
+		const legacyRoot = addRoot( LEGACY_ROOT_ID );
+
+		await boot();
+
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateRoot ).toHaveBeenCalledWith( legacyRoot );
+	} );
+
+	it( 'mounts nothing when neither root is present', async () => {
+		await boot();
+
+		expect( mockCreateRoot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'mounts one root, in the Settings slot', async () => {
+		addRoot( MODERN_ROOT_ID );
+		const settingsSlot = addRoot( SETTINGS_SLOT_ID );
+		addRoot( SUBPAGE_SLOT_ID );
+
+		await boot();
+
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateRoot ).toHaveBeenCalledWith( settingsSlot );
+	} );
+
+	it( 'waits for the chassis slots before mounting the modern app', async () => {
+		addRoot( MODERN_ROOT_ID );
+
+		await boot();
+		expect( mockCreateRoot ).not.toHaveBeenCalled();
+
+		addRoot( SETTINGS_SLOT_ID );
+		addRoot( SUBPAGE_SLOT_ID );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		expect( mockCreateRoot ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/index.tsx
+++ b/projects/plugins/boost/app/assets/src/js/index.tsx
@@ -1,11 +1,13 @@
 import * as WPElement from '@wordpress/element';
 import Main from './main';
+import ModernApp from '$layout/modern/modern-app';
+import { detectMode, LEGACY_ROOT_ID, waitForSlots } from '$lib/modern/mode';
 
 /**
- * Initial render function.
+ * Render today's dashboard into the root PHP gives it.
  */
-function render() {
-	const container = document.getElementById( 'jb-admin-settings' );
+function renderLegacy() {
+	const container = document.getElementById( LEGACY_ROOT_ID );
 
 	if ( null === container ) {
 		return;
@@ -14,6 +16,26 @@ function render() {
 	const component = <Main />;
 
 	WPElement.createRoot( container ).render( component );
+}
+
+/**
+ * Render the modern app once the chassis has created its slots.
+ *
+ * The root lives in the Settings slot and portals the sub-page into the other
+ * chassis mount, so one provider tree spans both and Settings is never remounted.
+ */
+async function renderModern() {
+	const slots = await waitForSlots();
+
+	WPElement.createRoot( slots.settings ).render( <ModernApp subpageSlot={ slots.subpage } /> );
+}
+
+function render() {
+	if ( detectMode() === 'modern' ) {
+		renderModern();
+	} else {
+		renderLegacy();
+	}
 }
 
 render();

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
@@ -39,6 +39,9 @@ jest.mock( './modern-subpage', () => ( {
 
 const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
 
+/** The route arg as the chassis writes it. */
+const SETTINGS_ARG = '&p=%2F%3Ftab%3Dsettings';
+
 const goTo = ( suffix: string ) => {
 	act( () => {
 		window.history.replaceState( null, '', `${ BASE_URL }${ suffix }` );
@@ -101,13 +104,47 @@ describe( 'ModernApp', () => {
 
 	it( 'records one page view per visible route activation', () => {
 		renderApp();
-		goTo( '&tab=settings' );
+		goTo( SETTINGS_ARG );
 		goTo( '#/cache-debug-log' );
 
 		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
 			'page_view_overview',
 			'page_view_settings',
 			'page_view_cache_debug_log',
+		] );
+	} );
+
+	it( 'records Settings on a cold load of the chassis Settings route', () => {
+		window.history.replaceState( null, '', `${ BASE_URL }${ SETTINGS_ARG }` );
+
+		renderApp();
+
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_settings',
+		] );
+	} );
+
+	it( 'records Settings when the chassis switches tab', () => {
+		renderApp();
+
+		goTo( SETTINGS_ARG );
+
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_overview',
+			'page_view_settings',
+		] );
+	} );
+
+	it( 'records Settings again on the way back from a sub-page', () => {
+		renderApp();
+
+		goTo( '#/cache-debug-log' );
+		goTo( SETTINGS_ARG );
+
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_overview',
+			'page_view_cache_debug_log',
+			'page_view_settings',
 		] );
 	} );
 
@@ -124,7 +161,7 @@ describe( 'ModernApp', () => {
 		goTo( '#/?tab=settings' );
 
 		expect( window.location.hash ).toBe( '' );
-		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( window.location.search ).toContain( 'p=%2F%3Ftab%3Dsettings' );
 		expect( mockRecordBoostEvent ).toHaveBeenLastCalledWith( 'page_view_settings', { path: '/' } );
 	} );
 

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.test.tsx
@@ -1,0 +1,149 @@
+/* This project does not load jest-dom, so its matchers are not available here. */
+/* eslint-disable jest-dom/prefer-in-document */
+import { act, render, within } from '@testing-library/react';
+import {
+	LOCATION_CHANGE_EVENT,
+	SETTINGS_SLOT_ID,
+	SUBPAGE_SLOT_ID,
+} from '../../../../../../_inc/runtime-contract';
+import ModernApp from './modern-app';
+
+const mockRecordBoostEvent = jest.fn();
+let mockShouldGetStarted = false;
+
+jest.mock( '$lib/utils/analytics', () => ( {
+	...jest.requireActual( '$lib/utils/analytics' ),
+	recordBoostEvent: ( ...args: unknown[] ) => mockRecordBoostEvent( ...args ),
+} ) );
+jest.mock( '$lib/stores/getting-started', () => ( {
+	useGettingStarted: () => ( {
+		shouldGetStarted: mockShouldGetStarted,
+		markGettingStartedComplete: jest.fn(),
+	} ),
+} ) );
+jest.mock( '@automattic/jetpack-react-data-sync-client', () => ( {
+	DataSyncProvider: ( { children }: { children: React.ReactNode } ) => children,
+} ) );
+jest.mock( '$features/critical-css/critical-css-context/critical-css-context-provider', () => ( {
+	__esModule: true,
+	default: ( { children }: { children: React.ReactNode } ) => children,
+} ) );
+jest.mock( './modern-settings', () => ( {
+	__esModule: true,
+	default: ( { hidden }: { hidden?: boolean } ) => <div data-testid="settings" hidden={ hidden } />,
+} ) );
+jest.mock( './modern-subpage', () => ( {
+	__esModule: true,
+	default: ( { subpage }: { subpage: string } ) => <div data-testid="subpage">{ subpage }</div>,
+} ) );
+
+const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
+
+const goTo = ( suffix: string ) => {
+	act( () => {
+		window.history.replaceState( null, '', `${ BASE_URL }${ suffix }` );
+		window.dispatchEvent( new Event( LOCATION_CHANGE_EVENT ) );
+	} );
+};
+
+const renderApp = () => {
+	const slots = {
+		settings: document.createElement( 'div' ),
+		subpage: document.createElement( 'div' ),
+	};
+	slots.settings.id = SETTINGS_SLOT_ID;
+	slots.subpage.id = SUBPAGE_SLOT_ID;
+	document.body.append( slots.settings, slots.subpage );
+
+	return {
+		slots,
+		...render( <ModernApp subpageSlot={ slots.subpage } />, { container: slots.settings } ),
+	};
+};
+
+describe( 'ModernApp', () => {
+	beforeEach( () => {
+		mockShouldGetStarted = false;
+		mockRecordBoostEvent.mockClear();
+		window.history.replaceState( null, '', BASE_URL );
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	it( 'renders Settings in the slot it mounts into, leaving the sub-page slot empty', () => {
+		const { slots } = renderApp();
+
+		expect( within( slots.settings ).getByTestId( 'settings' ) ).toBeTruthy();
+		expect( within( slots.subpage ).queryByTestId( 'subpage' ) ).toBeNull();
+	} );
+
+	it( 'keeps the Settings tree mounted while a sub-page shows', () => {
+		const { slots } = renderApp();
+		const settingsNode = within( slots.settings ).getByTestId( 'settings' );
+
+		goTo( '#/cache-debug-log' );
+
+		expect( within( slots.subpage ).getByText( 'cache-debug-log' ) ).toBeTruthy();
+		expect( within( slots.settings ).getByTestId( 'settings' ) ).toBe( settingsNode );
+	} );
+
+	it( 'renders one sub-page at a time', () => {
+		const { slots } = renderApp();
+
+		goTo( '#/cache-debug-log' );
+		goTo( '#/critical-css-advanced' );
+
+		expect( within( slots.subpage ).getAllByTestId( 'subpage' ) ).toHaveLength( 1 );
+		expect( within( slots.subpage ).getByText( 'critical-css-advanced' ) ).toBeTruthy();
+	} );
+
+	it( 'records one page view per visible route activation', () => {
+		renderApp();
+		goTo( '&tab=settings' );
+		goTo( '#/cache-debug-log' );
+
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_overview',
+			'page_view_settings',
+			'page_view_cache_debug_log',
+		] );
+	} );
+
+	it( 'does not record a second view for a repeated location event', () => {
+		renderApp();
+		goTo( '#/cache-debug-log' );
+		goTo( '#/cache-debug-log' );
+
+		expect( mockRecordBoostEvent ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'promotes a tab carried in the hash and records it once as Settings', () => {
+		renderApp();
+		goTo( '#/?tab=settings' );
+
+		expect( window.location.hash ).toBe( '' );
+		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( mockRecordBoostEvent ).toHaveBeenLastCalledWith( 'page_view_settings', { path: '/' } );
+	} );
+
+	it( 'redirects an onboarding user off a guarded route without recording it', () => {
+		mockShouldGetStarted = true;
+		const { slots } = renderApp();
+
+		expect( window.location.hash ).toBe( '#/getting-started' );
+		expect( within( slots.subpage ).getByText( 'getting-started' ) ).toBeTruthy();
+		expect( mockRecordBoostEvent.mock.calls.map( ( [ name ] ) => name ) ).toEqual( [
+			'page_view_getting_started',
+		] );
+	} );
+
+	it( 'leaves the onboarding page itself alone', () => {
+		mockShouldGetStarted = true;
+		window.history.replaceState( null, '', `${ BASE_URL }#/purchase-successful` );
+		const { slots } = renderApp();
+
+		expect( within( slots.subpage ).getByText( 'purchase-successful' ) ).toBeTruthy();
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-app.tsx
@@ -1,0 +1,61 @@
+import { StrictMode } from 'react';
+import { createPortal } from '@wordpress/element';
+import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
+import CriticalCssProvider from '$features/critical-css/critical-css-context/critical-css-context-provider';
+import { NoticeProvider } from '$features/notice/context';
+import { ModernNavigationProvider } from '$lib/navigation/navigation-context';
+import { useModernRoute } from '$lib/modern/use-modern-route';
+import { usePageView } from '$lib/modern/use-page-view';
+import ModernSettings from './modern-settings';
+import ModernSubpage from './modern-subpage';
+import { useOnboardingRedirect } from './use-onboarding-redirect';
+
+type ModernAppProps = {
+	subpageSlot: HTMLElement;
+};
+
+/**
+ * Settings renders in place and stays mounted; a sub-page is portalled out to
+ * the chassis mount that sits outside the tab shell.
+ *
+ * @param props             - Component props.
+ * @param props.subpageSlot - Chassis mount for the active sub-page.
+ */
+const ModernRoutes = ( { subpageSlot }: ModernAppProps ) => {
+	const route = useModernRoute();
+	const redirecting = useOnboardingRedirect( route );
+
+	usePageView( route, ! redirecting );
+
+	return (
+		<>
+			<ModernSettings hidden={ redirecting } />
+			{ route.subpage &&
+				! redirecting &&
+				createPortal( <ModernSubpage subpage={ route.subpage } />, subpageSlot ) }
+		</>
+	);
+};
+
+/**
+ * The data, notice and critical CSS providers sit above both screens, so moving
+ * between Settings and a sub-page never drops their state.
+ *
+ * @param props             - Component props.
+ * @param props.subpageSlot - Chassis mount for the active sub-page.
+ */
+const ModernApp = ( { subpageSlot }: ModernAppProps ) => (
+	<StrictMode>
+		<DataSyncProvider>
+			<ModernNavigationProvider>
+				<NoticeProvider>
+					<CriticalCssProvider>
+						<ModernRoutes subpageSlot={ subpageSlot } />
+					</CriticalCssProvider>
+				</NoticeProvider>
+			</ModernNavigationProvider>
+		</DataSyncProvider>
+	</StrictMode>
+);
+
+export default ModernApp;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
@@ -1,0 +1,5 @@
+.settings {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.module.scss
@@ -1,5 +1,11 @@
 .settings {
 	display: flex;
+
+	// display:flex here would otherwise beat the UA rule for the hidden attribute.
+	&[hidden] {
+		display: none;
+	}
+
 	flex-direction: column;
 	gap: 24px;
 }

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.test.tsx
@@ -1,0 +1,57 @@
+/* No jest-dom in this project, and the hidden-but-mounted assertion needs the node itself. */
+/* eslint-disable jest-dom/prefer-in-document, testing-library/no-container, testing-library/no-node-access */
+import { render, screen } from '@testing-library/react';
+import ModernSettings from './modern-settings';
+
+jest.mock( '$lib/stores/premium-features', () => ( {
+	usePremiumFeatures: () => mockPremiumFeatures,
+} ) );
+jest.mock( '../../pages/index', () => ( {
+	__esModule: true,
+	default: () => <div>settings body</div>,
+} ) );
+jest.mock( '$layout/settings-page/tips/tips', () => ( {
+	__esModule: true,
+	default: () => <div>tips</div>,
+} ) );
+jest.mock( '$layout/settings-page/support/support', () => ( {
+	__esModule: true,
+	default: () => <div>priority support</div>,
+} ) );
+jest.mock( '$features/notice/manager', () => ( {
+	__esModule: true,
+	default: () => <div>notices</div>,
+} ) );
+
+let mockPremiumFeatures: string[] = [];
+
+describe( 'ModernSettings', () => {
+	beforeEach( () => {
+		mockPremiumFeatures = [];
+	} );
+
+	it( 'renders the settings body without the chassis-owned header or speed scores', () => {
+		const { container } = render( <ModernSettings /> );
+
+		expect( screen.getByText( 'settings body' ) ).toBeTruthy();
+		expect( container.querySelector( '.jb-dashboard' ) ).toBeNull();
+	} );
+
+	it( 'shows priority support only on a plan that includes it', () => {
+		const view = render( <ModernSettings /> );
+		expect( screen.queryByText( 'priority support' ) ).toBeNull();
+		view.unmount();
+
+		mockPremiumFeatures = [ 'support' ];
+		render( <ModernSettings /> );
+
+		expect( screen.getByText( 'priority support' ) ).toBeTruthy();
+	} );
+
+	it( 'hides itself without unmounting while a redirect is pending', () => {
+		const { container } = render( <ModernSettings hidden /> );
+
+		expect( screen.getByText( 'settings body' ) ).toBeTruthy();
+		expect( container.querySelector( '[hidden]' ) ).not.toBeNull();
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-settings.tsx
@@ -1,0 +1,36 @@
+import clsx from 'clsx';
+import { usePremiumFeatures } from '$lib/stores/premium-features';
+import NoticeManager from '$features/notice/manager';
+import Support from '$layout/settings-page/support/support';
+import Tips from '$layout/settings-page/tips/tips';
+import Index from '../../pages/index';
+import styles from './modern-settings.module.scss';
+
+type ModernSettingsProps = {
+	hidden?: boolean;
+};
+
+/**
+ * @param props        - Component props.
+ * @param props.hidden - Hide while a redirect is pending, without unmounting.
+ */
+const ModernSettings = ( { hidden = false }: ModernSettingsProps ) => {
+	const premiumFeatures = usePremiumFeatures();
+	const hasPrioritySupport = premiumFeatures && premiumFeatures.includes( 'support' );
+
+	return (
+		<div className={ clsx( 'jb-modern-settings', styles.settings ) } hidden={ hidden }>
+			<div className="jb-section jb-section--main">
+				<Index />
+			</div>
+
+			<Tips />
+
+			{ hasPrioritySupport && <Support /> }
+
+			<NoticeManager />
+		</div>
+	);
+};
+
+export default ModernSettings;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.test.tsx
@@ -1,0 +1,43 @@
+/* This project does not load jest-dom, so its matchers are not available here. */
+/* eslint-disable jest-dom/prefer-in-document */
+import { render, screen } from '@testing-library/react';
+import ModernSubpage from './modern-subpage';
+import type { Subpage } from '../../../../../../_inc/runtime-contract';
+
+jest.mock( '../../pages/cache-debug-log/cache-debug-log', () => ( {
+	__esModule: true,
+	default: () => <div>cache debug log</div>,
+} ) );
+jest.mock( '../../pages/critical-css-advanced/critical-css-advanced', () => ( {
+	__esModule: true,
+	default: () => <div>critical css advanced</div>,
+} ) );
+jest.mock( '../../pages/getting-started/getting-started', () => ( {
+	__esModule: true,
+	default: () => <div>getting started</div>,
+} ) );
+jest.mock( '../../pages/purchase-success/purchase-success', () => ( {
+	__esModule: true,
+	default: () => <div>purchase success</div>,
+} ) );
+
+describe( 'ModernSubpage', () => {
+	it.each( [
+		[ 'cache-debug-log', 'cache debug log' ],
+		[ 'critical-css-advanced', 'critical css advanced' ],
+		[ 'getting-started', 'getting started' ],
+		[ 'purchase-successful', 'purchase success' ],
+	] )( 'renders %s', ( subpage, expected ) => {
+		render( <ModernSubpage subpage={ subpage as Subpage } /> );
+
+		expect( screen.getByText( expected ) ).toBeTruthy();
+	} );
+
+	it( 'renders only the requested sub-page', () => {
+		render( <ModernSubpage subpage="getting-started" /> );
+
+		expect(
+			screen.queryAllByText( /cache debug log|critical css advanced|purchase success/ )
+		).toHaveLength( 0 );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
@@ -23,6 +23,11 @@ const ModernSubpage = ( { subpage }: ModernSubpageProps ) => {
 		case 'purchase-successful':
 			return <PurchaseSuccess />;
 	}
+
+	// A sub-page added to the contract without a case here would render nothing.
+	subpage satisfies never;
+
+	return null;
 };
 
 export default ModernSubpage;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/modern-subpage.tsx
@@ -1,0 +1,28 @@
+import CacheDebugLog from '../../pages/cache-debug-log/cache-debug-log';
+import AdvancedCriticalCss from '../../pages/critical-css-advanced/critical-css-advanced';
+import GettingStarted from '../../pages/getting-started/getting-started';
+import PurchaseSuccess from '../../pages/purchase-success/purchase-success';
+import type { Subpage } from '../../../../../../_inc/runtime-contract';
+
+type ModernSubpageProps = {
+	subpage: Subpage;
+};
+
+/**
+ * @param props         - Component props.
+ * @param props.subpage - Sub-page to render.
+ */
+const ModernSubpage = ( { subpage }: ModernSubpageProps ) => {
+	switch ( subpage ) {
+		case 'cache-debug-log':
+			return <CacheDebugLog />;
+		case 'critical-css-advanced':
+			return <AdvancedCriticalCss />;
+		case 'getting-started':
+			return <GettingStarted />;
+		case 'purchase-successful':
+			return <PurchaseSuccess />;
+	}
+};
+
+export default ModernSubpage;

--- a/projects/plugins/boost/app/assets/src/js/layout/modern/use-onboarding-redirect.ts
+++ b/projects/plugins/boost/app/assets/src/js/layout/modern/use-onboarding-redirect.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react';
+import { useGettingStarted } from '$lib/stores/getting-started';
+import { navigateTo, subpageUrl } from '$lib/modern/routes';
+import type { ModernRoute } from '$lib/modern/routes';
+
+/**
+ * Whether a route may only be reached once onboarding is done, matching the
+ * legacy router's loader: Settings and two sub-pages, never Getting Started or
+ * Purchase Success themselves.
+ *
+ * @param route - Route being shown.
+ * @return Whether the route requires onboarding to be complete.
+ */
+function requiresOnboarding( route: ModernRoute ): boolean {
+	return (
+		route.subpage === null ||
+		route.subpage === 'cache-debug-log' ||
+		route.subpage === 'critical-css-advanced'
+	);
+}
+
+/**
+ * Send onboarding users to Getting Started, as today.
+ *
+ * @param route - Route being shown.
+ * @return Whether a redirect is pending, so the caller can hold the page view.
+ */
+export function useOnboardingRedirect( route: ModernRoute ): boolean {
+	const { shouldGetStarted } = useGettingStarted();
+	const redirecting = shouldGetStarted && requiresOnboarding( route );
+
+	useEffect( () => {
+		if ( redirecting ) {
+			navigateTo( subpageUrl( 'getting-started' ), { replace: true } );
+		}
+	}, [ redirecting ] );
+
+	return redirecting;
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.test.ts
@@ -4,23 +4,30 @@ import { navigateTo, resolveRoute, settingsUrl, subpageHref, subpageUrl } from '
 const url = ( suffix: string ) =>
 	`http://localhost/wp-admin/admin.php?page=jetpack-boost${ suffix }`;
 
+/** The route arg as the chassis writes it: the whole route, percent-encoded. */
+const SETTINGS_ARG = '&p=%2F%3Ftab%3Dsettings';
+
 describe( 'resolveRoute', () => {
 	it.each( [ '', '#', '#/' ] )( 'treats %p as the Overview root', suffix => {
 		expect( resolveRoute( url( suffix ) ).route ).toEqual( { subpage: null, tab: 'overview' } );
 	} );
 
-	it( 'reads the tab from the outer query', () => {
-		expect( resolveRoute( url( '&tab=settings' ) ).route ).toEqual( {
+	it( 'reads the tab out of the chassis route arg', () => {
+		expect( resolveRoute( url( SETTINGS_ARG ) ).route ).toEqual( {
 			subpage: null,
 			tab: 'settings',
 		} );
 	} );
 
-	it( 'promotes a tab carried in the hash to the outer query', () => {
+	it( 'ignores a tab written beside the route arg rather than inside it', () => {
+		expect( resolveRoute( url( '&tab=settings' ) ).route.tab ).toBe( 'overview' );
+	} );
+
+	it( 'promotes a tab carried in the hash into the route arg', () => {
 		const { route, normalizedUrl } = resolveRoute( url( '#/?tab=settings' ) );
 
 		expect( route ).toEqual( { subpage: null, tab: 'settings' } );
-		expect( normalizedUrl ).toBe( url( '&tab=settings' ) );
+		expect( normalizedUrl ).toBe( url( SETTINGS_ARG ) );
 	} );
 
 	it( 'parses the hash query before matching a sub-page', () => {
@@ -30,7 +37,7 @@ describe( 'resolveRoute', () => {
 	} );
 
 	it( 'lets a recognised hash win over the tab', () => {
-		expect( resolveRoute( url( '&tab=settings#/critical-css-advanced' ) ).route.subpage ).toBe(
+		expect( resolveRoute( url( `${ SETTINGS_ARG }#/critical-css-advanced` ) ).route.subpage ).toBe(
 			'critical-css-advanced'
 		);
 	} );
@@ -40,24 +47,28 @@ describe( 'resolveRoute', () => {
 	} );
 
 	it( 'normalizes nothing for a plain URL', () => {
-		expect( resolveRoute( url( '&tab=settings' ) ).normalizedUrl ).toBeNull();
+		expect( resolveRoute( url( SETTINGS_ARG ) ).normalizedUrl ).toBeNull();
 	} );
 } );
 
 describe( 'settingsUrl', () => {
-	it( 'clears the hash and sets the tab', () => {
-		expect( settingsUrl( url( '#/cache-debug-log' ) ) ).toBe( url( '&tab=settings' ) );
+	it( 'clears the hash and writes the tab into the route arg', () => {
+		expect( settingsUrl( url( '#/cache-debug-log' ) ) ).toBe( url( SETTINGS_ARG ) );
 	} );
 
-	it( 'leaves an existing settings tab alone', () => {
-		expect( settingsUrl( url( '&tab=settings' ) ) ).toBe( url( '&tab=settings' ) );
+	it( 'is idempotent', () => {
+		expect( settingsUrl( url( SETTINGS_ARG ) ) ).toBe( url( SETTINGS_ARG ) );
+	} );
+
+	it( 'replaces a sub-page route arg rather than appending to it', () => {
+		expect( settingsUrl( url( '&p=%2F%3Ftab%3Doverview' ) ) ).toBe( url( SETTINGS_ARG ) );
 	} );
 } );
 
 describe( 'subpageUrl', () => {
 	it( 'keeps the outer query', () => {
-		expect( subpageUrl( 'getting-started', url( '&tab=settings' ) ) ).toBe(
-			url( '&tab=settings#/getting-started' )
+		expect( subpageUrl( 'getting-started', url( SETTINGS_ARG ) ) ).toBe(
+			url( `${ SETTINGS_ARG }#/getting-started` )
 		);
 	} );
 

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/routes.ts
@@ -1,9 +1,9 @@
 /**
  * URL rules for the modern chassis.
  *
- * The wp-build route is `/` with `?tab=overview|settings` in the outer query,
- * owned by the chassis. Sub-pages keep today's hashes, and a recognised hash
- * wins over the tab.
+ * The chassis router keeps its whole route — path and query — inside the `p`
+ * wp-admin query arg, so the tab lives in there rather than beside it.
+ * Sub-pages keep today's hashes, and a recognised hash wins over the tab.
  */
 
 import {
@@ -12,6 +12,8 @@ import {
 	splitHash,
 } from '../../../../../../_inc/runtime-contract';
 import type { Subpage, Tab } from '../../../../../../_inc/runtime-contract';
+
+const ROUTE_ARG = 'p';
 
 export type ModernRoute = {
 	subpage: Subpage | null;
@@ -38,7 +40,7 @@ export function resolveRoute( href: string = window.location.href ): ResolvedRou
 		return { route: { subpage, tab: readTab( url.searchParams ) }, normalizedUrl: null };
 	}
 
-	const hashTab = readTab( splitHash( url.hash ).query );
+	const hashTab = tabFromQuery( splitHash( url.hash ).query );
 	if ( hashTab === 'settings' ) {
 		return {
 			route: { subpage: null, tab: 'settings' },
@@ -50,13 +52,23 @@ export function resolveRoute( href: string = window.location.href ): ResolvedRou
 }
 
 /**
- * Read the tab out of a query, defaulting to Overview.
+ * Read the tab out of any query, defaulting to Overview.
  *
  * @param query - Query to read.
  * @return The tab.
  */
-function readTab( query: URLSearchParams ): Tab {
+function tabFromQuery( query: URLSearchParams ): Tab {
 	return query.get( 'tab' ) === 'settings' ? 'settings' : 'overview';
+}
+
+/**
+ * Read the tab the chassis is on, from the route it keeps in the route arg.
+ *
+ * @param search - Query holding the route arg.
+ * @return The tab.
+ */
+function readTab( search: URLSearchParams ): Tab {
+	return tabFromQuery( splitHash( search.get( ROUTE_ARG ) ?? '' ).query );
 }
 
 /**
@@ -68,7 +80,7 @@ function readTab( query: URLSearchParams ): Tab {
 export function settingsUrl( href: string = window.location.href ): string {
 	const url = new URL( href );
 	url.hash = '';
-	url.searchParams.set( 'tab', 'settings' );
+	url.searchParams.set( ROUTE_ARG, '/?tab=settings' );
 
 	return url.toString();
 }

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-modern-route.test.tsx
@@ -4,6 +4,9 @@ import { useModernRoute } from './use-modern-route';
 
 const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
 
+/** The route arg as the chassis writes it. */
+const SETTINGS_ARG = '&p=%2F%3Ftab%3Dsettings';
+
 const goTo = ( suffix: string, event = LOCATION_CHANGE_EVENT ) => {
 	act( () => {
 		window.history.replaceState( null, '', `${ BASE_URL }${ suffix }` );
@@ -36,7 +39,7 @@ describe( 'useModernRoute', () => {
 	it( 'follows the chassis location event and history navigation', () => {
 		const { result } = renderHook( () => useModernRoute() );
 
-		goTo( '&tab=settings' );
+		goTo( SETTINGS_ARG );
 		expect( result.current.tab ).toBe( 'settings' );
 
 		goTo( '', 'popstate' );
@@ -49,7 +52,7 @@ describe( 'useModernRoute', () => {
 		goTo( '#/?tab=settings' );
 
 		expect( window.location.hash ).toBe( '' );
-		expect( window.location.search ).toContain( 'tab=settings' );
+		expect( window.location.search ).toContain( 'p=%2F%3Ftab%3Dsettings' );
 		expect( result.current ).toEqual( { subpage: null, tab: 'settings' } );
 	} );
 

--- a/projects/plugins/boost/app/assets/src/js/lib/modern/use-page-view.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/modern/use-page-view.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { getPageViewEventName, recordBoostEvent } from '$lib/utils/analytics';
+import type { ModernRoute } from './routes';
+
+/**
+ * Derive the page-view event to record for a route.
+ *
+ * @param route - Route being shown.
+ * @return Event name and the path property to send with it.
+ */
+function getPageViewEvent( route: ModernRoute ): { name: string; path: string } {
+	if ( route.subpage ) {
+		const path = `/${ route.subpage }`;
+
+		return { name: getPageViewEventName( path ), path };
+	}
+
+	return {
+		name: route.tab === 'settings' ? 'page_view_settings' : 'page_view_overview',
+		path: '/',
+	};
+}
+
+/**
+ * Record one page view per visible route activation.
+ *
+ * @param route   - Route being shown.
+ * @param enabled - False while a redirect is pending, so the route the user
+ *                never sees is not recorded.
+ */
+export function usePageView( route: ModernRoute, enabled: boolean ): void {
+	const lastRecorded = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			return;
+		}
+
+		const { name, path } = getPageViewEvent( route );
+		if ( lastRecorded.current === name ) {
+			return;
+		}
+
+		lastRecorded.current = name;
+		recordBoostEvent( name, { path } );
+	}, [ route, enabled ] );
+}

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.test.tsx
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react';
-import { LegacyNavigationProvider, useBoostNavigation } from './navigation-context';
+import {
+	LegacyNavigationProvider,
+	ModernNavigationProvider,
+	useBoostNavigation,
+} from './navigation-context';
 
 const mockNavigate = jest.fn();
 
@@ -20,6 +24,30 @@ describe( 'useBoostNavigation', () => {
 		);
 
 		consoleError.mockRestore();
+	} );
+} );
+
+describe( 'ModernNavigationProvider', () => {
+	const BASE_URL = 'http://localhost/wp-admin/admin.php?page=jetpack-boost';
+
+	beforeEach( () => {
+		window.history.replaceState( null, '', BASE_URL );
+	} );
+
+	const renderNavigation = () =>
+		renderHook( () => useBoostNavigation(), { wrapper: ModernNavigationProvider } );
+
+	it( 'sends returnToSettings to the chassis Settings route, clearing the hash', () => {
+		window.history.replaceState( null, '', `${ BASE_URL }#/cache-debug-log` );
+
+		renderNavigation().result.current.returnToSettings();
+
+		expect( window.location.hash ).toBe( '' );
+		expect( window.location.search ).toContain( 'p=%2F%3Ftab%3Dsettings' );
+	} );
+
+	it( 'offers the same destination as an href', () => {
+		expect( renderNavigation().result.current.settingsHref ).toContain( 'p=%2F%3Ftab%3Dsettings' );
 	} );
 } );
 

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
@@ -9,6 +9,8 @@ type NavigateOptions = {
 
 type BoostNavigation = {
 	returnToSettings: ( options?: NavigateOptions ) => void;
+	/** Where Settings lives, for links that must survive a middle click or copy. */
+	settingsHref: string;
 };
 
 const NavigationContext = createContext< BoostNavigation | null >( null );
@@ -32,7 +34,7 @@ export function useBoostNavigation(): BoostNavigation {
 export function LegacyNavigationProvider( { children }: { children: ReactNode } ) {
 	const navigate = useNavigate();
 	const navigation = useMemo< BoostNavigation >(
-		() => ( { returnToSettings: options => navigate( '/', options ) } ),
+		() => ( { returnToSettings: options => navigate( '/', options ), settingsHref: '#/' } ),
 		[ navigate ]
 	);
 
@@ -47,7 +49,10 @@ export function LegacyNavigationProvider( { children }: { children: ReactNode } 
  */
 export function ModernNavigationProvider( { children }: { children: ReactNode } ) {
 	const navigation = useMemo< BoostNavigation >(
-		() => ( { returnToSettings: options => navigateTo( settingsUrl(), options ) } ),
+		() => ( {
+			returnToSettings: options => navigateTo( settingsUrl(), options ),
+			settingsHref: settingsUrl(),
+		} ),
 		[]
 	);
 

--- a/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
+++ b/projects/plugins/boost/app/assets/src/js/lib/navigation/navigation-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo } from 'react';
 import { useNavigate } from 'react-router';
+import { navigateTo, settingsUrl } from '$lib/modern/routes';
 import type { ReactNode } from 'react';
 
 type NavigateOptions = {
@@ -33,6 +34,21 @@ export function LegacyNavigationProvider( { children }: { children: ReactNode } 
 	const navigation = useMemo< BoostNavigation >(
 		() => ( { returnToSettings: options => navigate( '/', options ) } ),
 		[ navigate ]
+	);
+
+	return <NavigationContext.Provider value={ navigation }>{ children }</NavigationContext.Provider>;
+}
+
+/**
+ * Navigation for the modern chassis, over the browser history.
+ *
+ * @param props          - Component props.
+ * @param props.children - Tree to provide navigation to.
+ */
+export function ModernNavigationProvider( { children }: { children: ReactNode } ) {
+	const navigation = useMemo< BoostNavigation >(
+		() => ( { returnToSettings: options => navigateTo( settingsUrl(), options ) } ),
+		[]
 	);
 
 	return <NavigationContext.Provider value={ navigation }>{ children }</NavigationContext.Provider>;

--- a/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
+++ b/projects/plugins/boost/app/assets/src/js/pages/cache-debug-log/cache-debug-log.tsx
@@ -12,7 +12,7 @@ import styles from './cache-debug-log.module.scss';
 
 const CacheDebugLog = () => {
 	const [ { data: debugLog } ] = useDebugLog();
-	const { returnToSettings } = useBoostNavigation();
+	const { returnToSettings, settingsHref } = useBoostNavigation();
 	const [ hasCopied, setHasCopied ] = useState( false );
 	const copyTimer = useRef< ReturnType< typeof setTimeout > | undefined >();
 
@@ -53,7 +53,7 @@ const CacheDebugLog = () => {
 			<ul className={ styles.breadcrumbs }>
 				<li>
 					<Text variant="body-lg">
-						<Link tone="neutral" href="#/" onClick={ handleBack }>
+						<Link tone="neutral" href={ settingsHref } onClick={ handleBack }>
 							{ 'Boost' /** "Boost" is a product name, do not translate. */ }
 						</Link>
 					</Text>

--- a/projects/plugins/boost/changelog/cycle-one-modern-mount
+++ b/projects/plugins/boost/changelog/cycle-one-modern-mount
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Mount the dashboard inside the modernization chassis when its filter is on. No change with the filter off.
+
+

--- a/projects/plugins/boost/tests/e2e/specs/modernization/dashboard.test.ts
+++ b/projects/plugins/boost/tests/e2e/specs/modernization/dashboard.test.ts
@@ -54,6 +54,9 @@ test.describe( 'Dashboard modernization', () => {
 		await expect( page.getByRole( 'tab', { name: 'Settings', exact: true } ) ).toBeVisible();
 		await expect( page.locator( '#jb-settings-tab-mount' ) ).toHaveCount( 1 );
 		await expect( page.locator( '#jb-subpage-mount' ) ).toHaveCount( 1 );
+
+		// The mount is only useful once the webpack app has rendered Settings into it.
+		await expect( page.locator( '#jb-settings-tab-mount .jb-modern-settings' ) ).toHaveCount( 1 );
 		await expect( page.locator( '#jb-admin-settings' ) ).toHaveCount( 0 );
 	} );
 

--- a/projects/plugins/boost/tsconfig.dashboard.json
+++ b/projects/plugins/boost/tsconfig.dashboard.json
@@ -1,9 +1,18 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
+	"compilerOptions": {
+		"paths": {
+			"$lib/*": [ "./app/assets/src/js/lib/*" ],
+			"$features/*": [ "./app/assets/src/js/features/*" ],
+			"$layout/*": [ "./app/assets/src/js/layout/*" ],
+			"$svg/*": [ "./app/assets/src/js/svg/*" ]
+		}
+	},
 	"include": [
 		"_inc/**/*",
 		"routes/**/*",
 		"packages/init/src/**/*",
+		"app/assets/src/js/lib/modern/**/*",
 		"app/assets/src/js/global.d.ts"
 	]
 }


### PR DESCRIPTION
Fixes BOOST-670. The last of the series, after #52132, #52133 and #52180.

## Proposed changes

Mount the dashboard inside the modernization chassis when `rsm_jetpack_ui_modernization_boost` is on. Inert with the filter off.

One root, mounted in the chassis Settings slot, portalling a sub-page into the mount outside the tab shell — so a single provider tree spans both and Settings is never remounted or stripped of its Data Sync, Notice and Critical CSS state. Settings drops the page header and speed scores, since the chassis owns the header and the Overview owns the scores, but keeps the type scale those controls rely on: `.jb-dashboard`'s tokens and component overrides become a shared mixin, while its page framing stays with the legacy page.

Routing reads and writes the tab through the `p` arg the chassis router keeps its route in, rather than beside it, so the tab, the returns and the page views all agree with the URLs the chassis actually writes.

The Critical CSS "advanced recommendations" link becomes a plain anchor: react-router's `Link` throws outside a `<Router>` and modern mode has none. It renders on today's dashboard too, so the replacement emits exactly what `Link` did — same href, no class.

## Related product discussion/links

* Contract: BOOST-665
* Parent: BOOST-633
* Sub-page refresh: BOOST-672

## Does this pull request change what data or activity we track or use?

Yes, modern mode only: `page_view_overview` is new. Existing event names are unchanged, and nothing changes with the filter off.

## Testing instructions

**Filter off (the default) — nothing should differ from trunk.** Build with `pnpm jetpack build plugins/boost --no-pnpm-install --production`, open **Jetpack → Boost**, and check Settings and all four sub-pages, including the Critical CSS "advanced recommendations" link and the Cache Log's Back. The shared stylesheet is split here, so the legacy page's compiled CSS is worth a glance: same declarations, only reordered.

<img src="https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-modern-mount/settings-filter-off.jpg" width="700" alt="Settings with the filter off" />

**Filter on** — `add_filter( 'rsm_jetpack_ui_modernization_boost', '__return_true' );` in an mu-plugin. Settings renders under the chassis header and tabs, with no second header and no speed scores, at the same type scale as the legacy page:

<img src="https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-modern-mount/settings-filter-on.jpg" width="700" alt="Settings with the filter on" />

A sub-page takes the full frame, with no tab shell and Back as the way out:

<img src="https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-boost-modern-mount/subpage-filter-on.jpg" width="700" alt="Critical CSS Advanced with the filter on" />

Then check the behaviour the screenshots can't show:

1. Overview → Settings → Overview: a half-filled control keeps its value.
2. `#/cache-debug-log`, then Back: you land on Settings, and only one sub-page tree ever renders.
3. A bookmarked `&p=%2F%3Ftab%3Dsettings` opens Settings; `#/?tab=settings` rewrites into that arg; `#/cache-debug-log?x=1` opens the Cache Log.
4. `pnpm --dir projects/plugins/boost test` — 184 tests, 27 new here.

## Known limitations

**Notices raised from a sub-page would be invisible.** `NoticeManager` lives in the Settings tree, which the chassis hides while a sub-page shows. Nothing raises a notice from a sub-page today.

**Two cosmetic gaps, both owned elsewhere.** The Overview tab renders empty — the chassis renders it as `null` pending #52069. And `cache-debug-log`, `getting-started` and `purchase-successful` each render their own `BoostAdminPage`, so they show a second Boost header inside the chassis header; BOOST-672 refreshes those pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzGT9kxxs229BAH6yUMoJ3
