### PR TITLE
Premium Analytics: pin the section header on the report pages, from one shared component

### DIFF
--- a/projects/packages/premium-analytics/changelog/section-header-pin
+++ b/projects/packages/premium-analytics/changelog/section-header-pin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Pin the section header on the report pages, as on the dashboard, from one shared component.

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/section-header.test.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/__tests__/section-header.test.tsx
@@ -59,4 +59,42 @@ describe( 'SectionHeader', () => {
 
 		expect( screen.getByRole( 'button', { name: 'Last 7 days' } ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the notice under the header row', () => {
+		render( <SectionHeader title="Traffic" notice={ <p>{ "Couldn't refresh." }</p> } /> );
+
+		expect( screen.getByText( "Couldn't refresh." ) ).toBeInTheDocument();
+	} );
+
+	it( 'hands the ref the root the heading sits in', () => {
+		const ref = jest.fn();
+
+		render( <SectionHeader ref={ ref } title="Traffic" /> );
+
+		expect( ref ).toHaveBeenCalledWith( expect.any( HTMLDivElement ) );
+		expect( ref.mock.calls[ 0 ][ 0 ] ).toContainElement( screen.getByRole( 'heading' ) );
+	} );
+
+	// The marker publishes the scroll timeline the band condenses on; it has to
+	// precede the band as its sibling, where the surface's timeline scope sees it.
+	it( 'precedes a pinned header with its hidden pin marker', () => {
+		const ref = jest.fn();
+
+		render( <SectionHeader ref={ ref } title="Traffic" pinned /> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- The marker is measured, never seen, so it has no accessible query target.
+		const marker = ref.mock.calls[ 0 ][ 0 ].previousElementSibling;
+
+		expect( marker ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( marker ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders no pin marker unless pinned', () => {
+		const ref = jest.fn();
+
+		render( <SectionHeader ref={ ref } title="Traffic" /> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- Asserting the absence of a sibling.
+		expect( ref.mock.calls[ 0 ][ 0 ].previousElementSibling ).toBeNull();
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
@@ -15,6 +15,9 @@ $section-header-visual-gap: 20px;
 // fitting that much sooner.
 $section-header-visual-stacked-max-inline-size: $section-header-stacked-max-inline-size + $section-header-visual-size + $section-header-visual-gap;
 
+// The scroll distance the condense runs over once the header pins. Tunable.
+$section-header-condense-distance: 40px;
+
 // The controls drop below the title, reading from the same edge.
 @mixin section-header-stacked {
 
@@ -126,52 +129,6 @@ $section-header-visual-stacked-max-inline-size: $section-header-stacked-max-inli
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-/*
- * Condenses the header into a compact bar as it pins: the title drops a step
- * on the type scale.
- *
- * The surface, not this component, knows where the header pins, so it opts in
- * by publishing a `--section-header-pin` view timeline whose `exit` phase
- * opens at the pin point (see the dashboard's pin marker in
- * `routes/dashboard/stage.module.scss`). Progress-driven, so it follows the
- * scroll in both directions.
- *
- * The @supports gate is load-bearing: without scroll-driven animation
- * support, the `animation` shorthand would run as a 0s time animation and its
- * `both` fill would freeze the header in the condensed state. Inside the gate
- * an unresolved timeline (a surface that publishes no marker) leaves the
- * animation inert, which is the resting layout.
- */
-@supports (animation-timeline: --section-header-pin) {
-
-	.condensing {
-
-		// Buys no height: the row is floored by the date controls beside it.
-		// What changes is what the pinned band reads as.
-		.title {
-			animation: condense-title linear both;
-			animation-timeline: --section-header-pin;
-			animation-range: exit;
-		}
-	}
-
-	// Scroll-driven, but still chrome moving under the reader.
-	@media (prefers-reduced-motion: reduce) {
-
-		.condensing .title {
-			animation: none;
-		}
-	}
-}
-
-@keyframes condense-title {
-
-	to {
-		font-size: var(--wpds-typography-font-size-xl);
-		line-height: var(--wpds-typography-line-height-xl);
-	}
-}
-
 .controls {
 	grid-area: controls;
 	min-inline-size: 0;
@@ -190,6 +147,107 @@ $section-header-visual-stacked-max-inline-size: $section-header-stacked-max-inli
 	// Never wider than its column, whose 0 minimum keeps the squeeze unaffected.
 	:global(.date-filters-panel) {
 		max-inline-size: 100%;
+	}
+}
+
+.notice {
+	margin-block-start: var(--wpds-dimension-gap-md);
+
+	// The slot's occupant may have nothing to say and render nothing; the
+	// wrapper must not keep its margin then.
+	&:empty {
+		display: none;
+	}
+}
+
+/*
+ * Pinned: a sticky band that stops at the top of the surface's scroll
+ * container while the content scrolls under it. Opaque, in the page header's
+ * fill: the band is page chrome, not the content's canvas, and the hairline is
+ * the edge between the two. It spans the page gutter itself, so a surface pads
+ * the content below it rather than the container the band pins in.
+ */
+.pinned {
+	position: sticky;
+	inset-block-start: 0;
+	// Above the content's own layers, which the surface caps with `isolation`
+	// rather than z-index values this band does not own.
+	z-index: 1;
+	background: var(--wpds-color-background-surface-neutral-strong);
+	border-block-end:
+		var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+	padding-inline: var(--wpds-dimension-padding-2xl);
+	padding-block: var(--wpds-dimension-gap-lg);
+	margin-block-end: var(--wpds-dimension-gap-lg);
+}
+
+/*
+ * Publishes the `--section-header-pin` timeline the band condenses on. In flow
+ * right before the band and costing no height, its top edge sits where the
+ * band comes to rest, so the view timeline's `exit` phase opens as the band
+ * pins and runs the condense distance. The surface's `timeline-scope` on the
+ * parent is what lets the band, a sibling, see it.
+ */
+.pinMarker {
+	block-size: $section-header-condense-distance;
+	margin-block-end: -#{$section-header-condense-distance};
+	visibility: hidden;
+	pointer-events: none;
+	view-timeline-name: --section-header-pin;
+	view-timeline-axis: block;
+}
+
+/*
+ * Condenses the band as it pins: the padding tightens, since there are no tabs
+ * left to clear, and the title drops a step on the type scale. Progress-driven,
+ * so it follows the scroll in both directions.
+ *
+ * The @supports gate is load-bearing: without scroll-driven animation
+ * support, the `animation` shorthand would run as a 0s time animation and its
+ * `both` fill would freeze the band in the condensed state. Inside the gate
+ * an unresolved timeline (a surface that declares no scope) leaves the
+ * animation inert, which is the resting layout.
+ */
+@supports (animation-timeline: --section-header-pin) {
+
+	.pinned {
+		animation: condense-band linear both;
+		animation-timeline: --section-header-pin;
+		animation-range: exit;
+
+		// Buys no height: the row is floored by the date controls beside it.
+		// What changes is what the pinned band reads as.
+		.title {
+			animation: condense-title linear both;
+			animation-timeline: --section-header-pin;
+			animation-range: exit;
+		}
+	}
+
+	// Scroll-driven, but still chrome moving under the reader.
+	@media (prefers-reduced-motion: reduce) {
+
+		.pinned,
+		.pinned .title {
+			animation: none;
+		}
+	}
+}
+
+@keyframes condense-band {
+
+	to {
+		padding-block-start: var(--wpds-dimension-gap-sm);
+		padding-block-end: var(--wpds-dimension-gap-sm);
+	}
+}
+
+@keyframes condense-title {
+
+	to {
+		font-size: var(--wpds-typography-font-size-xl);
+		line-height: var(--wpds-typography-line-height-xl);
 	}
 }
 

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.tsx
@@ -1,6 +1,6 @@
 import { Stack, Text } from '@jetpack-premium-analytics/externals';
 import clsx from 'clsx';
-import { ReactNode, Ref } from 'react';
+import { forwardRef, ForwardedRef, ReactNode, Ref } from 'react';
 import styles from './section-header.module.scss';
 
 export type SectionHeaderProps = {
@@ -29,11 +29,20 @@ export type SectionHeaderProps = {
 	busy?: boolean;
 
 	/**
-	 * Condenses into a compact bar once it pins: the title drops a type-scale
-	 * step. Requires the surface to publish a `--section-header-pin` view
-	 * timeline; falls back to resting layout without it.
+	 * Pins the header at the top of the surface's scroll container and
+	 * condenses it once pinned: a sticky band in the page header's fill,
+	 * spanning the page gutter on its own. The surface declares
+	 * `timeline-scope: --section-header-pin` on the header's parent, which
+	 * must span the content that scrolls under the band.
 	 */
-	condenseOnScroll?: boolean;
+	pinned?: boolean;
+
+	/**
+	 * Rendered under the header row. Pinned, it stays inside the band, so its
+	 * actions remain reachable however far the reader has scrolled. May
+	 * render nothing.
+	 */
+	notice?: ReactNode;
 
 	/**
 	 * Date controls anchored to the end of the header row. Left out, the cell is
@@ -50,23 +59,31 @@ export type SectionHeaderProps = {
  * subtitle, and the date controls share one row. Below a container-query width
  * the controls take their own row and the title wraps.
  *
- * @param {SectionHeaderProps} props - The props for the SectionHeader component.
+ * The ref reaches the header's root: the row a date control measures the room
+ * it has against.
+ *
+ * @param {SectionHeaderProps}  props - The props for the SectionHeader component.
+ * @param {Ref<HTMLDivElement>} ref   - Forwarded to the header's root element.
  * @return The section header element.
  */
-export function SectionHeader( {
-	title,
-	headingLevel = 2,
-	visual,
-	subTitle,
-	busy = false,
-	condenseOnScroll = false,
-	children,
-	controlsRef,
-}: SectionHeaderProps ) {
+function UnforwardedSectionHeader(
+	{
+		title,
+		headingLevel = 2,
+		visual,
+		subTitle,
+		busy = false,
+		pinned = false,
+		notice,
+		children,
+		controlsRef,
+	}: SectionHeaderProps,
+	ref: ForwardedRef< HTMLDivElement >
+) {
 	const HeadingTag = `h${ headingLevel }` as const;
 
-	return (
-		<div className={ clsx( styles.container, condenseOnScroll && styles.condensing ) }>
+	const header = (
+		<div ref={ ref } className={ clsx( styles.container, pinned && styles.pinned ) }>
 			<div className={ clsx( styles.layout, visual && styles.withVisual ) }>
 				{ visual ? (
 					<div className={ styles.visual } aria-hidden="true">
@@ -100,6 +117,23 @@ export function SectionHeader( {
 					</Stack>
 				) : null }
 			</div>
+
+			{ notice ? <div className={ styles.notice }>{ notice }</div> : null }
 		</div>
 	);
+
+	if ( ! pinned ) {
+		return header;
+	}
+
+	return (
+		<>
+			{ /* Marks where the header comes to rest, so the condense starts
+			     there. Measured, never seen. */ }
+			<div className={ styles.pinMarker } aria-hidden="true" />
+			{ header }
+		</>
+	);
 }
+
+export const SectionHeader = forwardRef( UnforwardedSectionHeader );

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/stories/section-header.stories.tsx
@@ -187,26 +187,25 @@ function YearDateControls( { containerElement }: { containerElement: HTMLElement
 
 type SectionHeaderStoryProps = {
 	title: ReactNode;
-	condenseOnScroll?: boolean;
+	pinned?: boolean;
 };
 
-function RollingSectionHeaderStory( { title, condenseOnScroll }: SectionHeaderStoryProps ) {
+function RollingSectionHeaderStory( { title, pinned }: SectionHeaderStoryProps ) {
 	return (
-		<SectionHeader title={ title } condenseOnScroll={ condenseOnScroll }>
+		<SectionHeader title={ title } pinned={ pinned }>
 			<RollingDateControls />
 		</SectionHeader>
 	);
 }
 
+// The year surface measures the header row it sits in, which the ref hands it.
 function YearSectionHeaderStory( { title }: SectionHeaderStoryProps ) {
-	const [ container, setContainer ] = useState< HTMLDivElement | null >( null );
+	const [ header, setHeader ] = useState< HTMLDivElement | null >( null );
 
 	return (
-		<div ref={ setContainer }>
-			<SectionHeader title={ title }>
-				<YearDateControls containerElement={ container } />
-			</SectionHeader>
-		</div>
+		<SectionHeader ref={ setHeader } title={ title }>
+			<YearDateControls containerElement={ header } />
+		</SectionHeader>
 	);
 }
 
@@ -270,51 +269,28 @@ export const Stacked: Story = {
 	),
 };
 
-/*
- * Story-only stand-in for what a surface provides around a pinned header: a
- * strip to scroll past and the pin marker publishing the view timeline. The
- * dashboard does this in `routes/dashboard/stage.module.scss`.
- */
-const PIN_TIMELINE = '--section-header-pin';
-const PIN_MARKER_STYLE = {
-	position: 'absolute',
-	insetBlockStart: 0,
-	inlineSize: 1,
-	blockSize: 40,
-	visibility: 'hidden',
-	pointerEvents: 'none',
-	viewTimelineName: PIN_TIMELINE,
-	viewTimelineAxis: 'block',
-} as const;
-
 /**
- * `condenseOnScroll` on a pinned header: scroll the box below, and once the
- * header clears the strip above it and pins, the title drops a type-scale step
- * over the next 40px. Nothing condenses while the header is still on its way
- * up, and the effect reverses as you scroll back up. Browsers without
- * scroll-driven animations, surfaces that publish no pin marker, and readers
- * who asked for reduced motion all keep the resting title.
+ * `pinned`: scroll the box below. The header clears the strip above it, pins at
+ * the top, and condenses over the next 40px: the band's padding tightens and
+ * the title drops a type-scale step. The effect follows the scroll in both
+ * directions. Browsers without scroll-driven animations and readers who asked
+ * for reduced motion keep the resting band; the pin itself needs neither.
+ *
+ * The scroll box stands in for the surface: it declares the timeline scope the
+ * band condenses on, and pads the content rather than itself, since the band
+ * spans the page gutter on its own.
  */
-export const CondensingOnScroll: Story = {
+export const Pinned: Story = {
 	args: {
 		title: 'Site traffic',
 	},
 	render: ( { title } ) => (
-		<div style={ { blockSize: 320, overflowY: 'auto' } }>
-			<div style={ { blockSize: 48 } }>Something to scroll past, as the section tabs are.</div>
-			<div style={ { position: 'relative', timelineScope: PIN_TIMELINE } }>
-				<div style={ PIN_MARKER_STYLE } aria-hidden="true" />
-				<div
-					style={ {
-						position: 'sticky',
-						insetBlockStart: 0,
-						background: 'var(--wpds-color-background-surface-neutral-strong)',
-					} }
-				>
-					<RollingSectionHeaderStory title={ title } condenseOnScroll />
-				</div>
-				<div style={ { blockSize: 900 } } />
+		<div style={ { blockSize: 320, overflowY: 'auto', timelineScope: '--section-header-pin' } }>
+			<div style={ { blockSize: 48, paddingInline: 24 } }>
+				Something to scroll past, as the section tabs are.
 			</div>
+			<RollingSectionHeaderStory title={ title } pinned />
+			<div style={ { blockSize: 900, paddingInline: 24 } }>Content scrolling under the band.</div>
 		</div>
 	),
 };

--- a/projects/packages/premium-analytics/packages/ui/src/section-tabs/section-tabs.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-tabs/section-tabs.module.scss
@@ -1,8 +1,12 @@
 .tabList {
+	// The page gutter, and the page header's fill: the tab bar and the section
+	// header under it are page chrome, so the block above the content reads as
+	// one plane. The header below owns the spacing between the two.
+	padding-inline: var(--wpds-dimension-padding-2xl);
+	background: var(--wpds-color-background-surface-neutral-strong);
 	border-block-end:
 		var(--wpds-border-width-xs) solid
 		var(--wpds-color-stroke-surface-neutral-weak);
-	margin-block-end: var(--wpds-dimension-gap-lg);
 }
 
 /*

--- a/projects/packages/premium-analytics/packages/ui/src/section-tabs/section-tabs.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/section-tabs/section-tabs.tsx
@@ -22,9 +22,8 @@ export interface SectionTabsProps< TabId extends string = string > {
 	children?: ReactNode;
 
 	/**
-	 * Optional class applied to the tab list wrapper. This component does not
-	 * own any horizontal page-gutter padding itself, so callers that render the
-	 * tab bar full-bleed (e.g. outside a padded content container) supply it here.
+	 * Optional class applied to the tab list wrapper, which already carries the
+	 * page gutter and the page header's fill.
 	 */
 	className?: string;
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/README.md
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/README.md
@@ -35,8 +35,8 @@ const label = __( 'All pages' );
 
 - **`ReportPageShell`** — the outer `Page` shell: the shared Jetpack visual,
   Stats breadcrumbs and page-level actions.
-- **`ReportPageLayout`** — the report content scaffold: optional internal tabs,
-  the section header, and stacked sections.
+- **`ReportPageLayout`** — the scroll area below the page header: optional
+  internal tabs, the section header pinned at its top, and stacked sections.
   `ReportPageSection` is the bordered card each section renders in.
 
 - **`ReportPerformanceChart`** — the multi-metric visits chart
@@ -82,8 +82,9 @@ set. `title` is the third: `getTabTitle( activeTab )` on a tabbed report, which
 falls back to the tab's label, and the report's `getTitle()` otherwise.
 
 Omit `dateFilters` on a report with no date window; the header is then the title
-alone. It does not pin, unlike the dashboard's — that lives in the surface's own
-CSS (`routes/dashboard/stage.module.scss`).
+alone. It pins at the top of the layout's scroll area and condenses on scroll,
+as the dashboard's does: the layout only declares the timeline scope the
+header's own pin marker publishes into.
 
 Pass `StatsBreadcrumbs` from `@jetpack-premium-analytics/ui` to the shell's
 `breadcrumbs` slot. It owns the leading `Stats` crumb and links it back to the

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.module.scss
@@ -1,13 +1,25 @@
+// The scroll container below the page header, so the tabs scroll away with
+// the content while the section header pins at its top. The scope is what
+// lets the header's pin marker reach the header beside it.
 .root {
-	display: flex;
-	flex-direction: column;
-	gap: var(--wpds-dimension-gap-lg);
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+	timeline-scope: --section-header-pin;
 }
 
 .sections {
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-gap-lg);
+	// The page gutter the tab bar and the pinned header carry themselves.
+	padding-inline: var(--wpds-dimension-padding-2xl);
+	padding-block-end: var(--wpds-dimension-padding-2xl);
+
+	// Caps every layer the tables raise (sticky columns, toolbars) under the
+	// pinned header, which then only has to outrank this box rather than
+	// z-index values it does not own.
+	isolation: isolate;
 }
 
 .section {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
@@ -11,7 +11,7 @@ import type { ReportDateFilters } from '@jetpack-premium-analytics/routing';
 import type { ReactNode } from 'react';
 
 export interface ReportPageLayoutProps {
-	/** Heading for the section on screen: `Posts & pages report`. */
+	/** Heading for the section on screen: `Posts & Pages report`. */
 	title: string;
 	/** Date-filter controller, from `useReportDateFilters`. Omit on a report with no date window. */
 	dateFilters?: ReportDateFilters;
@@ -22,7 +22,8 @@ export interface ReportPageLayoutProps {
 }
 
 /**
- * Second-level report page scaffold: tabs, section header, and stacked
+ * Second-level report page scaffold: the scroll area below the page header,
+ * holding the tabs, the section header pinned at its top, and the stacked
  * sections. The header shows only the range — interval/comparison controls
  * are hidden, not cleared, so they survive on the URL.
  *
@@ -33,7 +34,7 @@ export function ReportPageLayout( { title, dateFilters, tabs, children }: Report
 	return (
 		<div className={ styles.root }>
 			{ tabs }
-			<SectionHeader title={ title }>
+			<SectionHeader title={ title } pinned>
 				{ dateFilters ? <DateFiltersPanel { ...dateFilters } /> : null }
 			</SectionHeader>
 			<div className={ styles.sections }>{ children }</div>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-shell.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-shell.module.scss
@@ -1,22 +1,3 @@
 .page {
 	min-block-size: 0;
 }
-
-.content {
-	flex: 1 1 auto;
-	min-block-size: 0;
-	overflow-y: auto;
-
-	/*
-	 * Mirror the top padding of Page's own `hasPadding` content so the filters
-	 * row doesn't hug the header border — tabbed reports skip this because the
-	 * tab strip is designed to sit flush under the header.
-	 */
-	padding-block-start: var(--wpds-dimension-padding-lg);
-	padding-block-end: var(--wpds-dimension-padding-2xl);
-	padding-inline: var(--wpds-dimension-padding-2xl);
-}
-
-.contentFlush {
-	padding-block-start: 0;
-}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-shell.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-shell.tsx
@@ -3,32 +3,25 @@
  */
 import { Page } from '@wordpress/admin-ui';
 import clsx from 'clsx';
-import styles from './report-page-shell.module.scss';
-import type { ComponentProps } from 'react';
 /**
  * Internal dependencies
  */
+import styles from './report-page-shell.module.scss';
+import type { ComponentProps } from 'react';
 
-export type ReportPageShellProps = ComponentProps< typeof Page > & {
-	tabbed?: boolean;
-};
+export type ReportPageShellProps = ComponentProps< typeof Page >;
 
 /**
- * The shared outer shell for report pages, including the scrollable content
- * area and its alignment with the WordPress admin page header.
+ * The shared outer shell for report pages: the admin page header over a body
+ * its own child scrolls, rather than the page.
  *
  * @param {ReportPageShellProps} props - The component props.
  * @return The report page shell.
  */
-export function ReportPageShell( {
-	tabbed,
-	className,
-	children,
-	...pageProps
-}: ReportPageShellProps ) {
+export function ReportPageShell( { className, children, ...pageProps }: ReportPageShellProps ) {
 	return (
 		<Page { ...pageProps } className={ clsx( styles.page, className ) }>
-			<div className={ clsx( styles.content, tabbed && styles.contentFlush ) }>{ children }</div>
+			{ children }
 		</Page>
 	);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -17,23 +17,8 @@
 	// `@wordpress/admin-ui`; WOOA7S-1931).
 	overflow-y: auto;
 
-	// Own stacking context, so in-panel layers (the sticky section header,
+	// Own stacking context, so in-panel layers (the pinned section header,
 	// widget focus rings) never compete with the page header above.
 	position: relative;
 	z-index: 0;
-}
-
-// Scoped under the root to outweigh the shared tab bar's own single-class rule
-// rather than depend on which of the two stylesheets the bundle emits last.
-.root .tabList {
-	padding-inline: var(--wpds-dimension-padding-2xl);
-	z-index: 0;
-
-	// The page header's fill: the tabs and the section header below are page
-	// chrome, so the whole block above the grid reads as one plane and the
-	// canvas begins where the widgets do.
-	background: var(--wpds-color-background-surface-neutral-strong);
-
-	// The gap under the tabs moves into the section header's fill.
-	margin-block-end: 0;
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -50,7 +50,6 @@ export function DashboardSections( {
 			value={ value }
 			onChange={ onChange }
 			rootClassName={ styles.root }
-			className={ styles.tabList }
 		>
 			{ children }
 		</SectionTabs>

--- a/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.test.tsx
@@ -60,7 +60,7 @@ function renderDashboard( queryFn: () => Promise< unknown > ) {
 	render(
 		<AnalyticsQueryClientProvider>
 			<Widget queryFn={ queryFn } />
-			<RefreshFailureNotice className="refresh-failure" />
+			<RefreshFailureNotice />
 		</AnalyticsQueryClientProvider>
 	);
 }
@@ -135,7 +135,7 @@ describe( 'RefreshFailureNotice', () => {
 			<AnalyticsQueryClientProvider>
 				{ /* No `meta`: a thumbnail or a settings read, not a figure on screen. */ }
 				<UnscopedWidget queryFn={ queryFn } />
-				<RefreshFailureNotice className="refresh-failure" />
+				<RefreshFailureNotice />
 			</AnalyticsQueryClientProvider>
 		);
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/refresh-failure-notice/refresh-failure-notice.tsx
@@ -1,18 +1,12 @@
 import { AnalyticsQueryClientProvider, useRefreshFailure } from '@jetpack-premium-analytics/data';
 import { StaleDataNotice } from '@jetpack-premium-analytics/ui';
 
-type RefreshFailureNoticeProps = {
-	className?: string;
-};
-
 /**
  * Reads the shared query cache and renders the notice while a refresh is failing.
  *
- * @param {RefreshFailureNoticeProps} props           - Component props.
- * @param {string}                    props.className - Optional class for layout tweaks.
  * @return The notice, or `null`.
  */
-function ConnectedNotice( { className }: RefreshFailureNoticeProps ) {
+function ConnectedNotice() {
 	const failure = useRefreshFailure();
 
 	if ( ! failure.hasStaleData ) {
@@ -21,7 +15,6 @@ function ConnectedNotice( { className }: RefreshFailureNoticeProps ) {
 
 	return (
 		<StaleDataNotice
-			className={ className }
 			updatedAt={ failure.dataUpdatedAt }
 			onRetry={ failure.canRetry ? failure.retry : undefined }
 			isRetrying={ failure.isRetrying }
@@ -35,14 +28,12 @@ function ConnectedNotice( { className }: RefreshFailureNoticeProps ) {
  * Brings its own provider around the shared client, the way `WidgetRoot` does
  * for each widget — the dashboard stage itself sits above them all and has none.
  *
- * @param {RefreshFailureNoticeProps} props           - Component props.
- * @param {string}                    props.className - Optional class for layout tweaks.
  * @return The notice, or `null`.
  */
-export function RefreshFailureNotice( { className }: RefreshFailureNoticeProps ) {
+export function RefreshFailureNotice() {
 	return (
 		<AnalyticsQueryClientProvider>
-			<ConnectedNotice className={ className } />
+			<ConnectedNotice />
 		</AnalyticsQueryClientProvider>
 	);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -56,22 +56,17 @@
 	// never rendered.
 	flex: 1 1 auto;
 
-	// Containing block for the pin marker below, and the scope that lets the
-	// marker's timeline reach the header beside it: a named timeline is
-	// otherwise invisible to anything but its own descendants.
-	position: relative;
+	// Lets the pinned header's timeline, published by the marker beside it,
+	// reach the header: a named timeline is otherwise invisible to anything
+	// but its own descendants.
 	timeline-scope: --section-header-pin;
+}
 
+.body {
 	padding-block-end: var(--wpds-dimension-padding-3xl);
 	// Match the horizontal padding of the page header and the section tabs so the
 	// widget grid lines up with them instead of sitting flush to the edge.
 	padding-inline: var(--wpds-dimension-padding-2xl);
-}
-
-.refreshFailure {
-	// Sits below the header row inside the pinned band; the band's own bottom
-	// padding keeps it clear of the widgets.
-	margin-block-start: var(--wpds-dimension-gap-md);
 }
 
 .widgets {
@@ -88,83 +83,5 @@
 	section:first-of-type {
 		display: flex;
 		flex-direction: column;
-	}
-}
-
-/*
- * Publishes the `--section-header-pin` timeline the header condenses against:
- * only the route knows where the header pins, since what it clears is the
- * route's own tab list. The marker's top edge sits exactly where the header
- * comes to rest, so its view timeline's `exit` phase opens as the header
- * sticks, and its height is how far the condense runs. Measured, never
- * painted.
- */
-.pinMarker {
-	position: absolute;
-	inset-block-start: 0;
-	inline-size: 1px;
-	block-size: 40px;
-	visibility: hidden;
-	pointer-events: none;
-	view-timeline-name: --section-header-pin;
-	view-timeline-axis: block;
-}
-
-.sectionHeader {
-	// Pins at 0 rather than under the page header's height: the scroll
-	// container is the sections root, which begins where the page header ends.
-	position: sticky;
-	inset-block-start: 0;
-	z-index: 1;
-
-	/*
-	 * A stuck header must be opaque, and it takes the page header's fill: this
-	 * band is page chrome, not the widgets' canvas, and the hairline is the
-	 * edge between the two. The negative margin spans it across the panel's
-	 * gutter to cover content passing under it; the matching padding keeps the
-	 * header row in place and the container query's measured width unchanged.
-	 */
-	margin-inline: calc(-1 * var(--wpds-dimension-padding-2xl));
-	padding-inline: var(--wpds-dimension-padding-2xl);
-	background: var(--wpds-color-background-surface-neutral-strong);
-	border-block-end:
-		var(--wpds-border-width-xs) solid
-		var(--wpds-color-stroke-surface-neutral-weak);
-
-	// The gap above was the tab bar's bottom margin, moved inside the fill so
-	// the fill starts at the tabs' hairline.
-	padding-block-start: var(--wpds-dimension-gap-lg);
-	padding-block-end: var(--wpds-dimension-gap-lg);
-
-	margin-block-end: var(--wpds-dimension-gap-lg);
-}
-
-// Same gate as the component's condense (see `section-header.module.scss`):
-// without timeline support the 0s fallback animation would freeze the
-// padding in its pinned state.
-@supports (animation-timeline: --section-header-pin) {
-
-	.sectionHeader {
-		// Tightens the padding on the timeline the header condenses on: once
-		// pinned there are no tabs left to clear, and the band should cost the
-		// widgets as little height as it can.
-		animation: condense-section-header linear both;
-		animation-timeline: --section-header-pin;
-		animation-range: exit;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-
-		.sectionHeader {
-			animation: none;
-		}
-	}
-}
-
-@keyframes condense-section-header {
-
-	to {
-		padding-block-start: var(--wpds-dimension-gap-sm);
-		padding-block-end: var(--wpds-dimension-gap-sm);
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -16,7 +16,7 @@ import {
 } from './hooks';
 import { stage as Dashboard } from './stage';
 import type { SyncStatus } from '@jetpack-premium-analytics/site-sync';
-import type { ReactNode } from 'react';
+import type { ForwardedRef, ReactNode } from 'react';
 
 // Read inside the mocked functions, never at factory time — the factories run
 // while `./stage` is still importing, so these are in the temporal dead zone.
@@ -86,7 +86,22 @@ jest.mock( '@jetpack-premium-analytics/ui', () => ( {
 	),
 	OnboardingWelcomeModal: ( { open }: { open: boolean } ) =>
 		open ? <div data-testid="onboarding-welcome-modal" /> : null,
-	SectionHeader: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
+	// Forwards the ref and renders the notice slot after the row, since the
+	// stage relies on both: the ref feeds the year surface's measurement, and
+	// the notice's position in the band is asserted below.
+	SectionHeader: jest
+		.requireActual< typeof import('react') >( 'react' )
+		.forwardRef(
+			(
+				{ children, notice }: { children: ReactNode; notice?: ReactNode },
+				ref: ForwardedRef< HTMLDivElement >
+			) => (
+				<div ref={ ref }>
+					<div>{ children }</div>
+					{ notice }
+				</div>
+			)
+		),
 	SectionTabPanel: ( { value, children }: { value: string; children: ReactNode } ) =>
 		( mockMountedSectionSlugs ?? [ mockActiveSectionSlug ] ).includes( value ) ? (
 			<div>{ children }</div>
@@ -212,9 +227,7 @@ jest.mock( './components', () => ( {
 	onboardingTourSteps: () => [],
 	// A marker, not the real notice, which reads a query cache these tests do not
 	// stand up. Covered here: where the stage puts it.
-	RefreshFailureNotice: ( { className }: { className?: string } ) => (
-		<div data-testid="refresh-failure-notice" className={ className } />
-	),
+	RefreshFailureNotice: () => <div data-testid="refresh-failure-notice" />,
 	SectionSyncNotice: ( {
 		percentage,
 		hasError,

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -297,25 +297,18 @@ function Dashboard(): JSX.Element {
 										value={ section.slug }
 										className={ styles.content }
 									>
-										{ /* Marks where the header below comes to rest, so it starts
-								     condensing there. Measured, never seen. */ }
-										<div className={ styles.pinMarker } aria-hidden="true" />
-
-										<div ref={ setHeaderRef } className={ styles.sectionHeader }>
-											<SectionHeader
-												title={ resolveSectionHeading( section ) }
-												condenseOnScroll
-												controlsRef={ setControlsAnchor }
-											>
-												{ dateControls }
-											</SectionHeader>
-											{ /* Inside the pinned band, so its Retry stays reachable however
-										     far the reader has scrolled. */ }
-											<RefreshFailureNotice className={ styles.refreshFailure } />
-										</div>
+										<SectionHeader
+											ref={ setHeaderRef }
+											title={ resolveSectionHeading( section ) }
+											pinned
+											notice={ <RefreshFailureNotice /> }
+											controlsRef={ setControlsAnchor }
+										>
+											{ dateControls }
+										</SectionHeader>
 
 										{ activeSection === section.slug ? (
-											<>
+											<div className={ styles.body }>
 												{ isSectionAwaitingSync( section, isSyncFinished ) && ! isSyncComplete ? (
 													<SectionSyncNotice
 														percentage={ syncStatus?.percentage ?? 0 }
@@ -329,7 +322,7 @@ function Dashboard(): JSX.Element {
 												<div ref={ setWidgetsFrame }>
 													<WidgetDashboard.Widgets className={ styles.widgets } />
 												</div>
-											</>
+											</div>
 										) : null }
 									</SectionTabPanel>
 								) ) }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
@@ -8,14 +8,3 @@
 	flex: 1 1 auto;
 	min-block-size: 0;
 }
-
-.tabList {
-	padding-inline: var(--wpds-dimension-padding-2xl);
-
-	// The header below owns the gap to the tab bar, so the tablist's default
-	// bottom margin would stack on top of it. Doubled selector: SectionTabs'
-	// own rule hits this element at equal specificity, so order would decide.
-	&.tabList {
-		margin-block-end: 0;
-	}
-}

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.tsx
@@ -46,7 +46,6 @@ export function PostDetailTabs( { tabs, value, onChange, children }: PostDetailT
 			value={ value }
 			onChange={ onChange }
 			rootClassName={ styles.root }
-			className={ styles.tabList }
 		>
 			{ children }
 		</DetailPageTabs>

--- a/projects/packages/premium-analytics/routes/reports/comments/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/page.tsx
@@ -88,7 +88,6 @@ function CommentsReport(): JSX.Element {
 
 	return (
 		<ReportPageShell
-			tabbed
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/locations/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.tsx
@@ -147,7 +147,6 @@ export default function LocationsReportPage(): JSX.Element {
 
 	return (
 		<ReportPageShell
-			tabbed
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/posts/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.tsx
@@ -185,7 +185,6 @@ function PostsReport(): JSX.Element {
 
 	return (
 		<ReportPageShell
-			tabbed
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			actions={

--- a/projects/packages/premium-analytics/routes/reports/utm/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.tsx
@@ -111,7 +111,6 @@ function UtmReport(): JSX.Element {
 
 	return (
 		<ReportPageShell
-			tabbed
 			visual={ <StatsPageIcon /> }
 			breadcrumbs={ <StatsBreadcrumbs items={ [ { label: getLabel() } ] } /> }
 			actions={

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -139,16 +139,18 @@ function DashboardSectionsGridStory() {
 				{ sections.map( section => (
 					<Tabs.Panel key={ section.slug } value={ section.slug } className={ styles.content }>
 						{ activeSection === section.slug ? (
-							<WidgetDashboard
-								widgetTypes={ widgetTypes }
-								layout={ layout }
-								onLayoutChange={ setLayout }
-								resolveWidgetModule={ resolveWidgetModule }
-								editMode
-							>
-								<WidgetDashboard.NoWidgetsState />
-								<WidgetDashboard.Widgets className={ styles.widgets } />
-							</WidgetDashboard>
+							<div className={ styles.body }>
+								<WidgetDashboard
+									widgetTypes={ widgetTypes }
+									layout={ layout }
+									onLayoutChange={ setLayout }
+									resolveWidgetModule={ resolveWidgetModule }
+									editMode
+								>
+									<WidgetDashboard.NoWidgetsState />
+									<WidgetDashboard.Widgets className={ styles.widgets } />
+								</WidgetDashboard>
+							</div>
 						) : null }
 					</Tabs.Panel>
 				) ) }


### PR DESCRIPTION
Fixes #

## Proposed changes

The dashboard pinned its section header and condensed it on scroll; the report pages did not.

A first attempt to pin them was dropped from #51309 because it copied the dashboard's 67 lines almost verbatim. 

This moves the pin into `SectionHeader` and has both surfaces consume it.

### The pin lives in the component

`pinned` replaces `condenseOnScroll`. The component renders its pin marker in normal flow right before the header, and the header itself as the sticky band: the page header's fill and hairline, the page gutter, and the condense of the band's padding and the title once pinned, behind the same `@supports` and reduced-motion gates as before.

The marker costs no height, so the header no longer has to be the first child of the scroll container.

What a surface still owns is one declaration: `timeline-scope: --section-header-pin` on the header's parent, which spans the content scrolling under the band. The band pads the page gutter itself, so a surface pads the content below it rather than the scroll container, and no negative margins are needed anywhere.

Two things the dashboard's band carried come along as API.

A `notice` slot keeps the refresh-failure notice inside the band, reachable no matter how far the reader has scrolled. A forwarded ref reaches the band, which is the row the year surface measures itself against through `DateYearFilter`'s `containerElement`.

### The tab bar carries the page chrome

`SectionTabs` now pads the page gutter and takes the page header's fill by default, and no longer adds a bottom margin: the band below owns that spacing. The dashboard and post-detail overrides that restated the same rules go away.

### Report pages

`ReportPageLayout` becomes the scroll area below the page header: the tabs, the pinned header, then the sections, which cap their tables' layers with `isolation: isolate` so nothing paints over the band. `ReportPageShell` loses its `tabbed` prop and its inner scroll box; it is now `Page` plus `min-block-size: 0`, identical to `DetailPageShell`.

Visible on the report pages: the tab strip runs full-bleed in the page header's fill, one `gap-lg` separates it from the header where there were two, and the header pins and condenses as the dashboard's does. On the post detail page the tab strip takes the page header's fill instead of the canvas; its header still scrolls away, which is WOOA7S-2112.

The dashboard's `stage.module.scss` shrinks from 117 lines to 87, and the `Pinned` story replaces the hand-rolled `CondensingOnScroll` marker.

## Screenshots

**Report page, pinned and condensed**

<img width="971" height="554" alt="image" src="https://github.com/user-attachments/assets/ab9befda-d3de-4e75-9232-5e89302d4fe4" />

**Dashboard, unchanged**

<img width="1253" height="1000" alt="image" src="https://github.com/user-attachments/assets/8a7e7efd-a564-4cef-b1c1-b8069d89308c" />


**Walkthrough**

https://github.com/user-attachments/assets/b309c03a-1f8c-4696-becd-c5c4c53c8404


## Related product discussion/links

* Fixes [WOOA7S-1955](https://linear.app/a8c/issue/WOOA7S-1955/consolidate-the-section-header-across-every-analytics-page), under [WOOA7S-1793](https://linear.app/a8c/issue/WOOA7S-1793/implement-consistent-title-and-date-selection-component).
* Filed rather than done here: [WOOA7S-2112](https://linear.app/a8c/issue/WOOA7S-2112/detail-pages-pin-the-section-header), the same pin on the post and video detail pages, which need a condensed form for their visual first.
* [WOOA7S-1957](https://linear.app/a8c/issue/WOOA7S-1957/report-pages-drop-reportpageshell-and-render-page-directly) gets easier: the two shells are now the same component.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

```
jetpack build --deps packages/premium-analytics
```

* Open Stats v2 → All pages (tabbed) and Referrers (no tabs). Scroll down: the tab strip scrolls away, the header pins right under the page header and condenses over the first 40px, its padding tightening and the title dropping one type-scale step. Scrolling back up reverses it.
* With reduced motion on, the header still pins but keeps its resting size.
* Pinned, open the date picker: the popover sits above the band. Scroll the records table under the band, sorting a column on the way: nothing paints over the band.
* Narrow the window below ~720px: the controls stack under the title, inside the band, reading from the start edge.
* Dashboard, Traffic: the pin and condense are unchanged. Force a failed refresh (throttle the network offline and change the range): the notice sits inside the band and stays there while scrolled. Insights: the year pills still collapse into a select when the header row runs short.
* Post detail: only the tab strip's fill changes; the header still scrolls away.
* Storybook: `Packages/Premium Analytics/UI/SectionHeader` → `Pinned`, and `Widgets Toolkit/Components/ReportPage`.
* `pnpm run test section-header section-tabs report-page-layout routes/dashboard/stage` in `projects/packages/premium-analytics`.
