### PR TITLE
Likes: re-check widget visibility on layout changes, not just scroll

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-queue-late-reflow
+++ b/projects/plugins/jetpack/changelog/fix-likes-queue-late-reflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: Load like buttons that a late page reflow brings into view, instead of waiting for the reader to scroll.

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -347,6 +347,8 @@ function JetpackLikesWidgetQueueHandler() {
 	// Restore widgets to initial unloaded state when they are scrolled out of view.
 	jetpackUnloadScrolledOutWidgets();
 
+	jetpackObserveUnloadedWidgets();
+
 	var unloadedWidgetsInView = jetpackGetUnloadedWidgetsInView();
 
 	if ( unloadedWidgetsInView.length > 0 ) {
@@ -470,6 +472,28 @@ var jetpackWidgetsDelayedExec = function ( after, fn ) {
 };
 
 var jetpackOnScrollStopped = jetpackWidgetsDelayedExec( 250, JetpackLikesWidgetQueueHandler );
+
+// Scrolling is not the only thing that brings a widget into range. A stylesheet that lands late
+// reflows the page without firing a scroll event, and the queue would never look at that widget
+// again, leaving it on "Loading…" until the reader happens to scroll.
+var jetpackLikesWidgetObserver =
+	typeof IntersectionObserver === 'function'
+		? new IntersectionObserver( jetpackOnScrollStopped, {
+				rootMargin: `${ jetpackLikesLookAhead }px`,
+		  } )
+		: null;
+
+// Observing an element twice is a no-op, so every queue pass can call this to pick up widgets
+// added after load.
+function jetpackObserveUnloadedWidgets() {
+	if ( ! jetpackLikesWidgetObserver ) {
+		return;
+	}
+
+	document
+		.querySelectorAll( 'div.jetpack-likes-widget-unloaded' )
+		.forEach( widget => jetpackLikesWidgetObserver.observe( widget ) );
+}
 
 // Load initial batch of widgets, prior to any scrolling events.
 JetpackLikesWidgetQueueHandler();

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -480,6 +480,9 @@ var jetpackLikesWidgetObserver =
 	typeof IntersectionObserver === 'function'
 		? new IntersectionObserver( jetpackOnScrollStopped, {
 				rootMargin: `${ jetpackLikesLookAhead }px`,
+				// jetpackIsScrolledIntoView() wants the widget fully inside the band, so ask to be
+				// told when it gets there - crossing into partial overlap alone would not load it.
+				threshold: [ 0, 1 ],
 		  } )
 		: null;
 

--- a/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
+++ b/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
@@ -8,6 +8,10 @@ describe( 'Likes queue handler master iframe handshake', () => {
 	// the module cache but leaves these attached, so we track and detach them between tests to stop
 	// a stale masterReady handler from firing against the current test's DOM.
 	let trackedWindowListeners;
+	// The callback and observed elements of the IntersectionObserver the queue handler builds.
+	// jsdom has no IntersectionObserver, so tests that want one install the fake below.
+	let observerCallback;
+	let observedElements;
 
 	// Collect only the `queryMasterReady` pings the queue handler posts to the master iframe.
 	const queryReadyPings = () =>
@@ -71,6 +75,22 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		widget.appendChild( placeholder );
 
 		document.body.appendChild( widget );
+
+		return widget;
+	};
+
+	const installIntersectionObserver = () => {
+		window.IntersectionObserver = function ( callback ) {
+			observerCallback = callback;
+			this.observe = element => observedElements.push( element );
+			this.unobserve = () => {};
+			this.disconnect = () => {};
+		};
+	};
+
+	// jsdom gives every element a zero rect, which counts as in view. Place a widget explicitly.
+	const placeWidgetAt = ( widget, top ) => {
+		widget.getBoundingClientRect = () => ( { top, bottom: top + 55 } );
 	};
 
 	beforeEach( () => {
@@ -78,6 +98,8 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		jest.resetModules();
 
 		document.body.innerHTML = '';
+		observerCallback = undefined;
+		observedElements = [];
 
 		// Record every window listener the queue handler adds so afterEach can detach them.
 		trackedWindowListeners = [];
@@ -104,6 +126,7 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		trackedWindowListeners.forEach( ( { type, listener, options } ) =>
 			window.removeEventListener( type, listener, options )
 		);
+		delete window.IntersectionObserver;
 		jest.restoreAllMocks();
 	} );
 
@@ -146,5 +169,28 @@ describe( 'Likes queue handler master iframe handshake', () => {
 
 		// Recovery worked: the queue picked up the waiting widget and requested its data.
 		expect( initialBatches().length ).toBeGreaterThanOrEqual( 1 );
+	} );
+
+	it( 'loads a widget a late reflow brings into range, with no scroll event', async () => {
+		installIntersectionObserver();
+		const widget = addUnloadedPostWidget();
+		// At first paint the widget sits far below the fold, so the queue skips it.
+		placeWidgetAt( widget, 5000 );
+		answerPingsWithMasterReady();
+
+		require( '../queuehandler' );
+		await Promise.resolve();
+		jest.advanceTimersByTime( 500 );
+
+		expect( initialBatches() ).toHaveLength( 0 );
+		expect( observedElements ).toContain( widget );
+
+		// A stylesheet lands and the page reflows: no scroll event, but the widget is now in range.
+		placeWidgetAt( widget, 100 );
+		observerCallback();
+		jest.advanceTimersByTime( 250 );
+
+		expect( initialBatches().length ).toBeGreaterThanOrEqual( 1 );
+		expect( widget.querySelector( 'iframe.post-likes-widget' ) ).not.toBeNull();
 	} );
 } );


### PR DESCRIPTION
Related to BOOST-549

## Proposed changes

`JetpackLikesWidgetQueueHandler()` runs once when the master iframe reports ready, and after that only from the `scroll` listener. Its gate, `jetpackIsScrolledIntoView()`, requires a widget to sit entirely within the viewport plus a 2000px look-ahead. A widget outside that band at the single moment `masterReady` arrives is skipped — and nothing re-evaluates it until the reader scrolls.

A stylesheet that lands late reflows the page without firing a scroll event, so a widget that moves into range that way stays on "Loading…" indefinitely. Deferred and asynchronously loaded CSS makes that reflow routine — Jetpack Boost's Critical CSS swaps every stylesheet from `media="not all"` to its real media on load, which is exactly this shape. The same gap covers `resize` (an orientation change, or a mobile address bar collapsing) and widgets inserted after load by infinite scroll when no further scrolling follows.

This observes the unloaded widget wrappers with an `IntersectionObserver`, using the existing look-ahead distance as `rootMargin`, and lets it drive the queue pass that already exists. One mechanism then covers scrolling, resizing, late reflows and late-inserted widgets.

Deliberately conservative:

* The observer is only a **trigger**. `jetpackIsScrolledIntoView()` still decides what loads, so nothing changes about which widgets are eligible — only about when the question gets asked again.
* The `scroll` listener stays, as the fallback where `IntersectionObserver` is unavailable.
* `threshold: [ 0, 1 ]` rather than the default. `rootMargin` alone fires when a widget starts overlapping the band, but the gate accepts only one fully inside it — so a widget straddling the band edge is already past the `0` threshold, and a reflow carrying it fully into range would produce no callback at all. The `1` puts a callback exactly where the gate's answer changes.
* Nothing is ever unobserved, which the unload path does not depend on: `jetpackObserveUnloadedWidgets()` runs immediately after `jetpackUnloadScrolledOutWidgets()` and re-observes anything just returned to unloaded, and post-like widgets never return to unloaded at all. There is simply nothing to gain by unobserving.
* Widgets are observed only inside a queue pass, and inserting one into the DOM does not start a pass. A widget added after load — infinite scroll — is therefore not observed until the next pass, which in practice means the next scroll. That is unchanged from trunk: this PR does not extend the observer to cover it.

## Related product discussion/links

* BOOST-549 — a Like block stuck on "Loading…" with Boost's Critical CSS enabled. This is one of two independent fragilities I found in the Likes queue handler while investigating that report; it is not a full fix for it, and Automattic/jetpack#52141 is the Boost-side half.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated: from `projects/plugins/jetpack`, `NODE_PATH=tests:_inc/client pnpm exec jest --config=tests/jest.config.client.js modules/likes`. The new case fails on trunk — the widget is never observed, so nothing re-runs the queue — and passes here.

### Real-screen before / after

Reproduced on a fresh Jurassic Ninja site running Jetpack 16.2-beta, which already carries the #51113 `queryMasterReady` handshake — so a missed `masterReady` is not what is being fixed here. `SCRIPT_DEBUG` is on, so `modules/likes/queuehandler.js` is served unminified; the two runs below differ by exactly this PR's diff to that one file and nothing else.

The page is a post with the Like block below a 6000px spacer, plus an mu-plugin that emits one stylesheet as `media="not all"` with an `onload` flip and a 5s server-side delay. That is the same deferral shape Boost's Critical CSS uses, with the timing made deterministic rather than left to a race. At first paint the widget sits ~6000px down, far outside the 2000px look-ahead band. Five seconds later the stylesheet applies, the spacer collapses, and the widget lands at y=449 in a 965px viewport. Nothing scrolls at any point.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/likes-queue-relayout/before-late-reflow.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/likes-queue-relayout/after-late-reflow.png) |

Measured in the page ten seconds after load, with no scrolling in either run:

| | before | after |
|---|---|---|
| `window.scrollY` | `0` | `0` |
| spacer height | `40px` | `40px` |
| widget top | `449` | `449` |
| wrapper class | `jetpack-likes-widget-unloaded` | `jetpack-likes-widget-loaded` |
| widget iframes | `0` | `1` |

The widget is sitting in plain view in both runs. Before, the queue had already made its one pass while the widget was out of range and never looked again; after, the observer notices the reflow and the existing queue pass loads it.

To reproduce by hand without the mu-plugin, publish a post with the Like block more than ~2000px below the fold, load it, and without scrolling run `document.querySelector( '.jp-repro-spacer, .entry-content > :first-child' ).style.display = 'none'` to force the same reflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PoeBjaZrNBzXfX1j2rcnq



