### PR TITLE
Admin page layout: keep dashboard sidebars beside the content on boot 0.21

### DIFF
--- a/projects/js-packages/base-styles/admin-page-layout.scss
+++ b/projects/js-packages/base-styles/admin-page-layout.scss
@@ -162,18 +162,26 @@ $jp-breakpoint-mobile: 782px;
 	// a `display: block` div); `:has()` targets the whole chain regardless
 	// of depth. `min-width: 0` + `min-height: 0` let flex items shrink on
 	// both axes (defaults to content size which can cause overflow).
-	// `:not(:has(.boot-layout__stage))` stops the chain at the boot stage. A
-	// `@wordpress/boot` dashboard mounts <AdminPage> inside `.boot-layout__stage`,
-	// and the containers above it — `.boot-layout`, `.boot-layout__surfaces`
-	// (boot's stage|inspector flex ROW), and boot's `display: contents`
+	// The `:not(:has(...))` guard stops the chain at the boot stage. A
+	// `@wordpress/boot` dashboard mounts <AdminPage> inside boot's stage, and
+	// the containers above it — boot's layout root, its surfaces wrapper
+	// (the stage|inspector flex ROW), and boot's `display: contents`
 	// theme-provider wrapper — own that side-by-side layout. Flex-columning them
 	// would stack the inspector below the page and collapse boot's surfaces gap.
-	// Those ancestors all *contain* `.boot-layout__stage`, so the guard drops
-	// them while still flexing the stage (and anything below it) that the
-	// footer-pin chain needs. On non-boot pages nothing matches
-	// `.boot-layout__stage`, so the guard is always true and behavior is
-	// unchanged.
-	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage)) {
+	// Those ancestors all *contain* the stage, so the guard drops them while
+	// still flexing the stage (and anything below it) that the footer-pin chain
+	// needs. On non-boot pages nothing matches either selector, so the guard is
+	// always true and behavior is unchanged.
+	// The stage is `.boot-layout__stage` up to boot 0.20. From boot 0.21
+	// (WordPress/gutenberg#81756) boot's layout styles are CSS Modules and the
+	// class is `<hash>__stage`, so match the local name whatever the hash is.
+	// The wildcard is deliberately unanchored: `:has()` resolves its argument
+	// relative to the subject, so it can only ask about descendants — scoping
+	// it to an ancestor (wp-build's `[id$="-wp-admin-app"]` mount) makes the
+	// condition unsatisfiable and silently disables the whole guard.
+	// `packages/wp-build-polyfills` pins the class name in a test, so a rename
+	// fails CI instead of stacking a dashboard sidebar.
+	#wpbody-content :has(.jp-admin-page):not(:has(.boot-layout__stage, [class*="__stage"])) {
 		flex: 1 1 auto;
 		min-height: 0;
 		min-width: 0;

--- a/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
+++ b/projects/js-packages/base-styles/changelog/address-review-boot-stage-anchor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment only: document why the boot stage guard cannot be anchored to an ancestor.
+
+

--- a/projects/js-packages/base-styles/changelog/fix-forms-single-response-sidebar-layout
+++ b/projects/js-packages/base-styles/changelog/fix-forms-single-response-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin page layout: stop the flex chain at the boot stage again, so a dashboard's sidebar panel keeps its side-by-side layout on boot 0.21 and later.

--- a/projects/packages/activity-log/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/activity-log/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/activity-log/src/js/components/ActivityLog/upsell-callout.scss
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/upsell-callout.scss
@@ -24,11 +24,10 @@
 .jp-activity-log__upsell-callout-image {
 	display: block;
 	// Target 360px, capped at the container width on narrow screens. We set
-	// the size via `width` (not `width: 100%; max-width: 360px`) so it holds
-	// up under wp-build's boot layout, which applies
-	// `.boot-layout-container .boot-layout img { max-width: 100% }` at higher
-	// specificity than a single class — that override would otherwise beat a
-	// `max-width: 360px` and let the image stretch to fill the row.
+	// the size via `width` (not `width: 100%; max-width: 360px`) because
+	// wp-build's boot layout applies its own `max-width: 100%` to images, and a
+	// `max-width: 360px` here would be the one that loses when boot's rule is
+	// declared later.
 	width: 360px;
 	max-width: 100%;
 	height: auto;

--- a/projects/packages/forms/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/forms/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Restore multi-page printing of a single response.

--- a/projects/packages/forms/changelog/fix-forms-single-response-scroll-container
+++ b/projects/packages/forms/changelog/fix-forms-single-response-scroll-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses: Scroll a single response from the page edge instead of from inside the reading column.

--- a/projects/packages/forms/routes/response/style.scss
+++ b/projects/packages/forms/routes/response/style.scss
@@ -2,15 +2,14 @@
  * Standalone single response page (wp-build route) styles.
  */
 
+// This is the page's scrollable middle (the shared admin-page-layout mixin puts
+// `overflow: auto` on `.jp-admin-page__page`'s non-header child). It must stay
+// full width, or the scrollbar renders at the reading column's edge instead of
+// the window's. The measure therefore lives on the card below, not here.
 .jp-forms__single-response {
-	// `width: 100%` keeps the column a constant width regardless of each
-	// response's content. The page content area is a flex column, and an item
-	// with only `max-width` + auto inline margins shrink-wraps to its content
-	// (so width jumped per response); a definite width clamped by max-width
-	// pins it at a consistent, readable measure.
-	width: 100%;
-	max-width: 768px;
-	margin-inline: auto;
+	// No `width: 100%`: these boxes are content-box, so a full width plus the
+	// inline padding would overflow by exactly that padding and put a horizontal
+	// scrollbar on the page. As a stretched flex item it already fills the row.
 	padding-block: 24px;
 	padding-inline: 16px;
 }
@@ -55,6 +54,16 @@
 }
 
 .jp-forms__single-response-card {
+	// `width: 100%` keeps the column a constant width regardless of each
+	// response's content: this is a flex item, and one with only `max-width` +
+	// auto inline margins shrink-wraps to its content (so width jumped per
+	// response); a definite width clamped by max-width pins it at a consistent,
+	// readable measure. `border-box` so the 1px border stays inside that width
+	// rather than overflowing the scroll container.
+	box-sizing: border-box;
+	width: 100%;
+	max-width: 768px;
+	margin-inline: auto;
 	background-color: #fff;
 	border: 1px solid #e0e0e0;
 	border-radius: 8px;
@@ -161,18 +170,24 @@
 
 	// `@wordpress/boot`'s stage is a second scroll container above
 	// `.jp-admin-page`, so unwind it too and let the document grow with it.
+	// Boot's own classes come in two shapes; see the guard in
+	// `@automattic/jetpack-base-styles/admin-page-layout` for why.
 	html.wp-toolbar,
 	body.wp-admin,
 	#wpwrap,
 	.boot-layout,
 	.boot-layout__surfaces,
 	.boot-layout__stage,
+	[class*="__layout"],
+	[class*="__surfaces"],
+	[class*="__stage"],
 	.jp-admin-page,
 	.jp-admin-page__page,
 	.jp-admin-page__page > :not(:first-child):not(.jetpack-footer),
 	.jp-admin-page__page > :not(:first-child):not(.jetpack-footer) > * {
-		// `position` matters as much as `overflow`: `.boot-layout` is absolute, and
-		// browsers print only the first page of an out-of-flow subtree.
+		// `position` matters as much as `overflow`: boot's layout root is
+		// absolute, and browsers print only the first page of an out-of-flow
+		// subtree.
 		position: static !important;
 		inset: auto !important;
 		display: block !important;
@@ -202,6 +217,8 @@
 	}
 
 	.jp-forms__single-response-card {
+		max-width: none;
+		margin-inline: 0;
 		border: none;
 		border-radius: 0;
 		overflow: visible;

--- a/projects/packages/premium-analytics/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/premium-analytics/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
@@ -88,9 +88,9 @@ $section-header-visual-stacked-max-inline-size: $section-header-stacked-max-inli
 	background: var(--wpds-color-background-surface-neutral-weak);
 	color: var(--wpds-color-foreground-content-neutral-weak);
 
-	// The boot shell's `.boot-layout-container .boot-layout img` reset outranks
-	// a class here, so the box comes back through the square aspect ratio
-	// rather than a specificity contest.
+	// The boot shell resets images to `max-width: 100%; height: auto`, so the
+	// box comes back through the square aspect ratio rather than by fighting
+	// that reset.
 	img {
 		inline-size: 100%;
 		block-size: 100%;

--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -121,7 +121,7 @@ body.toplevel_page_jetpack-seo {
 // rest of Jetpack.
 
 // Two systems place Jetpack toasts and they disagree. `@wordpress/boot` renders
-// one `<SnackbarNotices className="boot-notices__snackbar">` per wp-build page
+// one `<SnackbarNotices>` per wp-build page
 // and pins it bottom-center; `<GlobalNotices>` in
 // @automattic/jetpack-components pins top-right, which is what Newsletter,
 // My Jetpack and VideoPress show.
@@ -141,13 +141,17 @@ body.toplevel_page_jetpack-seo {
 // but this one targets a class we don't own — so without the scope it would
 // move the snackbars on any other wp-build screen this stylesheet loaded on.
 
-// It also settles specificity. Boot injects its rule at runtime as
-// `.boot-layout .boot-notices__snackbar` (0,2,0); the body class puts this at
-// (0,3,1), so it wins outright rather than depending on load order.
+// It also settles specificity. Boot injects its rule at runtime as a
+// layout-scoped descendant (0,2,0); the body class puts this at (0,3,1), so it
+// wins outright rather than depending on load order. Boot's classes come in two
+// shapes; see the guard in `@automattic/jetpack-base-styles/admin-page-layout`
+// for why. Both selectors below are (0,2,0), so the specificity holds either
+// way.
 body.jetpack_page_jetpack-seo,
 body.toplevel_page_jetpack-seo {
 
-	.boot-layout .boot-notices__snackbar {
+	.boot-layout .boot-notices__snackbar,
+	[class*="__layout"] [class*="__notices-snackbar"] {
 		inset-block-start: auto;
 		inset-block-end: 0;
 		inset-inline: 0;

--- a/projects/packages/seo/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/seo/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Move the dashboard's toast notices back to the top right.

--- a/projects/packages/videopress/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/packages/videopress/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Comment accuracy only, no functional change.
+
+

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -68,11 +68,10 @@
 		}
 	}
 
-	// Override wp-build's `.boot-layout-container .boot-layout img { height:
-	// auto }` reset (specificity 0,2,1) without referencing wp-build's class
-	// names. Our own class chain has specificity (0,3,0), which beats the
-	// reset and lets the img fill its parent in both grid (large) and table
-	// (32x32) cells.
+	// Override wp-build's boot `img { height: auto }` reset without referencing
+	// boot's class names. That reset is wrapped in `:where()` (0,0,1), and our
+	// own class chain is (0,3,0), so the img fills its parent in both grid
+	// (large) and table (32x32) cells.
 	&__viewport &__thumbnail &__thumbnail-image {
 		width: 100%;
 		height: 100%;

--- a/projects/packages/wp-build-polyfills/changelog/address-review-boot-stage-anchor
+++ b/projects/packages/wp-build-polyfills/changelog/address-review-boot-stage-anchor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: added
+Comment: Test-only: pin the boot layout class contract.
+
+

--- a/projects/packages/wp-build-polyfills/tests/js/boot-layout-class-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/boot-layout-class-contract.test.js
@@ -1,0 +1,75 @@
+/**
+ * Pins the Boot layout class names our stylesheets select on.
+ *
+ * `admin-page-layout.scss` stops its flex chain at Boot's stage, and the Forms
+ * single-response print styles unwind Boot's stage and surfaces. Neither can be
+ * expressed without naming Boot's internal classes, which Boot documents as
+ * private — so a rename is a silent, total failure: a dead class inside
+ * `:not(:has())` makes the guard permanently true and the rule it guards starts
+ * applying everywhere. That is exactly how the 0.20 → 0.21 bump
+ * (WordPress/gutenberg#81756, plain classes → CSS Modules) shipped a stacked
+ * dashboard sidebar with nothing failing.
+ *
+ * Boot bakes its CSS Modules hashes in at publish time, so the class is a
+ * literal in the installed package and readable without a build.
+ */
+
+const assert = require( 'node:assert/strict' );
+const { readFileSync } = require( 'node:fs' );
+const path = require( 'node:path' );
+const { describe, it } = require( 'node:test' );
+
+// Local name => the file that renders an element carrying it.
+const RENDERED_CLASSES = {
+	stage: 'components/app/router.mjs',
+	inspector: 'components/app/router.mjs',
+	layout: 'components/root/single-page.mjs',
+	surfaces: 'components/root/single-page.mjs',
+};
+
+const bootBuildDir = () =>
+	path.join( path.dirname( require.resolve( '@wordpress/boot/package.json' ) ), 'build-module' );
+
+/**
+ * Class tokens ending in the given CSS Modules local name.
+ *
+ * Matches both shapes the guard supports: Boot's pre-0.21 `boot-layout__stage`
+ * and the hashed `d12c9efe707e6cb3__stage`.
+ *
+ * @param {string} source - File contents to scan.
+ * @param {string} local  - CSS Modules local name, e.g. `stage`.
+ * @return {string[]} Matching class tokens.
+ */
+function classTokens( source, local ) {
+	const pattern = new RegExp( `[A-Za-z0-9_-]*__${ local }(?![A-Za-z0-9_-])`, 'g' );
+	return [ ...new Set( source.match( pattern ) || [] ) ];
+}
+
+describe( 'boot layout class contract', () => {
+	for ( const [ local, file ] of Object.entries( RENDERED_CLASSES ) ) {
+		it( `still renders a class ending in __${ local }`, () => {
+			const source = readFileSync( path.join( bootBuildDir(), file ), 'utf8' );
+			const tokens = classTokens( source, local );
+
+			assert.ok(
+				tokens.length > 0,
+				`@wordpress/boot no longer renders a "${ local }" class in ${ file }. ` +
+					'Update the selectors in js-packages/base-styles/admin-page-layout.scss ' +
+					'and packages/forms/routes/response/style.scss to match, then update this test.'
+			);
+		} );
+	}
+
+	it( 'keeps the stage class matching the selector base-styles ships', () => {
+		const source = readFileSync( path.join( bootBuildDir(), RENDERED_CLASSES.stage ), 'utf8' );
+		const [ stage ] = classTokens( source, 'stage' );
+
+		// `[class*="__stage"]` in admin-page-layout.scss. Asserted as the
+		// substring test the stylesheet actually performs, not as an equality
+		// check against a hash that legitimately changes every Boot release.
+		assert.ok(
+			stage.includes( '__stage' ),
+			`Boot's stage class "${ stage }" no longer contains "__stage".`
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/fix-boot-021-dead-class-selectors
+++ b/projects/plugins/jetpack/changelog/fix-boot-021-dead-class-selectors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Restore multi-page printing of a single response. SEO: Move the dashboard's toast notices back to the top right.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-response-scroll-container
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-response-scroll-container
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Scroll a single response from the page edge instead of from inside the reading column.

--- a/projects/plugins/jetpack/changelog/fix-forms-single-response-sidebar-layout
+++ b/projects/plugins/jetpack/changelog/fix-forms-single-response-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: Show a selected response beside the responses list again instead of below it. Also fixes the same sidebar layout on the Newsletter and SEO dashboards.


### PR DESCRIPTION
This PR brings over the changes from https://github.com/Automattic/jetpack/pull/52096 to the 16.2 branch.


## Related product discussion/links
* C0BMP6FCJCA/p1788902669820399-slack

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
Build this. Visit forms > click on a response does it open as expected. 
Install the latest gutenberg. Does the same response open as expected? 

The same goes for newsletter. And the SEO content tab. 