### PR TITLE
Likes: hide the loading placeholder from JS, not only from CSS

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-placeholder-css-independent
+++ b/projects/plugins/jetpack/changelog/fix-likes-placeholder-css-independent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: Hide the "Loading…" placeholder from the widget itself, so it disappears even when the Likes stylesheet is slow or fails to load.

--- a/projects/plugins/jetpack/changelog/fix-likes-placeholder-css-independent
+++ b/projects/plugins/jetpack/changelog/fix-likes-placeholder-css-independent
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Likes: Hide the "Loading…" placeholder from the widget itself, so it disappears even when the Likes stylesheet is slow or fails to load.
+Likes: Hide the "Loading…" placeholder from the widget itself, so it disappears even when the Likes stylesheet fails to load.

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -414,6 +414,13 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 	wrapper.classList.add( 'jetpack-likes-widget-loading' );
 
 	wrapper.querySelector( 'iframe' ).addEventListener( 'load', e => {
+		// A widget scrolled out of view mid-load has its iframe dropped, and a reloaded one
+		// replaces it, either of which leaves this closure holding a detached iframe. Acting on
+		// it would hide a placeholder that is now the only thing the widget has left to show.
+		if ( ! wrapper.contains( e.target ) ) {
+			return;
+		}
+
 		JetpackLikesPostMessage(
 			{ event: 'loadLikeWidget', name: e.target.name, width: e.target.width },
 			window.frames[ 'likes-master' ]

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -419,6 +419,12 @@ function jetpackLoadLikeWidgetIframe( wrapperID ) {
 			window.frames[ 'likes-master' ]
 		);
 
+		// The stylesheet is otherwise the only thing that hides the placeholder, so one that never
+		// applies leaves "Loading…" sitting over a widget that loaded fine.
+		if ( placeholder ) {
+			placeholder.style.display = 'none';
+		}
+
 		wrapper.classList.remove( 'jetpack-likes-widget-loading' );
 		wrapper.classList.add( 'jetpack-likes-widget-loaded' );
 	} );
@@ -453,6 +459,14 @@ function jetpackUnloadScrolledOutWidgets() {
 			widgetWrapper.classList.remove( 'jetpack-likes-widget-loaded' );
 			widgetWrapper.classList.remove( 'jetpack-likes-widget-loading' );
 			widgetWrapper.classList.add( 'jetpack-likes-widget-unloaded' );
+
+			// An empty string removes the inline declaration rather than setting one, handing the
+			// placeholder back to the stylesheet. The `display: none` set on load would otherwise
+			// outrank it, leaving an unloaded widget with neither an iframe nor a placeholder.
+			const placeholder = widgetWrapper.querySelector( '.likes-widget-placeholder' );
+			if ( placeholder ) {
+				placeholder.style.display = '';
+			}
 
 			// Remove it from the list of loaded widgets.
 			jetpackCommentLikesLoadedWidgets.splice( i, 1 );

--- a/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
+++ b/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
@@ -93,6 +93,42 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		widget.getBoundingClientRect = () => ( { top, bottom: top + 55 } );
 	};
 
+	// Comment widgets are the ones that get unloaded again when they scroll out of view. The
+	// iframe lands after .comment-like-feedback, two levels below the wrapper, and the unload
+	// path walks back up from it — so the nesting here has to match modules/comment-likes.php.
+	const addUnloadedCommentWidget = () => {
+		const widget = document.createElement( 'div' );
+		widget.id = 'like-comment-wrapper-12345-99-abc123';
+		widget.className = 'jetpack-comment-likes-widget-wrapper jetpack-likes-widget-unloaded';
+		widget.dataset.src = 'https://widgets.wp.com/likes/#blog_id=12345&comment_id=99';
+		widget.dataset.name = 'like-comment-frame-12345-99-abc123';
+
+		const placeholder = document.createElement( 'div' );
+		placeholder.className = 'likes-widget-placeholder comment-likes-widget-placeholder';
+		widget.appendChild( placeholder );
+
+		const inner = document.createElement( 'div' );
+		inner.className = 'comment-likes-widget jetpack-likes-widget';
+		const feedback = document.createElement( 'span' );
+		feedback.className = 'comment-like-feedback';
+		inner.appendChild( feedback );
+		widget.appendChild( inner );
+
+		document.body.appendChild( widget );
+
+		return widget;
+	};
+
+	// Drive the queue to the point where it has created the iframe, then fire the load event
+	// jsdom never fires for a cross-origin src.
+	const loadWidget = async widget => {
+		answerPingsWithMasterReady();
+		require( '../queuehandler' );
+		await Promise.resolve();
+		jest.advanceTimersByTime( 500 );
+		widget.querySelector( 'iframe' ).dispatchEvent( new Event( 'load' ) );
+	};
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 		jest.resetModules();
@@ -192,5 +228,36 @@ describe( 'Likes queue handler master iframe handshake', () => {
 
 		expect( initialBatches().length ).toBeGreaterThanOrEqual( 1 );
 		expect( widget.querySelector( 'iframe.post-likes-widget' ) ).not.toBeNull();
+	} );
+
+	it( 'hides the loading placeholder itself, rather than leaving that to the stylesheet', async () => {
+		const widget = addUnloadedPostWidget();
+		const placeholder = widget.querySelector( '.likes-widget-placeholder' );
+
+		await loadWidget( widget );
+
+		expect( widget ).toHaveClass( 'jetpack-likes-widget-loaded' );
+		expect( placeholder ).not.toBeVisible();
+	} );
+
+	it( 'shows the placeholder again when a widget is unloaded', async () => {
+		const widget = addUnloadedCommentWidget();
+		const placeholder = widget.querySelector( '.likes-widget-placeholder' );
+
+		await loadWidget( widget );
+		expect( placeholder ).not.toBeVisible();
+
+		// Scroll the widget out of view: its iframe is dropped and the wrapper goes back to
+		// unloaded, so the placeholder has to become the visible state again. The wrapper needs
+		// moving too, or the same pass that unloads it finds it in view and reloads it.
+		const outOfView = () => ( { top: 50000, bottom: 50018 } );
+		widget.querySelector( 'iframe' ).getBoundingClientRect = outOfView;
+		widget.getBoundingClientRect = outOfView;
+		window.dispatchEvent( new Event( 'scroll' ) );
+		jest.advanceTimersByTime( 250 );
+
+		expect( widget ).toHaveClass( 'jetpack-likes-widget-unloaded' );
+		expect( widget.querySelectorAll( 'iframe' ) ).toHaveLength( 0 );
+		expect( placeholder ).toBeVisible();
 	} );
 } );

--- a/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
+++ b/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
@@ -119,14 +119,28 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		return widget;
 	};
 
-	// Drive the queue to the point where it has created the iframe, then fire the load event
-	// jsdom never fires for a cross-origin src.
-	const loadWidget = async widget => {
+	// Drive the queue to the point where it has created the widget's iframe.
+	const startQueue = async () => {
 		answerPingsWithMasterReady();
 		require( '../queuehandler' );
 		await Promise.resolve();
 		jest.advanceTimersByTime( 500 );
+	};
+
+	// ...and fire the load event jsdom never fires for a cross-origin src.
+	const loadWidget = async widget => {
+		await startQueue();
 		widget.querySelector( 'iframe' ).dispatchEvent( new Event( 'load' ) );
+	};
+
+	// The wrapper has to move as well as its iframe, or the same pass that unloads it finds it
+	// in view and reloads it.
+	const scrollOutOfView = widget => {
+		const outOfView = () => ( { top: 50000, bottom: 50018 } );
+		widget.querySelector( 'iframe' ).getBoundingClientRect = outOfView;
+		widget.getBoundingClientRect = outOfView;
+		window.dispatchEvent( new Event( 'scroll' ) );
+		jest.advanceTimersByTime( 250 );
 	};
 
 	beforeEach( () => {
@@ -247,17 +261,27 @@ describe( 'Likes queue handler master iframe handshake', () => {
 		await loadWidget( widget );
 		expect( placeholder ).not.toBeVisible();
 
-		// Scroll the widget out of view: its iframe is dropped and the wrapper goes back to
-		// unloaded, so the placeholder has to become the visible state again. The wrapper needs
-		// moving too, or the same pass that unloads it finds it in view and reloads it.
-		const outOfView = () => ( { top: 50000, bottom: 50018 } );
-		widget.querySelector( 'iframe' ).getBoundingClientRect = outOfView;
-		widget.getBoundingClientRect = outOfView;
-		window.dispatchEvent( new Event( 'scroll' ) );
-		jest.advanceTimersByTime( 250 );
+		// Its iframe is dropped and the wrapper goes back to unloaded, so the placeholder has to
+		// become the visible state again.
+		scrollOutOfView( widget );
 
 		expect( widget ).toHaveClass( 'jetpack-likes-widget-unloaded' );
 		expect( widget.querySelectorAll( 'iframe' ) ).toHaveLength( 0 );
+		expect( placeholder ).toBeVisible();
+	} );
+
+	it( 'ignores a load event from an iframe the widget has already dropped', async () => {
+		const widget = addUnloadedCommentWidget();
+		const placeholder = widget.querySelector( '.likes-widget-placeholder' );
+
+		await startQueue();
+
+		// Scroll away before the iframe reports back, so the queue drops it mid-load.
+		const droppedIframe = widget.querySelector( 'iframe' );
+		scrollOutOfView( widget );
+		droppedIframe.dispatchEvent( new Event( 'load' ) );
+
+		expect( widget ).toHaveClass( 'jetpack-likes-widget-unloaded' );
 		expect( placeholder ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Related to BOOST-549

## Proposed changes

**Scope first, because the linked issue invites the wrong reading:** this is about a Likes stylesheet that *never arrives at all* — a 404, a blocked request, a broken concatenated CSS bundle. It is **not** about Boost's Critical CSS, whose deferral is transient: `Display_Critical_CSS` defaults to the `async` method and gives every `<link>` its own `onload` flip, so the Likes CSS applies as soon as it downloads, long before the cross-origin widget iframe reports back. The never-arrives case is plausible on the BOOST-549 site, which has Page Optimize concatenating its CSS.

Whether a Like widget looks loaded is decided entirely by CSS today, and nothing in the DOM records it.

The server renders the placeholder inline (`extensions/blocks/like/render.php`):

```html
<div class='likes-widget-placeholder post-likes-widget-placeholder' style='height: 55px;'>
  <span class='loading'>Loading…</span>
</div>
```

`jetpackLoadLikeWidgetIframe()` inserts the iframe and swaps the wrapper's class to `jetpack-likes-widget-loaded`; it never touches the placeholder. The one thing that hides it is `modules/likes/style.css`:

```css
.jetpack-likes-widget-loaded .likes-widget-placeholder,
.jetpack-likes-widget-unloaded iframe,
.jetpack-likes-widget-loading iframe { display: none; }
```

So any failure to deliver that stylesheet — a 404, a blocked request, a broken concatenated CSS bundle — leaves "Loading…" sitting over a like button that loaded perfectly. It reads as a broken widget rather than an unstyled one, which is the wrong place to send whoever triages it.

A second commit guards the load handler against a stale closure: a comment widget scrolled out of view mid-load has its iframe removed (and a reloaded one replaces it), leaving the handler holding a detached iframe. Acting on it hides the placeholder and adds `loaded` to a wrapper that has no iframe, so the comment shows a blank gap where its like button belongs. It does recover — the closure never removes `unloaded`, so the next queue pass with the widget back in view reloads it — but nothing puts it right while the reader is looking at it. The stray class flip predates this PR; hiding the placeholder from JS is what lets it blank the widget without the stylesheet's help.

This hides the placeholder from the load handler, so the visible state follows the DOM, and clears that inline style again when a widget is unloaded — without which the stylesheet could no longer show the placeholder for the reloaded widget, and a comment-like widget scrolled back into view would show nothing at all.

## Related product discussion/links

* BOOST-549 — a Like block stuck on "Loading…". This is one of two independent fragilities I found in the Likes queue handler while investigating that report; Automattic/jetpack#52144 is the other and Automattic/jetpack#52141 is the Boost-side half. None of the three is a complete fix for the original report on its own.

Rebased on trunk now that #52144 has landed; the two overlapping regions in `queuehandler.test.js` are resolved here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated: from `projects/plugins/jetpack`, `NODE_PATH=tests:_inc/client pnpm exec jest --config=tests/jest.config.client.js modules/likes`. The two new cases fail on trunk and pass here.

### Real-screen before / after

Captured on a Jurassic Ninja site running Jetpack 16.2-beta, on a post whose Like block is above the fold, with the `jetpack_likes` stylesheet dequeued to stand in for one that never arrives. The two runs differ only by this PR's diff to `modules/likes/queuehandler.js`.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/likes-placeholder-css-independent/before-no-stylesheet.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/likes-placeholder-css-independent/after-no-stylesheet.png) |

Measured in the page six seconds after load:

| | before | after |
|---|---|---|
| Likes stylesheet present | `false` | `false` |
| wrapper class | `jetpack-likes-widget-loaded` | `jetpack-likes-widget-loaded` |
| widget iframes | `1` | `1` |
| iframe display | `inline` | `inline` |
| placeholder display | `block` | `none` |

The widget loads correctly in both runs - that was never the problem. The difference is whether "Loading…" is still sitting above it.

To reproduce: publish a post with the Like block, add an mu-plugin that runs `wp_dequeue_style( 'jetpack_likes' ); wp_deregister_style( 'jetpack_likes' );` late on `wp_enqueue_scripts`, and load the post.

### Also checked on the same site

Each row is trunk vs this branch with only `queuehandler.js` swapped.

| Check | trunk | this branch |
|---|---|---|
| Stylesheet dequeued, widget loads | `loaded`, 1 iframe, placeholder `block` (the screenshots above) | `loaded`, 1 iframe, placeholder `none` |
| Normal path, stylesheet present | — | `loaded`, iframe `block` 55px, placeholder `none` |
| Comment widget torn down mid-load, then its dropped iframe fires `load` | `unloaded,loaded`, 0 iframes, placeholder `none` — a blank gap | `unloaded`, 0 iframes, placeholder `block` — unchanged by the stale event |
| That widget scrolled back into view | reloads | reloads |

On the Critical CSS question, serving the Likes stylesheet the way `Display_Critical_CSS`'s async method does — `media="not all"` plus an `onload` flip, from an endpoint stalled 6s — trunk goes `loaded` with the placeholder still `block` at t=3216ms and clears it at t=8216ms when the CSS lands. Transient, exactly as described in the scope note above, and never the stuck state. (This branch clears it at t=3740ms, when the widget loads rather than when the CSS arrives, so the flash goes away as a side effect.)

Also worth checking that the normal path is unchanged, since the placeholder now carries an inline style:

1. With the stylesheet loading normally, a like button above the fold still appears with no "Loading…" left behind.
2. With **Comment Likes** enabled, scroll a comment-like widget out of view and back. It should unload and reload as before — the placeholder must reappear while it is unloaded, not vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PoeBjaZrNBzXfX1j2rcnq



