### PR TITLE
Premium Analytics: add the Totals column to the All-time traffic card

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-totals
+++ b/projects/packages/premium-analytics/changelog/update-post-all-time-traffic-totals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post detail: Add the Totals column to the All-time traffic card, with centred month labels and labels that stay in view while a long history scrolls; picking a total reads the page over that year.

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/build-all-time-traffic-rows.test.ts
@@ -89,6 +89,19 @@ describe( 'buildAllTimeTrafficRows', () => {
 		expect( buildAllTimeTrafficRows( { years: RESPONSE.years }, 'average', TODAY ) ).toEqual( [] );
 	} );
 
+	it( 'carries the year figure the endpoint reports under each metric', () => {
+		expect( buildAllTimeTrafficRows( RESPONSE, 'total', TODAY ).map( row => row.total ) ).toEqual( [
+			45, 30,
+		] );
+		expect( buildAllTimeTrafficRows( RESPONSE, 'average', TODAY ).map( row => row.total ) ).toEqual(
+			[ 3, 1 ]
+		);
+		expect(
+			buildAllTimeTrafficRows( { years: { '2026': { months: { '1': 5 } } } }, 'total', TODAY )[ 0 ]
+				.total
+		).toBeNull();
+	} );
+
 	it( 'returns no rows without yearly stats', () => {
 		expect( buildAllTimeTrafficRows( undefined, 'total', TODAY ) ).toEqual( [] );
 		expect( buildAllTimeTrafficRows( { years: {} }, 'total', TODAY ) ).toEqual( [] );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/period-range.test.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { monthRange } from '../period-range';
+import { monthRange, yearRange } from '../period-range';
 
 const bounds = {
 	lifeStartsAt: new Date( '2026-04-10T16:27:32Z' ),
@@ -53,5 +53,27 @@ describe( 'monthRange', () => {
 			from: new Date( '2026-01-01T00:00:00.000Z' ),
 			to: new Date( '2026-01-31T23:59:59.999Z' ),
 		} );
+	} );
+} );
+
+describe( 'yearRange', () => {
+	it( 'opens the year cut to the post life', () => {
+		expect( yearRange( 2026, bounds ) ).toEqual( {
+			from: new Date( '2026-04-10T00:00:00.000Z' ),
+			to: bounds.now,
+		} );
+	} );
+
+	it( 'opens a whole past year', () => {
+		expect(
+			yearRange( 2025, { ...bounds, lifeStartsAt: new Date( '2024-01-01T00:00:00Z' ) } )
+		).toEqual( {
+			from: new Date( '2025-01-01T00:00:00.000Z' ),
+			to: new Date( '2025-12-31T23:59:59.999Z' ),
+		} );
+	} );
+
+	it( 'has nothing to open for a year after today', () => {
+		expect( yearRange( 2027, bounds ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/__tests__/render.test.tsx
@@ -168,16 +168,17 @@ describe( 'PostAllTimeTraffic widget', () => {
 
 		const heatmap = screen.getByTestId( 'heatmap' );
 		expect( heatmap ).toHaveAttribute( 'data-row-labels', '2026|2025' );
-		expect( heatmap.dataset.columnLabels?.split( '|' ) ).toHaveLength( 12 );
+		// Twelve months and the Totals roll-up.
+		expect( heatmap.dataset.columnLabels?.split( '|' ) ).toHaveLength( 13 );
 		// The current year runs on to the clock's month, so only its opening is pinned.
 		const rows = heatmap.dataset.rows?.split( '|' ) ?? [];
 		// February had no views: a zero, as the endpoint reports it.
 		expect( rows[ 0 ]?.startsWith( '5,0,40' ) ).toBe( true );
 		// The months still to come are filler too, so the row stays a whole year.
-		expect( rows[ 0 ]?.split( ',' ) ).toHaveLength( 12 );
+		expect( rows[ 0 ]?.split( ',' ) ).toHaveLength( 13 );
 		expect( rows[ 0 ] ).not.toContain( '-' );
-		// Published in November: the months before it are filler.
-		expect( rows[ 1 ] ).toBe( '.,.,.,.,.,.,.,.,.,.,10,20' );
+		// Published in November: the months before it are filler; the year total closes the row.
+		expect( rows[ 1 ] ).toBe( '.,.,.,.,.,.,.,.,.,.,10,20,30' );
 		expect( screen.getByTestId( 'legend' ) ).toHaveTextContent( 'Fewer views/More views' );
 	} );
 
@@ -189,6 +190,22 @@ describe( 'PostAllTimeTraffic widget', () => {
 		expect( screen.getByTestId( 'legend' ) ).toHaveTextContent(
 			'Fewer views per day/More views per day'
 		);
+	} );
+
+	it( 'applies a clicked year total to the page as the year cut to the post life', async () => {
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		renderWidget();
+
+		await user.click( screen.getByRole( 'gridcell', { name: 'Totals 2025' } ) );
+
+		expect( mockOnChange ).toHaveBeenCalledWith(
+			{
+				from: new Date( '2025-11-10T00:00:00.000Z' ),
+				to: new Date( '2025-12-31T23:59:59.999Z' ),
+			},
+			'custom'
+		);
+		expect( mockOnApply ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'applies a clicked month to the page as a custom range cut to the post life', async () => {

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/build-all-time-traffic-rows.ts
@@ -33,6 +33,8 @@ export type AllTimeTrafficRow = {
 	year: number;
 	/** One entry per calendar month, January first. */
 	months: AllTimeTrafficMonth[];
+	/** The year's own figure under the same metric; `null` when the endpoint has none. */
+	total: number | null;
 };
 
 const monthOrder = ( { year, month }: MonthKey ) => year * MONTHS_IN_YEAR + month;
@@ -49,8 +51,9 @@ function reportedMonths( years: Record< string, StatsPostYear > ): number[] {
 /**
  * Turns the endpoint's per-year tables into one row per year, newest first.
  *
- * `years` carries each month's views and `averages` its views per day; the
- * months reported come from `years` under both metrics. A month the endpoint
+ * `years` carries each month's views and the year's total, `averages` its views
+ * per day with the year under `overall`; the months reported come from `years`
+ * under both metrics. A month the endpoint
  * leaves out inside the post's life is a zero, so the grid stays complete, the
  * way the daily heatmap draws every day of its range.
  *
@@ -104,7 +107,9 @@ export function buildAllTimeTrafficRows(
 			}
 		);
 
-		rows.push( { year, months } );
+		const total = ( metric === 'average' ? stats?.overall : stats?.total ) ?? null;
+
+		rows.push( { year, months, total } );
 	}
 
 	return rows;

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
@@ -15,11 +15,23 @@ import type { MonthKey } from './build-all-time-traffic-rows';
 export type PeriodBounds = {
 	/** Where the post's life starts; the range never starts before that day. */
 	lifeStartsAt?: Date;
-	/** The site timezone the calendar month is read in. */
+	/** The site timezone the calendar periods are read in. */
 	timeZone: string;
 	/** The range never ends after this instant. Defaults to the clock. */
 	now?: Date;
 };
+
+/** The bucket cut to the post's life, or `null` when none of it is inside. */
+function clampToLife( bucket: DateRange | null, { lifeStartsAt, timeZone }: PeriodBounds ) {
+	if ( ! bucket?.from || ! bucket.to ) {
+		return null;
+	}
+
+	const firstDay = lifeStartsAt ? startOfDayTZ( lifeStartsAt, timeZone ) : undefined;
+	const from = firstDay && firstDay > bucket.from ? firstDay : bucket.from;
+
+	return from.getTime() <= bucket.to.getTime() ? { from, to: bucket.to } : null;
+}
 
 /**
  * The page range for a month of the table: the calendar month in the site
@@ -30,7 +42,7 @@ export type PeriodBounds = {
  * @return The range to apply, or `null`.
  */
 export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | null {
-	const { lifeStartsAt, timeZone, now = new Date() } = bounds;
+	const { timeZone, now = new Date() } = bounds;
 	// The bucket the traffic chart opens on a click, cut at the clock.
 	const bucket = drillDateRange(
 		createTZDateFromParts( [ key.year, key.month, 1 ], timeZone ),
@@ -38,12 +50,19 @@ export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | n
 		now
 	);
 
-	if ( ! bucket?.from || ! bucket.to ) {
-		return null;
-	}
+	return clampToLife( bucket, bounds );
+}
 
-	const firstDay = lifeStartsAt ? startOfDayTZ( lifeStartsAt, timeZone ) : undefined;
-	const from = firstDay && firstDay > bucket.from ? firstDay : bucket.from;
+/**
+ * The page range for a year of the table, cut to the post's life.
+ *
+ * @param year   - The year to open.
+ * @param bounds - The post's life.
+ * @return The range to apply, or `null`.
+ */
+export function yearRange( year: number, bounds: PeriodBounds ): DateRange | null {
+	const { timeZone, now = new Date() } = bounds;
+	const bucket = drillDateRange( createTZDateFromParts( [ year, 0, 1 ], timeZone ), 'year', now );
 
-	return from.getTime() <= bucket.to.getTime() ? { from, to: bucket.to } : null;
+	return clampToLife( bucket, bounds );
 }

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -61,6 +61,33 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 	// page's period, read over by the other cards while this one stays all-time.
 	const { onChange, onApply, timeZone } = useReportDateFilters();
 
+	// No per-cell label: the chart names a cell from its column and row, the
+	// month and the year here. A month without views reads 0, as the endpoint
+	// reports it; the months outside the post's life are filler. The last
+	// column is the year's roll-up, a summary column outside the colour scale.
+	const columns = useMemo< HeatmapColumn[] >(
+		() => [
+			...Array.from( { length: MONTHS_IN_YEAR }, ( _column, month ) => ( {
+				label: formatMonth( month, { short: true } ),
+				data: rows.map( row => {
+					const value = row.months[ month ];
+
+					if ( typeof value !== 'number' ) {
+						return { value: null, placeholder: true };
+					}
+
+					return { value };
+				} ),
+			} ) ),
+			{
+				label: __( 'Totals', 'jetpack-premium-analytics-pkg' ),
+				summary: true,
+				data: rows.map( row => ( { value: row.total } ) ),
+			},
+		],
+		[ rows ]
+	);
+
 	const openPeriod = useCallback(
 		( cell: Element ) => {
 			const row = rows[ Number( cell.getAttribute( 'data-row' ) ) ];
@@ -71,18 +98,17 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 
 			const column = Number( cell.getAttribute( 'data-column' ) );
 			const bounds = { lifeStartsAt, timeZone };
-			// The thirteenth column is the year's roll-up, which opens the whole year.
-			const range =
-				column === MONTHS_IN_YEAR
-					? yearRange( row.year, bounds )
-					: monthRange( { year: row.year, month: column }, bounds );
+			// The year's roll-up opens the whole year.
+			const range = columns[ column ]?.summary
+				? yearRange( row.year, bounds )
+				: monthRange( { year: row.year, month: column }, bounds );
 
 			if ( range ) {
 				onChange( range, PRESET_CUSTOM );
 				onApply();
 			}
 		},
-		[ rows, lifeStartsAt, timeZone, onChange, onApply ]
+		[ rows, columns, lifeStartsAt, timeZone, onChange, onApply ]
 	);
 
 	// The chart owns the cells, so the click is read off its markup.
@@ -123,33 +149,6 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 	// Keep stale rows visible when a background refetch fails.
 	const showError = isError && rows.length === 0;
 
-	// No per-cell label: the chart names a cell from its column and row, the
-	// month and the year here. A month without views reads 0, as the endpoint
-	// reports it; the months outside the post's life are filler. The last
-	// column is the year's roll-up, a summary column outside the colour scale.
-	const columns = useMemo< HeatmapColumn[] >(
-		() => [
-			...Array.from( { length: MONTHS_IN_YEAR }, ( _column, month ) => ( {
-				label: formatMonth( month, { short: true } ),
-				data: rows.map( row => {
-					const value = row.months[ month ];
-
-					if ( typeof value !== 'number' ) {
-						return { value: null, placeholder: true };
-					}
-
-					return { value };
-				} ),
-			} ) ),
-			{
-				label: __( 'Totals', 'jetpack-premium-analytics-pkg' ),
-				summary: true,
-				data: rows.map( row => ( { value: row.total } ) ),
-			},
-		],
-		[ rows ]
-	);
-
 	const yearLabels = useMemo( () => rows.map( row => String( row.year ) ), [ rows ] );
 
 	const renderTooltip = useCallback(
@@ -159,7 +158,7 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 				// Named from the column and row, the way the chart names a cell to a
 				// screen reader: "Aug 2026". The year's roll-up is named by the year.
 				cellLabel={
-					column === MONTHS_IN_YEAR
+					columns[ column ]?.summary
 						? rowLabel ?? ''
 						: `${ columnLabel ?? '' } ${ rowLabel ?? '' }`.trim()
 				}
@@ -167,7 +166,7 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 				formatValue={ metric === 'average' ? formatDailyViewCount : formatViewCount }
 			/>
 		),
-		[ metric ]
+		[ metric, columns ]
 	);
 
 	return (

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/render.tsx
@@ -31,7 +31,7 @@ import {
 	resolveMetric,
 	type AllTimeTrafficMetric,
 } from './build-all-time-traffic-rows';
-import { monthRange } from './period-range';
+import { monthRange, yearRange } from './period-range';
 import styles from './style.module.css';
 import usePostAllTimeTraffic from './use-post-all-time-traffic';
 import type { PostAllTimeTrafficAttributes } from './widget';
@@ -61,7 +61,7 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 	// page's period, read over by the other cards while this one stays all-time.
 	const { onChange, onApply, timeZone } = useReportDateFilters();
 
-	const openMonth = useCallback(
+	const openPeriod = useCallback(
 		( cell: Element ) => {
 			const row = rows[ Number( cell.getAttribute( 'data-row' ) ) ];
 
@@ -69,8 +69,13 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 				return;
 			}
 
-			const month = Number( cell.getAttribute( 'data-column' ) );
-			const range = monthRange( { year: row.year, month }, { lifeStartsAt, timeZone } );
+			const column = Number( cell.getAttribute( 'data-column' ) );
+			const bounds = { lifeStartsAt, timeZone };
+			// The thirteenth column is the year's roll-up, which opens the whole year.
+			const range =
+				column === MONTHS_IN_YEAR
+					? yearRange( row.year, bounds )
+					: monthRange( { year: row.year, month: column }, bounds );
 
 			if ( range ) {
 				onChange( range, PRESET_CUSTOM );
@@ -86,10 +91,10 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 			const cell = ( event.target as Element ).closest( CELL_SELECTOR );
 
 			if ( cell ) {
-				openMonth( cell );
+				openPeriod( cell );
 			}
 		},
-		[ openMonth ]
+		[ openPeriod ]
 	);
 
 	// The grid names the selected cell through `aria-activedescendant`; Enter
@@ -109,10 +114,10 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 
 			if ( cell && event.currentTarget.contains( cell ) && cell.matches( CELL_SELECTOR ) ) {
 				event.preventDefault();
-				openMonth( cell );
+				openPeriod( cell );
 			}
 		},
-		[ openMonth ]
+		[ openPeriod ]
 	);
 
 	// Keep stale rows visible when a background refetch fails.
@@ -120,10 +125,11 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 
 	// No per-cell label: the chart names a cell from its column and row, the
 	// month and the year here. A month without views reads 0, as the endpoint
-	// reports it; the months outside the post's life are filler.
+	// reports it; the months outside the post's life are filler. The last
+	// column is the year's roll-up, a summary column outside the colour scale.
 	const columns = useMemo< HeatmapColumn[] >(
-		() =>
-			Array.from( { length: MONTHS_IN_YEAR }, ( _column, month ) => ( {
+		() => [
+			...Array.from( { length: MONTHS_IN_YEAR }, ( _column, month ) => ( {
 				label: formatMonth( month, { short: true } ),
 				data: rows.map( row => {
 					const value = row.months[ month ];
@@ -135,18 +141,28 @@ function PostAllTimeTrafficInner( { metric }: { metric: AllTimeTrafficMetric } )
 					return { value };
 				} ),
 			} ) ),
+			{
+				label: __( 'Totals', 'jetpack-premium-analytics-pkg' ),
+				summary: true,
+				data: rows.map( row => ( { value: row.total } ) ),
+			},
+		],
 		[ rows ]
 	);
 
 	const yearLabels = useMemo( () => rows.map( row => String( row.year ) ), [ rows ] );
 
 	const renderTooltip = useCallback(
-		( { value, columnLabel, rowLabel }: HeatmapTooltipData ) => (
+		( { value, columnLabel, rowLabel, column }: HeatmapTooltipData ) => (
 			<CalendarHeatmapTooltip
 				value={ value }
 				// Named from the column and row, the way the chart names a cell to a
-				// screen reader: "Aug 2026".
-				cellLabel={ `${ columnLabel ?? '' } ${ rowLabel ?? '' }`.trim() }
+				// screen reader: "Aug 2026". The year's roll-up is named by the year.
+				cellLabel={
+					column === MONTHS_IN_YEAR
+						? rowLabel ?? ''
+						: `${ columnLabel ?? '' } ${ rowLabel ?? '' }`.trim()
+				}
 				emptyLabel={ __( 'No views', 'jetpack-premium-analytics-pkg' ) }
 				formatValue={ metric === 'average' ? formatDailyViewCount : formatViewCount }
 			/>

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/stories/post-all-time-traffic-widget.stories.tsx
@@ -1,8 +1,8 @@
 /**
  * The All-time traffic widget is the post detail Traffic view's history card:
- * every month of the scoped post's views, one row per year, as total views or
- * views per day (the `metric` attribute, which the framed host offers in the
- * header). It reads the post's whole life regardless of the page period, and
+ * every month of the scoped post's views, one row per year closed by the year's
+ * roll-up, as total views or views per day (the `metric` attribute, which the
+ * framed host offers in the header). It reads the post's whole life regardless of the page period, and
  * picking a month applies that month to the page. The post scope arrives through
  * `reportParams.post_id` (seeded from the detail page URL in product); the
  * `hasPostScope` control toggles it to exercise the scopeless empty state.
@@ -96,7 +96,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"All-time traffic\" widget: every month of the scoped post's views, one row per year, as total views or views per day. The `metric` attribute has `relevance: 'high'`, so the framed host renders its select in the header; the close-up stories set it as an arg. It always covers the post's whole life, whatever period the page shows, and picking a month applies that month to the page. Without a post scope the widget renders a scopeless empty state.",
+					"The \"All-time traffic\" widget: every month of the scoped post's views, one row per year closed by a Totals column outside the colour scale, as total views or views per day. The `metric` attribute has `relevance: 'high'`, so the framed host renders its select in the header; the close-up stories set it as an arg. It always covers the post's whole life, whatever period the page shows, and picking a month applies that month to the page. Without a post scope the widget renders a scopeless empty state.",
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
@@ -24,3 +24,31 @@
 	align-content: start;
 	overflow: auto;
 }
+
+/* The chart starts its column labels at the track's edge, which suits a
+ * calendar; here each label names its column, so it sits over the middle. */
+.root .chart [role="row"][aria-hidden="true"] > span {
+	text-align: center;
+}
+
+/* The grid is the scroll container, so the label row and the year column stay
+ * in view while a long history scrolls; the corner covers where they cross. */
+.root .chart [role="row"][aria-hidden="true"] > span,
+.root .chart [role="row"][aria-rowindex] > span:first-child {
+	position: sticky;
+	z-index: 1;
+	background: var(--wpds-color-background-surface-neutral-strong);
+}
+
+.root .chart [role="row"][aria-hidden="true"] > span {
+	inset-block-start: 0;
+}
+
+.root .chart [role="row"][aria-rowindex] > span:first-child {
+	inset-inline-start: 0;
+}
+
+.root .chart [role="row"][aria-hidden="true"] > span:first-child {
+	inset-inline-start: 0;
+	z-index: 2;
+}

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/style.module.css
@@ -37,7 +37,9 @@
 .root .chart [role="row"][aria-rowindex] > span:first-child {
 	position: sticky;
 	z-index: 1;
-	background: var(--wpds-color-background-surface-neutral-strong);
+
+	/* The chart's own background, which its cell fills mix against too. */
+	background: var(--a8c-charts-color-background);
 }
 
 .root .chart [role="row"][aria-hidden="true"] > span {

--- a/projects/plugins/jetpack/changelog/update-post-all-time-traffic-totals
+++ b/projects/plugins/jetpack/changelog/update-post-all-time-traffic-totals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Premium Analytics: Add the Totals column to the post detail All-time traffic card; picking a total reads the page over that year.

--- a/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-totals
+++ b/projects/plugins/premium-analytics/changelog/update-post-all-time-traffic-totals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Post detail: Add the Totals column to the All-time traffic card; picking a total reads the page over that year.

--- a/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-totals
+++ b/projects/plugins/wpcomsh/changelog/update-post-all-time-traffic-totals
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: Add the Totals column to the post detail All-time traffic card; picking a total reads the page over that year.


### PR DESCRIPTION
Fixes UNI-771. Part of UNI-755. Builds on #52127 (the metric switch) and #52135 (the chart's summary column), both on trunk now.

## Proposed changes

The All-time traffic card draws a post's monthly views, one row per year. The design closes each row with a bold **Totals** figure and centres the month labels over their columns; both needed pieces the chart did not have.

### The Totals column

The widget adds a thirteenth column flagged `summary: true`, the roll-up column #52135 adds to `HeatmapChart`: outside the colour scale, unfilled, its figure always printed and emphasised. Its values are the endpoint's own, `years[Y].total` under Total views and `averages[Y].overall` under Daily average, so the year figure matches the classic Stats table rather than a sum or a mean of the cells on screen. The tooltip names a total by its year and its value, in views or views per day like the month cells.

Picking a total reads the page over that year, cut to the post's life, the way picking a month reads it over that month. Enter and Space on the keyboard-selected total do the same.

### Labels

The month labels sit centred over their columns, and the label row and the year column stay in view while a long history scrolls inside the card. Both are the widget's own CSS over the chart's markup, as agreed in UNI-773 to keep the chart change to the column itself.

## Related product discussion/links

* UNI-755 is the parent issue; UNI-769 (#52118), UNI-770 (#52127), UNI-772 (#52131), UNI-773 (#52135) and UNI-771 (this change) are its sub-tasks.
* WOOA7S-2046 files the same replacement; WOOA7S-2015 is the Insights table that reuses the column.

## Does this pull request change what data or activity we track or use?

No. The widget reads the yearly figures the `stats/post` endpoint already returns alongside the monthly ones.

## Testing instructions

Build the package with `jetpack build --deps packages/premium-analytics` (the `--deps` picks up the chart change), open Stats v2 and go to the detail page of a post with some views.

The All-time traffic card ends each row with a bold **Totals** figure with no fill, the month labels sit centred over their columns, and the data cells keep the shades they had before, so the totals did not stretch the scale. Hover a total: the tooltip reads "N views" and the year. Switch the header select to **Daily average**: the totals become the year's views per day and the tooltip says so.

Click a total: the period control switches to that year (the publish year starts on the publish day, the current year ends today), the URL carries `preset=custom` with the range, and the other cards refetch for it. Tab to the grid, move with the arrow keys onto a total and press Enter: the same year applies.

On a post with many years, or a short tile, scroll the table inside the card: the month labels and the year column stay in view.

Unit tests, from the package: `pnpm run test -- widgets/post-all-time-traffic`.

### Screenshots

[After: the card with the Totals column under Total views]

[After: the card under Daily average, with the tooltip on a total]

[Video: picking a total and the page reading over the year]

