### PR TITLE
RTC: Skip evaluating eligibility when the collab setting is off

### DIFF
--- a/projects/packages/rtc/changelog/perf-rtc-check
+++ b/projects/packages/rtc/changelog/perf-rtc-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Skip unnecessary eligibility checks when real-time collaboration is disabled.

--- a/projects/packages/rtc/src/class-rtc.php
+++ b/projects/packages/rtc/src/class-rtc.php
@@ -118,7 +118,7 @@ class RTC {
 	 * @return bool
 	 */
 	public static function is_turned_on() {
-		return self::is_allowed() && (bool) get_option( self::OPTION_NEW );
+		return (bool) get_option( self::OPTION_NEW ) && self::is_allowed();
 	}
 
 	/**
@@ -293,6 +293,11 @@ class RTC {
 	 * @return mixed
 	 */
 	public static function filter_rtc_option( $value ) {
+		// An explicitly disabled setting needs no eligibility check.
+		if ( '0' === $value ) {
+			return $value;
+		}
+
 		// RTC not allowed: force the option off, regardless of what's in the DB.
 		if ( ! self::is_allowed() ) {
 			return '0';

--- a/projects/plugins/mu-wpcom-plugin/changelog/perf-rtc-check
+++ b/projects/plugins/mu-wpcom-plugin/changelog/perf-rtc-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Skip unnecessary eligibility checks when real-time collaboration is disabled.

--- a/projects/plugins/wpcomsh/changelog/perf-rtc-check
+++ b/projects/plugins/wpcomsh/changelog/perf-rtc-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+RTC: Skip unnecessary eligibility checks when real-time collaboration is disabled.


### PR DESCRIPTION
Fixes #

## Proposed changes

RTC: Skip evaluating eligibility when the collab setting is off

Gutenberg experiment reads invoke RTC's `filter_experiments()` callback, including during HTML sanitization. On pages with many comments, this repeatedly triggers eligibility checks even when collaboration is disabled.

* Read the collaboration option before checking eligibility in `is_turned_on()`, allowing a falsey option value to short-circuit.
* Return immediately from `filter_rtc_option()` for a stored `'0'`, avoiding an eligibility check for an explicitly disabled setting.

Tested on a WordPress.com P2 post with 740 replies, with five page loads before and after:

* Average wall time (sandbox): **16.74s → 14.90s**
* `RTC::is_allowed()` calls: **22,350 → 0** per load.
 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Use a site with the Jetpack RTC integration loaded and Gutenberg 23.8+.

1. With the `wp_collaboration_enabled` option absent, verify that `RTC::is_turned_on()` returns false and the RTC experiment remains disabled.
2. Repeat with the option explicitly stored as `'0'`. Verify that these reads do not call `RTC::is_allowed()`.
3. Enable collaboration on an eligible site. Verify that `RTC::is_turned_on()` returns true and collaboration still works in the post editor.
4. With the option enabled but RTC eligibility denied through `jetpack_rtc_enabled`, verify that `RTC::is_turned_on()` returns false and the RTC experiment remains disabled.
5. For performance verification, load a comment-heavy P2 post with collaboration disabled. Compare wall time and `RTC::is_allowed()` call counts before and after the change.