### PR TITLE
Forms: fix webhook URL validation for loopback addresses

### DIFF
--- a/projects/packages/forms/changelog/forms-webhook-blocked-ip-filter
+++ b/projects/packages/forms/changelog/forms-webhook-blocked-ip-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Webhooks: Add the jetpack_forms_webhook_blocked_ip filter, so a site can allow a webhook destination Forms would otherwise reject.

--- a/projects/packages/forms/changelog/forms-webhook-loopback-validation-FORMS-786
+++ b/projects/packages/forms/changelog/forms-webhook-loopback-validation-FORMS-786
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Webhooks: Block loopback and unspecified addresses when validating webhook URLs, including the NAT64 and 6to4 spellings.
+Webhooks: Block loopback and unspecified addresses when validating webhook URLs, including the IPv6 spellings that embed an IPv4 address.

--- a/projects/packages/forms/changelog/forms-webhook-loopback-validation-FORMS-786
+++ b/projects/packages/forms/changelog/forms-webhook-loopback-validation-FORMS-786
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Webhooks: Block loopback and unspecified addresses when validating webhook URLs, including the NAT64 and 6to4 spellings.

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -206,10 +206,10 @@ class Form_Webhooks {
 	 * Check if an IP address is blocked as a webhook destination.
 	 *
 	 * @param string $ip  The IP address to check.
-	 * @param string $url The webhook URL being validated, when known.
+	 * @param string $url The webhook URL being validated.
 	 * @return bool True if the IP should be blocked.
 	 */
-	private function is_blocked_ip( $ip, $url = '' ) {
+	private function is_blocked_ip( $ip, $url ) {
 		$blocked = $this->ip_is_in_blocked_range( $ip );
 
 		/**
@@ -279,11 +279,8 @@ class Form_Webhooks {
 				return false;
 			}
 
-			/*
-			 * Loopback (::1) and the unspecified address (::), the IPv6 counterpart of 0.0.0.0.
-			 * Binary comparison handles every spelling (0:0:0:0:0:0:0:1, ::0:1).
-			 */
-			if ( $ip_binary === inet_pton( '::1' ) || $ip_binary === inet_pton( '::' ) ) {
+			// Loopback ::1, by binary comparison so every spelling matches (0:0:0:0:0:0:0:1, ::0:1).
+			if ( $ip_binary === inet_pton( '::1' ) ) {
 				return true;
 			}
 
@@ -299,6 +296,7 @@ class Form_Webhooks {
 				if (
 					"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff" === $prefix12 // IPv4-mapped ::ffff:0:0/96.
 					|| "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" === $prefix12 // IPv4-compatible ::/96.
+					|| "\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00" === $prefix12 // IPv4-translated ::ffff:0:0:0/96.
 					|| "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00" === $prefix12 // NAT64 64:ff9b::/96.
 				) {
 					$embedded = substr( $ip_binary, 12, 4 );

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -106,7 +106,7 @@ class Form_Webhooks {
 			return;
 		}
 
-		$webhooks = $this->get_enabled_webhooks( $form->attributes );
+		$webhooks = $this->get_enabled_webhooks( $form->attributes, $post_id );
 
 		if ( empty( $webhooks ) ) {
 			return;
@@ -119,6 +119,21 @@ class Form_Webhooks {
 			$response = $this->send_webhook( $form_data, $webhook, $post_id );
 			$this->log_response_to_post_meta( $post_id, $response );
 		}
+	}
+
+	/**
+	 * Record a URL that failed validation, so a skipped webhook is as diagnosable as a failed request.
+	 *
+	 * @param int|null $post_id The feedback post ID, if known.
+	 * @param WP_Error $error   The validation error.
+	 */
+	private function log_validation_error_to_post_meta( $post_id, $error ) {
+		if ( empty( $post_id ) ) {
+			return;
+		}
+
+		update_post_meta( $post_id, '_jetpack_forms_webhook_error', sanitize_text_field( $error->get_error_message() ) );
+		$this->track_webhook_request( 'error' );
 	}
 
 	/**
@@ -188,27 +203,69 @@ class Form_Webhooks {
 	}
 
 	/**
-	 * Check if an IP address is in a blocked range.
+	 * Check if an IP address is blocked as a webhook destination.
 	 *
-	 * @param string $ip The IP address to check.
+	 * @param string $ip  The IP address to check.
+	 * @param string $url The webhook URL being validated, when known.
 	 * @return bool True if the IP should be blocked.
 	 */
-	private function is_blocked_ip( $ip ) {
+	private function is_blocked_ip( $ip, $url = '' ) {
+		$blocked = $this->ip_is_in_blocked_range( $ip );
+
+		/**
+		 * Filters whether a resolved address is rejected as a webhook destination.
+		 *
+		 * Forms validates ahead of wp_safe_remote_request(), so core's own
+		 * `http_request_host_is_external` escape hatch is never reached. This is the
+		 * equivalent for a site that deliberately points a webhook at its own network.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool   $blocked Whether the address is blocked.
+		 * @param string $ip      The address being checked.
+		 * @param string $url     The webhook URL being validated, when known.
+		 */
+		return (bool) apply_filters( 'jetpack_forms_webhook_blocked_ip', $blocked, $ip, $url );
+	}
+
+	/**
+	 * Check whether an IP address falls in a range we refuse to send webhooks to.
+	 *
+	 * @param string $ip The IP address to check.
+	 * @return bool True if the address is in a blocked range.
+	 */
+	private function ip_is_in_blocked_range( $ip ) {
 		// Strip IPv6 zone identifier if present (e.g., fe80::1%eth0 -> fe80::1)
 		$ip = preg_replace( '/%.*$/', '', $ip );
 
-		// Check IPv4 link-local addresses (169.254.0.0/16)
-		// This range includes the AWS/cloud metadata endpoint (169.254.169.254)
 		if ( filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-			$ip_long = ip2long( $ip );
-			// 169.254.0.0/16 = 2851995648 to 2852061183
-			if ( $ip_long !== false && $ip_long >= 2851995648 && $ip_long <= 2852061183 ) {
+			// Azure Wire Server, which fronts Azure internal services including the metadata endpoint.
+			if ( '168.63.129.16' === $ip ) {
 				return true;
 			}
 
-			// Block Azure Wire Server (168.63.129.16)
-			// Used for Azure internal services including Instance Metadata Service
-			if ( $ip === '168.63.129.16' ) {
+			$ip_long = ip2long( $ip );
+			if ( false === $ip_long ) {
+				return false;
+			}
+
+			/*
+			 * Octet math rather than range comparisons: ip2long() returns a negative int on 32-bit
+			 * PHP for anything above 127.255.255.255, which silently defeats a `>=` range check.
+			 */
+			$first_octet  = ( $ip_long >> 24 ) & 0xff;
+			$second_octet = ( $ip_long >> 16 ) & 0xff;
+
+			/*
+			 * Loopback (127.0.0.0/8) and "this network" (0.0.0.0/8). Core blocks both, but
+			 * wp_http_validate_url() skips that check when the host matches the site's own home host.
+			 */
+			if ( 127 === $first_octet || 0 === $first_octet ) {
+				return true;
+			}
+
+			// Link-local 169.254.0.0/16, which holds the AWS/cloud metadata endpoint.
+			if ( 169 === $first_octet && 254 === $second_octet ) {
 				return true;
 			}
 
@@ -222,21 +279,39 @@ class Form_Webhooks {
 				return false;
 			}
 
-			// Check for IPv6 loopback (::1) using binary comparison
-			// This handles all valid representations (e.g., 0:0:0:0:0:0:0:1, ::0:1)
-			if ( $ip_binary === inet_pton( '::1' ) ) {
+			/*
+			 * Loopback (::1) and the unspecified address (::), the IPv6 counterpart of 0.0.0.0.
+			 * Binary comparison handles every spelling (0:0:0:0:0:0:0:1, ::0:1).
+			 */
+			if ( $ip_binary === inet_pton( '::1' ) || $ip_binary === inet_pton( '::' ) ) {
 				return true;
 			}
 
-			// Check for IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
-			// These are 16 bytes where first 10 are zeros, next 2 are 0xff, last 4 are IPv4
-			if ( strlen( $ip_binary ) === 16 &&
-				substr( $ip_binary, 0, 10 ) === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" &&
-				substr( $ip_binary, 10, 2 ) === "\xff\xff" ) {
-				// Extract the embedded IPv4 address (last 4 bytes) and check it
-				$ipv4 = inet_ntop( substr( $ip_binary, 12, 4 ) );
-				if ( $ipv4 && $this->is_blocked_ip( $ipv4 ) ) {
-					return true;
+			/*
+			 * Decode the IPv6 forms that embed an IPv4 address and check that address, so
+			 * 127.0.0.1 is caught however it is spelled -- 64:ff9b::7f00:1 and 2002:7f00:1::1
+			 * both reach loopback.
+			 */
+			if ( 16 === strlen( $ip_binary ) ) {
+				$prefix12 = substr( $ip_binary, 0, 12 );
+				$embedded = null;
+
+				if (
+					"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff" === $prefix12 // IPv4-mapped ::ffff:0:0/96.
+					|| "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" === $prefix12 // IPv4-compatible ::/96.
+					|| "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00" === $prefix12 // NAT64 64:ff9b::/96.
+				) {
+					$embedded = substr( $ip_binary, 12, 4 );
+				} elseif ( "\x20\x02" === substr( $ip_binary, 0, 2 ) ) {
+					// 6to4 2002::/16 carries the embedded IPv4 gateway in bytes 2-5.
+					$embedded = substr( $ip_binary, 2, 4 );
+				}
+
+				if ( null !== $embedded ) {
+					$ipv4 = inet_ntop( $embedded );
+					if ( $ipv4 && $this->ip_is_in_blocked_range( $ipv4 ) ) {
+						return true;
+					}
 				}
 			}
 
@@ -271,7 +346,8 @@ class Form_Webhooks {
 	 * Performs validation:
 	 * - Valid URL format
 	 * - HTTPS scheme requirement
-	 * - Blocks link-local and private IP ranges not covered by wp_safe_remote_request()
+	 * - Blocks loopback, link-local, and cloud-metadata addresses, plus IPv6 private (ULA) ranges.
+	 *   IPv4 RFC1918 ranges are left to wp_safe_remote_request().
 	 *
 	 * @param string $url The webhook URL to validate.
 	 * @return bool|WP_Error True if valid, WP_Error with reason if invalid.
@@ -313,7 +389,7 @@ class Form_Webhooks {
 
 		// If host is already an IP, check it directly
 		if ( filter_var( $host, FILTER_VALIDATE_IP ) ) {
-			if ( $this->is_blocked_ip( $host ) ) {
+			if ( $this->is_blocked_ip( $host, $url ) ) {
 				return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
 			}
 			return true;
@@ -321,7 +397,7 @@ class Form_Webhooks {
 
 		// For hostnames, check IPv4 via gethostbyname
 		$ipv4 = gethostbyname( $host );
-		if ( $ipv4 !== $host && $this->is_blocked_ip( $ipv4 ) ) {
+		if ( $ipv4 !== $host && $this->is_blocked_ip( $ipv4, $url ) ) {
 			return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
 		}
 
@@ -332,7 +408,7 @@ class Form_Webhooks {
 			$aaaa_records = @dns_get_record( $host, DNS_AAAA );
 			if ( $aaaa_records ) {
 				foreach ( $aaaa_records as $record ) {
-					if ( isset( $record['ipv6'] ) && $this->is_blocked_ip( $record['ipv6'] ) ) {
+					if ( isset( $record['ipv6'] ) && $this->is_blocked_ip( $record['ipv6'], $url ) ) {
 						return new WP_Error( 'blocked_ip', __( 'Webhook URL cannot point to private or internal networks.', 'jetpack-forms' ) );
 					}
 				}
@@ -345,10 +421,11 @@ class Form_Webhooks {
 	/**
 	 * Get the enabled webhooks from the form attributes.
 	 *
-	 * @param array $attributes - the attributes of the contact form.
+	 * @param array    $attributes - the attributes of the contact form.
+	 * @param int|null $post_id - the feedback post to record validation failures on.
 	 * @return array Array of enabled webhooks.
 	 */
-	private function get_enabled_webhooks( $attributes = array() ) {
+	private function get_enabled_webhooks( $attributes = array(), $post_id = null ) {
 		if ( empty( $attributes['webhooks'] ) || ! is_array( $attributes['webhooks'] ) ) {
 			return array();
 		}
@@ -383,6 +460,7 @@ class Form_Webhooks {
 			$url_validation = $this->validate_webhook_url( $setup['url'] );
 			if ( is_wp_error( $url_validation ) ) {
 				do_action( 'jetpack_forms_log', 'webhook_skipped', $url_validation->get_error_code(), $setup );
+				$this->log_validation_error_to_post_meta( $post_id, $url_validation );
 				continue;
 			}
 

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -1377,10 +1377,15 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test that webhook blocks IPv6 spellings that embed the IPv4 loopback address.
-	 * NAT64 and 6to4 both carry an embedded IPv4 that routes to 127.0.0.1.
+	 * NAT64, 6to4, and the IPv4-translated form all carry an embedded IPv4 that routes to 127.0.0.1.
 	 */
 	public function test_send_webhooks_blocks_ipv6_embedded_loopback() {
-		foreach ( array( 'https://[64:ff9b::7f00:1]/webhook', 'https://[2002:7f00:1::1]/webhook' ) as $url ) {
+		$urls = array(
+			'https://[64:ff9b::7f00:1]/webhook',  // NAT64.
+			'https://[2002:7f00:1::1]/webhook',   // 6to4.
+			'https://[::ffff:0:7f00:1]/webhook',  // IPv4-translated.
+		);
+		foreach ( $urls as $url ) {
 			$form   = $this->create_mock_form(
 				array(
 					'webhooks' => array(
@@ -1435,7 +1440,8 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that the jetpack_forms_webhook_blocked_ip filter can allow an otherwise blocked address.
+	 * Test that the jetpack_forms_webhook_blocked_ip filter can allow an otherwise blocked address,
+	 * and that it receives the documented arguments in the documented order.
 	 */
 	public function test_blocked_ip_filter_can_allow_loopback() {
 		$form   = $this->create_mock_form(
@@ -1455,7 +1461,16 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		add_filter( 'jetpack_forms_webhook_blocked_ip', '__return_false' );
+		$filter_args = array();
+		add_filter(
+			'jetpack_forms_webhook_blocked_ip',
+			function ( $blocked, $ip, $url ) use ( &$filter_args ) {
+				$filter_args[] = array( $blocked, $ip, $url );
+				return false;
+			},
+			10,
+			3
+		);
 
 		$http_request_made = false;
 		add_filter(
@@ -1473,7 +1488,14 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		$this->assertTrue( $http_request_made, 'Filter should allow the webhook through' );
+		/*
+		 * pre_http_request short-circuits ahead of core's own URL check, so this asserts that the
+		 * Forms layer allowed the request, not that a loopback webhook would be delivered.
+		 */
+		$this->assertTrue( $http_request_made, 'Filter should let the request past Forms validation' );
+		$this->assertCount( 1, $filter_args, 'Filter should run once for the resolved address' );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertSame( array( true, '127.0.0.1', 'https://127.0.0.1/webhook' ), $filter_args[0] );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -852,7 +852,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test webhook is blocked when URL points to localhost.
-	 * SSRF protection is handled at request time by wp_safe_remote_request().
+	 * SSRF protection should block 127.0.0.0/8 at validation time.
 	 */
 	public function test_send_webhooks_blocks_localhost_urls() {
 		$form   = $this->create_mock_form(
@@ -872,20 +872,39 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Prevent actual network requests - return WP_Error simulating blocked private IP
+		// Prevent actual network requests - return WP_Error if filter is reached
+		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
-			function () {
-				return new \WP_Error( 'http_request_not_executed', 'A valid URL was not provided.' );
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
 		);
 
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// wp_safe_remote_request() blocks private IPs and returns WP_Error, which gets logged
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for localhost URLs' );
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for loopback URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1357,6 +1376,307 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that webhook blocks IPv6 spellings that embed the IPv4 loopback address.
+	 * NAT64 and 6to4 both carry an embedded IPv4 that routes to 127.0.0.1.
+	 */
+	public function test_send_webhooks_blocks_ipv6_embedded_loopback() {
+		foreach ( array( 'https://[64:ff9b::7f00:1]/webhook', 'https://[2002:7f00:1::1]/webhook' ) as $url ) {
+			$form   = $this->create_mock_form(
+				array(
+					'webhooks' => array(
+						array(
+							'webhook_id' => 'test-webhook',
+							'url'        => $url,
+							'format'     => 'json',
+							'method'     => 'POST',
+							'enabled'    => true,
+						),
+					),
+				)
+			);
+			$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+			$post_id = $this->create_feedback_post( $form, $fields );
+
+			$http_request_made = false;
+			add_filter(
+				'pre_http_request',
+				function () use ( &$http_request_made ) {
+					$http_request_made = true;
+					return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
+				}
+			);
+
+			$logged_events = array();
+			add_action(
+				'jetpack_forms_log',
+				function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+					$logged_events[] = array(
+						'event'  => $event,
+						'reason' => $reason,
+						'data'   => $data,
+					);
+				},
+				10,
+				3
+			);
+
+			$webhooks = Form_Webhooks::init();
+			$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+			$this->assertFalse( $http_request_made, "HTTP request should not be made for $url" );
+			$this->assertCount( 1, $logged_events, "One skip should be logged for $url" );
+			// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+			$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'], "$url should be blocked_ip" );
+
+			remove_all_filters( 'pre_http_request' );
+			remove_all_actions( 'jetpack_forms_log' );
+		}
+	}
+
+	/**
+	 * Test that the jetpack_forms_webhook_blocked_ip filter can allow an otherwise blocked address.
+	 */
+	public function test_blocked_ip_filter_can_allow_loopback() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://127.0.0.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		add_filter( 'jetpack_forms_webhook_blocked_ip', '__return_false' );
+
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'body'     => '{}',
+					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+				);
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertTrue( $http_request_made, 'Filter should allow the webhook through' );
+	}
+
+	/**
+	 * Test that a webhook rejected at validation records the reason on the feedback post.
+	 */
+	public function test_send_webhooks_records_validation_error_on_post_meta() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://127.0.0.1/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
+		$this->assertNotEmpty( $error_meta, 'A blocked webhook should still leave a diagnosable trail' );
+		$this->assertStringContainsString( 'private or internal networks', $error_meta );
+	}
+
+	/**
+	 * Test that webhook blocks the IPv6 unspecified address.
+	 * SSRF protection should block ::, the IPv6 counterpart of 0.0.0.0.
+	 */
+	public function test_send_webhooks_blocks_ipv6_unspecified() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[::]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Prevent actual network requests - return WP_Error if filter is reached
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for :: URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test that webhook blocks the "this network" range.
+	 * SSRF protection should block 0.0.0.0/8 at validation time.
+	 */
+	public function test_send_webhooks_blocks_this_network_range() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://0.0.0.0/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Prevent actual network requests - return WP_Error if filter is reached
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for 0.0.0.0/8 URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
+	 * Test that webhook blocks IPv4-mapped IPv6 loopback addresses.
+	 * SSRF protection should block ::ffff:127.0.0.1 which maps to the IPv4 loopback range.
+	 */
+	public function test_send_webhooks_blocks_ipv4_mapped_ipv6_loopback() {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://[::ffff:127.0.0.1]/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		// Prevent actual network requests - return WP_Error if filter is reached
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for IPv4-mapped loopback URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
+	}
+
+	/**
 	 * Test that webhook blocks fc00:: addresses (part of fc00::/7 unique local range).
 	 * SSRF protection should block fc00::/8 in addition to fd00::/8.
 	 */
@@ -1400,8 +1720,7 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 	/**
 	 * Test webhook is blocked when URL uses localhost hostname.
-	 * SSRF protection should block localhost - either at validation (if resolves to 127.0.0.1)
-	 * or at request time via wp_safe_remote_request().
+	 * SSRF protection should resolve localhost to 127.0.0.1 and block it at validation time.
 	 */
 	public function test_send_webhooks_blocks_localhost_hostname() {
 		$form   = $this->create_mock_form(
@@ -1421,17 +1740,13 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
-		// Track if HTTP request was made
+		// Prevent actual network requests - return WP_Error if filter is reached
 		$http_request_made = false;
 		add_filter(
 			'pre_http_request',
 			function () use ( &$http_request_made ) {
 				$http_request_made = true;
-				return array(
-					'response' => array( 'code' => 200 ),
-					'body'     => '{}',
-					'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
-				);
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
 			}
 		);
 
@@ -1452,12 +1767,12 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// localhost should be blocked - either at validation or by wp_safe_remote_request
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertTrue(
-			! $http_request_made || ! empty( $error_meta ) || ! empty( $logged_events ),
-			'localhost hostname should be blocked or fail'
-		);
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for the localhost hostname' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**
@@ -1767,12 +2082,39 @@ class Form_Webhooks_Test extends BaseTestCase {
 
 		$post_id = $this->create_feedback_post( $form, $fields );
 
+		// Prevent actual network requests - return WP_Error if filter is reached
+		$http_request_made = false;
+		add_filter(
+			'pre_http_request',
+			function () use ( &$http_request_made ) {
+				$http_request_made = true;
+				return new \WP_Error( 'http_request_not_executed', 'Request should have been blocked.' );
+			}
+		);
+
+		$logged_events = array();
+		add_action(
+			'jetpack_forms_log',
+			function ( $event, $reason, $data = null ) use ( &$logged_events ) {
+				$logged_events[] = array(
+					'event'  => $event,
+					'reason' => $reason,
+					'data'   => $data,
+				);
+			},
+			10,
+			3
+		);
+
 		$webhooks = Form_Webhooks::init();
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
-		// Zero-padded localhost should be blocked by wp_safe_remote_request
-		$error_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_error', true );
-		$this->assertNotEmpty( $error_meta, 'Error should be logged for zero-padded localhost URLs' );
+		$this->assertFalse( $http_request_made, 'HTTP request should not be made for zero-padded loopback URLs' );
+		$this->assertCount( 1, $logged_events );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'webhook_skipped', $logged_events[0]['event'] );
+		// @phan-suppress-next-line PhanTypeArraySuspiciousNull, PhanTypeInvalidDimOffset
+		$this->assertEquals( 'blocked_ip', $logged_events[0]['reason'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/forms-webhook-blocked-ip-filter
+++ b/projects/plugins/jetpack/changelog/forms-webhook-blocked-ip-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Forms: Add a filter to allow webhook destinations that would otherwise be rejected as internal.

--- a/projects/plugins/jetpack/changelog/forms-webhook-loopback-validation-FORMS-786
+++ b/projects/plugins/jetpack/changelog/forms-webhook-loopback-validation-FORMS-786
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Block webhook URLs that point at loopback or unspecified addresses.


### PR DESCRIPTION
Fixes FORMS-786

## Proposed changes

`Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname` passes in CI and fails on macOS. Same commit, same tree — the difference is the host resolver, and chasing it turned up a gap in the address checks the test was covering.

`Form_Webhooks::is_blocked_ip()` rejects IPv6 loopback (`::1`), link-local, and ULA, but its IPv4 branch only covered `169.254.0.0/16` and one cloud host address. Nothing rejected `127.0.0.0/8`.

So `https://localhost/webhook` cleared validation on the `gethostbyname()` result, and the only thing that stopped it was the AAAA lookup further down. glibc answers `::1` for `localhost`; macOS returns nothing for it over DNS. Hence green on Linux, red on a Mac.

* Reject `127.0.0.0/8` and `0.0.0.0/8`, plus `::` alongside `::1`. `::` rather than `::1` is the IPv4 counterpart of `0.0.0.0`.
* Decode the IPv6 spellings that embed an IPv4 address before checking it, so `127.0.0.1` is recognized however it is written — `64:ff9b::7f00:1` (NAT64) and `2002:7f00:1::1` (6to4) both resolve to it. The existing `::ffff:` handling was also ineffective for loopback, since it recursed into `is_blocked_ip( '127.0.0.1' )` and got `false`.
* Replace the link-local range comparison with octet math. On 32-bit PHP `ip2long()` returns a negative int above `127.255.255.255`, so `>= 2851995648` never matched there and `169.254.0.0/16` went unrecognized.

**Sites can override the check**

Because Forms validates ahead of `wp_safe_remote_request()`, core's `http_request_host_is_external` filter is never reached, leaving no way to allow a webhook aimed at the site's own host. New filter:

```php
add_filter( 'jetpack_forms_webhook_blocked_ip', function ( $blocked, $ip, $url ) {
	return '127.0.0.1' === $ip ? false : $blocked;
}, 10, 3 );
```

Scope worth being precise about: this only helps where core would let the request through on its own. That is the same-host case — a site whose `home` is `https://localhost` with a webhook aimed at `https://localhost/...`, where `wp_http_validate_url()` skips its address check entirely. For any other host, core applies its own check afterward and still refuses `10.0.0.0/8` and friends, so the filter alone will not deliver such a webhook.

**Rejections are diagnosable**

A webhook rejected during validation was skipped in `get_enabled_webhooks()` and left nothing behind, while a request-time failure wrote `_jetpack_forms_webhook_error` and bumped the request stat. Validation failures now record the same way.

**Tests**

Four existing tests asserted almost nothing — `test_send_webhooks_blocks_zero_padded_ip` had no `pre_http_request` stub at all, so it made a real network call and passed on the connection failure. Those are tightened, with new coverage for `0.0.0.0/8`, `::`, the NAT64/6to4 spellings, the filter, and the error record.

## Note on behavior

`wp_http_validate_url()` keeps its address check inside `if ( ! $same_host )`, so when a webhook host matches the site's own `home` host, core does not apply it. A site whose home host resolves to loopback, with a webhook aimed at that same host, previously sent and now does not — hence the `plugins/jetpack` changelog entries, and the filter above for anyone who wants the previous behavior.

An earlier attempt at this fix (https://github.com/Automattic/jetpack/pull/46526) was closed on the grounds that core already covers these ranges, which is true apart from that case.

## Related product discussion/links

* https://linear.app/a8c/issue/FORMS-786
* Follow-up, consolidating onto `packages/ip`: https://linear.app/a8c/issue/FORMS-787

## Does this pull request change what data or activity we track or use?

The `jetpack_forms_webhook_request` stat now counts validation-time rejections as errors, where before it only counted request-time failures. No new data is collected.

## Testing instructions

This one is platform-dependent, so run it on both if you can.

* Run the Forms PHP suite: `jetpack test php packages/forms`. Natively, that is `composer install` in `tools/php-test-env` and in `projects/packages/forms`, then `composer phpunit` from the package.
* All 49 `Form_Webhooks_Test` cases should pass. On trunk, `test_send_webhooks_blocks_localhost_hostname` fails on macOS and passes on Linux.
* To watch that split for yourself, run the same worktree through a Linux container (vendor dirs from the host install are reused, so run the installs first):

```
docker run --rm -v "$PWD:$PWD" -w "$PWD/projects/packages/forms" php:8.3-cli \
  bash -lc "php vendor/bin/phpunit -c phpunit.12.xml.dist tests/php/service/Form_Webhooks_Test.php"
```

* Functional check: point a form's webhook at `https://localhost/webhook`, submit an entry, and confirm nothing is sent and the entry records an error. Then add the `jetpack_forms_webhook_blocked_ip` filter above returning `false`, submit again, and confirm the request is attempted.
