### PR TITLE
Newsletter: add an Action Bar toggle to Subscriptions settings

### DIFF
--- a/projects/packages/newsletter/changelog/add-action-bar-toggle
+++ b/projects/packages/newsletter/changelog/add-action-bar-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Subscriptions: add an Action Bar visibility toggle on WordPress.com Simple sites.

--- a/projects/packages/newsletter/src/settings/components/toggle.tsx
+++ b/projects/packages/newsletter/src/settings/components/toggle.tsx
@@ -19,6 +19,8 @@ interface ToggleProps {
 	linkText?: string;
 	isExternal?: boolean;
 	onLinkClick?: () => void;
+	/** Show the toggle checked when the stored value is false, for negatively named settings. */
+	invert?: boolean;
 }
 
 /**
@@ -36,6 +38,7 @@ interface ToggleProps {
  * @param {string}   props.linkText    - Text for the link. Omit for a plain toggle.
  * @param {boolean}  props.isExternal  - Whether the link is external (default: true)
  * @param {Function} props.onLinkClick - Optional callback when link is clicked
+ * @param {boolean}  props.invert      - Whether to display the negation of the stored value (default: false)
  * @return {JSX.Element} The toggle control, with a link in the label when `url`/`linkText` are set.
  */
 export function Toggle( {
@@ -46,17 +49,18 @@ export function Toggle( {
 	linkText,
 	isExternal = true,
 	onLinkClick,
+	invert = false,
 }: ToggleProps ): JSX.Element {
+	const value = !! ( data as Record< string, unknown > )[ field.id ];
+
 	const handleChange = useCallback( () => {
-		onChange( {
-			[ field.id ]: ! ( data as Record< string, unknown > )[ field.id ],
-		} as DeepPartial< NewsletterSettings > );
-	}, [ data, field.id, onChange ] );
+		onChange( { [ field.id ]: ! value } as DeepPartial< NewsletterSettings > );
+	}, [ value, field.id, onChange ] );
 
 	return (
 		<ToggleControl
 			__nextHasNoMarginBottom
-			checked={ !! ( data as Record< string, unknown > )[ field.id ] }
+			checked={ invert ? ! value : value }
 			onChange={ handleChange }
 			label={
 				url && linkText ? (

--- a/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
@@ -203,7 +203,7 @@ export function LegacySubscriptionsSection( {
 					onChange={ fieldOnChange }
 					invert
 					url={ ACTION_BAR_SUPPORT_URL }
-					linkText={ __( 'Learn more about the Action Bar', 'jetpack-newsletter' ) }
+					linkText={ __( 'Learn more', 'jetpack-newsletter' ) }
 				/>
 			),
 		},

--- a/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/legacy-subscriptions-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getSiteType } from '@automattic/jetpack-script-data';
+import { getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { DataForm, type Field } from '@wordpress/dataviews';
 import { useCallback } from '@wordpress/element';
@@ -14,6 +14,8 @@ import { Card, Text } from '@wordpress/ui';
 import { Toggle, ToggleWithEditorLink } from '../components/toggle';
 import { getNewsletterScriptData } from '../script-data';
 import type { NewsletterSettings } from '../types';
+
+const ACTION_BAR_SUPPORT_URL = 'https://wordpress.com/support/action-bar/';
 
 interface LegacySubscriptionsSectionProps {
 	data: NewsletterSettings;
@@ -190,6 +192,21 @@ export function LegacySubscriptionsSection( {
 			type: 'boolean' as const,
 			Edit: Toggle,
 		},
+		{
+			id: 'wpcom_hide_action_bar',
+			label: __( 'Show the Action Bar on the front end of the site', 'jetpack-newsletter' ),
+			type: 'boolean' as const,
+			Edit: ( { data: formData, field, onChange: fieldOnChange } ) => (
+				<Toggle
+					data={ formData }
+					field={ field }
+					onChange={ fieldOnChange }
+					invert
+					url={ ACTION_BAR_SUPPORT_URL }
+					linkText={ __( 'Learn more about the Action Bar', 'jetpack-newsletter' ) }
+				/>
+			),
+		},
 	];
 
 	return (
@@ -239,6 +256,17 @@ export function LegacySubscriptionsSection( {
 									label: __( 'Comments', 'jetpack-newsletter' ),
 									children: [ 'stb_enabled', 'stc_enabled' ],
 								},
+								// Simple-only: the Action Bar is a WordPress.com feature. Gating
+								// the layout is enough — DataForm renders only what it lists.
+								...( isSimpleSite()
+									? [
+											{
+												id: 'action_bar',
+												label: __( 'Action Bar', 'jetpack-newsletter' ),
+												children: [ 'wpcom_hide_action_bar' ],
+											},
+									  ]
+									: [] ),
 							],
 						} }
 						onChange={ onChange }

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import { getAdminUrl, getSiteType } from '@automattic/jetpack-script-data';
+import { getAdminUrl, getSiteType, isSimpleSite } from '@automattic/jetpack-script-data';
 import { ToggleControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -35,6 +35,10 @@ const PLACEMENT_SLUG_BY_KEY: Record< string, string > = {
 	jetpack_subscriptions_subscribe_post_end_enabled: 'post_end',
 	jetpack_subscribe_floating_button_enabled: 'floating_button',
 };
+
+// The Action Bar is a WordPress.com Simple feature, so its documentation only
+// exists on the WordPress.com support site.
+const ACTION_BAR_SUPPORT_URL = 'https://wordpress.com/support/action-bar/';
 
 interface SubscriptionsSectionProps {
 	data: NewsletterSettings;
@@ -198,6 +202,11 @@ export function SubscriptionsSection( {
 		( next: boolean ) => onChange( { stc_enabled: next } ),
 		[ onChange ]
 	);
+	// The label reads positively, the option stores "hidden" — hence the negation.
+	const handleActionBarToggle = useCallback(
+		( next: boolean ) => onChange( { wpcom_hide_action_bar: ! next } ),
+		[ onChange ]
+	);
 
 	// Editor link for the navigation block templates. Both Navigation toggles
 	// open the same `index` template — the Subscribe block and the Subscriber
@@ -338,6 +347,28 @@ export function SubscriptionsSection( {
 									/>
 								</Stack>
 							</Stack>
+
+							{ isSimpleSite() && (
+								<Stack gap="sm" direction="column">
+									<Text variant="heading-sm" render={ <h3 /> }>
+										{ __( 'Action Bar', 'jetpack-newsletter' ) }
+									</Text>
+									<ToggleControl
+										__nextHasNoMarginBottom
+										checked={ ! data.wpcom_hide_action_bar }
+										onChange={ handleActionBarToggle }
+										label={ __(
+											'Show the Action Bar on the front end of the site',
+											'jetpack-newsletter'
+										) }
+										help={
+											<Link openInNewTab href={ ACTION_BAR_SUPPORT_URL }>
+												{ __( 'Learn more about the Action Bar', 'jetpack-newsletter' ) }
+											</Link>
+										}
+									/>
+								</Stack>
+							) }
 						</Stack>
 					</Fieldset.Root>
 				</Stack>

--- a/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscriptions-section.tsx
@@ -357,14 +357,16 @@ export function SubscriptionsSection( {
 										__nextHasNoMarginBottom
 										checked={ ! data.wpcom_hide_action_bar }
 										onChange={ handleActionBarToggle }
-										label={ __(
-											'Show the Action Bar on the front end of the site',
-											'jetpack-newsletter'
-										) }
-										help={
-											<Link openInNewTab href={ ACTION_BAR_SUPPORT_URL }>
-												{ __( 'Learn more about the Action Bar', 'jetpack-newsletter' ) }
-											</Link>
+										label={
+											<span>
+												{ __(
+													'Show the Action Bar on the front end of the site',
+													'jetpack-newsletter'
+												) }{ ' ' }
+												<Link openInNewTab href={ ACTION_BAR_SUPPORT_URL }>
+													{ __( 'Learn more', 'jetpack-newsletter' ) }
+												</Link>
+											</span>
 										}
 									/>
 								</Stack>

--- a/projects/packages/newsletter/src/settings/types.ts
+++ b/projects/packages/newsletter/src/settings/types.ts
@@ -32,6 +32,8 @@ export interface NewsletterSettings {
 		subscribe_modal_heading: string;
 	};
 	newsletter_has_active_plan: boolean;
+	/** WordPress.com Simple only — mirrors the `wpcom_hide_action_bar` blog option. */
+	wpcom_hide_action_bar?: boolean;
 	[ key: string ]: unknown;
 }
 

--- a/projects/packages/newsletter/tests/subscriptions-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscriptions-section.test.tsx
@@ -66,7 +66,32 @@ jest.mock( '@wordpress/components', () => ( {
 			onChange={ e => onChange?.( e.target.checked ) }
 		/>
 	),
-	ToggleControl: ( { label }: { label: React.ReactNode } ) => <div>{ label }</div>,
+	ToggleControl: ( {
+		label,
+		help,
+		checked,
+		onChange,
+	}: {
+		label: React.ReactNode;
+		help?: React.ReactNode;
+		checked?: boolean;
+		onChange?: ( next: boolean ) => void;
+	} ) => (
+		<div>
+			<input
+				type="checkbox"
+				// Only string labels can name the control here; the toggles with
+				// element labels aren't queried by name.
+				aria-label={ typeof label === 'string' ? label : undefined }
+				checked={ checked }
+				// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+				// eslint-disable-next-line react/jsx-no-bind
+				onChange={ e => onChange?.( e.target.checked ) }
+			/>
+			{ label }
+			{ help }
+		</div>
+	),
 } ) );
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
@@ -79,6 +104,7 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	getSiteType: jest.fn( () => 'jetpack' ),
 	getAdminUrl: jest.fn( ( p: string ) => `https://example.com/wp-admin/${ p }` ),
+	isSimpleSite: jest.fn( () => false ),
 } ) );
 
 jest.mock( '../src/settings/script-data', () => ( {
@@ -89,7 +115,8 @@ jest.mock( '../src/settings/script-data', () => ( {
 	} ) ),
 } ) );
 
-import { render, screen } from '@testing-library/react';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { getNewsletterScriptData } from '../src/settings/script-data';
 import { SubscriptionsSection } from '../src/settings/sections/subscriptions-section';
 import type { NewsletterSettings } from '../src/settings/types';
@@ -228,5 +255,55 @@ describe( 'SubscriptionsSection — Preview and edit gating', () => {
 			} ),
 		} );
 		expect( previewLinks() ).toHaveLength( 2 );
+	} );
+} );
+
+describe( 'SubscriptionsSection — Action Bar toggle', () => {
+	const LABEL = /Show the Action Bar on the front end of the site/;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'is hidden off WordPress.com Simple', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( false );
+		renderSection();
+		expect( screen.queryByRole( 'checkbox', { name: LABEL } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Action Bar' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders on WordPress.com Simple, checked when the Action Bar is not hidden', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( true );
+		renderSection( { data: buildData( { wpcom_hide_action_bar: false } ) } );
+		expect( screen.getByRole( 'checkbox', { name: LABEL } ) ).toBeChecked();
+		expect(
+			screen.getByRole( 'link', { name: 'Learn more about the Action Bar' } )
+		).toHaveAttribute( 'href', 'https://wordpress.com/support/action-bar/' );
+	} );
+
+	it( 'renders unchecked when the Action Bar is hidden', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( true );
+		renderSection( { data: buildData( { wpcom_hide_action_bar: true } ) } );
+		expect( screen.getByRole( 'checkbox', { name: LABEL } ) ).not.toBeChecked();
+	} );
+
+	it( 'stages the negated value when toggled off', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( true );
+		const onChange = jest.fn();
+		renderSection( { data: buildData( { wpcom_hide_action_bar: false } ), onChange } );
+		// user-event is not a dependency of this package.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'checkbox', { name: LABEL } ) );
+		expect( onChange ).toHaveBeenCalledWith( { wpcom_hide_action_bar: true } );
+	} );
+
+	it( 'stages the negated value when toggled on', () => {
+		( isSimpleSite as jest.Mock ).mockReturnValue( true );
+		const onChange = jest.fn();
+		renderSection( { data: buildData( { wpcom_hide_action_bar: true } ), onChange } );
+		// user-event is not a dependency of this package.
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'checkbox', { name: LABEL } ) );
+		expect( onChange ).toHaveBeenCalledWith( { wpcom_hide_action_bar: false } );
 	} );
 } );

--- a/projects/packages/newsletter/tests/subscriptions-section.test.tsx
+++ b/projects/packages/newsletter/tests/subscriptions-section.test.tsx
@@ -78,17 +78,19 @@ jest.mock( '@wordpress/components', () => ( {
 		onChange?: ( next: boolean ) => void;
 	} ) => (
 		<div>
-			<input
-				type="checkbox"
-				// Only string labels can name the control here; the toggles with
-				// element labels aren't queried by name.
-				aria-label={ typeof label === 'string' ? label : undefined }
-				checked={ checked }
-				// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
-				// eslint-disable-next-line react/jsx-no-bind
-				onChange={ e => onChange?.( e.target.checked ) }
-			/>
-			{ label }
+			{ /* Wrapping mirrors ToggleControl's own label association, so element
+			     labels (text plus an inline link) still name the control. */ }
+			{ /* eslint-disable-next-line jsx-a11y/label-has-associated-control */ }
+			<label>
+				<input
+					type="checkbox"
+					checked={ checked }
+					// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+					// eslint-disable-next-line react/jsx-no-bind
+					onChange={ e => onChange?.( e.target.checked ) }
+				/>
+				{ label }
+			</label>
 			{ help }
 		</div>
 	),
@@ -276,9 +278,10 @@ describe( 'SubscriptionsSection — Action Bar toggle', () => {
 		( isSimpleSite as jest.Mock ).mockReturnValue( true );
 		renderSection( { data: buildData( { wpcom_hide_action_bar: false } ) } );
 		expect( screen.getByRole( 'checkbox', { name: LABEL } ) ).toBeChecked();
-		expect(
-			screen.getByRole( 'link', { name: 'Learn more about the Action Bar' } )
-		).toHaveAttribute( 'href', 'https://wordpress.com/support/action-bar/' );
+		expect( screen.getByRole( 'link', { name: 'Learn more' } ) ).toHaveAttribute(
+			'href',
+			'https://wordpress.com/support/action-bar/'
+		);
 	} );
 
 	it( 'renders unchecked when the Action Bar is hidden', () => {

--- a/projects/packages/newsletter/tests/toggle.test.tsx
+++ b/projects/packages/newsletter/tests/toggle.test.tsx
@@ -100,6 +100,37 @@ describe( 'Toggle', () => {
 		expect( onChange ).toHaveBeenCalledWith( { jetpack_author_in_email: true } );
 	} );
 
+	it( 'shows the negation of the stored value when invert is set', () => {
+		render(
+			<Toggle
+				data={ { jetpack_author_in_email: true } as NewsletterSettings }
+				field={ createField() }
+				onChange={ jest.fn() }
+				invert
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
+	} );
+
+	it( 'still stores the flipped raw value when invert is set', () => {
+		const onChange = jest.fn();
+
+		render(
+			<Toggle
+				data={ { jetpack_author_in_email: true } as NewsletterSettings }
+				field={ createField() }
+				onChange={ onChange }
+				invert
+			/>
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event
+		fireEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( { jetpack_author_in_email: false } );
+	} );
+
 	it( 'renders a plain label when url/linkText are omitted', () => {
 		render(
 			<Toggle


### PR DESCRIPTION
Fixes NL-903

## Proposed changes

The Action Bar's Subscribe button is one of the ways anonymous visitors subscribe to a WordPress.com Simple site, but the only switch for it lives in Settings > General, a screen away from every other subscribe placement.

This adds a "Show the Action Bar on the front end of the site" toggle to the Subscriptions card on the Newsletter settings screen, for Simple sites only. It writes the same `wpcom_hide_action_bar` blog option the General settings checkbox does, so the two screens stay in sync.

Both Subscriptions layouts get it: the modernized placement-card grid, and the legacy DataForm list behind `isModernized`.

### Rationale

Settings > General frames this negatively ("Hide the Action Bar"). Every sibling toggle on the newsletter screen frames it positively ("Add the Subscribe block...", "Enable the 'Subscribe to comments' option..."), so the label here reads "Show the Action Bar" and the stored value gets negated at the boundary instead. Having one switch in that group work backwards from its seven neighbours seemed like a good way to collect bug reports :)

The legacy section's shared `Toggle` derives its checked state straight from `data[field.id]`, so it can't express that on its own. It gained an optional `invert` prop that changes what renders as checked and nothing about what gets stored.

No wpcom companion PR is needed. The v1.4 site-settings endpoint already reads and writes `wpcom_hide_action_bar`, and that's the endpoint the newsletter screen talks to on Simple sites already.

Two things this deliberately leaves alone: the Settings > General checkbox stays where it is, and nothing changes on Atomic or self-hosted sites, where there's no Action Bar to hide.

## Related product discussion/links

* NL-903

## Does this pull request change what data or activity we track or use?

No new events. The existing `jetpack_newsletter_section_save` event's `changed_keys` property can now include `wpcom_hide_action_bar`, the same way it already reports every other key in the Subscriptions card.

## Testing instructions

You'll need a WordPress.com Simple site. The toggle is gated on `isSimpleSite()`, so it won't render on Jurassic Ninja / Atomic / self-hosted. Sandbox a Simple site against this branch.

* Go to `Settings > General` and note the current state of "Action Bar visibility".
* Go to `Jetpack > Newsletter`. In the Subscriptions card, below Comments, there's a new "Action Bar" group with the toggle on (assuming you hadn't already hidden the Action Bar).
* Turn it off, save, and load the site's front end in a logged-out window. The Action Bar is gone.
* Back in `Settings > General`, "Hide the Action Bar on the front end of the site" is now checked. Uncheck it there, save, and the newsletter toggle picks it up on reload.
* Follow the "Learn more about the Action Bar" link and check that it opens the support page in a new tab.

To check the gating, load `Jetpack > Newsletter` on a Jurassic Ninja site. The Subscriptions card should look exactly like it does on trunk, with no Action Bar group.
