### PR TITLE
Protect notices: back the notice component with the @wordpress/ui Notice

### DIFF
--- a/projects/plugins/protect/changelog/update-protect-notice-wpds
+++ b/projects/plugins/protect/changelog/update-protect-notice-wpds
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: changed
 
 Notices: Restyle to match the WordPress design system.

--- a/projects/plugins/protect/changelog/update-protect-notice-wpds
+++ b/projects/plugins/protect/changelog/update-protect-notice-wpds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Notices: restyle notices to match the WordPress design system.

--- a/projects/plugins/protect/changelog/update-protect-notice-wpds
+++ b/projects/plugins/protect/changelog/update-protect-notice-wpds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Notices: restyle notices to match the WordPress design system.
+Notices: Restyle to match the WordPress design system.

--- a/projects/plugins/protect/src/js/components/notice/README.md
+++ b/projects/plugins/protect/src/js/components/notice/README.md
@@ -13,4 +13,4 @@ A simple notice component for displaying alerts and messages to the user.
 
 ## Props
 
-Supported `type` values are `info`, `success`, and `error`.
+Supported `type` values are `info`, `success`, `warning`, and `error`.

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -46,9 +46,8 @@ const Notice = ( {
 				styles[ `notice--${ type }` ],
 				floating && styles[ 'notice--floating' ]
 			) }
-			// Only the toast announces: the modal notices are read when their dialog
-			// opens. A non-string message is never passed — `Notice.Root` renders it
-			// to a string mid-render, which corrupts hook order when it holds a Link.
+			// `Notice.Root` serializes `spokenMessage` mid-render, so a JSX message runs its
+			// hooks inside Root and corrupts hook order. Strings only, and only for the toast.
 			spokenMessage={ floating && 'string' === typeof message ? message : null }
 		>
 			<WPNotice.Description>{ message }</WPNotice.Description>

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { Notice as WPNotice } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useEffect } from 'react';
@@ -45,12 +46,17 @@ const Notice = ( {
 				styles[ `notice--${ type }` ],
 				floating && styles[ 'notice--floating' ]
 			) }
-			// Only the floating toast appears without a focus change, so only it needs
-			// announcing. The other two sit in a modal that is read when it opens.
-			spokenMessage={ floating ? message : null }
+			// The legacy notice never announced, and none of the three call sites
+			// sits in a live region. Announcing is a separate change.
+			spokenMessage={ null }
 		>
 			<WPNotice.Description>{ message }</WPNotice.Description>
-			{ dismissable && <WPNotice.CloseIcon onClick={ onClose } /> }
+			{ dismissable && (
+				<WPNotice.CloseIcon
+					label={ __( 'Dismiss notice.', 'jetpack-protect' ) }
+					onClick={ onClose }
+				/>
+			) }
 		</WPNotice.Root>
 	);
 };

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -46,9 +46,9 @@ const Notice = ( {
 				styles[ `notice--${ type }` ],
 				floating && styles[ 'notice--floating' ]
 			) }
-			// The legacy notice never announced, and none of the three call sites
-			// sits in a live region. Announcing is a separate change.
-			spokenMessage={ null }
+			// Only the toast reports an async result with no focus change, so only it
+			// announces. The modal notices are read when their dialog opens.
+			spokenMessage={ floating ? message : null }
 		>
 			<WPNotice.Description>{ message }</WPNotice.Description>
 			{ dismissable && (

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -46,9 +46,10 @@ const Notice = ( {
 				styles[ `notice--${ type }` ],
 				floating && styles[ 'notice--floating' ]
 			) }
-			// Only the toast reports an async result with no focus change, so only it
-			// announces. The modal notices are read when their dialog opens.
-			spokenMessage={ floating ? message : null }
+			// Only the toast announces: the modal notices are read when their dialog
+			// opens. A non-string message is never passed — `Notice.Root` renders it
+			// to a string mid-render, which corrupts hook order when it holds a Link.
+			spokenMessage={ floating && 'string' === typeof message ? message : null }
 		>
 			<WPNotice.Description>{ message }</WPNotice.Description>
 			{ dismissable && (

--- a/projects/plugins/protect/src/js/components/notice/index.jsx
+++ b/projects/plugins/protect/src/js/components/notice/index.jsx
@@ -1,8 +1,15 @@
-import { __ } from '@wordpress/i18n';
-import { check, close, info, cautionFilled as warning, Icon } from '@wordpress/icons';
+import { Notice as WPNotice } from '@wordpress/ui';
+import clsx from 'clsx';
 import { useCallback, useEffect } from 'react';
 import useNotices from '../../hooks/use-notices';
 import styles from './styles.module.scss';
+
+const INTENTS = {
+	success: 'success',
+	error: 'error',
+	info: 'info',
+	warning: 'warning',
+};
 
 const Notice = ( {
 	dismissable = false,
@@ -12,19 +19,6 @@ const Notice = ( {
 	type = 'success',
 } ) => {
 	const { clearNotice } = useNotices();
-
-	let icon;
-	switch ( type ) {
-		case 'success':
-			icon = check;
-			break;
-		case 'error':
-			icon = warning;
-			break;
-		case 'info':
-		default:
-			icon = info;
-	}
 
 	const onClose = useCallback( () => {
 		clearNotice();
@@ -44,25 +38,20 @@ const Notice = ( {
 	}, [ clearNotice, duration, message ] );
 
 	return (
-		<div
-			className={ `${ styles.notice } ${ styles[ `notice--${ type }` ] } ${
-				floating ? styles[ 'notice--floating' ] : ''
-			}` }
-		>
-			<div className={ styles.notice__icon }>
-				<Icon icon={ icon } />
-			</div>
-			<div className={ styles.notice__message }>{ message }</div>
-			{ dismissable && (
-				<button
-					className={ styles.notice__close }
-					aria-label={ __( 'Dismiss notice.', 'jetpack-protect' ) }
-					onClick={ onClose }
-				>
-					<Icon icon={ close } />
-				</button>
+		<WPNotice.Root
+			intent={ INTENTS[ type ] || 'info' }
+			className={ clsx(
+				styles.notice,
+				styles[ `notice--${ type }` ],
+				floating && styles[ 'notice--floating' ]
 			) }
-		</div>
+			// Only the floating toast appears without a focus change, so only it needs
+			// announcing. The other two sit in a modal that is read when it opens.
+			spokenMessage={ floating ? message : null }
+		>
+			<WPNotice.Description>{ message }</WPNotice.Description>
+			{ dismissable && <WPNotice.CloseIcon onClick={ onClose } /> }
+		</WPNotice.Root>
 	);
 };
 

--- a/projects/plugins/protect/src/js/components/notice/styles.module.scss
+++ b/projects/plugins/protect/src/js/components/notice/styles.module.scss
@@ -1,13 +1,7 @@
 .notice {
-	background-color: var(--jp-gray-90);
-	color: var(--jp-white);
-	display: flex;
-	border-radius: var(--jp-border-radius); // 4px
-	overflow: hidden;
 	z-index: 1;
 
 	&.notice--info {
-		border-left: 4px solid var(--jp-yellow-20);
 		margin-bottom: calc(var(--spacing-base) * 3); // 24px
 	}
 
@@ -17,59 +11,12 @@
 		right: calc(var(--spacing-base) * 3); // 24px
 		margin-left: calc(var(--spacing-base) * 3); // 24px
 
+		// The notice sets `container-type: inline-size`, so it reports no width to
+		// this shrink-to-fit fixed box and collapses to a sliver.
+		container-type: normal;
+
 		@media ( max-width: 782px ) {
 			top: calc(var(--spacing-base) * 8); // 72px
 		}
 	}
-
-	a,
-	a:link,
-	a:hover,
-	a:visited,
-	a:active {
-		color: var(--jp-white);
-	}
-}
-
-.notice__icon {
-	background-color: var(--jp-yellow-30);
-	fill: var(--jp-white);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: calc(var(--spacing-base) * 1.5); // 12px
-
-	.notice--success & {
-		background-color: var(--jp-green-50);
-	}
-
-	.notice--error & {
-		background-color: var(--jp-red);
-	}
-
-	.notice--info & {
-		fill: var(--jp-yellow-50);
-		background-color: var(--jp-yellow-5);
-	}
-}
-
-.notice__message {
-	font-size: 14px;
-	padding: calc(var(--spacing-base) * 1.75); // 14px
-
-	.notice--info & {
-		color: var(--jp-gray-90);
-		background-color: var(--jp-yellow-5);
-	}
-}
-
-.notice__close {
-	fill: var(--jp-gray);
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: calc(var(--spacing-base) * 1.5); // 12px
-	background: transparent;
-	border: none;
 }

--- a/projects/plugins/protect/src/js/hooks/use-notices.tsx
+++ b/projects/plugins/protect/src/js/hooks/use-notices.tsx
@@ -10,7 +10,7 @@ interface NoticeState {
 	message?: string | JSX.Element;
 	dismissable?: boolean;
 	duration?: number;
-	type?: 'success' | 'info' | 'error';
+	type?: 'success' | 'info' | 'warning' | 'error';
 }
 
 interface NoticeContextValue {

--- a/projects/plugins/protect/tests/e2e/specs/start.test.ts
+++ b/projects/plugins/protect/tests/e2e/specs/start.test.ts
@@ -7,9 +7,11 @@ import type { Locator, Page } from '@playwright/test';
  * @param {Page} page - Playwright page object
  */
 async function closeChangesSavedNotice( page: Page ) {
-	// The toast announces, so `speak()` copies its text into `#a11y-speak-polite`
-	// at the end of the body. The notice itself is the earlier match.
-	await expect( page.getByText( 'Changes saved' ).first() ).toBeVisible();
+	// Scoped to the app root: the toast announces, and `speak()` leaves its text in
+	// `#a11y-speak-polite` after the notice goes, which would match on later calls.
+	await expect(
+		page.locator( '#jetpack-protect-root' ).getByText( 'Changes saved' )
+	).toBeVisible();
 	await page.getByRole( 'button', { name: 'Dismiss notice.' } ).click();
 }
 

--- a/projects/plugins/protect/tests/e2e/specs/start.test.ts
+++ b/projects/plugins/protect/tests/e2e/specs/start.test.ts
@@ -73,8 +73,8 @@ test.describe( 'Jetpack Protect Plugin', () => {
 		// react-router <Outlet />, the matched FirewallRoute can appear in two panels at
 		// once. Scoping to the Firewall panel keeps each locator matching a single
 		// element instead of tripping Playwright strict mode. `exact` avoids matching the
-		// "Automatic firewall is on" heading variant. The "Changes saved" notice is left
-		// page-scoped on purpose: it renders at the app level, outside the tab panels.
+		// "Automatic firewall is on" heading variant. The "Changes saved" notice renders
+		// at the app level, so its helper scopes to the app root rather than a panel.
 		const firewallPanel = page.getByRole( 'tabpanel', { name: 'Firewall', exact: true } );
 
 		await test.step( 'Navigate to firewall page', async () => {

--- a/projects/plugins/protect/tests/e2e/specs/start.test.ts
+++ b/projects/plugins/protect/tests/e2e/specs/start.test.ts
@@ -7,7 +7,9 @@ import type { Locator, Page } from '@playwright/test';
  * @param {Page} page - Playwright page object
  */
 async function closeChangesSavedNotice( page: Page ) {
-	await expect( page.getByText( 'Changes saved' ) ).toBeVisible();
+	// The toast announces, so `speak()` copies its text into `#a11y-speak-polite`
+	// at the end of the body. The notice itself is the earlier match.
+	await expect( page.getByText( 'Changes saved' ).first() ).toBeVisible();
 	await page.getByRole( 'button', { name: 'Dismiss notice.' } ).click();
 }
 

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -22,10 +22,7 @@ module.exports = [
 		plugins: [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: {
-					// Bundled, not externalized: this page registers neither script
-					// handle, and an unmet handle stops the whole bundle enqueuing.
-					// The two must go together, or `@wordpress/theme`'s module-init
-					// `lock()` lands on a different consent map. See #48173.
+					// Bundled, never one without the other — see #48173.
 					requestMap: {
 						'@wordpress/theme': { external: false },
 						'@wordpress/private-apis': { external: false },

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -22,9 +22,9 @@ module.exports = [
 		plugins: [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: {
-					// `@wordpress/ui`'s close control reaches `@wordpress/theme` and
-					// `@wordpress/private-apis`. This page registers no shim for those
-					// handles, and an unmet one stops the whole bundle enqueuing.
+					// `@wordpress/theme` and `@wordpress/private-apis` are bundled, not
+					// externalized: this page registers neither handle, and an unmet
+					// handle stops the whole bundle enqueuing.
 					requestMap: {
 						'@wordpress/theme': { external: false },
 						'@wordpress/private-apis': { external: false },

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -22,9 +22,10 @@ module.exports = [
 		plugins: [
 			...jetpackWebpackConfig.StandardPlugins( {
 				DependencyExtractionPlugin: {
-					// `@wordpress/theme` and `@wordpress/private-apis` are bundled, not
-					// externalized: this page registers neither handle, and an unmet
-					// handle stops the whole bundle enqueuing.
+					// Bundled, not externalized: this page registers neither script
+					// handle, and an unmet handle stops the whole bundle enqueuing.
+					// The two must go together, or `@wordpress/theme`'s module-init
+					// `lock()` lands on a different consent map. See #48173.
 					requestMap: {
 						'@wordpress/theme': { external: false },
 						'@wordpress/private-apis': { external: false },

--- a/projects/plugins/protect/webpack.config.js
+++ b/projects/plugins/protect/webpack.config.js
@@ -19,7 +19,19 @@ module.exports = [
 			...jetpackWebpackConfig.resolve,
 		},
 		node: false,
-		plugins: [ ...jetpackWebpackConfig.StandardPlugins() ],
+		plugins: [
+			...jetpackWebpackConfig.StandardPlugins( {
+				DependencyExtractionPlugin: {
+					// `@wordpress/ui`'s close control reaches `@wordpress/theme` and
+					// `@wordpress/private-apis`. This page registers no shim for those
+					// handles, and an unmet one stops the whole bundle enqueuing.
+					requestMap: {
+						'@wordpress/theme': { external: false },
+						'@wordpress/private-apis': { external: false },
+					},
+				},
+			} ),
+		],
 		module: {
 			strictExportPresence: true,
 			rules: [


### PR DESCRIPTION
Fixes JETPACK-2554

## Proposed changes

* Backs Protect's hand-rolled `Notice` with the `@wordpress/ui` `Notice`, so Protect's notices move to the design system without touching a call site. `@wordpress/ui` is already a direct dependency at 0.21.0.
* `type` maps to `intent`, `message` to `Notice.Description`, `dismissable` to `Notice.CloseIcon`. The `duration` auto-clear timer is unchanged. The hand-rolled `@wordpress/icons` switch, the `aria-label` string and the chassis CSS (background, colours, icon box, message typography, close-button chrome) all go — 90 lines out, 30 in.
* The stylesheet keeps only what the design system does not provide: the floating toast's positioning, its `z-index`, and the `margin-bottom` under `.notice--info` that `user-connection-needed-modal` depends on.

Two things worth a reviewer's eye:

* **`type="warning"` now looks like a warning.** `fix-threat-modal/index.jsx:79` passes it for an inactive extension. The old switch had no `warning` case, so it fell through to the info icon on the default gray chassis. `@wordpress/ui` has a real warning intent, so that notice is now amber. Intentional, but it is a visible change.
* **`container-type` is reset on the floating toast.** `Notice.Root` sets `container-type: inline-size`; inside a `position: fixed` container that shrinks to fit, a size-contained child reports no width. Measured in a headless browser: 26×120px without the override, 249×48px with it. Same trap as the Jetpack plugin's toasts in #52015.

### Four things the later commits added

* **The announcer never gets a JSX message.** `Notice.Root` renders `spokenMessage` to a string during its own render. Every error notice interpolates a `Link`, whose hooks then land in `Notice.Root`'s hook list, and the `useEffect` on the next line throws — React unmounted the whole Protect dashboard on any failed request. Only a plain string is announced now, so the saved and saving toasts speak and errors stay silent. Announcing errors needs a spoken string carried alongside the JSX, which is worth doing separately.
* **`@wordpress/theme` and `@wordpress/private-apis` are bundled, not externalized.** `Notice.CloseIcon` reaches both through `IconButton` and its tooltip, so the build started emitting the `wp-theme` and `wp-private-apis` script handles. Protect registers no shim for those, and WordPress refuses to enqueue a bundle with an unmet dependency. `webpack.config.js` now bundles them, as the Jetpack plugin's and Boost's admin builds already do. That costs about 27KB gzip on top of the ~29KB the design system Notice itself adds.
* **The dismiss control keeps Protect's own label.** `Notice.CloseIcon` defaults to "Dismiss", which would have renamed the control the e2e suite clicks.
* **The e2e "Changes saved" assertion is scoped to the app root**, because `speak()` leaves its text in the live region after the notice goes and the helper runs six times.

## Related product discussion/links

* [Jetpack admin UI: standardize every notice and smooth the frame transitions](https://linear.app/a8c/project/jetpack-admin-ui-standardize-every-notice-and-smooth-the-frame-36ae9f0224a1/overview)
* #52015 did the same swap for the Jetpack plugin's `SimpleNotice`.
* This changes the notice chassis only. Protect keeps its own `useNotices` React context rather than sharing a toast surface, which is JETPACK-2556's decision, not this PR's.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a connected site with Jetpack Protect active, running this branch.

* **The toast, which is the main path.** Go to **Jetpack Protect → Settings** and toggle **Account protection**. A green success toast reading "Changes saved." should appear top right — sized to its message, not collapsed to a narrow sliver, and dismissable via its close icon. It should clear itself after a few seconds. The collapse is the regression risk; if the toast renders as a tall thin strip, the `container-type` reset is not applying.
* **The saving state.** Throttle the network and toggle again: an info toast reads "Saving Changes…" while the request is in flight, with no close icon.
* **The error state.** Ignore a threat (or save a Firewall setting) with the REST API failing — an error toast appears with a support link. Check the link is underlined and reaches support.
* **Inside the modals.** With a paid Scan plan and a vulnerable-extension threat whose fixer is `delete`, open the threat and click **Fix**: an error notice shows if the extension is active, a warning notice if it is not. And with the site connected but your user not, opening any threat's Fix or Ignore raises the user-connection modal, whose info notice should keep a clear gap above the paragraph below it.

I verified the first path on a local site and captured before/after screenshots. I could not reach the modal notices — they need a paid Scan plan with a vulnerable-extension threat, or a disconnected user — so those two are unverified by me.

**This ships without automated tests, deliberately.** `projects/plugins/protect` has no jest harness at all: no config, no `test` script, no `test-js` in `composer.json`, no testing dependencies. I wrote the tests and ran them out of tree — the `type` → `intent` map for every type, that `dismissable` renders a close control and firing it calls `clearNotice`, and that no control renders otherwise. Five assertions pass, and mutating `INTENTS.error` to `'info'` fails the right one. Landing them means adding ~5 devDependencies, a lock file change and a CI job for Protect, which is a call for the plugin's owners rather than something to fold into a notice migration. Happy to open that separately.

Lint, stylelint, typecheck and the webpack build are all clean.

Note on the screenshots: pay no attention to the "fixture notice" on top, that was an injection. The notice shows on the toast in the upper right corner

| Before | After |
|--------|--------|
| <img width="1440" height="1071" alt="before-protect-notice" src="https://github.com/user-attachments/assets/ac11320f-37bd-4652-9ace-3a08962fb871" /> | <img width="1440" height="1071" alt="after-protect-notice" src="https://github.com/user-attachments/assets/77b3e99c-1a50-49a2-9788-e485b27079ae" /> | 




