### PR TITLE
Charts: add summary columns to the HeatmapChart

### DIFF
--- a/projects/js-packages/charts/changelog/fix-heatmap-chart-keyboard-tooltip-loop
+++ b/projects/js-packages/charts/changelog/fix-heatmap-chart-keyboard-tooltip-loop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+HeatmapChart: Fix an endless re-render when the keyboard tooltip opens on a chart without row labels.

--- a/projects/js-packages/charts/changelog/update-heatmap-chart-summary-column
+++ b/projects/js-packages/charts/changelog/update-heatmap-chart-summary-column
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-HeatmapChart: Add summary columns, per-row roll-ups drawn outside the colour scale.
+HeatmapChart: Add summary columns, per-row roll-ups drawn outside the color scale.

--- a/projects/js-packages/charts/changelog/update-heatmap-chart-summary-column
+++ b/projects/js-packages/charts/changelog/update-heatmap-chart-summary-column
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+HeatmapChart: Add summary columns, per-row roll-ups drawn outside the colour scale.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -114,12 +114,16 @@ $focus-ring-width: var(--wpds-border-width-focus);
 }
 
 // A roll-up beside the grid, on another scale from it: no fill, its figure
-// always printed and emphasised, set one gap apart from the data columns.
+// always printed and emphasised. The margin is deliberate on top of the grid's
+// own gap: the roll-up sits one gap further from the data columns than they
+// sit from each other, the way a table sets its totals apart, and the auto
+// track grows by the same amount.
 .heatmap-chart__cell--summary {
 	background: none;
 	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
 }
 
+// The same offset as its cells, so the label stays over them.
 .heatmap-chart__col-label--summary {
 	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
 	font-weight: var(--wpds-typography-font-weight-emphasis);

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -113,6 +113,22 @@ $focus-ring-width: var(--wpds-border-width-focus);
 	background: color-mix(in sRGB, var(--a8c-charts-color-track) 45%, transparent);
 }
 
+// A roll-up beside the grid, on another scale from it: no fill, its figure
+// always printed and emphasised, set one gap apart from the data columns.
+.heatmap-chart__cell--summary {
+	background: none;
+	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
+}
+
+.heatmap-chart__col-label--summary {
+	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
+	font-weight: var(--wpds-typography-font-weight-emphasis);
+}
+
+.heatmap-chart__cell--summary .heatmap-chart__cell-value {
+	font-weight: var(--wpds-typography-font-weight-emphasis);
+}
+
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -114,23 +114,34 @@ $focus-ring-width: var(--wpds-border-width-focus);
 }
 
 // A roll-up beside the grid, on another scale from it: no fill, its figure
-// always printed and emphasised. The margin is deliberate on top of the grid's
-// own gap: the roll-up sits one gap further from the data columns than they
-// sit from each other, the way a table sets its totals apart, and the auto
-// track grows by the same amount.
+// always printed and emphasised.
 .heatmap-chart__cell--summary {
 	background: none;
-	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
 }
 
-// The same offset as its cells, so the label stays over them.
 .heatmap-chart__col-label--summary {
-	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
 	font-weight: var(--wpds-typography-font-weight-emphasis);
 }
 
 .heatmap-chart__cell--summary .heatmap-chart__cell-value {
 	font-weight: var(--wpds-typography-font-weight-emphasis);
+}
+
+// Compact rows are `compactCellSize` tall, so the figure shrinks to fit them.
+.heatmap-chart__grid--compact .heatmap-chart__cell--summary .heatmap-chart__cell-value {
+	font-size: var(--wpds-typography-font-size-xs);
+	line-height: 1;
+}
+
+// Deliberately on top of the grid gap: one extra gap sets a summary column
+// apart from the data beside it, on cells and label alike, and the auto track
+// grows by the same amount.
+.heatmap-chart__gap-start {
+	margin-inline-start: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
+}
+
+.heatmap-chart__gap-end {
+	margin-inline-end: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs));
 }
 
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -331,6 +331,21 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		gridStyle[ '--a8c-charts-dimension-heatmap-cell-size' ] = `${ compactCellSize }px`;
 	}
 
+	// A summary column sits one gap apart from the data on either side; two
+	// summaries side by side share no extra gap.
+	const summaryGaps = ( columnIndex: number ) => {
+		if ( ! data[ columnIndex ]?.summary ) {
+			return {};
+		}
+
+		return {
+			[ styles[ 'heatmap-chart__gap-start' ] ]:
+				columnIndex > 0 && ! data[ columnIndex - 1 ]?.summary,
+			[ styles[ 'heatmap-chart__gap-end' ] ]:
+				columnIndex < columns - 1 && ! data[ columnIndex + 1 ]?.summary,
+		};
+	};
+
 	const activeDescendant =
 		selectedIndex !== undefined
 			? `${ chartId }-cell-${ Math.floor( selectedIndex / rows ) }-${ selectedIndex % rows }`
@@ -385,6 +400,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 									key={ `col-${ columnIndex }` }
 									className={ clsx( styles[ 'heatmap-chart__col-label' ], {
 										[ styles[ 'heatmap-chart__col-label--summary' ] ]: column.summary,
+										...summaryGaps( columnIndex ),
 									} ) }
 								>
 									{ column.label }
@@ -476,6 +492,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 													[ styles[ 'heatmap-chart__cell--strong' ] ]:
 														filled && cellHasLightText( normalized ),
 													[ styles[ 'heatmap-chart__cell--summary' ] ]: column.summary,
+													...summaryGaps( columnIndex ),
 													[ styles[ 'heatmap-chart__cell--selected' ] ]:
 														selectedIndex === flatIndex,
 												} ) }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -43,6 +43,10 @@ import type { CSSProperties, FC } from 'react';
 // the rendered fill is the primary mixed over the chart background at 0.15 + 0.85 * intensity.
 const CELL_MIX_FLOOR = 0.15;
 
+// One instance, not a `[]` default in the signature: `buildTooltipData` keys on
+// it, and a fresh array per render re-ran the keyboard tooltip effect endlessly.
+const NO_ROW_LABELS: string[] = [];
+
 const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	data,
 	chartId: providedChartId,
@@ -55,7 +59,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	maxCellHeight,
 	minCellWidth,
 	minCellHeight,
-	rowLabels = [],
+	rowLabels = NO_ROW_LABELS,
 	primaryColor,
 	gap = 'md',
 	withTooltips = false,

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -316,9 +316,14 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	const rowTrack = compact
 		? 'var(--a8c-charts-dimension-heatmap-cell-size)'
 		: `minmax(${ minCellHeight ?? 0 }px, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
+	// A summary column takes an `auto` track: a roll-up is wider than a cell,
+	// and a shared track would stretch every cell to fit it.
+	const columnTracks = data.some( column => column.summary )
+		? data.map( column => ( column.summary ? 'auto' : columnTrack ) ).join( ' ' )
+		: `repeat(${ columns }, ${ columnTrack })`;
 	const gridStyle: Record< string, string | number > = {
 		'--a8c-charts-color-heatmap-primary': primaryColorHex,
-		gridTemplateColumns: `auto repeat(${ columns }, ${ columnTrack })`,
+		gridTemplateColumns: `auto ${ columnTracks }`,
 		gridTemplateRows: `auto repeat(${ rows }, ${ rowTrack })`,
 	};
 	if ( compact ) {
@@ -378,7 +383,9 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 							{ data.map( ( column, columnIndex ) => (
 								<span
 									key={ `col-${ columnIndex }` }
-									className={ styles[ 'heatmap-chart__col-label' ] }
+									className={ clsx( styles[ 'heatmap-chart__col-label' ], {
+										[ styles[ 'heatmap-chart__col-label--summary' ] ]: column.summary,
+									} ) }
 								>
 									{ column.label }
 								</span>
@@ -437,7 +444,9 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 
 										const value = cell?.value ?? null;
 										const present = isPresent( value );
-										const normalized = present ? getNormalizedValue( value, extent ) : 0;
+										// A summary cell is on another scale, so it takes no fill.
+										const filled = present && ! column.summary;
+										const normalized = filled ? getNormalizedValue( value, extent ) : 0;
 										const flatIndex = columnIndex * rows + rowIndex;
 										const info = buildTooltipData( columnIndex, rowIndex );
 										const accessibleName =
@@ -453,7 +462,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 											<div
 												key={ `cell-${ columnIndex }-${ rowIndex }` }
 												id={ `${ chartId }-cell-${ columnIndex }-${ rowIndex }` }
-												data-testid="heatmap-cell"
+												data-testid={ column.summary ? 'heatmap-cell-summary' : 'heatmap-cell' }
 												role="gridcell"
 												// Focus stays on the grid (aria-activedescendant); cells are
 												// focusable but out of the tab order.
@@ -463,14 +472,15 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 												data-column={ columnIndex }
 												data-row={ rowIndex }
 												className={ clsx( styles[ 'heatmap-chart__cell' ], {
-													[ styles[ 'heatmap-chart__cell--filled' ] ]: present,
+													[ styles[ 'heatmap-chart__cell--filled' ] ]: filled,
 													[ styles[ 'heatmap-chart__cell--strong' ] ]:
-														present && cellHasLightText( normalized ),
+														filled && cellHasLightText( normalized ),
+													[ styles[ 'heatmap-chart__cell--summary' ] ]: column.summary,
 													[ styles[ 'heatmap-chart__cell--selected' ] ]:
 														selectedIndex === flatIndex,
 												} ) }
 												style={
-													present
+													filled
 														? ( {
 																'--a8c-charts-heatmap-cell-intensity': normalized,
 														  } as CSSProperties )
@@ -479,7 +489,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 												onMouseMove={ handleCellMouseMove }
 												onMouseLeave={ handleCellMouseLeave }
 											>
-												{ drawValues && present && (
+												{ ( drawValues || column.summary ) && present && (
 													<span className={ styles[ 'heatmap-chart__cell-value' ] }>
 														{ /* Compact display; tooltip and aria-label keep full precision. */ }
 														{ formatNumberCompact( value ) }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -316,10 +316,14 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	const rowTrack = compact
 		? 'var(--a8c-charts-dimension-heatmap-cell-size)'
 		: `minmax(${ minCellHeight ?? 0 }px, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
-	// A summary column takes an `auto` track: a roll-up is wider than a cell,
-	// and a shared track would stretch every cell to fit it.
+	// A summary column takes a content-sized track: a roll-up is wider than a
+	// cell, and a shared track would stretch every cell to fit it. `max-content`
+	// as the max keeps the leftover width out of it once the data tracks hit
+	// `maxCellWidth`, where a plain `auto` would absorb it.
 	const columnTracks = data.some( column => column.summary )
-		? data.map( column => ( column.summary ? 'auto' : columnTrack ) ).join( ' ' )
+		? data
+				.map( column => ( column.summary ? 'minmax(auto, max-content)' : columnTrack ) )
+				.join( ' ' )
 		: `repeat(${ columns }, ${ columnTrack })`;
 	const gridStyle: Record< string, string | number > = {
 		'--a8c-charts-color-heatmap-primary': primaryColorHex,

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/use-heatmap-colors.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/use-heatmap-colors.ts
@@ -4,7 +4,8 @@ export const isPresent = ( value: number | null | undefined ): value is number =
 	value !== null && value !== undefined && ! isNaN( value );
 
 /**
- * Get the min and max values from heatmap data, ignoring null/NaN.
+ * Get the min and max values from heatmap data, ignoring null/NaN. Summary
+ * columns stay out: a roll-up on the scale would flatten every real cell.
  * @param data - The heatmap columns
  * @return Tuple of [min, max] values
  */
@@ -12,6 +13,9 @@ export const getValueExtent = ( data: HeatmapColumn[] ): [ number, number ] => {
 	let min = Infinity;
 	let max = -Infinity;
 	for ( const column of data ) {
+		if ( column.summary ) {
+			continue;
+		}
 		for ( const cell of column.data ) {
 			if ( ! isPresent( cell.value ) ) {
 				continue;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -60,6 +60,13 @@ type HeatmapColumn = {
 	label?: string;
 	/** Ordered array of cells for this column. */
 	data: HeatmapCell[];
+	/**
+	 * A summary column: a per-row roll-up such as a total or an average. It
+	 * stays out of the colour scale, so its cells draw no fill and always
+	 * print their figure, emphasised, on a track wide enough for it. It sits
+	 * wherever it appears in `data`. The chart never computes it.
+	 */
+	summary?: boolean;
 };
 ```
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -61,10 +61,9 @@ type HeatmapColumn = {
 	/** Ordered array of cells for this column. */
 	data: HeatmapCell[];
 	/**
-	 * A summary column: a per-row roll-up such as a total or an average. It
-	 * stays out of the colour scale, so its cells draw no fill and always
-	 * print their figure, emphasised, on a track wide enough for it. It sits
-	 * wherever it appears in `data`. The chart never computes it.
+	 * A per-row roll-up such as a total or an average. Left out of the color
+	 * scale, drawn unfilled with its figure always printed, on an `auto` track
+	 * one gap apart from the data beside it. The chart never computes it.
 	 */
 	summary?: boolean;
 };

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -106,6 +106,20 @@ In-cell values use compact notation (e.g. `748.5K`, `1.2M`) so large numbers fit
 
 <Canvas of={ HeatmapStories.LargeValues } />
 
+## Summary Column
+
+A column flagged `summary: true` is a per-row roll-up, such as a total or an average, and sits outside the colour scale: its values never feed the extent, its cells draw no fill and always print their figure (compact mode included), emphasised, on a track wide enough for it. It draws wherever it appears in `data`, and hover, tooltips and keyboard navigation reach it like any other column. The chart never computes the roll-up: pass the figures to show.
+
+<Canvas of={ HeatmapStories.WithSummaryColumn } />
+
+<Source
+	language="tsx"
+	code={ `<HeatmapChart
+		data={ [ ...columns, { label: 'Total', summary: true, data: rowTotals } ] }
+		rowLabels={ rowLabels }
+	/>` }
+/>
+
 ## Cell Size Bounds
 
 Non-compact heatmaps normally divide the available width and height evenly across all cells. Use maximum bounds to keep sparse grids from producing oversized cells. Width and height caps are independent: setting only `maxCellWidth` keeps the normal full-height row layout, while setting `maxCellHeight` content-sizes the chart vertically.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -108,7 +108,7 @@ In-cell values use compact notation (e.g. `748.5K`, `1.2M`) so large numbers fit
 
 ## Summary Column
 
-A column flagged `summary: true` is a per-row roll-up, such as a total or an average, and sits outside the colour scale: its values never feed the extent, its cells draw no fill and always print their figure (compact mode included), emphasised, on a track wide enough for it. It draws wherever it appears in `data`, and hover, tooltips and keyboard navigation reach it like any other column. The chart never computes the roll-up: pass the figures to show.
+A column flagged `summary: true` is a per-row roll-up, such as a total or an average, and sits outside the color scale: its values never feed the extent, its cells draw no fill and always print their figure (smaller in compact mode), emphasised, on a track wide enough for it, one gap apart from the data on either side. It draws wherever it appears in `data`, and hover, tooltips and keyboard navigation reach it like any other column. The chart never computes the roll-up: pass the figures to show.
 
 <Canvas of={ HeatmapStories.WithSummaryColumn } />
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -5,6 +5,7 @@ import {
 } from '../../../stories/chart-decorator';
 import {
 	heatmapActivityMatrix,
+	heatmapActivityMatrixWithTotals,
 	heatmapCalendarSeries,
 	heatmapLargeValueMatrix,
 	heatmapPartialMonthCalendarSeries,
@@ -69,6 +70,13 @@ export const LargeValues: Story = {
 	args: {
 		...Default.args,
 		data: heatmapLargeValueMatrix,
+	},
+};
+
+export const WithSummaryColumn: Story = {
+	args: {
+		...Default.args,
+		data: heatmapActivityMatrixWithTotals,
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -500,6 +500,14 @@ describe( 'HeatmapChart summary column', () => {
 		);
 	} );
 
+	test( 'keeps the summary track content-sized when the data tracks are capped', () => {
+		renderChart( { data: withTotals, maxCellWidth: 32 } );
+
+		expect( screen.getByRole( 'grid', { name: /heatmap/i } ) ).toHaveStyle( {
+			gridTemplateColumns: 'auto minmax(0px, 32px) minmax(0px, 32px) minmax(auto, max-content)',
+		} );
+	} );
+
 	test( 'reaches the summary column by keyboard, with its tooltip', async () => {
 		renderChart( { data: withTotals, withTooltips: true } );
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -445,3 +445,48 @@ describe( 'HeatmapChart tooltip position', () => {
 		} );
 	} );
 } );
+
+describe( 'HeatmapChart summary column', () => {
+	const withTotals: HeatmapColumn[] = [
+		...data,
+		{ label: 'Total', summary: true, data: [ { value: 400 }, { value: 200 }, { value: null } ] },
+	];
+
+	test( 'keeps the summary column out of the colour scale', () => {
+		renderChart( { data: withTotals } );
+		// 4 is still the data maximum, so it keeps full intensity.
+		expect(
+			screen
+				.getByRole( 'gridcell', { name: 'W2: 4' } )
+				.style.getPropertyValue( '--a8c-charts-heatmap-cell-intensity' )
+		).toBe( '1' );
+		expect(
+			screen
+				.getByRole( 'gridcell', { name: 'Total: 400' } )
+				.style.getPropertyValue( '--a8c-charts-heatmap-cell-intensity' )
+		).toBe( '' );
+	} );
+
+	test( 'draws every summary cell, printing its figure even in compact mode', () => {
+		renderChart( { data: withTotals, compact: true } );
+		expect( screen.getAllByTestId( 'heatmap-cell-summary' ) ).toHaveLength( 3 );
+		expect( screen.getByRole( 'gridcell', { name: 'Total: 400' } ) ).toHaveTextContent( '400' );
+		expect( screen.getByRole( 'gridcell', { name: 'Total: No data' } ) ).toBeEmptyDOMElement();
+		expect( screen.getByRole( 'grid' ) ).toHaveAttribute( 'aria-colcount', '3' );
+	} );
+
+	test( 'reaches the summary column by keyboard, with its tooltip', async () => {
+		renderChart( { data: withTotals, withTooltips: true } );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+		const user = userEvent.setup();
+
+		grid.focus();
+		await user.keyboard( '{ArrowDown}{ArrowRight}{ArrowRight}' );
+
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-2-0$/ )
+		);
+		expect( within( screen.getByRole( 'tooltip' ) ).getByText( '400' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -411,6 +411,19 @@ const mockRects = () =>
 		} as DOMRect;
 	} );
 
+describe( 'HeatmapChart keyboard tooltip', () => {
+	test( 'opens on the selected cell without row labels', async () => {
+		renderChart( { withTooltips: true } );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+		const user = userEvent.setup();
+
+		grid.focus();
+		await user.keyboard( '{ArrowDown}' );
+
+		expect( within( screen.getByRole( 'tooltip' ) ).getByText( '1' ) ).toBeInTheDocument();
+	} );
+} );
+
 describe( 'HeatmapChart tooltip position', () => {
 	afterEach( () => {
 		jest.restoreAllMocks();

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -452,7 +452,7 @@ describe( 'HeatmapChart summary column', () => {
 		{ label: 'Total', summary: true, data: [ { value: 400 }, { value: 200 }, { value: null } ] },
 	];
 
-	test( 'keeps the summary column out of the colour scale', () => {
+	test( 'keeps the summary column out of the color scale', () => {
 		renderChart( { data: withTotals } );
 		// 4 is still the data maximum, so it keeps full intensity.
 		expect(
@@ -473,6 +473,31 @@ describe( 'HeatmapChart summary column', () => {
 		expect( screen.getByRole( 'gridcell', { name: 'Total: 400' } ) ).toHaveTextContent( '400' );
 		expect( screen.getByRole( 'gridcell', { name: 'Total: No data' } ) ).toBeEmptyDOMElement();
 		expect( screen.getByRole( 'grid' ) ).toHaveAttribute( 'aria-colcount', '3' );
+	} );
+
+	test( 'sets a summary apart from the data on either side, but not from another summary', () => {
+		renderChart( {
+			data: [
+				{ label: 'Lead', summary: true, data: [ { value: 7 }, { value: 8 }, { value: 9 } ] },
+				...withTotals,
+				{ label: 'Mean', summary: true, data: [ { value: 2 }, { value: 1 }, { value: 3 } ] },
+			],
+		} );
+
+		const lead = screen.getByRole( 'gridcell', { name: 'Lead: 7' } );
+		expect( lead ).toHaveClass( 'heatmap-chart__gap-end' );
+		expect( lead ).not.toHaveClass( 'heatmap-chart__gap-start' );
+
+		const total = screen.getByRole( 'gridcell', { name: 'Total: 400' } );
+		expect( total ).toHaveClass( 'heatmap-chart__gap-start' );
+		expect( total ).not.toHaveClass( 'heatmap-chart__gap-end' );
+
+		const mean = screen.getByRole( 'gridcell', { name: 'Mean: 2' } );
+		expect( mean ).not.toHaveClass( 'heatmap-chart__gap-start' );
+		expect( mean ).not.toHaveClass( 'heatmap-chart__gap-end' );
+		expect( screen.getByRole( 'gridcell', { name: 'W1: 1' } ) ).not.toHaveClass(
+			'heatmap-chart__gap-start'
+		);
 	} );
 
 	test( 'reaches the summary column by keyboard, with its tooltip', async () => {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/use-heatmap-colors.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/use-heatmap-colors.test.ts
@@ -11,6 +11,14 @@ describe( 'getValueExtent', () => {
 		expect( getValueExtent( data ) ).toEqual( [ 0, 20 ] );
 	} );
 
+	test( 'leaves summary columns out of the extent', () => {
+		const withTotals: HeatmapColumn[] = [
+			...data,
+			{ label: 'Total', summary: true, data: [ { value: 500 }, { value: 900 }, { value: null } ] },
+		];
+		expect( getValueExtent( withTotals ) ).toEqual( [ 0, 20 ] );
+	} );
+
 	test( 'returns [0, 0] for all-empty data', () => {
 		expect( getValueExtent( [ { data: [ { value: null } ] } ] ) ).toEqual( [ 0, 0 ] );
 	} );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -29,12 +29,9 @@ export type HeatmapColumn = {
 	label?: string;
 	data: HeatmapCell[];
 	/**
-	 * A summary column: a per-row roll-up such as a total or an average. It
-	 * stays out of the colour scale, where a roll-up would flatten every real
-	 * cell to the bottom, so its cells draw no fill and always print their
-	 * figure, emphasised, on a track wide enough for it. It sits wherever it
-	 * appears in `data`; hover, tooltips and keyboard navigation reach it like
-	 * any other column. The chart never computes it: pass the figures to show.
+	 * A per-row roll-up such as a total or an average. Left out of the color
+	 * scale, drawn unfilled with its figure always printed, on an `auto` track
+	 * one gap apart from the data beside it. The chart never computes it.
 	 */
 	summary?: boolean;
 };

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -28,6 +28,15 @@ export type HeatmapColumn = {
 	/** x-axis label for this column. Empty/omitted renders blank. */
 	label?: string;
 	data: HeatmapCell[];
+	/**
+	 * A summary column: a per-row roll-up such as a total or an average. It
+	 * stays out of the colour scale, where a roll-up would flatten every real
+	 * cell to the bottom, so its cells draw no fill and always print their
+	 * figure, emphasised, on a track wide enough for it. It sits wherever it
+	 * appears in `data`; hover, tooltips and keyboard navigation reach it like
+	 * any other column. The chart never computes it: pass the figures to show.
+	 */
+	summary?: boolean;
 };
 
 export type HeatmapTooltipData = {

--- a/projects/js-packages/charts/src/stories/sample-data/index.ts
+++ b/projects/js-packages/charts/src/stories/sample-data/index.ts
@@ -1036,6 +1036,30 @@ export const heatmapActivityMatrix: HeatmapColumn[] = Array.from(
 );
 
 /**
+ * Activity matrix with a trailing summary column (13 columns × 7 rows)
+ *
+ * The activity matrix plus a `Total` column flagged `summary`, holding each
+ * row's sum: outside the colour scale, unfilled, emphasised.
+ * - Category: matrix
+ * - Data points: 91
+ * - Suitable for: HeatmapChart (summary column)
+ */
+export const heatmapActivityMatrixWithTotals: HeatmapColumn[] = [
+	...heatmapActivityMatrix,
+	{
+		label: 'Total',
+		summary: true,
+		data: Array.from( { length: 7 }, ( _row, row ) => ( {
+			label: `Total, Row ${ row + 1 }`,
+			value: heatmapActivityMatrix.reduce(
+				( sum, column ) => sum + ( column.data[ row ].value ?? 0 ),
+				0
+			),
+		} ) ),
+	},
+];
+
+/**
  * Large-value matrix for the heatmap chart (12 columns × 7 rows)
  *
  * Same shape as the activity matrix but with values up to ~1,000,000, to exercise


### PR DESCRIPTION
Fixes UNI-773. Part of UNI-755.

## Proposed changes

A heatmap often ends with a per-row roll-up: the year's total beside its twelve months, an average beside a week of readings. `HeatmapChart` had no way to draw one.

Every column in `data` feeds the color scale, so a roll-up an order of magnitude above any cell flattens the whole grid to the bottom, and a consumer cannot add the column from outside without rebuilding the chart's grid, keyboard navigation, and tooltips to keep it aligned and reachable.

### The `summary` flag

A column flagged `summary: true` in `data` is a roll-up. It stays part of the same array, so where it sits (trailing or leading), how many there are, `aria-colcount`, arrow-key navigation, and the tooltip payload need no special handling.

The chart changes in four places: `getValueExtent()` leaves summary columns out, so the scale stays the data's; summary cells draw no fill and always print their figure, compact mode included, with emphasised weight, and a `null` value renders blank; the column takes an `auto` track, since a roll-up is wider than a cell, and sits one extra gap apart from the data columns, the way a table sets its totals apart; and its label is emphasised like its cells.

The chart never computes the roll-up. A total and an average weight their months differently, and the consumer usually already has the figure from its data source, so it passes the numbers it wants shown.

Consumers that need to tell a roll-up apart in a tooltip read `data[ column ].summary` off the payload.

### Docs and stories

The API reference and the docs page describe the flag, and a `WithSummaryColumn` story draws the activity matrix with a `Total` column of its row sums.

## Related product discussion/links

* UNI-755 is the parent issue; UNI-771 adopts this column in the post detail All-time traffic card.
* WOOA7S-2015 is the Insights table that needs the same column.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From `projects/js-packages/charts`, run the Storybook with `pnpm run storybook` and open Charts Library → Heatmap Chart → With Summary Column.

The last column, `Total`, shows each row's sum as a bold figure with no fill, one extra gap from the grid, on a track wide enough for the figure; the data cells keep the same shades as the Default story, so the totals don't stretch the scale.

Hover a total: the tooltip names it and its value. Tab to the grid and move with the arrow keys: the selection reaches the totals and shows their tooltip. Turn on `compact` in the controls: the totals still print their figure.

Unit tests, from the package: `pnpm run test -- --testPathPatterns=src/charts/heatmap-chart`.

### Screenshots

<img width="1548" height="896" alt="image" src="https://github.com/user-attachments/assets/46063cc5-232f-4066-a179-68cb466e325d" />


## Follow-ups

- [ ] UNI-771: the All-time traffic card draws its Totals column with the flag.

