### PR TITLE
Jetpack notices: remove the CSS the notice migration left dead

### DIFF
--- a/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
+++ b/projects/plugins/jetpack/_inc/client/at-a-glance/style.scss
@@ -431,15 +431,6 @@
 
 		.dops-card.is-compact {
 			flex-grow: 0;
-
-			a.dops-notice__action {
-				margin-left: 0;
-				padding-left: 0;
-
-				@include breakpoints.breakpoint( "<480px" ) {
-					text-transform: none;
-				}
-			}
 		}
 	}
 

--- a/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/dash-item/style.scss
@@ -24,11 +24,6 @@
 		a:hover {
 			text-decoration: underline;
 		}
-
-		.dops-notice {
-			margin-top: rem.convert(-1px);
-			margin-bottom: rem.convert(-1px);
-		}
 	}
 }
 
@@ -124,14 +119,6 @@
 
 	.dops-button {
 		font-style: normal;
-	}
-
-	&.is-working,
-	&.is-premium-inactive {
-
-		.dops-section-header__actions {
-			color: colors.$gray-text-min;
-		}
 	}
 }
 

--- a/projects/plugins/jetpack/_inc/client/components/notice/style.scss
+++ b/projects/plugins/jetpack/_inc/client/components/notice/style.scss
@@ -113,10 +113,6 @@
 
 .dops-notice__text {
 
-	a.dops-notice__text-no-underline {
-		text-decoration: none;
-	}
-
 	a,
 	a:visited {
 		text-decoration: underline;
@@ -146,11 +142,6 @@
 			margin-top: 0;
 		}
 	}
-}
-
-.dops-notice__button {
-	cursor: pointer;
-	margin-left: 0.428em;
 }
 
 // "X" for dismissing a notice

--- a/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/pro-status/index.jsx
@@ -151,11 +151,7 @@ class ProStatus extends Component {
 			<>
 				{ message }
 				{ action && (
-					<a
-						className="dops-notice__text-no-underline"
-						onClick={ handleClickForTracking( type, feature ) }
-						href={ actionUrl }
-					>
+					<a onClick={ handleClickForTracking( type, feature ) } href={ actionUrl }>
 						{ action }
 					</a>
 				) }

--- a/projects/plugins/jetpack/_inc/client/settings/style.scss
+++ b/projects/plugins/jetpack/_inc/client/settings/style.scss
@@ -18,20 +18,12 @@
 	a:visited {
 		color: var(--jp-black-80);
 		text-decoration: underline;
-
-		&.dops-notice__action {
-			color: var(--jp-gray-20);
-		}
 	}
 
 	a:hover,
 	a:active {
 		color: var(--jp-black);
 		text-decoration-thickness: var(--jp-underline-thickness);
-
-		&.dops-notice__action {
-			color: var(--jp-white);
-		}
 	}
 
 	a.dops-banner,

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -256,13 +256,6 @@ $twitter-pofile-image-padding: 17px;
 	top: 1em;
 }
 
-.jp-stats-odyssey-disabled-notice {
-
-	@include breakpoints.breakpoint(">480px") {
-		width: calc(100% - 26px);
-	}
-}
-
 .jp-stats-odyssey-toggle {
 	margin-bottom: 20px;
 }

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -258,17 +258,6 @@ $twitter-pofile-image-padding: 17px;
 
 .jp-stats-odyssey-disabled-notice {
 
-	@include breakpoints.breakpoint("<480px") {
-
-		a.dops-notice__action {
-			white-space: initial;
-		}
-
-		a.dops-notice__action .gridicon {
-			display: none;
-		}
-	}
-
 	@include breakpoints.breakpoint(">480px") {
 		width: calc(100% - 26px);
 	}

--- a/projects/plugins/jetpack/_inc/client/traffic/style.scss
+++ b/projects/plugins/jetpack/_inc/client/traffic/style.scss
@@ -256,26 +256,6 @@ $twitter-pofile-image-padding: 17px;
 	top: 1em;
 }
 
-.jp-stats-odyssey-toggle {
-	margin-bottom: 20px;
-}
-
-.jp-stats-odyssey-toggle > .components-base-control {
-	margin-bottom: 0;
-}
-
 .jp-stats-form-fieldset {
 	margin-bottom: 20px;
-}
-
-.jp-stats-odyssey-badge {
-	color: #008710;
-	background-color: #d0e6b8;
-	border-radius: 3px;
-	font-size: 10px;
-	line-height: 18px;
-	margin-left: 8px;
-	padding: 0 6px;
-	text-transform: uppercase;
-	display: inline-block;
 }

--- a/projects/plugins/jetpack/changelog/update-prune-dead-dops-notice-css
+++ b/projects/plugins/jetpack/changelog/update-prune-dead-dops-notice-css
@@ -1,5 +1,3 @@
 Significance: patch
 Type: other
-Comment: Remove CSS rules left dead by the notice migration
-
-
+Comment: Remove CSS rules left dead by the notice migration and the Legacy Stats removal

--- a/projects/plugins/jetpack/changelog/update-prune-dead-dops-notice-css
+++ b/projects/plugins/jetpack/changelog/update-prune-dead-dops-notice-css
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Remove CSS rules left dead by the notice migration
+
+


### PR DESCRIPTION
Fixes JETPACK-2542

## Proposed changes

* Removes CSS left dead by #52015, which rewrote `SimpleNotice` to render the `@wordpress/ui` `Notice` and dropped the `dops-notice` class family from every React notice.
* Nine rules across five stylesheets. Six from the notice migration: the `.dops-notice` margin and the unreachable `.dops-section-header.is-working` block in `dash-item`, `a.dops-notice__action` in `at-a-glance`, `traffic` and `settings`, and `.dops-notice__text-no-underline` / `.dops-notice__button` in `components/notice`.
* Two more that review turned up: the whole `.jp-stats-odyssey-disabled-notice` block in `traffic`, and the `dops-notice__text-no-underline` class `pro-status` still put on its action link.
* And three neighbours of that Odyssey block — `.jp-stats-odyssey-toggle`, its `> .components-base-control`, and `.jp-stats-odyssey-badge`. They lost their markup in #40384 alongside the notice, and nothing in `projects/` emits them. `.jp-stats-form-fieldset` sits between them and is still live, so this is a three-rule removal rather than a range delete.

The chassis stylesheet stays. `components/admin-notices/index.jsx` still rebuilds server-rendered VaultPress, WooCommerce and core notices into `dops-notice` markup with jQuery, so `components/notice/style.scss`, `scss/shared/_main.scss:45` and `components/jetpack-notices/style.scss` are all still live and untouched.

**Why they are dead:** `AdminNotices` prepends its rebuilt markup into `#jp-admin-notices`, rendered at `_inc/client/main.jsx:855` and `:885` as a sibling of the page content. A rule scoped under `.jp-dash-item`, `.dops-card.is-compact` or `.jp-settings-container` can never reach it.

One other producer exists and is also out of reach: `plugins/vaultpress/vaultpress.php:963` prints the same class family server-side, but only from its own `ui_*` methods, so it lands on `admin.php?page=vaultpress` and never on a Jetpack screen. It ships its own copies of the two unscoped rules deleted here, in `nav-styles.css`.

`.jp-stats-odyssey-disabled-notice` is a different case: that container is emitted nowhere in the repo, so the whole block goes rather than just the rules inside it.

## Related product discussion/links

* [Jetpack admin UI: standardize every notice and smooth the frame transitions](https://linear.app/a8c/project/jetpack-admin-ui-standardize-every-notice-and-smooth-the-frame-36ae9f0224a1/overview)
* #52015 — the migration this is debt from.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

CSS-only, and the point is that **nothing changes visually**. Two checks.

**1. The deleted selectors match nothing.** On a connected site running this branch, open **Jetpack → Dashboard**, then visit each Settings tab (Security, Performance, Writing, Sharing, Discussion, Traffic, Reader). On each, paste this in the browser console:

```js
[
  '.jp-dash-item .dops-section-header__actions .dops-notice',
  '.jp-dash-item .dops-section-header.is-working, .jp-dash-item .dops-section-header.is-premium-inactive',
  '.dops-card.is-compact a.dops-notice__action',
  '.jp-stats-odyssey-disabled-notice a.dops-notice__action',
  '.jp-settings-container a.dops-notice__action',
  '.dops-notice__text a.dops-notice__text-no-underline',
  '.dops-notice__button',
].forEach( s => console.log( document.querySelectorAll( s ).length, s ) );
```

Every count must be `0` — on this branch and on `trunk` alike. A rule whose selector matches nothing cannot change rendering.

**2. The chassis still works.** The jQuery path is what keeps the rest of that stylesheet alive, so confirm it still renders. With VaultPress or WooCommerce active you will see their notices re-skinned at the top of any Jetpack screen. Without either, drop this in a mu-plugin:

```php
add_action( 'admin_notices', function () {
	echo '<div class="wrap vp-notice vp-registered"><h3>Fixture</h3><p class="vp-message">Body copy. <a href="#">A link</a></p></div>';
} );
```

Then open **Jetpack → Dashboard**. The notice must render inside the dark Jetpack chassis with its icon, not as raw admin markup, and `document.querySelectorAll( '#jp-admin-notices .dops-notice' ).length` must be `1`. It carries no dismiss control — the re-skinner adds one only on the `vp-deactivated` branch — so do not read its absence as a failure.

Also worth an eye while you are there: At a Glance cards, the Security and Traffic settings cards, and the Sharing screen should look exactly as they do on `trunk`.

I verified both checks on a local site: all seven selectors returned 0 across 8 screens, the fixture rendered in the chassis, and before/after screenshots of Traffic, Sharing and the fixture page were pixel-identical. `pnpm run test-gui` in `projects/plugins/jetpack` passes 56 suites / 498 tests, and stylelint is clean on all five files.

Proof on the screenshots is that they are byte identical

| Header | Header |
|--------|--------|
| <img width="1440" height="4200" alt="before-vp-chassis" src="https://github.com/user-attachments/assets/5f78e45b-d339-4ad5-a5d2-d16054ac3e1f" /> | <img width="1440" height="4200" alt="after-vp-chassis" src="https://github.com/user-attachments/assets/37281157-918a-43c1-8e79-38b1fe19f13c" /> | 
| <img width="1440" height="1772" alt="before-settings-security" src="https://github.com/user-attachments/assets/0f829e11-f35d-47bd-98a4-82689c33258f" /> | <img width="1440" height="1931" alt="after-settings-security" src="https://github.com/user-attachments/assets/56e8e92b-2ac4-4ba6-a60d-f22cc6ea297f" /> |
| <img width="1440" height="1254" alt="before-settings-sharing" src="https://github.com/user-attachments/assets/0d9b0e8d-1fe5-45ff-807c-3d746e7eebd9" /> | <img width="1440" height="1254" alt="after-settings-sharing" src="https://github.com/user-attachments/assets/7436b029-c0e4-4e2b-81a6-700a8b0295c8" /> |
| <img width="1440" height="2959" alt="before-settings-traffic" src="https://github.com/user-attachments/assets/b56ff7d9-4260-4a60-b6c3-9029f8678b8e" /> | <img width="1440" height="2959" alt="after-settings-traffic" src="https://github.com/user-attachments/assets/496ace98-06c9-4c62-9af8-6ce8fff86fbf" /> |
