### PR TITLE
Premium Analytics: show Skip tour on every step of the onboarding tour

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-onboarding-tour-skip-control
+++ b/projects/packages/premium-analytics/changelog/update-pa-onboarding-tour-skip-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: show the Skip tour button on every step of the spotlight tour.

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.module.scss
@@ -29,19 +29,6 @@ $spotlight-dim-color: rgba(0, 0, 0, 0.5);
 	max-inline-size: calc(100vw - 2 * var(--wpds-dimension-padding-2xl));
 }
 
-.skip {
-	// A skip link's recipe, clipped away until it takes focus: keyboard and
-	// screen reader users get a way out and the card stays as designed.
-	&:not(:focus-visible) {
-		position: absolute;
-		inline-size: 1px;
-		block-size: 1px;
-		overflow: hidden;
-		clip-path: inset(50%);
-		white-space: nowrap;
-	}
-}
-
 @media (prefers-reduced-motion: reduce) {
 
 	.halo {

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.tsx
@@ -104,8 +104,8 @@ function haloStyle( rect: DOMRect ): CSSProperties {
 /**
  * One step of a spotlight tour: the page dims except for a halo around the
  * anchor, and a card beside it carries the step's copy, its position in the
- * tour and the way forward. Escape and the skip control, shown on focus, leave
- * the tour; clicks on the dimmed page do nothing.
+ * tour, Skip tour and the way forward. Escape and Skip tour leave the tour;
+ * clicks on the dimmed page do nothing.
  */
 export function SpotlightStep( {
 	anchor,
@@ -174,12 +174,8 @@ export function SpotlightStep( {
 								) }
 							</Text>
 							<Stack direction="row" align="center" gap="sm">
-								{ /* The Close part is what makes Base UI trap focus. It stays out
-								     of sight until focused, as the design draws no skip control. */ }
-								<Popover.Close
-									className={ styles.skip }
-									render={ <Button variant="minimal" tone="neutral" /> }
-								>
+								{ /* The Close part is what makes Base UI trap focus. */ }
+								<Popover.Close render={ <Button variant="minimal" tone="neutral" /> }>
 									{ __( 'Skip tour', 'jetpack-premium-analytics-pkg' ) }
 								</Popover.Close>
 								<Button ref={ nextRef } variant="solid" onClick={ onNext }>

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/spotlight-step.tsx
@@ -164,7 +164,7 @@ export function SpotlightStep( {
 					<Stack direction="column" gap="sm">
 						<Popover.Title>{ title }</Popover.Title>
 						<Popover.Description>{ description }</Popover.Description>
-						<Stack direction="row" align="center" justify="space-between" gap="md">
+						<Stack direction="row" align="center" justify="space-between" gap="md" wrap="wrap">
 							<Text variant="body-sm">
 								{ sprintf(
 									/* translators: 1: the current step number, 2: the number of steps in the tour. */

--- a/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/spotlight-step/stories/spotlight-step.stories.tsx
@@ -18,9 +18,8 @@ const meta: Meta< typeof SpotlightStep > = {
 					'the anchor, and a card beside it carries the copy, the "n of m" ' +
 					'counter and Continue, or Finish on the last step.\n\n' +
 					'The step renders nothing until its anchor is mounted, so a tour can ' +
-					'declare steps for elements that appear later. Escape and a skip ' +
-					'control that shows up on focus call `onDismiss`; clicks on the ' +
-					'dimmed page do nothing, as the design draws no skip control.',
+					'declare steps for elements that appear later. Escape and Skip tour ' +
+					'call `onDismiss`; clicks on the dimmed page do nothing.',
 			},
 		},
 	},
@@ -125,8 +124,8 @@ function TourDemo() {
 /**
  * The onboarding steps on a mock of the dashboard header: the first widget,
  * the date controls, Customize and the options menu. Continue walks them, Finish
- * ends, Escape leaves at any point; the button that appears afterwards
- * restarts the tour.
+ * ends, Escape and Skip tour leave at any point; the button that appears
+ * afterwards restarts the tour.
  */
 export const Default: Story = {
 	render: () => <TourDemo />,

--- a/projects/plugins/jetpack/changelog/update-pa-onboarding-tour-skip-control
+++ b/projects/plugins/jetpack/changelog/update-pa-onboarding-tour-skip-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: show the Skip tour button on every step of the onboarding tour.

--- a/projects/plugins/premium-analytics/changelog/update-pa-onboarding-tour-skip-control
+++ b/projects/plugins/premium-analytics/changelog/update-pa-onboarding-tour-skip-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Onboarding: show the Skip tour button on every step of the spotlight tour.


### PR DESCRIPTION
Resolves UNI-768.

## Proposed changes

Follow-up to #51975. The spotlight card's Skip tour button existed only so Base UI would trap focus, and stayed clipped away until it took keyboard focus (Shift+Tab from Continue). Escape leaves the tour too, and clicks on the dimmed page do nothing, so a mouse user had no discoverable way out besides clicking Continue through every step. Design agreed the button should be visible.

* `SpotlightStep` no longer hides `Popover.Close`: Skip tour sits next to Continue on every step, as a minimal neutral button. The skip-link styles are gone from the module.
* Focus, dismissal and tracking are unchanged: initial focus still lands on Continue, Tab still cycles between the two buttons, and Skip tour still dismisses with `reason=close`.

<img width="1256" height="656" alt="截圖 2026-09-09 晚上10 37 07" src="https://github.com/user-attachments/assets/bf5412ff-ecc4-4a61-adf3-7948df34951c" />

<img width="687" height="244" alt="截圖 2026-09-09 晚上10 48 47" src="https://github.com/user-attachments/assets/14971ed6-e1ac-4759-844a-5fec5ab15364" />

## Why

Once the tour started there was no visible way out for a mouse user. Clicks on the dimmed page do nothing by design, so the only remaining exit was hidden behind keyboard focus. The tour is short, but a visible Skip tour is cheaper than making people click through it.

## Related product discussion/links

* Linear: UNI-768, where design asked for the visible button.
* #51975 added the hidden control.

## Does this pull request change what data or activity we track or use?

No. `jetpack_premium_analytics_onboarding_dismiss` already carried `reason=close` for this button, with `phase=tour` and the 1-based `step`. The welcome modal's X sends the same event with `phase=modal`, `step=0`, so the two exits stay distinguishable.

## Testing instructions

* Build the package and open the Premium Analytics dashboard as a user who has not seen the onboarding, or clear the preference from the console and reload:

  ```js
  wp.data
    .dispatch( 'core/preferences' )
    .set( 'jetpack-premium-analytics/dashboard', 'onboardingCompletedAt', null );
  ```

* Press Take a quick tour. The step card shows Skip tour to the left of Continue, and focus is on Continue.
* Press Continue: Skip tour is still there on every step, including the last one next to Finish.
* Click Skip tour: the tour ends and does not come back on reload. In the Network panel, the `t.gif` request for `jetpack_premium_analytics_onboarding_dismiss` carries `phase=tour`, the current `step` and `reason=close`. Closing the welcome modal with its X instead sends `phase=modal`, `step=0`, `reason=close`.
* Tab from Continue still reaches Skip tour and wraps back; Escape still leaves the tour.
* Storybook, from `projects/packages/premium-analytics` after `pnpm run build`: Packages › Premium Analytics › UI › SpotlightStep.
* Unit tests from the package: `pnpm run test -- packages/ui/src/spotlight-step routes/dashboard/components/onboarding-tour`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9pfTryGMx4DbKYXsR67UM


