### PR TITLE
Forms: register each data store only once per page

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
+++ b/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Responses dashboard: register the responses store only once per page.
+Responses dashboard: register each of the dashboard's data stores only once per page.

--- a/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
+++ b/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Responses dashboard: register the responses store only once per page.

--- a/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
+++ b/projects/packages/forms/changelog/fix-forms-duplicate-store-registration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Responses dashboard: register each of the dashboard's data stores only once per page.
+Stop the Forms data stores from logging a duplicate registration error in the browser console.

--- a/projects/packages/forms/src/dashboard/store/index.js
+++ b/projects/packages/forms/src/dashboard/store/index.js
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 import * as actions from './actions.js';
 import reducer from './reducer.js';
 import * as resolvers from './resolvers.js';
@@ -13,4 +13,8 @@ export const store = createReduxStore( STORE_NAME, {
 	resolvers,
 } );
 
-register( store );
+// Each route bundle ships its own copy of this module, so ask the default
+// registry rather than trusting module scope to run only once per page.
+if ( ! select( STORE_NAME ) ) {
+	register( store );
+}

--- a/projects/packages/forms/src/form-editor/store/panel-state.ts
+++ b/projects/packages/forms/src/form-editor/store/panel-state.ts
@@ -2,7 +2,7 @@
  * Small data store to manage which inspector panel should be opened.
  * This allows the pre-publish panel to communicate with the block's edit component.
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 
 export const PANEL_STATE_STORE = 'jetpack-forms/panel-state';
 
@@ -56,6 +56,8 @@ const store = createReduxStore( PANEL_STATE_STORE, {
 	selectors,
 } );
 
-register( store );
+if ( ! select( PANEL_STATE_STORE ) ) {
+	register( store );
+}
 
 export { store, actions, selectors, reducer, DEFAULT_STATE };

--- a/projects/packages/forms/src/store/config/index.ts
+++ b/projects/packages/forms/src/store/config/index.ts
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 import * as actions from './actions.ts';
 import reducer from './reducer.ts';
 import * as resolvers from './resolvers.ts';
@@ -13,7 +13,9 @@ export const store = createReduxStore( CONFIG_STORE, {
 	resolvers,
 } );
 
-register( store );
+if ( ! select( CONFIG_STORE ) ) {
+	register( store );
+}
 
 export * from './actions.ts';
 export * from './selectors.ts';

--- a/projects/packages/forms/src/store/form-step-preview.js
+++ b/projects/packages/forms/src/store/form-step-preview.js
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 
 const DEFAULT_STATE = {
 	// Map of form client IDs to their single step mode state
@@ -162,4 +162,6 @@ export const store = createReduxStore( STORE_NAME, {
 	selectors,
 } );
 
-register( store );
+if ( ! select( STORE_NAME ) ) {
+	register( store );
+}

--- a/projects/packages/forms/src/store/integrations/index.ts
+++ b/projects/packages/forms/src/store/integrations/index.ts
@@ -1,4 +1,4 @@
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, register, select } from '@wordpress/data';
 import * as actions from './actions.ts';
 import reducer from './reducer.ts';
 import * as resolvers from './resolvers.ts';
@@ -13,7 +13,9 @@ export const store = createReduxStore( INTEGRATIONS_STORE, {
 	resolvers,
 } );
 
-register( store );
+if ( ! select( INTEGRATIONS_STORE ) ) {
+	register( store );
+}
 
 export * from './actions.ts';
 export * from './selectors.ts';

--- a/projects/packages/forms/tests/js/blocks/contact-form/shared/hooks/use-form-block-defaults.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/contact-form/shared/hooks/use-form-block-defaults.test.jsx
@@ -7,6 +7,7 @@ let integrations = [];
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	createReduxStore: jest.fn(),
 	register: jest.fn(),
+	select: jest.fn(),
 	useDispatch: () => ( { __unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent } ),
 	useSelect: selector =>
 		selector( () => ( {

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-page-header-details.test.jsx
@@ -176,6 +176,7 @@ let mockFormRecord = { title: { rendered: 'My Form' }, status: 'publish' };
 await jest.unstable_mockModule( '@wordpress/data', () => ( {
 	createReduxStore: jest.fn( () => 'mock-store' ),
 	register: jest.fn(),
+	select: jest.fn(),
 	useSelect: jest.fn( callback => {
 		const fakeSelect = () => ( {
 			getEntityRecord: () => mockFormRecord,

--- a/projects/packages/forms/tests/js/dashboard/store-registration.test.js
+++ b/projects/packages/forms/tests/js/dashboard/store-registration.test.js
@@ -3,21 +3,26 @@
  */
 import { describe, expect, it, jest } from '@jest/globals';
 
-// Hand every re-import the same @wordpress/data instance, so the two module
-// copies share one registry the way two route bundles share one page.
+// Pin one @wordpress/data instance across resetModules, or each re-import gets
+// a fresh registry and the duplicate registration can never happen.
 const wpData = await import( '@wordpress/data' );
 await jest.unstable_mockModule( '@wordpress/data', () => ( { ...wpData } ) );
 
-const importStoreModule = () => import( '../../../src/dashboard/store/index.js' );
+const storeModules = [
+	[ 'FORM_RESPONSES', () => import( '../../../src/dashboard/store/index.js' ) ],
+	[ 'jetpack/forms/config', () => import( '../../../src/store/config/index.ts' ) ],
+	[ 'jetpack/forms/integrations', () => import( '../../../src/store/integrations/index.ts' ) ],
+];
 
-describe( 'dashboard store registration', () => {
+describe.each( storeModules )( '%s store registration', ( storeName, importModule ) => {
 	it( 'registers once when a second bundle evaluates the module', async () => {
-		const first = await importStoreModule();
+		const first = await importModule();
 
 		jest.resetModules();
-		const second = await importStoreModule();
+		const second = await importModule();
 
 		expect( second ).not.toBe( first );
-		expect( wpData.select( first.STORE_NAME ) ).toBeTruthy();
+		expect( wpData.select( storeName ) ).toBeTruthy();
+		expect( console ).not.toHaveErrored();
 	} );
 } );

--- a/projects/packages/forms/tests/js/dashboard/store-registration.test.js
+++ b/projects/packages/forms/tests/js/dashboard/store-registration.test.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+
+// Hand every re-import the same @wordpress/data instance, so the two module
+// copies share one registry the way two route bundles share one page.
+const wpData = await import( '@wordpress/data' );
+await jest.unstable_mockModule( '@wordpress/data', () => ( { ...wpData } ) );
+
+const importStoreModule = () => import( '../../../src/dashboard/store/index.js' );
+
+describe( 'dashboard store registration', () => {
+	it( 'registers once when a second bundle evaluates the module', async () => {
+		const first = await importStoreModule();
+
+		jest.resetModules();
+		const second = await importStoreModule();
+
+		expect( second ).not.toBe( first );
+		expect( wpData.select( first.STORE_NAME ) ).toBeTruthy();
+	} );
+} );

--- a/projects/packages/forms/tests/js/store/registration.test.js
+++ b/projects/packages/forms/tests/js/store/registration.test.js
@@ -12,6 +12,8 @@ const storeModules = [
 	[ 'FORM_RESPONSES', () => import( '../../../src/dashboard/store/index.js' ) ],
 	[ 'jetpack/forms/config', () => import( '../../../src/store/config/index.ts' ) ],
 	[ 'jetpack/forms/integrations', () => import( '../../../src/store/integrations/index.ts' ) ],
+	[ 'jetpack/forms/single-step', () => import( '../../../src/store/form-step-preview.js' ) ],
+	[ 'jetpack-forms/panel-state', () => import( '../../../src/form-editor/store/panel-state.ts' ) ],
 ];
 
 describe.each( storeModules )( '%s store registration', ( storeName, importModule ) => {


### PR DESCRIPTION
Fixes #

## Proposed changes

* Guard the five module-scope `register()` calls in `packages/forms` so each data store registers once per page.

`wp-build` emits one esbuild bundle per route, and webpack emits the editor bundles, both with `@wordpress/data` externalised to `window.wp.data`. Each bundle inlines its own copy of a store module while they share one registry, so the module-scope `register()` runs once per bundle. `build/routes/registry.php` puts all three dashboard routes on the same page.

Stores guarded: `FORM_RESPONSES` (dashboard only), `jetpack/forms/config`, `jetpack/forms/integrations` (both screens), `jetpack-forms/panel-state` and `jetpack/forms/single-step` (editor only).

A module-scope flag cannot fix this, and neither can the `store-holder.jsx` static-class pattern — both are per-module-instance.

## Before / after

Counts are for arriving via **Jetpack → Forms**. Before: two `FORM_RESPONSES` errors and one `jetpack/forms/config`. After: none from this package. The post editor logged four; after, none.

**Entry path changes the count.** Arriving with `p=%2Fresponses%2Finbox` already in the URL — reload, bookmark, back/forward — gives one `FORM_RESPONSES` and no `config` before the fix, because fewer route bundles are in play. Both paths reproduced twice on a Jurassic Ninja site.

**The responses page is not silent after this change.** `jetpack-connection`, `jetpack-modules` and `wordpress-com/plans` still duplicate there. They come from `js-packages/connection` and `js-packages/jetpack-shared-stores` and need their own fix.

## Cost worth stating

The guard removes the only signal that a *foreign* store has taken one of these names. Planting a decoy store shows a console warning on trunk and silence here — the decoy wins either way, so nothing breaks that was not already broken, but the warning is gone. `FORM_RESPONSES` is un-namespaced and all-caps, so it is the one plausible collision.

## Related product discussion/links

* FORMS-797

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open **Jetpack → Forms** with the console open. On trunk you get two `Store "FORM_RESPONSES" is already registered.` errors and one for `jetpack/forms/config`; with this branch, none.
* Open a post in the editor and add a Form block. On trunk, four duplicate-registration errors; with this branch, none.
* Confirm the responses list loads, filters and folder counts work, marking read/spam/trash works, the unread menu badge updates, and the integrations modal lists its integrations.

Verified live on a Jurassic Ninja site with three submitted responses: all of the above still work, and `wp.data.select()` shows each store registered exactly once with resolved data.
