### PR TITLE
VideoPress: Fix private video thumbnail frame selection

### DIFF
--- a/projects/packages/videopress/changelog/fix-private-video-thumbnail-frames
+++ b/projects/packages/videopress/changelog/fix-private-video-thumbnail-frames
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix selecting thumbnail frames from private videos and prefer browser-compatible video renditions.

--- a/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
@@ -2,6 +2,7 @@ import { RangeControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button, Dialog } from '@wordpress/ui';
 import { useEffect, useRef, useState, type ReactElement } from 'react';
+import FetchErrorNotice from '../fetch-error-notice';
 
 // Exported for unit testing.
 export const END_GUARD_SECONDS = 0.05;
@@ -124,8 +125,11 @@ function FrameScrubber( { src, onChange }: FrameScrubberProps ): ReactElement {
 }
 
 type Props = {
-	src: string;
+	src?: string;
 	isOpen: boolean;
+	isLoading: boolean;
+	hasError: boolean;
+	onRetry: () => void;
 	onClose: () => void;
 	onConfirm: ( atTimeMs: number ) => void;
 };
@@ -138,6 +142,9 @@ type Props = {
  * @param props           - Component props.
  * @param props.src       - Source URL of the video to scrub.
  * @param props.isOpen    - Whether the dialog is open.
+ * @param props.isLoading - Whether the source URL is still loading.
+ * @param props.hasError  - Whether the source URL could not be loaded.
+ * @param props.onRetry   - Called to retry loading the source URL.
  * @param props.onClose   - Called when the user dismisses the dialog without confirming.
  * @param props.onConfirm - Called with the selected timestamp in milliseconds when the user confirms.
  * @return The dialog element.
@@ -145,16 +152,19 @@ type Props = {
 export default function SelectFrameDialog( {
 	src,
 	isOpen,
+	isLoading,
+	hasError,
+	onRetry,
 	onClose,
 	onConfirm,
 }: Props ): ReactElement {
 	const [ selectedMs, setSelectedMs ] = useState< number | null >( null );
 
 	useEffect( () => {
-		if ( ! isOpen ) {
-			setSelectedMs( null );
-		}
-	}, [ isOpen ] );
+		setSelectedMs( null );
+	}, [ isOpen, src ] );
+
+	const canConfirm = Boolean( src ) && ! isLoading && ! hasError && selectedMs != null;
 
 	return (
 		<Dialog.Root
@@ -173,7 +183,16 @@ export default function SelectFrameDialog( {
 					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-videopress-pkg' ) } />
 				</Dialog.Header>
 				<Dialog.Content>
-					{ isOpen && <FrameScrubber src={ src } onChange={ setSelectedMs } /> }
+					{ isOpen && isLoading && <Spinner /> }
+					{ isOpen && hasError && (
+						<FetchErrorNotice
+							message={ __( "We couldn't load this video.", 'jetpack-videopress-pkg' ) }
+							onRetry={ onRetry }
+						/>
+					) }
+					{ isOpen && ! isLoading && ! hasError && src && (
+						<FrameScrubber key={ src } src={ src } onChange={ setSelectedMs } />
+					) }
 				</Dialog.Content>
 				<Dialog.Footer>
 					<Dialog.Action render={ <Button variant="outline" /> }>
@@ -181,9 +200,9 @@ export default function SelectFrameDialog( {
 					</Dialog.Action>
 					<Button
 						variant="solid"
-						disabled={ selectedMs == null }
+						disabled={ ! canConfirm }
 						onClick={ () => {
-							if ( selectedMs != null ) {
+							if ( canConfirm && selectedMs != null ) {
 								onConfirm( selectedMs );
 							}
 						} }

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/private-thumbnail-source.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/private-thumbnail-source.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { makeLibraryItem } from '../../../test-utils/library-item';
+import ThumbnailCard from '../thumbnail-card';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/jetpack-components/global-notices', () => ( {
+	useGlobalNotices: () => ( {
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+	} ),
+} ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+const sourceUrl = 'https://videos.files.wordpress.com/abc123/original.mov';
+const playbackUrl = 'https://videos.files.wordpress.com/abc123/video_dvd.mp4?download=1';
+const privateVideo = makeLibraryItem( {
+	thumbnailUrl: 'https://videos.files.wordpress.com/abc123/poster.jpg',
+	sourceUrl,
+	playbackUrl,
+	isPrivate: true,
+} );
+
+/**
+ * Create an isolated query cache without automatic retries.
+ *
+ * @return The query provider wrapper.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+}
+
+/**
+ * Find the video inside the portaled dialog.
+ *
+ * @return The video element, if mounted.
+ */
+function getVideo(): HTMLVideoElement | null {
+	return document.querySelector( 'video' );
+}
+
+beforeEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+it( 'waits for a shared playback token before loading the private MP4 rendition', async () => {
+	let resolveToken: ( value: { playback_token: string } ) => void = () => {};
+	mockedApiFetch.mockReturnValueOnce(
+		new Promise( resolve => {
+			resolveToken = resolve;
+		} )
+	);
+	const user = userEvent.setup();
+	render( <ThumbnailCard video={ privateVideo } />, { wrapper: makeWrapper() } );
+	await user.click( screen.getByRole( 'button', { name: /select from video/i } ) );
+
+	expect( getVideo() ).toBeNull();
+	expect( mockedApiFetch ).toHaveBeenCalledTimes( 1 );
+	expect( mockedApiFetch ).toHaveBeenCalledWith( {
+		path: '/wpcom/v2/videopress/playback-jwt/abc123',
+		method: 'POST',
+	} );
+
+	resolveToken( { playback_token: 'token-123' } );
+	await waitFor( () =>
+		expect( getVideo() ).toHaveAttribute( 'src', `${ playbackUrl }&metadata_token=token-123` )
+	);
+	expect( mockedApiFetch ).toHaveBeenCalledTimes( 1 );
+} );
+
+it.each( [ 'empty', 'rejected' ] )(
+	'offers retry without loading video when the token is %s',
+	async failure => {
+		if ( failure === 'empty' ) {
+			mockedApiFetch.mockResolvedValue( { playback_token: '' } );
+		} else {
+			mockedApiFetch.mockRejectedValue( { code: 'rest_forbidden', message: 'Forbidden' } );
+		}
+		const user = userEvent.setup();
+		render( <ThumbnailCard video={ privateVideo } />, { wrapper: makeWrapper() } );
+		await user.click( screen.getByRole( 'button', { name: /select from video/i } ) );
+
+		const retry = await screen.findByRole( 'button', { name: 'Retry' } );
+		expect( getVideo() ).toBeNull();
+
+		mockedApiFetch.mockResolvedValue( { playback_token: 'retry-token' } );
+		await user.click( retry );
+		await waitFor( () =>
+			expect( getVideo() ).toHaveAttribute( 'src', `${ playbackUrl }&metadata_token=retry-token` )
+		);
+	}
+);
+
+it( 'signs the private original when there is no MP4 rendition', async () => {
+	mockedApiFetch.mockResolvedValue( { playback_token: 'token-123' } );
+	const user = userEvent.setup();
+	render( <ThumbnailCard video={ { ...privateVideo, playbackUrl: undefined } } />, {
+		wrapper: makeWrapper(),
+	} );
+	await user.click( screen.getByRole( 'button', { name: /select from video/i } ) );
+
+	await waitFor( () =>
+		expect( getVideo() ).toHaveAttribute( 'src', `${ sourceUrl }?metadata_token=token-123` )
+	);
+} );
+
+it.each( [
+	{ label: 'MP4 rendition', sourceUrl, playbackUrl, expected: playbackUrl },
+	{ label: 'original fallback', sourceUrl, playbackUrl: undefined, expected: sourceUrl },
+	{
+		label: 'rendition without an original',
+		sourceUrl: undefined,
+		playbackUrl,
+		expected: playbackUrl,
+	},
+] )( 'loads a public $label without requesting a token', async video => {
+	const user = userEvent.setup();
+	render( <ThumbnailCard video={ { ...privateVideo, ...video, isPrivate: false } } />, {
+		wrapper: makeWrapper(),
+	} );
+	await user.click( screen.getByRole( 'button', { name: /select from video/i } ) );
+
+	expect( getVideo() ).toHaveAttribute( 'src', video.expected );
+	expect( mockedApiFetch ).not.toHaveBeenCalled();
+} );
+
+it( 'resets the selected frame when the source changes', async () => {
+	mockedApiFetch.mockResolvedValue( { playback_token: 'token-123' } );
+	const user = userEvent.setup();
+	const { rerender } = render( <ThumbnailCard video={ privateVideo } />, {
+		wrapper: makeWrapper(),
+	} );
+	await user.click( screen.getByRole( 'button', { name: /select from video/i } ) );
+	await waitFor( () => expect( getVideo() ).not.toBeNull() );
+	const video = getVideo() as HTMLVideoElement;
+	Object.defineProperty( video, 'duration', { configurable: true, value: 30 } );
+	fireEvent.durationChange( video );
+	const confirm = screen.getByRole( 'button', { name: /select this frame/i } );
+	expect( confirm ).not.toHaveAttribute( 'aria-disabled', 'true' );
+
+	rerender(
+		<ThumbnailCard video={ { ...privateVideo, playbackUrl: `${ sourceUrl }?updated=1` } } />
+	);
+	await waitFor( () => expect( getVideo() ).not.toBe( video ) );
+	expect( confirm ).toHaveAttribute( 'aria-disabled', 'true' );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { media, upload } from '@wordpress/icons';
 import { Card, Field, Skeleton, Stack, Text } from '@wordpress/ui';
+import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
-import { usePosterUrl } from '../../hooks/use-poster-url';
+import { usePlaybackTokenQuery, usePosterUrl } from '../../hooks/use-poster-url';
 import { useUpdateVideoPoster } from '../../hooks/use-update-video-poster';
 import { selectImageFromMediaLibrary } from '../../utils/select-image-from-media-library';
 import SelectFrameDialog from './select-frame-dialog';
@@ -34,6 +35,17 @@ function EditableThumbnailCard( { video }: Props ): ReactElement {
 	const updatePoster = useUpdateVideoPoster();
 	const posterUrl = usePosterUrl( video );
 	const [ dialogOpen, setDialogOpen ] = useState( false );
+	const playbackToken = usePlaybackTokenQuery( video.guid, video.isPrivate && dialogOpen );
+	const sourceUrl = video.playbackUrl ?? video.sourceUrl;
+	const isSourceLoading = video.isPrivate && ! playbackToken.data && playbackToken.isFetching;
+	const hasSourceError = video.isPrivate && ! playbackToken.data && ! isSourceLoading;
+	let frameSourceUrl = sourceUrl;
+	if ( video.isPrivate ) {
+		frameSourceUrl =
+			sourceUrl && playbackToken.data
+				? addQueryArgs( sourceUrl, { metadata_token: playbackToken.data } )
+				: undefined;
+	}
 
 	/*
 	 * `usePosterUrl` returns null both when there is no poster at all and
@@ -112,7 +124,7 @@ function EditableThumbnailCard( { video }: Props ): ReactElement {
 						<ThumbnailTile
 							icon={ media }
 							label={ __( 'Select from video', 'jetpack-videopress-pkg' ) }
-							disabled={ isBusy || ! video.sourceUrl }
+							disabled={ isBusy || ! sourceUrl }
 							onClick={ () => setDialogOpen( true ) }
 						/>
 					</Stack>
@@ -125,8 +137,11 @@ function EditableThumbnailCard( { video }: Props ): ReactElement {
 				</Field.Root>
 			</Card.Content>
 			<SelectFrameDialog
-				src={ video.sourceUrl ?? '' }
+				src={ frameSourceUrl }
 				isOpen={ dialogOpen }
+				isLoading={ isSourceLoading }
+				hasError={ hasSourceError }
+				onRetry={ () => playbackToken.refetch() }
 				onClose={ () => setDialogOpen( false ) }
 				onConfirm={ handleConfirmFrame }
 			/>

--- a/projects/packages/videopress/src/dashboard/hooks/use-poster-url.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-poster-url.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import type { LibraryItem } from '../types/library';
 
@@ -8,20 +8,14 @@ const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 type PlaybackJwtResponse = { playback_token?: string };
 
 /**
- * Fetch a short-lived playback JWT for a VideoPress GUID. The token is
- * required to access poster (and stream) URLs of private videos and is
- * appended as `?metadata_token=<jwt>` to those URLs.
- *
- * The query is keyed by guid alone so concurrent renders of the same
- * private video (e.g. multiple rows of the same library) share one
- * request, and the token is cached for ~24h to match the JWT lifetime.
+ * Share a playback JWT query by GUID, caching it for one day.
  *
  * @param guid    - VideoPress GUID, or '' for non-VideoPress items.
  * @param enabled - Skip the request when false (e.g. for public videos).
- * @return The token (or undefined while loading / disabled).
+ * @return The playback-token query, including loading and retry state.
  */
-export function usePlaybackToken( guid: string, enabled: boolean ): string | undefined {
-	const query = useQuery( {
+export function usePlaybackTokenQuery( guid: string, enabled: boolean ): UseQueryResult< string > {
+	return useQuery( {
 		queryKey: [ 'videopress-playback-token', guid ],
 		queryFn: async () => {
 			const res = await apiFetch< PlaybackJwtResponse >( {
@@ -34,7 +28,17 @@ export function usePlaybackToken( guid: string, enabled: boolean ): string | und
 		staleTime: ONE_DAY_MS,
 		gcTime: ONE_DAY_MS,
 	} );
-	return query.data;
+}
+
+/**
+ * Resolve the shared playback token for a VideoPress GUID.
+ *
+ * @param guid    - VideoPress GUID, or '' for non-VideoPress items.
+ * @param enabled - Skip the request when false (e.g. for public videos).
+ * @return The token (or undefined while loading / disabled).
+ */
+export function usePlaybackToken( guid: string, enabled: boolean ): string | undefined {
+	return usePlaybackTokenQuery( guid, enabled ).data;
 }
 
 /**

--- a/projects/plugins/jetpack/changelog/fix-private-video-thumbnail-frames
+++ b/projects/plugins/jetpack/changelog/fix-private-video-thumbnail-frames
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix selecting thumbnail frames from private videos and prefer browser-compatible video renditions.

--- a/projects/plugins/videopress/changelog/fix-private-video-thumbnail-frames
+++ b/projects/plugins/videopress/changelog/fix-private-video-thumbnail-frames
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix selecting thumbnail frames from private videos and prefer browser-compatible video renditions.


### PR DESCRIPTION
## Proposed changes

Selecting a thumbnail frame from a private video in the modern dashboard loads the original video URL without a playback token and receives a 403. The poster and preview player obtain their tokens separately, so successful playback elsewhere does not authenticate the frame picker.

Reuse the dashboard's checked playback-token query for the frame source. Wait for a nonempty token before mounting the video, and offer Retry when the request fails or returns an empty token. Prefer the existing MP4 rendition when available, falling back to the original upload, and reset the frame selection when the source changes.

## Related product discussion/links

Found while testing thumbnail selection for a private video on an Atomic site.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated validation: all 1,275 VideoPress JavaScript tests across 130 suites pass, along with the package build, TypeScript check, ESLint, and formatting checks. Eight new tests exercise the real dialog and video element; seven failed against the previous implementation. They cover delayed, empty and rejected tokens, retry, query deduplication, existing URL parameters, rendition/original fallback, and selection reset.

Reproduced the original failure on an authenticated Atomic site: the current private poster loads with a playback token, and the preview iframe carries one, while the thumbnail picker sets its video source to the unsigned original movie URL and displays the loading error. This confirms the affected URL path in the installed code; the PR build has not yet been installed there.

Browser validation used the actual card, dialog and token hooks with a local synthetic video and controlled token responses. Verified private playback and frame selection, no video request while a token is pending or missing, recovery after Retry, and public playback without a token. Poster saving was stubbed in this fixture; the live Atomic save remains to be checked with this build.

1. Install the PR build on a test site with VideoPress and open a processed private video in the modern VideoPress dashboard.
2. Choose **Select from video**. Confirm the video loads and can be scrubbed. In Network, its request should include `metadata_token` and return 200 or 206. An available MP4 rendition should be preferred over the original upload.
3. Select a different frame and confirm the new thumbnail persists after reloading the page.
4. Repeat with a public video; the picker should load without requesting a playback token.
5. In a test environment, delay or fail the playback-token request. The picker should wait or show its error with Retry, without requesting an unsigned private video. Allow the request again and verify Retry recovers.

