### PR TITLE
Boost: keep the Jetpack Likes script in place for Defer JS

### DIFF
--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -501,10 +501,10 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Chang
 	 * Concatenated scripts share one <script> tag, but handle_exclusions() marks a script's own
 	 * tag - a concatenated script has none to mark, so this module would move it.
 	 *
-	 * @param bool   $do_concat Whether the script may be concatenated.
+	 * @param mixed  $do_concat Whether the script may be concatenated, as left by earlier filters.
 	 * @param string $handle    Script handle from register_ or enqueue_ methods.
 	 *
-	 * @return bool
+	 * @return mixed False when this module vetoes, otherwise $do_concat unchanged.
 	 */
 	public function should_concatenate( $do_concat, $handle ) {
 		if ( $do_concat && in_array( $handle, $this->get_exclude_handles(), true ) ) {

--- a/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
+++ b/projects/plugins/boost/app/modules/optimizations/render-blocking-js/class-render-blocking-js.php
@@ -215,6 +215,7 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Chang
 
 		// Handle exclusions.
 		add_filter( 'script_loader_tag', array( $this, 'handle_exclusions' ), 10, 2 );
+		add_filter( 'js_do_concat', array( $this, 'should_concatenate' ), 10, 2 );
 
 		$this->output_filter->add_callback( array( $this, 'handle_output_stream' ) );
 	}
@@ -462,6 +463,23 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Chang
 	}
 
 	/**
+	 * Handles that must keep their place in the document, as provided by
+	 * `jetpack_boost_render_blocking_js_exclude_handles`.
+	 *
+	 * @return array
+	 */
+	private function get_exclude_handles() {
+		/**
+		 * Filter to provide an array of registered script handles that should not be moved to the end of the document.
+		 *
+		 * @param array $script_handles array of script handles. Remove any scripts that should not be moved to the end of the documents.
+		 *
+		 * @since   1.0.0
+		 */
+		return (array) apply_filters( 'jetpack_boost_render_blocking_js_exclude_handles', array() );
+	}
+
+	/**
 	 * Exclude certain scripts from being processed by this class.
 	 *
 	 * @param string $tag    <script> opening tag.
@@ -470,20 +488,31 @@ class Render_Blocking_JS implements Feature, Changes_Output_On_Activation, Chang
 	 * @return string
 	 */
 	public function handle_exclusions( $tag, $handle ) {
-		/**
-		 * Filter to provide an array of registered script handles that should not be moved to the end of the document.
-		 *
-		 * @param array $script_handles array of script handles. Remove any scripts that should not be moved to the end of the documents.
-		 *
-		 * @since   1.0.0
-		 */
-		$exclude_handles = apply_filters( 'jetpack_boost_render_blocking_js_exclude_handles', array() );
-
-		if ( ! in_array( $handle, $exclude_handles, true ) ) {
+		if ( ! in_array( $handle, $this->get_exclude_handles(), true ) ) {
 			return $tag;
 		}
 
 		return $this->add_ignore_attribute( $tag );
+	}
+
+	/**
+	 * Whether Minify JS may concatenate a script, given the handles excluded from deferral.
+	 *
+	 * Concatenated scripts share one <script> tag, but handle_exclusions() marks a script's own
+	 * tag - a concatenated script has none to mark, so this module would move it.
+	 *
+	 * @param bool   $do_concat Whether the script may be concatenated.
+	 * @param string $handle    Script handle from register_ or enqueue_ methods.
+	 *
+	 * @return bool
+	 */
+	public function should_concatenate( $do_concat, $handle ) {
+		if ( $do_concat && in_array( $handle, $this->get_exclude_handles(), true ) ) {
+			return false;
+		}
+
+		// Not a fresh boolean: Concatenate_JS concatenates only on `true === $do_concat`.
+		return $do_concat;
 	}
 
 	/**

--- a/projects/plugins/boost/changelog/fix-likes-stuck-loading-defer-js
+++ b/projects/plugins/boost/changelog/fix-likes-stuck-loading-defer-js
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Defer JS: Stop moving the Jetpack Likes script out of place, so Like blocks and comment likes no longer stick on "Loading…".

--- a/projects/plugins/boost/compatibility/jetpack.php
+++ b/projects/plugins/boost/compatibility/jetpack.php
@@ -15,10 +15,15 @@ require_once __DIR__ . '/lib/class-sync-jetpack-module-status.php';
  * Exclude Jetpack likes scripts from deferred JS. They are already in the footer,
  * and are sensitive to having their order changed relative to their companion iframe.
  *
+ * The queue handler is listed unconditionally: the Like block and Comment Likes enqueue it
+ * without the `likes` module, so is_module_active( 'likes' ) would miss them.
+ *
  * @param array $exclusions The default array of scripts to exclude from deferral.
  */
 function exclude_jetpack_likes_scripts_defer( $exclusions ) {
 	static $likes_enabled = null;
+
+	$exclusions[] = 'jetpack_likes_queuehandler';
 
 	if ( null === $likes_enabled ) {
 		$likes_enabled = \Jetpack::is_module_active( 'likes' );
@@ -30,7 +35,6 @@ function exclude_jetpack_likes_scripts_defer( $exclusions ) {
 			array(
 				'jquery-core',
 				'postmessage',
-				'jetpack_likes_queuehandler',
 			)
 		);
 	}

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_JS_Strategy_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_JS_Strategy_Test.php
@@ -3,6 +3,7 @@
 namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
 
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Render_Blocking_JS\Render_Blocking_JS;
 use WorDBless\BaseTestCase;
 use WP_HTML_Tag_Processor;
 use WP_Scripts;
@@ -74,6 +75,7 @@ class Concatenate_JS_Strategy_Test extends BaseTestCase {
 				'defer'        => $processor->get_attribute( 'defer' ),
 				'async'        => $processor->get_attribute( 'async' ),
 				'data-handles' => $processor->get_attribute( 'data-handles' ),
+				'ignored'      => $processor->get_attribute( 'data-jetpack-boost' ),
 			);
 		}
 		return $tags;
@@ -166,5 +168,42 @@ class Concatenate_JS_Strategy_Test extends BaseTestCase {
 		$this->assertMatchesRegularExpression( '~/(?:_jb_static/\?\?|boost-cache/static/)~', $tags[0]['src'] );
 		$this->assertNull( $tags[0]['defer'] );
 		$this->assertNull( $tags[0]['async'] );
+	}
+
+	public function exclude_consumer_from_defer( $handles ) {
+		$handles[] = 'boost-strategy-consumer';
+		return $handles;
+	}
+
+	/**
+	 * A script excluded from deferred JS must not be concatenated: concatenated scripts share one
+	 * tag, so it would have none of its own to carry the ignore attribute and would be moved.
+	 */
+	public function test_handle_excluded_from_defer_is_not_bundled() {
+		$defer = new Render_Blocking_JS();
+		$defer->setup();
+		add_filter( 'jetpack_boost_render_blocking_js_exclude_handles', array( $this, 'exclude_consumer_from_defer' ) );
+		add_filter( 'js_do_concat', array( $defer, 'should_concatenate' ), 10, 2 );
+		add_filter( 'script_loader_tag', array( $defer, 'handle_exclusions' ), 10, 2 );
+
+		$scripts = new Concatenate_JS( new WP_Scripts() );
+		$scripts->enqueue( $this->register( $scripts, 'consumer' ) );
+		$scripts->enqueue( $this->register( $scripts, 'other' ) );
+		$scripts->enqueue( $this->register( $scripts, 'last' ) );
+
+		$tags = $this->render( $scripts );
+
+		remove_filter( 'jetpack_boost_render_blocking_js_exclude_handles', array( $this, 'exclude_consumer_from_defer' ) );
+		remove_filter( 'js_do_concat', array( $defer, 'should_concatenate' ), 10 );
+		remove_filter( 'script_loader_tag', array( $defer, 'handle_exclusions' ), 10 );
+
+		$this->assertCount( 2, $tags );
+		$this->assertSame( 'boost-strategy-consumer-js', $tags[0]['id'] );
+		$this->assertStringContainsString( '/consumer.js', $tags[0]['src'] );
+		$this->assertSame( 'ignore', $tags[0]['ignored'] );
+
+		$this->assertStringNotContainsString( '/consumer.js', $tags[1]['src'] );
+		$this->assertStringNotContainsString( 'boost-strategy-consumer', (string) $tags[1]['data-handles'] );
+		$this->assertNull( $tags[1]['ignored'] );
 	}
 }

--- a/projects/plugins/boost/tests/php/modules/optimizations/render-blocking-js/Render_Blocking_JS_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/render-blocking-js/Render_Blocking_JS_Test.php
@@ -326,6 +326,7 @@ class Render_Blocking_JS_Test extends MockeryTestCase {
 
 		Filters\expectAdded( 'jetpack_boost_output_filtering_last_buffer' )->never();
 		Filters\expectAdded( 'script_loader_tag' )->never();
+		Filters\expectAdded( 'js_do_concat' )->never();
 		Filters\expectRemoved( 'do_shortcode_tag' )->once();
 
 		$initial_ob_level = ob_get_level();
@@ -348,6 +349,7 @@ class Render_Blocking_JS_Test extends MockeryTestCase {
 
 		Filters\expectAdded( 'jetpack_boost_output_filtering_last_buffer' )->once();
 		Filters\expectAdded( 'script_loader_tag' )->once();
+		Filters\expectAdded( 'js_do_concat' )->once();
 
 		$initial_ob_level = ob_get_level();
 
@@ -507,5 +509,34 @@ class Render_Blocking_JS_Test extends MockeryTestCase {
 		}
 
 		return $method->invoke( $this->instance );
+	}
+
+	/**
+	 * A handle excluded from deferral must not be concatenated either, or the exclusion is
+	 * dropped and the script gets moved anyway.
+	 */
+	public function test_excluded_handle_is_kept_out_of_concatenation() {
+		Filters\expectApplied( 'jetpack_boost_render_blocking_js_exclude_handles' )
+			->twice()
+			->andReturn( array( 'jetpack_likes_queuehandler' ) );
+
+		$this->assertFalse( $this->instance->should_concatenate( true, 'jetpack_likes_queuehandler' ) );
+		$this->assertTrue( $this->instance->should_concatenate( true, 'some-other-handle' ) );
+	}
+
+	/**
+	 * A handle this module does not own keeps whatever the previous filter returned: Concatenate_JS
+	 * acts only on `true === $do_concat`, so promoting a truthy 1 would concatenate a kept-out script.
+	 */
+	public function test_concatenation_decision_is_passed_through_untouched() {
+		Filters\expectApplied( 'jetpack_boost_render_blocking_js_exclude_handles' )
+			->once()
+			->andReturn( array( 'jetpack_likes_queuehandler' ) );
+
+		$this->assertSame( 1, $this->instance->should_concatenate( 1, 'some-other-handle' ) );
+
+		// A falsy decision comes straight back without the list being consulted at all.
+		$this->assertFalse( $this->instance->should_concatenate( false, 'some-other-handle' ) );
+		$this->assertSame( 0, $this->instance->should_concatenate( 0, 'jetpack_likes_queuehandler' ) );
 	}
 }


### PR DESCRIPTION
Related to BOOST-549

**Note on reproducing.** The reports behind BOOST-549 are of a Like button stuck on "Loading…". I could not reproduce that symptom, and it may not reproduce on trunk at all: Jetpack #51113 (August 7) added a `queryMasterReady` handshake that lets a late-running queue handler recover from a missed `masterReady`. That handshake papers over the symptom; it does not restore the exclusion Boost is dropping, which is what this PR fixes. The testing instructions below therefore check the markup rather than the button — a working like button is not evidence the bug is absent.

## Proposed changes

Boost already excludes Jetpack's `jetpack_likes_queuehandler` from Defer Non-Essential JavaScript, because moving it relative to its companion `#likes-master` iframe leaves like buttons stuck on "Loading…". That exclusion had two holes, and together they explain the reports:

* **The exclusion was gated on the `likes` module being active.** The Like *block* registers on any connected site with no dependency on that module (`extensions/blocks/like/like.php`), and `modules/comment-likes.php` enqueues the same handle too. On a block-only site the exclusion never fired, so Defer JS moved the script. `jetpack_likes_queuehandler` is now listed unconditionally; `jquery-core`/`postmessage` stay behind the module gate.
* **Concatenation silently dropped the exclusion.** The exclusion is applied through `script_loader_tag`, but `Concatenate_JS::do_items()` only re-applies that filter for single-handle bundles. Bundle the handle with anything else and `handle_exclusions()` never runs, the `data-jetpack-boost="ignore"` attribute is never added, and Defer JS moves the whole bundle — which is why both Defer JS *and* Concatenate JS had to be switched off to work around it. `Render_Blocking_JS` now also answers `js_do_concat`, refusing concatenation for any handle registered through `jetpack_boost_render_blocking_js_exclude_handles`, so those handles keep a tag of their own and their exclusion survives.

The `js_do_concat` change is general: it fixes the same silent failure for any plugin (or third party) using the documented exclusion filter, not just Likes.

Tests: two unit tests for the new filter, registration assertions added to the existing `start_output_filtering` tests, and an integration test in `Concatenate_JS_Strategy_Test` that renders through both modules. That last one was verified to fail without the fix — all three scripts collapse into one un-ignored bundle — and pass with it.

Boost unit suite 179/179 and with-wordpress suite 210/210 pass; PHPCS is clean on all changed files.

## Related product discussion/links

* BOOST-549

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack-connected test site, install Jetpack and Jetpack Boost from this branch.
2. Make sure the **Likes** module is **off** (`wp jetpack module deactivate likes`), so the Like block is the only thing enqueueing the queue handler.
3. Add a post containing the **Like** block and publish it.
4. In Boost, enable **Defer Non-Essential JavaScript** and **Concatenate JS**.
5. Load the post on the front end as a logged-out visitor and view source.

With the module off, the block registers the handle with `strategy => defer`, which Minify JS never bundles — so steps 2-5 exercise the module-gate hole on its own, with concatenation not yet in the picture.

**Before:** `jetpack_likes_queuehandler` has its own tag, carries no `data-jetpack-boost="ignore"` attribute, and has been moved to just before `</body>`.

**After:** the same tag carries `data-jetpack-boost="ignore"` and stays in the footer above the `#likes-master` iframe.

Step 6 is where bundling enters: with the Likes module on, `modules/likes.php` registers the handle first and without a strategy, so the block's `defer` never applies and the script becomes bundle-eligible.

Also worth checking, to confirm concatenation no longer drops the exclusion:

6. Repeat with the Likes module **on** and both Boost modules on. The queue handler should likewise stay out of the bundle and keep its ignore attribute — before this change it was bundled, and moved.
7. Turn Defer Non-Essential JavaScript **off**, leaving Concatenate JS on. Bundling should be unaffected for every other handle (the `js_do_concat` filter is only registered while deferral is active for the request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PoeBjaZrNBzXfX1j2rcnq





