### PR TITLE
Forms: version the welcome guide's analytics and decouple slide tracking from Guide

### DIFF
--- a/projects/packages/forms/changelog/add-forms-welcome-guide-slide-tracking
+++ b/projects/packages/forms/changelog/add-forms-welcome-guide-slide-tracking
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Form editor: track welcome guide slides without depending on how the guide component reuses its pages.

--- a/projects/packages/forms/changelog/add-forms-welcome-guide-slide-tracking
+++ b/projects/packages/forms/changelog/add-forms-welcome-guide-slide-tracking
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Form editor: track welcome guide slides without depending on how the guide component reuses its pages.
+Form editor: Record every welcome guide slide a reader reaches, including after navigating back.

--- a/projects/packages/forms/changelog/add-forms-welcome-guide-version
+++ b/projects/packages/forms/changelog/add-forms-welcome-guide-version
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Form editor: record which version of the welcome guide each analytics event describes.

--- a/projects/packages/forms/changelog/add-forms-welcome-guide-version
+++ b/projects/packages/forms/changelog/add-forms-welcome-guide-version
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Form editor: record which version of the welcome guide each analytics event describes.
+Form editor: Record which version of the welcome guide each analytics event describes.

--- a/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { GUIDE_VERSION } from './pages';
 
 /** Fired once each time the guide opens. */
@@ -55,12 +55,8 @@ export function useGuideTracks() {
 interface SlideTrackerProps {
 	/** Zero-based index of the slide being shown. */
 	index: number;
-	/** Total number of slides, so a drop-off can be read without knowing the guide. */
-	slideCount: number;
-	/** Why the guide is open. */
-	origin: GuideOrigin;
-	/** Records the event. */
-	record: ( event: string, props?: TracksProps ) => void;
+	/** Reports the one-based slide now on screen. */
+	report: ( slide: number ) => void;
 }
 
 /**
@@ -69,46 +65,24 @@ interface SlideTrackerProps {
  * `Guide` keeps its page number in internal state and exposes no change
  * callback, but it renders only the current page — so a component sitting
  * inside that page reports the slide simply by being the one that is mounted.
- * The effect keys on `index` rather than on mount, because React reuses this
- * element across page changes instead of remounting it.
  *
- * @param props            - Component props
- * @param props.index      - Zero-based index of the slide being shown
- * @param props.slideCount - Total number of slides
- * @param props.origin     - Why the guide is open
- * @param props.record     - Records the event
+ * This deliberately keeps no memory of what it has already reported: it reports
+ * the slide it is showing, every time it is mounted or the slide changes, and
+ * leaves the caller to decide what counts as a repeat. That is what makes it
+ * indifferent to whether `Guide` reuses this element across page changes or
+ * remounts it, which is an implementation detail of `@wordpress/components`
+ * rather than a promise it makes.
+ *
+ * @param props        - Component props
+ * @param props.index  - Zero-based index of the slide being shown
+ * @param props.report - Reports the one-based slide now on screen
  * @return Nothing; this renders no markup.
  */
-export const SlideTracker = ( { index, slideCount, origin, record }: SlideTrackerProps ) => {
-	/*
-	 * Only the slide is a reason to report. `origin` and `slideCount` are fixed
-	 * for an opening, and `record`'s identity is not something this component
-	 * should depend on — including them would re-report the same slide the
-	 * moment any of them changed, which is a duplicate event rather than a
-	 * navigation. Refs keep the values current without making them triggers.
-	 */
-	const latest = useRef( { slideCount, origin, record } );
-	latest.current = { slideCount, origin, record };
-
-	// The opening reports its own first slide, after the view event and after
-	// the analytics hook has identified the user. This reports the moves.
-	const hasSeenFirstSlide = useRef( false );
-
+export const SlideTracker = ( { index, report }: SlideTrackerProps ) => {
 	useEffect( () => {
-		if ( ! hasSeenFirstSlide.current ) {
-			hasSeenFirstSlide.current = true;
-			return;
-		}
-
-		const current = latest.current;
-
-		current.record( SLIDE_VIEW_EVENT, {
-			// One-based, to read naturally against `slide_count` in a report.
-			slide: index + 1,
-			slide_count: current.slideCount,
-			origin: current.origin,
-		} );
-	}, [ index ] );
+		// One-based, to read naturally against `slide_count` in a report.
+		report( index + 1 );
+	}, [ index, report ] );
 
 	return null;
 };

--- a/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/analytics.tsx
@@ -10,6 +10,7 @@
 
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useCallback, useEffect, useRef } from '@wordpress/element';
+import { GUIDE_VERSION } from './pages';
 
 /** Fired once each time the guide opens. */
 export const VIEW_EVENT = 'jetpack_forms_welcome_guide_view';
@@ -34,6 +35,10 @@ interface Tracks {
 /**
  * Records a guide event with the properties every one of them carries.
  *
+ * `guide_version` is added here rather than at the call sites so that no event
+ * can be added later that forgets it — a single event missing the version is
+ * enough to make a report choose between dropping it and guessing.
+ *
  * @return A recorder taking an event name and any extra properties.
  */
 export function useGuideTracks() {
@@ -41,7 +46,7 @@ export function useGuideTracks() {
 
 	return useCallback(
 		( event: string, props: TracksProps = {} ) => {
-			tracks.recordEvent( event, props );
+			tracks.recordEvent( event, { ...props, guide_version: GUIDE_VERSION } );
 		},
 		[ tracks ]
 	);

--- a/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
@@ -124,19 +124,13 @@ export const FormWelcomeGuide = () => {
 	 */
 	const currentSlide = useRef( 1 );
 
-	// Whether the guide was open on the previous render, so a new opening can be
-	// spotted. See the reset below.
-	const wasOpen = useRef( false );
-
 	const recordSlideView = useCallback(
 		( slide: number ) => {
 			/*
-			 * The tracker reports its slide whenever it mounts, and an opening
-			 * records its own first slide in the effect below — so the first
-			 * report of an opening is always a duplicate of one already made.
-			 * Comparing against the last slide recorded drops it. Unlike asking
-			 * the tracker whether this is its first run, that holds however
-			 * often `Guide` chooses to remount it.
+			 * The tracker reports its slide whenever it mounts, and the effect
+			 * below records the opening's own first slide — so an opening's
+			 * first report always duplicates one already made. Comparing
+			 * against the last slide recorded drops it.
 			 */
 			if ( slide === currentSlide.current ) {
 				return;
@@ -181,21 +175,6 @@ export const FormWelcomeGuide = () => {
 		isFormEditor &&
 		isWelcomeGuideOpen( { preference, isForced, isEligible, isClosed, isReopened } );
 
-	/*
-	 * Start each opening back at slide 1, and do it during render rather than in
-	 * the effect below. The tracker sits inside the guide, so its effects run
-	 * before this component's: a guide closed on slide 4 and then reopened would
-	 * have its first report compared against 4, pass as a navigation, and record
-	 * a slide 1 the effect is about to record again.
-	 *
-	 * Safe to write during render because it only ever restates the opening
-	 * value, so a repeated render cannot move it.
-	 */
-	if ( isOpen && ! wasOpen.current ) {
-		currentSlide.current = 1;
-	}
-	wasOpen.current = isOpen;
-
 	// One view per opening, not per render.
 	useEffect( () => {
 		if ( ! isOpen ) {
@@ -204,6 +183,16 @@ export const FormWelcomeGuide = () => {
 
 		record( VIEW_EVENT, { origin, slide_count: SLIDE_COUNT } );
 		record( SLIDE_VIEW_EVENT, { slide: 1, slide_count: SLIDE_COUNT, origin } );
+
+		/*
+		 * Rewind on the way out rather than on the way in. The tracker sits
+		 * inside the guide, so its effects run before this one: resetting when
+		 * the next opening starts would land after that opening's first report
+		 * had already been compared against the slide the user left on.
+		 */
+		return () => {
+			currentSlide.current = 1;
+		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only a change in `isOpen` is a new viewing; `origin` is fixed for one.
 	}, [ isOpen ] );
 

--- a/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/index.tsx
@@ -115,20 +115,37 @@ export const FormWelcomeGuide = () => {
 	 */
 	const origin: GuideOrigin = isForced ? 'forced' : ( isReopened && 'menu' ) || 'auto';
 
-	// The slide the user is on, so a dismissal says how far they got. Held in a
-	// ref because only the dismissal reads it, and re-rendering on every slide
-	// change would rebuild the whole guide.
+	/*
+	 * The last slide recorded for this opening. It says how far the user got
+	 * when they leave, and it is what separates a navigation from the tracker
+	 * re-reporting a slide it is already on. Held in a ref because only the
+	 * recorders read it, and re-rendering on every slide change would rebuild
+	 * the whole guide.
+	 */
 	const currentSlide = useRef( 1 );
 
+	// Whether the guide was open on the previous render, so a new opening can be
+	// spotted. See the reset below.
+	const wasOpen = useRef( false );
+
 	const recordSlideView = useCallback(
-		( event: string, props: Record< string, string | number | boolean > = {} ) => {
-			if ( typeof props.slide === 'number' ) {
-				currentSlide.current = props.slide;
+		( slide: number ) => {
+			/*
+			 * The tracker reports its slide whenever it mounts, and an opening
+			 * records its own first slide in the effect below — so the first
+			 * report of an opening is always a duplicate of one already made.
+			 * Comparing against the last slide recorded drops it. Unlike asking
+			 * the tracker whether this is its first run, that holds however
+			 * often `Guide` chooses to remount it.
+			 */
+			if ( slide === currentSlide.current ) {
+				return;
 			}
 
-			record( event, props );
+			currentSlide.current = slide;
+			record( SLIDE_VIEW_EVENT, { slide, slide_count: SLIDE_COUNT, origin } );
 		},
-		[ record ]
+		[ origin, record ]
 	);
 
 	const recordDismiss = useCallback( () => {
@@ -164,13 +181,27 @@ export const FormWelcomeGuide = () => {
 		isFormEditor &&
 		isWelcomeGuideOpen( { preference, isForced, isEligible, isClosed, isReopened } );
 
+	/*
+	 * Start each opening back at slide 1, and do it during render rather than in
+	 * the effect below. The tracker sits inside the guide, so its effects run
+	 * before this component's: a guide closed on slide 4 and then reopened would
+	 * have its first report compared against 4, pass as a navigation, and record
+	 * a slide 1 the effect is about to record again.
+	 *
+	 * Safe to write during render because it only ever restates the opening
+	 * value, so a repeated render cannot move it.
+	 */
+	if ( isOpen && ! wasOpen.current ) {
+		currentSlide.current = 1;
+	}
+	wasOpen.current = isOpen;
+
 	// One view per opening, not per render.
 	useEffect( () => {
 		if ( ! isOpen ) {
 			return;
 		}
 
-		currentSlide.current = 1;
 		record( VIEW_EVENT, { origin, slide_count: SLIDE_COUNT } );
 		record( SLIDE_VIEW_EVENT, { slide: 1, slide_count: SLIDE_COUNT, origin } );
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- Only a change in `isOpen` is a new viewing; `origin` is fixed for one.
@@ -253,12 +284,7 @@ export const FormWelcomeGuide = () => {
 		...page,
 		content: (
 			<>
-				<SlideTracker
-					index={ index }
-					origin={ origin }
-					record={ recordSlideView }
-					slideCount={ SLIDE_COUNT }
-				/>
+				<SlideTracker index={ index } report={ recordSlideView } />
 				{ page.content }
 			</>
 		),

--- a/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
@@ -19,11 +19,27 @@ export interface GuidePage {
 }
 
 /**
+ * Which revision of the slides below the analytics describe.
+ *
+ * Bump this whenever a change would make old and new events unsafe to pool:
+ * slides reordered, or copy rewritten enough that "left on slide 3" stops
+ * meaning what it meant before. `slide_count` already catches a slide being
+ * added or removed; this catches everything else.
+ *
+ * Events recorded before this property existed carry no `guide_version` at all,
+ * and describe the same slides as version 1 — so a report covering that period
+ * should read a missing value as 1.
+ */
+export const GUIDE_VERSION = 1;
+
+/**
  * The slides, in order.
  *
  * Copy is held as thunks so `__()` runs when the guide is built rather than at
  * module load, which would translate before the locale data has arrived. Each
  * slide names its own artwork, so a slide can't drift away from its image.
+ *
+ * Editing these means deciding whether GUIDE_VERSION above needs bumping.
  */
 const SLIDES = [
 	{

--- a/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
+++ b/projects/packages/forms/src/form-editor/welcome-guide/pages.tsx
@@ -38,8 +38,6 @@ export const GUIDE_VERSION = 1;
  * Copy is held as thunks so `__()` runs when the guide is built rather than at
  * module load, which would translate before the locale data has arrived. Each
  * slide names its own artwork, so a slide can't drift away from its image.
- *
- * Editing these means deciding whether GUIDE_VERSION above needs bumping.
  */
 const SLIDES = [
 	{

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
@@ -43,12 +43,8 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	),
 } ) );
 
-/*
- * Whether the mocked `Guide` throws its page away on every change instead of
- * reusing the element. Real `Guide` reuses it today, so that is the default —
- * but that is an implementation detail of @wordpress/components rather than
- * anything it promises, and the slide tracking has to survive either choice.
- */
+// Whether the mocked `Guide` throws its page away on every change instead of
+// reusing the element. Real `Guide` reuses it today, so that is the default.
 let guideRemountsPages = false;
 
 /*
@@ -421,11 +417,9 @@ describe( 'FormWelcomeGuide', () => {
 		} );
 
 		/*
-		 * The tracker reports by being mounted inside the page, so whether it
-		 * survives a page change is `Guide`'s decision rather than ours. If it
-		 * ever starts remounting, a tracker that suppressed its own first run
-		 * would suppress every slide instead of just the opening one, and every
-		 * test above would keep passing.
+		 * A tracker that suppressed its own first run would, under remounting,
+		 * suppress every slide instead of just the opening one — and every
+		 * other test in this file would keep passing.
 		 */
 		it( 'records the same slides whether or not Guide remounts each page', async () => {
 			guideRemountsPages = true;
@@ -463,6 +457,24 @@ describe( 'FormWelcomeGuide', () => {
 			).toEqual( [ 1, 2, 3, 1 ] );
 		} );
 
+		// The other route to a fresh opening: the component stays mounted while
+		// in-editor navigation leaves the form editor and comes back.
+		it( 'records the opening slide once after leaving the form editor and returning', async () => {
+			const user = userEvent.setup();
+			const { rerender } = render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+
+			currentPostType = 'page';
+			rerender( <FormWelcomeGuide /> );
+			currentPostType = 'jetpack_form';
+			rerender( <FormWelcomeGuide /> );
+
+			expect(
+				allOf( 'jetpack_forms_welcome_guide_slide_view' ).map( props => props.slide )
+			).toEqual( [ 1, 2, 1 ] );
+		} );
+
 		it( 'reports how far the user got when they leave', async () => {
 			const user = userEvent.setup();
 			render( <FormWelcomeGuide /> );
@@ -486,6 +498,14 @@ describe( 'FormWelcomeGuide', () => {
 			const guideEvents = recordEvent.mock.calls.filter( ( [ name ] ) =>
 				name.startsWith( 'jetpack_forms_welcome_guide_' )
 			);
+
+			/*
+			 * Pinned to a real integer first: the comparison below comes from
+			 * the same module it is checking, so an absent constant would
+			 * otherwise match `undefined` against itself and pass. Tracks types
+			 * a field from its first value, and undefined would poison it.
+			 */
+			expect( GUIDE_VERSION ).toEqual( expect.any( Number ) );
 
 			// view, slide 1, slide 2, dismiss — so an event recorded without the
 			// version would have to be one of these four.

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
@@ -44,6 +44,14 @@ await jest.unstable_mockModule( '@wordpress/data', () => ( {
 } ) );
 
 /*
+ * Whether the mocked `Guide` throws its page away on every change instead of
+ * reusing the element. Real `Guide` reuses it today, so that is the default —
+ * but that is an implementation detail of @wordpress/components rather than
+ * anything it promises, and the slide tracking has to survive either choice.
+ */
+let guideRemountsPages = false;
+
+/*
  * `Guide` renders into a portal and pulls in a large slice of
  * @wordpress/components. The mock keeps the two behaviours the tests depend
  * on: it renders only the page you are on, and it owns the page number — which
@@ -58,7 +66,7 @@ await jest.unstable_mockModule( '@wordpress/components', () => ( {
 		return (
 			<div data-testid="guide">
 				{ contentLabel }
-				{ pages[ current ]?.content }
+				<div key={ guideRemountsPages ? current : 'page' }>{ pages[ current ]?.content }</div>
 				<button type="button" onClick={ goForward }>
 					Next
 				</button>
@@ -111,6 +119,7 @@ describe( 'FormWelcomeGuide', () => {
 		seedPreferences();
 		setSearch( '' );
 		currentPostType = 'jetpack_form';
+		guideRemountsPages = false;
 		window.jetpackFormsWelcomeGuide = { isEligible: true };
 	} );
 
@@ -409,6 +418,49 @@ describe( 'FormWelcomeGuide', () => {
 				.map( ( [ , props ] ) => props.slide );
 
 			expect( slides ).toEqual( [ 1, 2, 3, 2 ] );
+		} );
+
+		/*
+		 * The tracker reports by being mounted inside the page, so whether it
+		 * survives a page change is `Guide`'s decision rather than ours. If it
+		 * ever starts remounting, a tracker that suppressed its own first run
+		 * would suppress every slide instead of just the opening one, and every
+		 * test above would keep passing.
+		 */
+		it( 'records the same slides whether or not Guide remounts each page', async () => {
+			guideRemountsPages = true;
+			const user = userEvent.setup();
+			render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Previous' } ) );
+
+			expect(
+				allOf( 'jetpack_forms_welcome_guide_slide_view' ).map( props => props.slide )
+			).toEqual( [ 1, 2, 3, 2 ] );
+		} );
+
+		/*
+		 * A reopened guide starts at slide 1 again, and the tracker mounts and
+		 * reports it before this component's own effects run. Recording it from
+		 * both places would double-count the opening slide of every reopen.
+		 */
+		it( 'records the opening slide once when a guide closed part-way is reopened', async () => {
+			const user = userEvent.setup();
+			const { rerender } = render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+			// The dismissal is stored, then Options -> Welcome Guide brings it back.
+			seedPreferences( { jetpackForms: false, coreWelcomeGuide: true } );
+			rerender( <FormWelcomeGuide /> );
+
+			expect(
+				allOf( 'jetpack_forms_welcome_guide_slide_view' ).map( props => props.slide )
+			).toEqual( [ 1, 2, 3, 1 ] );
 		} );
 
 		it( 'reports how far the user got when they leave', async () => {

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/index.test.jsx
@@ -79,6 +79,7 @@ await jest.unstable_mockModule( '@wordpress/components', () => ( {
 const { FormWelcomeGuide, PREFERENCE_NAME, PREFERENCE_SCOPE } = await import(
 	'../../../../src/form-editor/welcome-guide/index'
 );
+const { GUIDE_VERSION } = await import( '../../../../src/form-editor/welcome-guide/pages' );
 
 const CORE_SCOPE = 'core/edit-post';
 
@@ -420,6 +421,25 @@ describe( 'FormWelcomeGuide', () => {
 			expect( recordEvent ).toHaveBeenCalledWith(
 				'jetpack_forms_welcome_guide_dismiss',
 				expect.objectContaining( { slide: 2, slide_count: 5, origin: 'auto' } )
+			);
+		} );
+
+		it( 'stamps every event with the guide version, not just the first', async () => {
+			const user = userEvent.setup();
+			render( <FormWelcomeGuide /> );
+
+			await user.click( screen.getByRole( 'button', { name: 'Next' } ) );
+			await user.click( screen.getByRole( 'button', { name: 'Finish' } ) );
+
+			const guideEvents = recordEvent.mock.calls.filter( ( [ name ] ) =>
+				name.startsWith( 'jetpack_forms_welcome_guide_' )
+			);
+
+			// view, slide 1, slide 2, dismiss — so an event recorded without the
+			// version would have to be one of these four.
+			expect( guideEvents ).toHaveLength( 4 );
+			expect( guideEvents.map( ( [ , props ] ) => props.guide_version ) ).toEqual(
+				Array( 4 ).fill( GUIDE_VERSION )
 			);
 		} );
 	} );

--- a/projects/packages/forms/tests/js/form-editor/welcome-guide/pages.test.jsx
+++ b/projects/packages/forms/tests/js/form-editor/welcome-guide/pages.test.jsx
@@ -17,6 +17,8 @@ describe( 'welcome-guide/pages', () => {
 		expect( new Set( WELCOME_GUIDE_IMAGES ).size ).toBe( WELCOME_GUIDE_IMAGES.length );
 	} );
 
+	// Reordering or rewording this table means deciding whether GUIDE_VERSION
+	// needs bumping — see its docblock in pages.tsx.
 	test.each( [
 		[ 0, 'Welcome to the form editor', 'welcome.webp' ],
 		[ 1, 'Add fields', 'add-fields.webp' ],


### PR DESCRIPTION
## Proposed changes

Two improvements to the welcome guide's Tracks instrumentation, found while verifying the events added in PR 51668 actually fire and carry what we think they carry. Neither changes what the guide does; both change how much its analytics can be trusted later.

**1. Every event now carries `guide_version`.**

The events say which slide the user reached. None of them said which guide the user was looking at. That is fine until the slides change: reorder them, or rewrite the copy enough that a slide is making a different point, and "left on slide 3" quietly stops meaning what it meant last month, with nothing in the data separating the two.

* `GUIDE_VERSION` lives in `pages.tsx`, directly above the slides it versions, so editing them puts the decision to bump it in front of whoever is editing.
* It is injected in `useGuideTracks()` rather than at the three call sites, so an event added later cannot forget it. The hook's docblock already promised "the properties every one of them carries"; now it delivers one.
* `slide_count` already catches a slide being added or removed. This catches the rest.

Starting value is `1`. Events recorded before this property existed carry no `guide_version` and describe the same slides, so a report covering that period should read a missing value as `1`. That is noted in the constant's docblock.

**2. Slide tracking no longer depends on how `Guide` reconciles its pages.**

`SlideTracker` reports the slide by being the component mounted inside it, and used its own first effect run to mean "this is the opening slide, which the parent already recorded." That only holds because `Guide` reuses the element across page changes instead of remounting it, which is an implementation detail of the components package rather than anything it promises.

If it ever keys its pages, the tracker remounts on every slide, every run looks like the first, and **every `slide_view` after the opening one silently disappears**. The existing tests mock `Guide`, so they would all keep passing while the data quietly went wrong.

The fix moves the decision to the caller. `FormWelcomeGuide` already keeps the last recorded slide in a ref for the dismiss event, so it compares against that: a report matching it is the opening slide or a re-report, anything else is a navigation. The tracker keeps no memory of its own and behaves identically whether it is reused or remounted. That also makes it indifferent to `record` changing identity, which is why it previously needed a second ref.

One subtlety worth flagging for review: the reset back to slide 1 happens **during render**, not in the open effect. The tracker sits inside the guide, so its effects run before this component's. With the reset in the effect, a guide closed on slide 4 and then reopened would have its first report compared against 4, pass as a navigation, and record a slide 1 that the effect was about to record again. There is a test for exactly that.

Net effect on `analytics.tsx` is about 25 lines removed.

## Related product discussion/links

* Follow-up from a Tracks verification pass on the welcome guide instrumentation added in PR 51668.

## Does this pull request change what data or activity we track or use?

Yes, in one narrow way: it adds a property, `guide_version`, to the three existing `jetpack_forms_welcome_guide_*` events. The value is a hardcoded integer constant in the bundle (`1`). It carries no user, site, or request data, and is not derived from anything about the person triggering the event. No new events, no events removed, and no change to the existing properties.

The second change adds no data. It is about making sure the events we already send keep being sent.

## Testing instructions

Reviewing the diff plus the unit tests is probably enough. To watch the events land:

* On a Jetpack-connected site (a Jurassic Ninja site works), go to `/wp-admin/post-new.php?post_type=jetpack_form&jetpack_forms_welcome_guide=1`. The query argument forces the guide open regardless of whether it has been dismissed.
* With devtools' Network tab filtered to `pixel.wp.com`, step through with **Next**, jump around with the page dots, go **Previous**, then close with **Start building**, the X, or Escape.
* Expected, on the `t.gif` requests whose `_en` starts with `jetpack_forms_welcome_guide_`:
  * `guide_version=1` on all of them, alongside `origin`, `slide_count`, and (except on `_view`) `slide`.
  * One `_slide_view` per slide you land on, including the first, and no duplicates. Jumping from slide 2 straight to slide 5 with the dots records `slide=5` only, not 3 and 4 as well.
  * One `_dismiss`, carrying the slide you were on.
* Reopening from **Options → Welcome Guide** starts a fresh `_view` with `origin=menu` and exactly one `slide=1` event, even if you closed the guide part-way through.

To run the automated coverage:

```
jetpack test js packages/forms
```

Three cases were added, all in `FormWelcomeGuide › analytics`:

* `stamps every event with the guide version, not just the first`
* `records the same slides whether or not Guide remounts each page`
* `records the opening slide once when a guide closed part-way is reopened`

Each was checked against the pre-change code rather than just added green:

* Removing the `guide_version` injection from `useGuideTracks()` fails the first.
* The remount case fails on the previous implementation, recording `[1]` where it should record `[1, 2, 3, 2]` — that is the silent loss described above.
* Moving the slide reset from render into the open effect fails the third, recording `[1, 2, 3, 1, 1]`.

### Verified live

Not just unit tested. I built the form-editor bundle from this branch and dropped it onto a Jetpack-connected Jurassic Ninja site running 16.2-beta, then read the actual `pixel.wp.com/t.gif` requests. The site was serving this build (asset hash `38357146b0ae93c68880`, versus `38de7c690d7c01fefe2c` for the shipped one), and the shipped bundle it replaced contained zero occurrences of `guide_version`, so the before/after is unambiguous.

Every event below carried `guide_version=1`, plus `blog_id` and the user identity (`_ui` / `_ut=wpcom:user_id` / `_ul`):

| Action | Recorded |
| --- | --- |
| First load, guide opens by itself | `_view` `origin=auto slide_count=5`, then `_slide_view slide=1` |
| Next, Next, Previous | `_slide_view` slides `2`, `3`, `2` — three events, no duplicates |
| Page dot, slide 2 straight to 5 | one `_slide_view slide=5`, no 3 or 4 |
| Escape | `_dismiss` `origin=auto slide=5` |
| Options → Welcome Guide, after closing on slide 5 | `_view` `origin=menu`, then exactly one `_slide_view slide=1` |
| Walk to slide 3, close with the X | `_dismiss` `origin=menu slide=3` |
| Options → Welcome Guide again, after closing on slide 3 | `_view` `origin=menu`, then exactly one `_slide_view slide=1` |
| Reload the editor after the dismissal persisted | nothing at all; `isEligible` is `false` |
| `?jetpack_forms_welcome_guide=1` | `_view` and `_slide_view`, both `origin=forced` |
| "Start building" on the last slide | `_dismiss` `origin=forced slide=5` |

The two reopen rows are the ones to look at: those are the exact case the render-time reset exists for, and each recorded its opening slide once rather than twice. A full guide load emits precisely two events, one `_view` and one `_slide_view`, with nothing stray.

Also green locally: `jetpack test js packages/forms` (1491 tests), lint clean. `pnpm run typecheck` reports one error in `src/hooks/use-copy-confirmation.ts`, which I confirmed is present on a clean tree and unrelated to this branch.

The one thing no live run can show is the remount case, because today's `Guide` reuses the element — that is what the `records the same slides whether or not Guide remounts each page` unit test is for, and it fails on the previous implementation.
