### PR TITLE
Tests: shim getGroups() so WordPress trunk's test case runs on PHPUnit 10+

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-wp-unittestcase-fix-getgroups
+++ b/projects/plugins/jetpack/changelog/fix-wp-unittestcase-fix-getgroups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+Comment: Tests only: shim getGroups() for WordPress trunk on PHPUnit 10+.
+

--- a/projects/plugins/jetpack/changelog/fix-wp-unittestcase-fix-getgroups
+++ b/projects/plugins/jetpack/changelog/fix-wp-unittestcase-fix-getgroups
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
-Comment: Tests only: shim getGroups() for WordPress trunk on PHPUnit 10+.
+Comment: Tests only: Sync WP_UnitTestCase_Fix with wpcomsh. Fix isn't needed here, but keeping the copies in sync is good.
 

--- a/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
@@ -115,8 +115,9 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		}
 
 		/**
-		 * For core's `WP_UnitTestCase_Base::set_up()`, which asks for the test's
-		 * groups by their PHPUnit 9 name whenever `WP_RUN_CORE_TESTS` is defined.
+		 * For `WP_UnitTestCase_Base::set_up()` to call.
+		 *
+		 * Only needed for wpcomsh which sets `WP_RUN_CORE_TESTS` as the only way to bypass a cache.
 		 *
 		 * @return string[]
 		 */

--- a/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/jetpack/tests/php/WP_UnitTestCase_Fix.php
@@ -115,6 +115,16 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		}
 
 		/**
+		 * For core's `WP_UnitTestCase_Base::set_up()`, which asks for the test's
+		 * groups by their PHPUnit 9 name whenever `WP_RUN_CORE_TESTS` is defined.
+		 *
+		 * @return string[]
+		 */
+		public function getGroups() {
+			return $this->groups();
+		}
+
+		/**
 		 * Obsolete method where PHPUnit is mis-processing the doc comment to see a `@group` that doesn't exist.
 		 * This redefinition hides the "bad" doc comment from PHPUnit.
 		 */

--- a/projects/plugins/wpcomsh/changelog/fix-wp-unittestcase-fix-getgroups
+++ b/projects/plugins/wpcomsh/changelog/fix-wp-unittestcase-fix-getgroups
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Tests only: shim getGroups() for WordPress trunk on PHPUnit 10+.
+

--- a/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
@@ -115,8 +115,9 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		}
 
 		/**
-		 * For core's `WP_UnitTestCase_Base::set_up()`, which asks for the test's
-		 * groups by their PHPUnit 9 name whenever `WP_RUN_CORE_TESTS` is defined.
+		 * For `WP_UnitTestCase_Base::set_up()` to call.
+		 *
+		 * Only needed for wpcomsh which sets `WP_RUN_CORE_TESTS` as the only way to bypass a cache.
 		 *
 		 * @return string[]
 		 */

--- a/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
+++ b/projects/plugins/wpcomsh/tests/WP_UnitTestCase_Fix.php
@@ -115,6 +115,16 @@ if ( explode( '.', \PHPUnit\Runner\Version::id() )[0] >= 10 ) {
 		}
 
 		/**
+		 * For core's `WP_UnitTestCase_Base::set_up()`, which asks for the test's
+		 * groups by their PHPUnit 9 name whenever `WP_RUN_CORE_TESTS` is defined.
+		 *
+		 * @return string[]
+		 */
+		public function getGroups() {
+			return $this->groups();
+		}
+
+		/**
 		 * Obsolete method where PHPUnit is mis-processing the doc comment to see a `@group` that doesn't exist.
 		 * This redefinition hides the "bad" doc comment from PHPUnit.
 		 */


### PR DESCRIPTION
## Proposed changes

The "PHP tests: PHP 8.4 WP trunk" job fails on every wpcomsh PR since this morning with 146 errors of the form:

```
Call to undefined method StagingSitePingsTest::getGroups()
/tmp/wordpress-trunk/tests/phpunit/includes/abstract-testcase.php:155
```

WordPress trunk r63560 ("Build/Test Tools: Block ungrouped external HTTP requests") makes `WP_UnitTestCase_Base::set_up()` call `$this->getGroups()` whenever `WP_RUN_CORE_TESTS` is defined. That is the PHPUnit 9 method name, which core's own harness runs on; PHPUnit 10 renamed it `groups()`, and the monorepo runs core's framework on PHPUnit 11/12. wpcomsh's `StagingSitePingsTest` defines the constant to defeat the static cache in `wp_get_environment_type()`, and a `define` cannot be undone, so every test after it in the process hits the new path and errors.

* Add a `getGroups()` alias returning `$this->groups()` to the `WP_UnitTestCase_Fix` trait, which already exists to bridge core's test case to newer PHPUnit. Both plugins carrying a copy of the trait (jetpack and wpcomsh) get it, so the copies stay identical apart from their `@package` line.

Tests only, no shipped code changes.

## Related product discussion/links

* Seen on #52139.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* The "PHP tests: PHP 8.4 WP trunk" job on this PR is the test: it should pass, where on trunk it currently fails with the errors above for wpcomsh.
* The other PHP test jobs should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
