### PR TITLE
Forms: move the --jp-forms-* tokens out of the legacy stylesheet

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
+++ b/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
@@ -1,4 +1,4 @@
 Significance: patch
-Type: changed
+Type: fixed
 
-Dashboard: define the Forms CSS custom properties in a shared partial.
+Dashboard: restore the missing border on the responses comment panel.

--- a/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
+++ b/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: define the Forms CSS custom properties in a shared partial.

--- a/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
+++ b/projects/packages/forms/changelog/fix-forms-extract-jp-forms-tokens
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Dashboard: restore the missing border on the responses comment panel.
+Dashboard: Restore the missing border on the responses comment panel.

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -13,6 +13,12 @@ $inspector-padding: 16px;
 	gap: 0 !important;
 }
 
+// The notes panel draws a full-width top border; drop the last field's inset
+// one so the two don't stack into a double line.
+.jp-forms__inbox-response-data:has(+ .jp-forms__feedback-comments) .jp-forms__field-preview:last-child {
+	border-block-end: none;
+}
+
 .jp-forms__inbox__tip-container {
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
 	margin: auto 0 0 0;

--- a/projects/packages/forms/src/dashboard/_forms-vars.scss
+++ b/projects/packages/forms/src/dashboard/_forms-vars.scss
@@ -1,18 +1,5 @@
-// Shared by both dashboards; three legacy-only tokens stay in style.scss.
+// Shared by both dashboards; legacy-only tokens stay in style.scss.
 :root {
-	// Forms-specific variables
-	--jp-forms-font-size-regular: 14px;
 	--jp-forms-border-color: #dcdcde;
 	--jp-forms-border-radius: var(--jp-border-radius, 4px);
-	--jp-forms-white: var(--jp-white, #fff);
-	--jp-forms-input-wrapper-height: var(--jp-input-wrapper-height, 40px);
-	--jp-forms-spacing-base: var(--spacing-base, 8px);
-	--jp-forms-page-padding-inline: 20px;
-	--jp-forms-black: var(--jp-black, #000);
-
-	--jp-forms-color-darker-10: var(--jp-black-80, #2c3338);
-
-	--jp-forms-focus-shadow: 0 0 0 1px var(--jp-forms-white), 0 0 0 3px var(--jp-forms-color-darker-10);// jetpack color would be nicer: #0b9e08;
-
-	--jp-forms-z-modal: 10010;
 }

--- a/projects/packages/forms/src/dashboard/_forms-vars.scss
+++ b/projects/packages/forms/src/dashboard/_forms-vars.scss
@@ -1,0 +1,22 @@
+// Shared by both dashboards. `--jp-forms-white-off` and
+// `--jp-forms-color-darker-20` are deliberately not here: their only readers
+// fall back to a WPDS token, which is what wp-build renders today.
+:root {
+	// Forms-specific variables
+	--jp-forms-font-size-regular: 14px;
+	--jp-forms-border-color: #dcdcde;
+	--jp-forms-border-radius: var(--jp-border-radius, 4px);
+	--jp-forms-white: var(--jp-white, #fff);
+	--jp-forms-input-wrapper-height: var(--jp-input-wrapper-height, 40px);
+	--jp-forms-spacing-base: var(--spacing-base, 8px);
+	--jp-forms-page-padding-inline: 20px;
+	--jp-forms-black: var(--jp-black, #000);
+
+	--jp-forms-color-darker-10: var(--jp-black-80, #2c3338);
+
+	--jp-forms-focus-shadow: 0 0 0 1px var(--jp-forms-white), 0 0 0 3px var(--jp-forms-color-darker-10);// jetpack color would be nicer: #0b9e08;
+
+	// Z-index values for modal stacking
+	--jp-forms-z-modal-backdrop: 10005;
+	--jp-forms-z-modal: 10010;
+}

--- a/projects/packages/forms/src/dashboard/_forms-vars.scss
+++ b/projects/packages/forms/src/dashboard/_forms-vars.scss
@@ -1,6 +1,4 @@
-// Shared by both dashboards. `--jp-forms-white-off` and
-// `--jp-forms-color-darker-20` are deliberately not here: their only readers
-// fall back to a WPDS token, which is what wp-build renders today.
+// Shared by both dashboards; three legacy-only tokens stay in style.scss.
 :root {
 	// Forms-specific variables
 	--jp-forms-font-size-regular: 14px;
@@ -16,7 +14,5 @@
 
 	--jp-forms-focus-shadow: 0 0 0 1px var(--jp-forms-white), 0 0 0 3px var(--jp-forms-color-darker-10);// jetpack color would be nicer: #0b9e08;
 
-	// Z-index values for modal stacking
-	--jp-forms-z-modal-backdrop: 10005;
 	--jp-forms-z-modal: 10010;
 }

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -1,13 +1,27 @@
 @use "@automattic/jetpack-base-styles/root-variables";
 @use "./forms-vars";
 
-// Legacy-only: on wp-build each of these changes what renders today. The first
-// two shadow the WPDS fallbacks their readers use; the backdrop's reader has
-// none and would drop the file-preview overlay under the admin bar.
+// Legacy-only. wp-build reads just three of these, and defining them would
+// change what renders: white-off and darker-20 would shadow WPDS fallbacks,
+// and the backdrop would sink the file-preview overlay under the admin bar.
 :root {
+	// Forms-specific variables
+	--jp-forms-font-size-regular: 14px;
+	--jp-forms-white: var(--jp-white, #fff);
 	--jp-forms-white-off: var(--jp-white-off, #f9f9f6);
+	--jp-forms-input-wrapper-height: var(--jp-input-wrapper-height, 40px);
+	--jp-forms-spacing-base: var(--spacing-base, 8px);
+	--jp-forms-page-padding-inline: 20px;
+	--jp-forms-black: var(--jp-black, #000);
+
+	--jp-forms-color-darker-10: var(--jp-black-80, #2c3338);
 	--jp-forms-color-darker-20: var(--jp-black-80, #2c3338);
+
+	--jp-forms-focus-shadow: 0 0 0 1px var(--jp-forms-white), 0 0 0 3px var(--jp-forms-color-darker-10);// jetpack color would be nicer: #0b9e08;
+
+	// Z-index values for modal stacking
 	--jp-forms-z-modal-backdrop: 10005;
+	--jp-forms-z-modal: 10010;
 }
 
 body[class*="_page_jetpack-forms"],

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -1,11 +1,13 @@
 @use "@automattic/jetpack-base-styles/root-variables";
 @use "./forms-vars";
 
-// Legacy-only: on wp-build these two would shadow the WPDS fallbacks their
-// readers rely on, so they stay here and go when this file does.
+// Legacy-only: on wp-build each of these changes what renders today. The first
+// two shadow the WPDS fallbacks their readers use; the backdrop's reader has
+// none and would drop the file-preview overlay under the admin bar.
 :root {
 	--jp-forms-white-off: var(--jp-white-off, #f9f9f6);
 	--jp-forms-color-darker-20: var(--jp-black-80, #2c3338);
+	--jp-forms-z-modal-backdrop: 10005;
 }
 
 body[class*="_page_jetpack-forms"],

--- a/projects/packages/forms/src/dashboard/style.scss
+++ b/projects/packages/forms/src/dashboard/style.scss
@@ -1,25 +1,11 @@
 @use "@automattic/jetpack-base-styles/root-variables";
+@use "./forms-vars";
 
+// Legacy-only: on wp-build these two would shadow the WPDS fallbacks their
+// readers rely on, so they stay here and go when this file does.
 :root {
-	// Forms-specific variables
-	--jp-forms-font-size-regular: 14px;
-	--jp-forms-border-color: #dcdcde;
-	--jp-forms-border-radius: var(--jp-border-radius, 4px);
-	--jp-forms-white: var(--jp-white, #fff);
 	--jp-forms-white-off: var(--jp-white-off, #f9f9f6);
-	--jp-forms-input-wrapper-height: var(--jp-input-wrapper-height, 40px);
-	--jp-forms-spacing-base: var(--spacing-base, 8px);
-	--jp-forms-page-padding-inline: 20px;
-	--jp-forms-black: var(--jp-black, #000);
-
-	--jp-forms-color-darker-10: var(--jp-black-80, #2c3338);
 	--jp-forms-color-darker-20: var(--jp-black-80, #2c3338);
-
-	--jp-forms-focus-shadow: 0 0 0 1px var(--jp-forms-white), 0 0 0 3px var(--jp-forms-color-darker-10);// jetpack color would be nicer: #0b9e08;
-
-	// Z-index values for modal stacking
-	--jp-forms-z-modal-backdrop: 10005;
-	--jp-forms-z-modal: 10010;
 }
 
 body[class*="_page_jetpack-forms"],

--- a/projects/packages/forms/src/dashboard/wp-build/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/style.scss
@@ -4,6 +4,7 @@
 
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 @use "@wordpress/base-styles/breakpoints";
+@use "../forms-vars";
 
 body.jetpack_page_jetpack-forms-responses-wp-admin,
 body.jetpack-forms-responses {

--- a/projects/plugins/jetpack/changelog/fix-forms-extract-jp-forms-tokens
+++ b/projects/plugins/jetpack/changelog/fix-forms-extract-jp-forms-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms: show the missing border on the responses dashboard comment panel.

--- a/projects/plugins/jetpack/changelog/fix-forms-extract-jp-forms-tokens
+++ b/projects/plugins/jetpack/changelog/fix-forms-extract-jp-forms-tokens
@@ -1,4 +1,0 @@
-Significance: patch
-Type: bugfix
-
-Forms: show the missing border on the responses dashboard comment panel.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Move `--jp-forms-border-color` and `--jp-forms-border-radius` out of `src/dashboard/style.scss` into `src/dashboard/_forms-vars.scss`, loaded by both `src/dashboard/wp-build/style.scss` and the legacy stylesheet.
* Keep the other twelve `--jp-forms-*` tokens in the legacy stylesheet, so they go with it in the follow-up.
* In the inbox inspector, drop the last field's separator when the notes panel follows it, so the restored border does not stack into a double line.

`style.scss` is the sole definition site for these properties and is not reached by any wp-build bundle, so the dashboard every site now serves renders with all of them undefined. It is also deleted by the follow-up that removes the legacy tree, so the definitions wp-build needs have to move somewhere first.

## What each token does on the live dashboard

Verified on a Jurassic Ninja site by deploying trunk and this branch in turn and diffing every custom property. Of the 2 tokens this defines, **one** changes anything visible:

* **`--jp-forms-border-color`** — read with no fallback by `feedback-comments/style.scss:9`, so that declaration is dropped today. Defining it restores the notes-panel border: `border-top` goes from `0px none` to `1px solid rgb(220, 220, 222)`.
* It is also read **with a literal fallback** at `feedback-comments/style.scss:48` and `:108` (`var(--jp-forms-border-color, #ddd)`). Those shift `#ddd` → `#dcdcde` — a one-per-channel difference, sub-perceptual, but a real change and not covered by a no-fallback/WPDS-fallback split.
* **`--jp-forms-border-radius`** resolves to the same `4px` its literal fallbacks already used, but those sites are now coupled to `--jp-border-radius`. Latent, no current effect.

Three tokens have wp-build readers and stay behind because defining them would change what renders:

* **`--jp-forms-white-off`** and **`--jp-forms-color-darker-20`** are read with a *WPDS* fallback, which is what wp-build renders today. Defining them would shadow it.
* **`--jp-forms-z-modal-backdrop`** is read by `preview-file/style.scss:25`, which ships in the `response` and `responses` route bundles, with no fallback. `:nth-of-type(2)` counts `div` siblings rather than overlays. `wp-admin/admin-header.php` opens exactly one body-level `div` (`#wpwrap`) and `@wordpress/components` portals `Modal` straight into `document.body`, so the single overlay on the wp-build response page *is* the second `div` and the selector matches. Defining the token would take the file-preview overlay from `z-index: 100000` to `10005`, under `#wpadminbar` (99999).

The other nine have no reader in any wp-build bundle — eight have no reader anywhere, and `--jp-forms-z-modal` is read only by the legacy inspector — so they stay in `style.scss` too.

## The notes panel separator

The inbox inspector renders the response fields and the notes panel as siblings. For collection-format responses every field row has a `border-bottom` inset by the container's padding, and nothing separates the last row from the panel, so the restored full-width `border-top` lands directly beneath it: two 1px lines touching. `routes/responses/response/style.scss` now drops the last row's border when the panel follows, as `routes/response/style.scss` already does inside the standalone response card.

Measured by computed style on a local site with this branch's tokens applied, reproducing the collection-format markup in the DOM: the two borders touch (gap `0`), and with the rule a single `1px solid rgb(220, 220, 222)` line remains.

## Where the tokens go

Not `routes/shared.scss` — `routes/response/style.scss` does not import it. The common denominator is `src/dashboard/wp-build/style.scss`, imported by all three route stages.

A third reader file, `components/inspector/style.scss`, also reads `--jp-forms-border-color` and `--jp-forms-z-modal`, but it is dead on wp-build: it is imported by `inspector/body.tsx`, which is reachable only through `inspector/index.tsx`, and no route imports either, so it is absent from every route bundle. It does still ship in the legacy dashboard stylesheet, which keeps every token either way.

## Related product discussion/links

* FORMS-799

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The notes panel renders only when `jetpack_forms_notes_enable` returns true, which it does not by default. Enable it first, for example in a mu-plugin:

```php
add_filter( 'jetpack_forms_notes_enable', '__return_true' );
```

On **Jetpack → Forms**, open a response. The notes panel gains a top border; nothing else changes. On a response submitted with the current field format, there is a single line between the last field and the panel, not two.

```js
const cs = getComputedStyle( document.documentElement );
cs.getPropertyValue( '--jp-forms-border-color' )        // "#dcdcde"  — newly defined
cs.getPropertyValue( '--jp-forms-border-radius' )       // "4px"      — newly defined
cs.getPropertyValue( '--jp-forms-white-off' )           // ""         — must stay empty
cs.getPropertyValue( '--jp-forms-color-darker-20' )     // ""         — must stay empty
cs.getPropertyValue( '--jp-forms-z-modal-backdrop' )    // ""         — must stay empty
```

The last three are the regression guard. If the first two resolve, the WPDS fallbacks in the notes panel have been shadowed. If the third resolves, open a response with an image attachment and click the file: the preview modal's backdrop drops below the admin bar.

Verified live: a full diff of every custom property between trunk and this branch shows exactly the added `--jp-forms-*` and nothing else — no `--wpds-*`, `--wp-*` or other `--jp-*` movement. The later scope changes are verified by compiling both entry stylesheets: the wp-build output defines exactly `--jp-forms-border-color` and `--jp-forms-border-radius`, and the legacy output is unchanged from trunk, all 14 token definitions and every other rule included.
