### PR TITLE
Newsletter: register the email blocks WordPress.com defines in PHP

### DIFF
--- a/projects/plugins/jetpack/changelog/add-nl-869-register-email-blocks
+++ b/projects/plugins/jetpack/changelog/add-nl-869-register-email-blocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: register the email design editor's WordPress.com blocks on the client.

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -12,6 +12,8 @@
  */
 import { ExperimentalEmailEditor } from '@woocommerce/email-editor';
 import apiFetch from '@wordpress/api-fetch';
+import { useBlockProps } from '@wordpress/block-editor';
+import { getBlockType, registerBlockType } from '@wordpress/blocks';
 import { Notice } from '@wordpress/components';
 import { createRoot, StrictMode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -273,6 +275,53 @@ export function getTemplateId( bundle ) {
 }
 
 /**
+ * Register the email blocks the bootstrap describes and no client defines.
+ *
+ * They are registered in PHP only, on every host including Simple, so without this the editor
+ * reports each one as an unsupported block. WordPress.com allowlists the namespaces it owns, but
+ * a site is still free to have registered one itself, so anything already registered is left
+ * alone rather than replaced by a placeholder.
+ *
+ * Dynamic blocks with no client-side edit, so the canvas shows a labelled placeholder. What the
+ * subscriber receives is rendered server-side and is unaffected.
+ *
+ * @param {object} bundle - The response from the bootstrap route.
+ * @return {void}
+ */
+export function registerEmailBlocks( bundle ) {
+	const blocks = Array.isArray( bundle?.blocks ) ? bundle.blocks : [];
+
+	blocks.forEach( block => {
+		if ( ! block?.name || getBlockType( block.name ) ) {
+			return;
+		}
+
+		// Falls back to the slug on anything that is not a usable string. A non-string title is
+		// not just unlabelled: it reaches the placeholder as a React child, and an object there
+		// throws rather than rendering.
+		const title = typeof block.title === 'string' && block.title ? block.title : block.name;
+
+		// Named and capitalised so it reads as a component: `useBlockProps` is a hook, and an
+		// anonymous arrow here trips rules-of-hooks.
+		const EmailBlockPlaceholder = () => <div { ...useBlockProps() }>{ title }</div>;
+
+		registerBlockType( block.name, {
+			apiVersion: 3,
+			title,
+			description: block.description || '',
+			category: block.category || 'design',
+			attributes: block.attributes || {},
+
+			// Template furniture rather than blocks a creator adds by hand.
+			supports: { ...( block.supports || {} ), html: false, inserter: false },
+
+			edit: EmailBlockPlaceholder,
+			save: () => null,
+		} );
+	} );
+}
+
+/**
  * What the screen shows when it could not load.
  *
  * The design lives on another site, so without this "nothing appeared" and "your
@@ -320,6 +369,12 @@ export async function mountEmailDesignEditor() {
 		} );
 
 		const config = buildEditorConfig( bundle, data );
+
+		// Before the render, not after: the template is parsed on first render and its blocks are
+		// resolved against the registry at that moment. Registering later leaves the same
+		// unsupported-block errors, which looks identical to this never running.
+		registerEmailBlocks( bundle );
+
 		const postId = getTemplateId( bundle );
 		const preload = buildPreloadMap( bundle, postId );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -34,6 +34,16 @@ jest.mock( '@woocommerce/email-editor', () => ( {
 	ExperimentalEmailEditor: MockEmailEditor,
 } ) );
 
+const mockRegisterBlockType = jest.fn();
+const mockGetBlockType = jest.fn();
+
+jest.mock( '@wordpress/blocks', () => ( {
+	registerBlockType: ( ...args ) => mockRegisterBlockType( ...args ),
+	getBlockType: ( ...args ) => mockGetBlockType( ...args ),
+} ) );
+
+jest.mock( '@wordpress/block-editor', () => ( { useBlockProps: () => ( {} ) } ) );
+
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
 /**
@@ -151,6 +161,8 @@ describe( 'Email design editor entry point', () => {
 		mockRender.mockClear();
 		mockUse.mockClear();
 		mockCreatePreloadingMiddleware.mockClear();
+		mockRegisterBlockType.mockClear();
+		mockGetBlockType.mockReset();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( bootstrapBundle() );
 		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
@@ -643,6 +655,81 @@ describe( 'Email design editor entry point', () => {
 				'/wp/v2/templates?context=edit',
 				'/wp/v2/templates?context=view',
 			] );
+		} );
+	} );
+
+	describe( 'the email blocks WordPress.com registers in PHP', () => {
+		const { registerEmailBlocks } = jest.requireActual( '../src/index' );
+
+		const payload = blocks => ( { blocks } );
+
+		it( 'registers each one the site has no definition for', () => {
+			registerEmailBlocks(
+				payload( [
+					{ name: 'wpcom/email-header', title: 'Email header', category: 'text' },
+					{ name: 'wpcom/email-footer', title: 'Email footer' },
+				] )
+			);
+
+			expect( mockRegisterBlockType ).toHaveBeenCalledTimes( 2 );
+			expect( mockRegisterBlockType ).toHaveBeenCalledWith(
+				'wpcom/email-header',
+				expect.objectContaining( { title: 'Email header', category: 'text' } )
+			);
+			// Defaulted rather than left undefined, which would fail block registration.
+			expect( mockRegisterBlockType ).toHaveBeenCalledWith(
+				'wpcom/email-footer',
+				expect.objectContaining( { category: 'design', attributes: {} } )
+			);
+		} );
+
+		it( 'leaves a block the site already registered alone', () => {
+			mockGetBlockType.mockReturnValue( { name: 'wpcom/email-header' } );
+
+			registerEmailBlocks( payload( [ { name: 'wpcom/email-header', title: 'Ours' } ] ) );
+
+			// Registering over a real implementation would replace it with a placeholder.
+			expect( mockRegisterBlockType ).not.toHaveBeenCalled();
+		} );
+
+		// The last case is not just an unlabelled block: a non-string title reaches the
+		// placeholder as a React child, and an object there throws instead of rendering.
+		it.each( [
+			[ 'reported no title', undefined ],
+			[ 'reported an empty title', '' ],
+			[ 'reported a title that is not a string', { rendered: 'Email header' } ],
+		] )( 'labels a block that %s with its slug', ( _label, title ) => {
+			registerEmailBlocks( payload( [ { name: 'lately/bulletin-intro', title } ] ) );
+
+			expect( mockRegisterBlockType ).toHaveBeenCalledWith(
+				'lately/bulletin-intro',
+				expect.objectContaining( { title: 'lately/bulletin-intro' } )
+			);
+		} );
+
+		it.each( [
+			[ 'no blocks key', {} ],
+			[ 'a non-array', { blocks: 'nope' } ],
+			[ 'an entry with no name', { blocks: [ { title: 'Nameless' } ] } ],
+		] )( 'registers nothing given %s', ( _label, bundle ) => {
+			expect( () => registerEmailBlocks( bundle ) ).not.toThrow();
+			expect( mockRegisterBlockType ).not.toHaveBeenCalled();
+		} );
+
+		it( 'registers before the editor renders, not after', async () => {
+			const order = [];
+			mockRegisterBlockType.mockImplementation( () => order.push( 'register' ) );
+			mockRender.mockImplementation( () => order.push( 'render' ) );
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( { blocks: [ { name: 'wpcom/email-header', title: 'Email header' } ] } )
+			);
+			window.JetpackEmailDesignEditor = pageData();
+
+			await loadEntryPoint();
+
+			// The template is parsed on first render and resolved against the registry then, so
+			// registering afterwards leaves the same unsupported-block errors.
+			expect( order ).toEqual( [ 'register', 'render' ] );
 		} );
 	} );
 


### PR DESCRIPTION
## Proposed changes

Registers the email blocks that only exist in WordPress.com PHP, so the design editor stops reporting each one as an unsupported block.

<img width="1269" height="500" alt="Screenshot 2026-09-09 at 2 15 24 PM" src="https://github.com/user-attachments/assets/8e5e02ed-3fa2-4f10-b75b-ebf8f4e8cd68" />



The second of the chunks split out of #51846, after #52055. Its WordPress.com counterpart adds a `blocks` key to the bootstrap response; this is the client that consumes it. Until both are in place the canvas shows one "your site doesn't include support for this block" error per block.

* **No host has a client-side definition.** The six wpcom email blocks, and Lately's three, are registered in PHP only — there is no `registerBlockType` for any of them anywhere. This was confirmed on Simple with the screen running, not inferred: it is not an Atomic and self-hosted gap.
* **Two guards, not one.** WordPress.com allowlists the namespaces it owns before describing anything. This side skips any block the site already has registered, so a real implementation is never replaced by a placeholder — a site is free to have registered one itself.
* **Registered before the render.** The template is parsed on first render and resolved against the registry at that moment, so registering afterwards leaves the same unsupported-block errors and looks identical to this never running. There is a test pinning the order.
* **Defaults rather than undefined.** A block that reports no title is labelled with its slug, and a missing category or attributes map is defaulted — block registration fails outright on `undefined`.

### What this does and does not give you

The canvas goes from six errors to six labelled placeholders reading Email Header, Post Header, Post Content, Post Footer, Email Footer and Digest Posts.

**It is not a preview of the email.** These blocks have no client-side `edit`, so each renders as its title. Rendered previews are follow-up work with a dependency that is not yet scoped: `wpcom-email-customizations.css` is never enqueued as a stylesheet — it is read with `file_get_contents()` and inlined at send time — so the email CSS does not reach the editor canvas at all, and block markup dropped into `edit` today would render as unstyled tables.

What subscribers receive is rendered server-side and is unaffected by any of this.

## Related product discussion/links

* NL-869

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs the WordPress.com counterpart deployed to the sandbox or blog you are testing against, and the same setup as #52055: the `email-design-editor` sticker on the connected blog, and the `jetpack-email-design` flag on.

1. **Before this branch**, open **Appearance → Email Design**. Every block in the canvas reads "Your site doesn't include support for the `wpcom/email-…` block."
2. **With this branch**, the same screen shows a labelled box per block instead — Email Header, Post Header, Post Content, Post Footer, Email Footer. The digest template also shows Digest Posts.
