### PR TITLE
Newsletter: route the email design save to WordPress.com, and fix the screen around it

### DIFF
--- a/projects/plugins/jetpack/changelog/add-nl-873-email-design-save-path
+++ b/projects/plugins/jetpack/changelog/add-nl-873-email-design-save-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Newsletter: route the email design editor's Styles panel save to WordPress.com.

--- a/projects/plugins/jetpack/changelog/add-nl-873-email-design-save-path
+++ b/projects/plugins/jetpack/changelog/add-nl-873-email-design-save-path
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Newsletter: route the email design editor's Styles panel save to WordPress.com.
+Newsletter: save the email design to WordPress.com, and run the design screen in fullscreen.

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -113,6 +113,22 @@ class Jetpack_Email_Design_Editor {
 	 */
 	public static function on_load() {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+		add_filter( 'admin_body_class', array( __CLASS__, 'add_fullscreen_body_class' ) );
+	}
+
+	/**
+	 * Put the screen in fullscreen mode before the bundle has loaded.
+	 *
+	 * `wp-editor` hides the admin menu on this class, and the editor sets it from a React
+	 * component — so it cannot apply until the bundle has loaded and the bootstrap has answered,
+	 * and the page visibly reflows a few seconds in. Setting it here makes fullscreen the layout
+	 * from first paint. The admin bar is untouched, which keeps a way out if the editor fails.
+	 *
+	 * @param string $classes Space-separated admin body classes.
+	 * @return string
+	 */
+	public static function add_fullscreen_body_class( $classes ) {
+		return trim( $classes . ' is-fullscreen-mode' );
 	}
 
 	/**
@@ -182,13 +198,12 @@ class Jetpack_Email_Design_Editor {
 			#wpfooter { display: none; }
 			#' . self::HANDLE . ' {
 				position: fixed;
-				/* Above the admin menu\'s submenus (9999) and below #wpadminbar (99999): the editor
-				   paints notices and popovers against the viewport, so below this they land behind
-				   the admin menu. This also caps everything inside, which is why the snackbar
-				   below cannot simply ask for more. */
+				/* Below #wpadminbar (99999) so the editor\'s own popovers and snackbars, which ask
+				   for 100000, cannot cover it — this caps everything inside. The admin menu is
+				   hidden on this screen, so there is nothing else left to clear. */
 				z-index: 99990;
 				inset-block: var(--wp-admin--admin-bar--height, 32px) 0;
-				inset-inline: 160px 0;
+				inset-inline: 0;
 			}
 			/* wp-edit-post pins this and the screen does not load it, so without this the
 			   snackbar renders in flow beside the header instead of over the canvas. */
@@ -196,10 +211,6 @@ class Jetpack_Email_Design_Editor {
 				position: absolute;
 				inset-block-end: 20px;
 				inset-inline-start: 20px;
-			}
-			body.folded #' . self::HANDLE . ' { inset-inline-start: 36px; }
-			@media screen and (max-width: 782px) {
-				#' . self::HANDLE . ' { inset-inline-start: 0; }
 			}
 		';
 	}

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/class-jetpack-email-design-editor.php
@@ -182,12 +182,20 @@ class Jetpack_Email_Design_Editor {
 			#wpfooter { display: none; }
 			#' . self::HANDLE . ' {
 				position: fixed;
-				/* Above #adminmenuwrap (9990) and below #wpadminbar (100000): the editor paints
-				   notices and popovers against the viewport, so without this they land behind
-				   the admin menu. */
-				z-index: 9991;
+				/* Above the admin menu\'s submenus (9999) and below #wpadminbar (99999): the editor
+				   paints notices and popovers against the viewport, so below this they land behind
+				   the admin menu. This also caps everything inside, which is why the snackbar
+				   below cannot simply ask for more. */
+				z-index: 99990;
 				inset-block: var(--wp-admin--admin-bar--height, 32px) 0;
 				inset-inline: 160px 0;
+			}
+			/* wp-edit-post pins this and the screen does not load it, so without this the
+			   snackbar renders in flow beside the header instead of over the canvas. */
+			#' . self::HANDLE . ' .components-editor-notices__snackbar {
+				position: absolute;
+				inset-block-end: 20px;
+				inset-inline-start: 20px;
 			}
 			body.folded #' . self::HANDLE . ' { inset-inline-start: 36px; }
 			@media screen and (max-width: 782px) {

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -188,6 +188,20 @@ function getGlobalStylesPostId( bundle ) {
  * @param {object} bundle - The response from the bootstrap route.
  * @return {object} Preload entries, empty when the bundle carries no global styles.
  */
+/**
+ * A theme.json half as an object, whatever shape it arrived in.
+ *
+ * Off Simple the bootstrap is proxied through `json_decode( …, true )`, so an empty `{}` comes
+ * back as `[]`. The editor writes edits onto whatever it finds, and a property set on an array is
+ * dropped by `JSON.stringify` — the swatch flashes and nothing persists. See NL-871.
+ *
+ * @param {*} value - `styles` or `settings` as it arrived.
+ * @return {object} The value when it is a usable object, an empty object otherwise.
+ */
+function objectOrEmpty( value ) {
+	return value && 'object' === typeof value && ! Array.isArray( value ) ? value : {};
+}
+
 function globalStylesPreloads( bundle ) {
 	const globalStyles = bundle?.global_styles;
 	const id = getGlobalStylesPostId( bundle );
@@ -201,7 +215,14 @@ function globalStylesPreloads( bundle ) {
 	// The GETs resolve after the OPTIONS, so omitting it here overwrites the OPTIONS answer with a
 	// flat no and the Styles panel never renders.
 	const allow = globalStyles.can_edit ? 'GET, POST, PUT' : 'GET';
-	const record = { body: globalStyles.record, headers: { Allow: allow } };
+	const record = {
+		body: {
+			...globalStyles.record,
+			styles: objectOrEmpty( globalStyles.record.styles ),
+			settings: objectOrEmpty( globalStyles.record.settings ),
+		},
+		headers: { Allow: allow },
+	};
 
 	return {
 		[ `/wp/v2/global-styles/${ id }` ]: record,
@@ -397,7 +418,11 @@ export function createDesignSaveMiddleware( id ) {
 			);
 		}
 
-		return { id, settings: design.settings ?? {}, styles: design.styles ?? {} };
+		return {
+			id,
+			settings: objectOrEmpty( design.settings ),
+			styles: objectOrEmpty( design.styles ),
+		};
 	};
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -351,10 +351,21 @@ export function createDesignSaveMiddleware( id ) {
 			return next( options );
 		}
 
+		// Only the theme.json halves: core-data hands over its whole record, and its `id` is the
+		// sentinel that stands in for a post that does not exist. Sanitizing drops it either way,
+		// but sending it makes every save look like it lost a property to anything comparing what
+		// was sent against what was stored. `version` and `isGlobalStylesUserThemeJSON` are the
+		// store's to set, so they are not ours to send.
+		const { styles, settings } = options.data ?? {};
+		const submitted = {
+			...( undefined === styles ? {} : { styles } ),
+			...( undefined === settings ? {} : { settings } ),
+		};
+
 		const saved = await apiFetch( {
 			path: BOOTSTRAP_PATH,
 			method: 'POST',
-			data: { design: options.data ?? {} },
+			data: { design: submitted },
 		} );
 
 		// The route answers with an envelope — `{ blog_id, design, discarded }` — around a read-back

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -398,6 +398,35 @@ export function createDesignSaveMiddleware( id ) {
 }
 
 /**
+ * Tell the creator when a design saved here would never reach anyone.
+ *
+ * `renders_through_email_editor` is the blog's state, not the reader's — independent of
+ * `can_edit`, which asks whether *this person* may edit. Only `false` warns: `null` means
+ * WordPress.com could not determine it during a deploy window, and warning a creator whose blog is
+ * fine is a false alarm they cannot act on. Pinned, not a snackbar — it is a standing condition.
+ * See NL-864.
+ *
+ * @param {object} bundle - The response from the bootstrap route.
+ * @return {void}
+ */
+export function reportInactiveEmailDesign( bundle ) {
+	if ( false !== bundle?.renders_through_email_editor ) {
+		return;
+	}
+
+	dispatch( noticesStore ).createNotice(
+		'warning',
+		__(
+			'Email design is not active on this site, so changes saved here will not affect the emails your subscribers receive.',
+			'jetpack'
+		),
+		// The editor's pinned notice list reads this context and this type; the default context
+		// only reaches its snackbars.
+		{ context: 'email-editor', type: 'default', isDismissible: false }
+	);
+}
+
+/**
  * What the screen shows when it could not load.
  *
  * The design lives on another site, so without this "nothing appeared" and "your
@@ -450,6 +479,7 @@ export async function mountEmailDesignEditor() {
 		// resolved against the registry at that moment. Registering later leaves the same
 		// unsupported-block errors, which looks identical to this never running.
 		registerEmailBlocks( bundle );
+		reportInactiveEmailDesign( bundle );
 
 		const postId = getTemplateId( bundle );
 		const preload = buildPreloadMap( bundle, postId );

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -106,7 +106,11 @@ export function buildEditorConfig( bundle, data ) {
 	Object.entries( urls ).forEach( ( [ key, value ] ) => assertNavigableUrl( value, key ) );
 
 	return {
-		editorSettings: { ...bundle.editor_settings, ...editorSettings },
+		// Forced last so neither half can turn it off. The package renders core's `FullscreenMode`
+		// on this, which hides the admin menu — without it a full-viewport editor sits beside a menu
+		// whose flyouts open over the canvas, and no z-index satisfies both. Forced rather than the
+		// `fullscreenMode` preference so it is not a per-user toggle; it also brings the back button.
+		editorSettings: { ...bundle.editor_settings, ...editorSettings, isFullScreenForced: true },
 		theme: bundle.editor_theme,
 		urls,
 		userEmail,

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -15,7 +15,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { useBlockProps } from '@wordpress/block-editor';
 import { getBlockType, registerBlockType } from '@wordpress/blocks';
 import { Notice } from '@wordpress/components';
-import { dispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { dispatch, select } from '@wordpress/data';
 import { createRoot, StrictMode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -356,11 +357,17 @@ export function createDesignSaveMiddleware( id ) {
 		// but sending it makes every save look like it lost a property to anything comparing what
 		// was sent against what was stored. `version` and `isGlobalStylesUserThemeJSON` are the
 		// store's to set, so they are not ours to send.
-		const { styles, settings } = options.data ?? {};
-		const submitted = {
-			...( undefined === styles ? {} : { styles } ),
-			...( undefined === settings ? {} : { settings } ),
-		};
+		// core-data drops unchanged keys from its edits, so `options.data` routinely carries one half
+		// — a styles-only save is the ordinary case here, not an anomaly. The store replaces the
+		// whole document rather than merging, so sending that half alone would destroy the other.
+		// The editor's own view — persisted record plus pending edits — is what the creator means.
+		const edited = select( coreStore ).getEditedEntityRecord( 'root', 'globalStyles', id );
+
+		if ( ! edited ) {
+			throw new Error( 'Email design save found no global styles record to read.' );
+		}
+
+		const submitted = { styles: edited.styles ?? {}, settings: edited.settings ?? {} };
 
 		const saved = await apiFetch( {
 			path: BOOTSTRAP_PATH,

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -355,10 +355,14 @@ export function createDesignSaveMiddleware( id ) {
 			data: { design: options.data ?? {} },
 		} );
 
-		// The route answers with a read-back rather than an echo: sanitizing drops anything outside
-		// the theme.json schema, so a save can succeed into invisibility. Hand core-data what was
-		// actually stored, so the panel shows what survived.
-		return { id, ...( saved && 'object' === typeof saved ? saved : {} ) };
+		// The route answers with an envelope — `{ blog_id, design, discarded }` — around a read-back
+		// of what was stored, since sanitizing drops anything outside the theme.json schema. Unwrap
+		// it: core-data takes what comes back as the record itself, and the canvas is drawn by
+		// merging that record's `styles` and `settings` over the theme, so handing back the envelope
+		// leaves both undefined and the canvas snaps to its pre-edit design.
+		const design = saved?.design ?? {};
+
+		return { id, settings: design.settings ?? {}, styles: design.styles ?? {} };
 	};
 }
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -31,6 +31,9 @@ const TEMPLATE_POST_TYPE = 'wp_template';
 // and `data:` would execute rather than navigate.
 const NAVIGABLE_PROTOCOLS = [ 'http:', 'https:' ];
 
+// A save arrives as any of these, depending on whether core-data creates or updates.
+const WRITE_METHODS = [ 'POST', 'PUT', 'PATCH' ];
+
 /**
  * Check that a URL the editor will navigate to is one the browser can navigate to.
  *
@@ -322,6 +325,44 @@ export function registerEmailBlocks( bundle ) {
 }
 
 /**
+ * Catch the Styles panel's save and send it to WordPress.com instead.
+ *
+ * The editor writes a core-data `globalStyles` entity, but the design is stored in a WordPress.com
+ * blog option rather than a post, so the write has to be re-addressed to the bootstrap route.
+ *
+ * Matched on this one record's exact path and nothing else. The editor also holds the *site's* own
+ * global-styles record, at edit context, so anything broader would push the site's design through
+ * the email endpoint — and would look correct while doing it on Simple, where the site and the
+ * shadow blog are the same database.
+ *
+ * @param {number} id - The global-styles id the bundle named.
+ * @return {Function} An `apiFetch` middleware.
+ */
+export function createDesignSaveMiddleware( id ) {
+	const target = `/wp/v2/global-styles/${ id }`;
+
+	return async ( options, next ) => {
+		const path = 'string' === typeof options.path ? options.path.split( '?' )[ 0 ] : '';
+		const method = ( options.method || 'GET' ).toUpperCase();
+
+		if ( target !== path || ! WRITE_METHODS.includes( method ) ) {
+			return next( options );
+		}
+
+		const saved = await apiFetch( {
+			path: BOOTSTRAP_PATH,
+			method: 'POST',
+			data: { design: options.data ?? {} },
+		} );
+
+		// The route answers with a read-back rather than an echo: sanitizing drops anything outside
+		// the theme.json schema, so a save can succeed into invisibility. Hand core-data what was
+		// actually stored, so the panel shows what survived.
+		return { id, ...( saved && 'object' === typeof saved ? saved : {} ) };
+	};
+}
+
+/**
  * What the screen shows when it could not load.
  *
  * The design lives on another site, so without this "nothing appeared" and "your
@@ -377,6 +418,10 @@ export async function mountEmailDesignEditor() {
 
 		const postId = getTemplateId( bundle );
 		const preload = buildPreloadMap( bundle, postId );
+
+		if ( config.globalStylesPostId ) {
+			apiFetch.use( createDesignSaveMiddleware( config.globalStylesPostId ) );
+		}
 
 		if ( preload ) {
 			// Registered last so it runs first: api-fetch applies middlewares right to

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/src/index.jsx
@@ -15,8 +15,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { useBlockProps } from '@wordpress/block-editor';
 import { getBlockType, registerBlockType } from '@wordpress/blocks';
 import { Notice } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
 import { createRoot, StrictMode } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
 import { addQueryArgs } from '@wordpress/url';
 
 // Declared by the Jetpack plugin on every platform, answered by WordPress.com, so
@@ -361,6 +363,17 @@ export function createDesignSaveMiddleware( id ) {
 		// merging that record's `styles` and `settings` over the theme, so handing back the envelope
 		// leaves both undefined and the canvas snaps to its pre-edit design.
 		const design = saved?.design ?? {};
+
+		// `discarded` means the save succeeded and kept none of it: sanitizing drops whatever falls
+		// outside the theme.json schema. Without saying so, the panel goes clean and the creator is
+		// told their edit was saved when the stored design no longer contains it.
+		if ( saved?.discarded ) {
+			dispatch( noticesStore ).createNotice(
+				'error',
+				__( 'Those changes could not be saved to your email design.', 'jetpack' ),
+				{ type: 'snackbar', isDismissible: true }
+			);
+		}
 
 		return { id, settings: design.settings ?? {}, styles: design.styles ?? {} };
 	};

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -785,6 +785,60 @@ describe( 'Email design editor entry point', () => {
 			} );
 		} );
 
+		it( 'sends only the design, not the record it came from', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: {
+						// core-data hands over its whole record.
+						id: ourId,
+						title: { rendered: 'Email styles' },
+						_links: { self: [] },
+						version: 3,
+						isGlobalStylesUserThemeJSON: true,
+						styles: { color: { background: '#c0ffee' } },
+						settings: { color: { palette: { custom: [] } } },
+					},
+				},
+				jest.fn()
+			);
+
+			// The sentinel id is not a theme.json key, so it is dropped on the way through — and
+			// sending it makes every save look like it lost a property.
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: {
+						design: {
+							styles: { color: { background: '#c0ffee' } },
+							settings: { color: { palette: { custom: [] } } },
+						},
+					},
+				} )
+			);
+		} );
+
+		it( 'omits a half the panel did not send', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { id: ourId, styles: { color: { text: '#003300' } } },
+				},
+				jest.fn()
+			);
+
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					data: { design: { styles: { color: { text: '#003300' } } } },
+				} )
+			);
+		} );
+
 		it( 'hands back what was stored, not what was sent', async () => {
 			// Sanitizing drops anything outside the theme.json schema, so the read-back can differ
 			// from the submission. The panel has to show what survived.

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -743,7 +743,12 @@ describe( 'Email design editor entry point', () => {
 
 		it( 'sends the design to WordPress.com rather than to the site', async () => {
 			const next = jest.fn();
-			mockApiFetch.mockResolvedValueOnce( { styles: { color: { background: '#c0ffee' } } } );
+			// The shape WordPress.com actually answers with: a read-back wrapped in an envelope.
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 12345,
+				design: { styles: { color: { background: '#c0ffee' } }, settings: {} },
+				discarded: false,
+			} );
 
 			const result = await createDesignSaveMiddleware( ourId )(
 				{
@@ -761,11 +766,46 @@ describe( 'Email design editor entry point', () => {
 				data: { design: { styles: { color: { background: '#c0ffee' } } } },
 			} );
 
-			// What comes back is a read-back of what was stored, carrying the id core-data expects.
+			// core-data takes this as the record itself, and the canvas is drawn from its `styles`
+			// and `settings`. Handing back the envelope leaves both undefined and the canvas snaps
+			// to its pre-edit design.
 			expect( result ).toEqual( {
 				id: ourId,
+				settings: {},
 				styles: { color: { background: '#c0ffee' } },
 			} );
+		} );
+
+		it( 'hands back what was stored, not what was sent', async () => {
+			// Sanitizing drops anything outside the theme.json schema, so the read-back can differ
+			// from the submission. The panel has to show what survived.
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 12345,
+				design: { styles: { color: { background: '#ffffff' } }, settings: {} },
+				discarded: false,
+			} );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: { color: { background: 'color-mix(in srgb, #fff 50%, #000)' } } },
+				},
+				jest.fn()
+			);
+
+			expect( result.styles ).toEqual( { color: { background: '#ffffff' } } );
+		} );
+
+		it( 'survives an envelope carrying no design', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 12345, design: null, discarded: true } );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				jest.fn()
+			);
+
+			expect( result ).toEqual( { id: ourId, settings: {}, styles: {} } );
 		} );
 
 		it.each( [ 'POST', 'PUT', 'PATCH' ] )( 'catches a %s', async method => {

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -48,6 +48,7 @@ jest.mock( '@wordpress/block-editor', () => ( { useBlockProps: () => ( {} ) } ) 
 // which `@wordpress/components` needs at import time by way of `@wordpress/rich-text`.
 const { select, dispatch } = jest.requireActual( '@wordpress/data' );
 const { store: noticesStore } = jest.requireActual( '@wordpress/notices' );
+const { store: coreStore } = jest.requireActual( '@wordpress/core-data' );
 
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
@@ -750,6 +751,21 @@ describe( 'Email design editor entry point', () => {
 		const { createDesignSaveMiddleware } = jest.requireActual( '../src/index' );
 		const ourId = 999999999;
 
+		/**
+		 * Put a design in core-data, which is where the middleware reads what to send.
+		 *
+		 * @param {object} design - `styles` and `settings` as the record holds them.
+		 * @return {void}
+		 */
+		const storeDesign = design =>
+			dispatch( coreStore ).receiveEntityRecords( 'root', 'globalStyles', [
+				{ id: ourId, ...design },
+			] );
+
+		beforeEach( () => {
+			storeDesign( { styles: {}, settings: {} } );
+		} );
+
 		it( 'sends the design to WordPress.com rather than to the site', async () => {
 			const next = jest.fn();
 			// The shape WordPress.com actually answers with: a read-back wrapped in an envelope.
@@ -758,6 +774,8 @@ describe( 'Email design editor entry point', () => {
 				design: { styles: { color: { background: '#c0ffee' } }, settings: {} },
 				discarded: false,
 			} );
+
+			storeDesign( { styles: { color: { background: '#c0ffee' } }, settings: {} } );
 
 			const result = await createDesignSaveMiddleware( ourId )(
 				{
@@ -772,7 +790,7 @@ describe( 'Email design editor entry point', () => {
 			expect( mockApiFetch ).toHaveBeenCalledWith( {
 				path: '/wpcom/v2/email-editor-bootstrap',
 				method: 'POST',
-				data: { design: { styles: { color: { background: '#c0ffee' } } } },
+				data: { design: { styles: { color: { background: '#c0ffee' } }, settings: {} } },
 			} );
 
 			// core-data takes this as the record itself, and the canvas is drawn from its `styles`
@@ -788,21 +806,17 @@ describe( 'Email design editor entry point', () => {
 		it( 'sends only the design, not the record it came from', async () => {
 			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
 
+			// core-data holds the whole record, envelope keys and all.
+			storeDesign( {
+				title: { rendered: 'Email styles' },
+				version: 3,
+				isGlobalStylesUserThemeJSON: true,
+				styles: { color: { background: '#c0ffee' } },
+				settings: { color: { palette: { custom: [] } } },
+			} );
+
 			await createDesignSaveMiddleware( ourId )(
-				{
-					path: `/wp/v2/global-styles/${ ourId }`,
-					method: 'PUT',
-					data: {
-						// core-data hands over its whole record.
-						id: ourId,
-						title: { rendered: 'Email styles' },
-						_links: { self: [] },
-						version: 3,
-						isGlobalStylesUserThemeJSON: true,
-						styles: { color: { background: '#c0ffee' } },
-						settings: { color: { palette: { custom: [] } } },
-					},
-				},
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
 				jest.fn()
 			);
 
@@ -820,21 +834,29 @@ describe( 'Email design editor entry point', () => {
 			);
 		} );
 
-		it( 'omits a half the panel did not send', async () => {
+		// The regression this replaced a refusal with. core-data strips unchanged keys from its
+		// edits, so an ordinary styles-only save arrives with no `settings` at all — and the store
+		// replaces rather than merges, so forwarding that would wipe whatever settings held.
+		it( 'sends both halves when only one of them was edited', async () => {
 			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: {}, discarded: false } );
+			storeDesign( {
+				styles: { color: { text: '#003300' } },
+				settings: { color: { palette: { custom: [ { slug: 'brand' } ] } } },
+			} );
 
 			await createDesignSaveMiddleware( ourId )(
-				{
-					path: `/wp/v2/global-styles/${ ourId }`,
-					method: 'PUT',
-					data: { id: ourId, styles: { color: { text: '#003300' } } },
-				},
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
 				jest.fn()
 			);
 
 			expect( mockApiFetch ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					data: { design: { styles: { color: { text: '#003300' } } } },
+					data: {
+						design: {
+							styles: { color: { text: '#003300' } },
+							settings: { color: { palette: { custom: [ { slug: 'brand' } ] } } },
+						},
+					},
 				} )
 			);
 		} );
@@ -852,7 +874,10 @@ describe( 'Email design editor entry point', () => {
 				{
 					path: `/wp/v2/global-styles/${ ourId }`,
 					method: 'PUT',
-					data: { styles: { color: { background: 'color-mix(in srgb, #fff 50%, #000)' } } },
+					data: {
+						styles: { color: { background: 'color-mix(in srgb, #fff 50%, #000)' } },
+						settings: {},
+					},
 				},
 				jest.fn()
 			);
@@ -864,7 +889,11 @@ describe( 'Email design editor entry point', () => {
 			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: null, discarded: true } );
 
 			await createDesignSaveMiddleware( ourId )(
-				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: {}, settings: {} },
+				},
 				jest.fn()
 			);
 
@@ -887,7 +916,11 @@ describe( 'Email design editor entry point', () => {
 			} );
 
 			await createDesignSaveMiddleware( ourId )(
-				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: {}, settings: {} },
+				},
 				jest.fn()
 			);
 
@@ -898,7 +931,11 @@ describe( 'Email design editor entry point', () => {
 			mockApiFetch.mockResolvedValueOnce( { blog_id: 12345, design: null, discarded: true } );
 
 			const result = await createDesignSaveMiddleware( ourId )(
-				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: {}, settings: {} },
+				},
 				jest.fn()
 			);
 
@@ -909,7 +946,7 @@ describe( 'Email design editor entry point', () => {
 			mockApiFetch.mockResolvedValueOnce( {} );
 
 			await createDesignSaveMiddleware( ourId )(
-				{ path: `/wp/v2/global-styles/${ ourId }`, method, data: {} },
+				{ path: `/wp/v2/global-styles/${ ourId }`, method, data: { styles: {}, settings: {} } },
 				jest.fn()
 			);
 
@@ -948,7 +985,11 @@ describe( 'Email design editor entry point', () => {
 			mockApiFetch.mockResolvedValueOnce( {} );
 
 			await createDesignSaveMiddleware( ourId )(
-				{ path: `/wp/v2/global-styles/${ ourId }?_locale=user`, method: 'PUT', data: {} },
+				{
+					path: `/wp/v2/global-styles/${ ourId }?_locale=user`,
+					method: 'PUT',
+					data: { styles: {}, settings: {} },
+				},
 				next
 			);
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -574,7 +574,7 @@ describe( 'Email design editor entry point', () => {
 			expect( preloadedMap() ).not.toHaveProperty( '/wp/v2/templates' );
 		} );
 
-		it( 'installs nothing when the bundle carries neither half', async () => {
+		it( 'preloads nothing when the bundle carries neither half', async () => {
 			mockApiFetch.mockResolvedValue(
 				bootstrapBundle( { templates: undefined, global_styles: undefined } )
 			);
@@ -584,8 +584,12 @@ describe( 'Email design editor entry point', () => {
 
 			// WordPress.com does not send these yet. The editor must still mount rather than
 			// the entry throwing on a key that is not there.
-			expect( mockUse ).not.toHaveBeenCalled();
+			expect( mockCreatePreloadingMiddleware ).not.toHaveBeenCalled();
 			expect( renderedTheErrorState() ).toBe( false );
+
+			// The save middleware still installs: the page named a record even though the
+			// bundle carried none, and a write to it is still ours to catch.
+			expect( mockUse ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		describe( 'the Allow header the preloaded responses carry', () => {
@@ -730,6 +734,100 @@ describe( 'Email design editor entry point', () => {
 			// The template is parsed on first render and resolved against the registry then, so
 			// registering afterwards leaves the same unsupported-block errors.
 			expect( order ).toEqual( [ 'register', 'render' ] );
+		} );
+	} );
+
+	describe( 'when the Styles panel saves', () => {
+		const { createDesignSaveMiddleware } = jest.requireActual( '../src/index' );
+		const ourId = 999999999;
+
+		it( 'sends the design to WordPress.com rather than to the site', async () => {
+			const next = jest.fn();
+			mockApiFetch.mockResolvedValueOnce( { styles: { color: { background: '#c0ffee' } } } );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{
+					path: `/wp/v2/global-styles/${ ourId }`,
+					method: 'PUT',
+					data: { styles: { color: { background: '#c0ffee' } } },
+				},
+				next
+			);
+
+			expect( next ).not.toHaveBeenCalled();
+			expect( mockApiFetch ).toHaveBeenCalledWith( {
+				path: '/wpcom/v2/email-editor-bootstrap',
+				method: 'POST',
+				data: { design: { styles: { color: { background: '#c0ffee' } } } },
+			} );
+
+			// What comes back is a read-back of what was stored, carrying the id core-data expects.
+			expect( result ).toEqual( {
+				id: ourId,
+				styles: { color: { background: '#c0ffee' } },
+			} );
+		} );
+
+		it.each( [ 'POST', 'PUT', 'PATCH' ] )( 'catches a %s', async method => {
+			mockApiFetch.mockResolvedValueOnce( {} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method, data: {} },
+				jest.fn()
+			);
+
+			expect( mockApiFetch ).toHaveBeenCalled();
+		} );
+
+		it( "leaves a write to the site's own record alone", async () => {
+			const next = jest.fn( () => 'went to the network' );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: '/wp/v2/global-styles/59', method: 'PUT', data: { styles: {} } },
+				next
+			);
+
+			// The regression this middleware exists to avoid: the site's design must never be
+			// routed through the email endpoint, which would look correct on Simple while doing it.
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( next ).toHaveBeenCalled();
+			expect( result ).toBe( 'went to the network' );
+		} );
+
+		it( 'leaves reads of our own record alone', async () => {
+			const next = jest.fn( () => 'went to the preload' );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }?context=edit`, method: 'GET' },
+				next
+			);
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( result ).toBe( 'went to the preload' );
+		} );
+
+		it( 'catches the write whatever query string it carries', async () => {
+			const next = jest.fn();
+			mockApiFetch.mockResolvedValueOnce( {} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }?_locale=user`, method: 'PUT', data: {} },
+				next
+			);
+
+			expect( next ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not match an id that merely starts the same', async () => {
+			const next = jest.fn();
+
+			await createDesignSaveMiddleware( 99 )(
+				{ path: '/wp/v2/global-styles/991', method: 'PUT', data: {} },
+				next
+			);
+
+			expect( mockApiFetch ).not.toHaveBeenCalled();
+			expect( next ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -44,6 +44,11 @@ jest.mock( '@wordpress/blocks', () => ( {
 
 jest.mock( '@wordpress/block-editor', () => ( { useBlockProps: () => ( {} ) } ) );
 
+// The real stores rather than mocks. Mocking `@wordpress/data` wholesale drops `combineReducers`,
+// which `@wordpress/components` needs at import time by way of `@wordpress/rich-text`.
+const { select, dispatch } = jest.requireActual( '@wordpress/data' );
+const { store: noticesStore } = jest.requireActual( '@wordpress/notices' );
+
 const ELEMENT_ID = 'jetpack-email-design-editor';
 
 /**
@@ -163,6 +168,10 @@ describe( 'Email design editor entry point', () => {
 		mockCreatePreloadingMiddleware.mockClear();
 		mockRegisterBlockType.mockClear();
 		mockGetBlockType.mockReset();
+		// By type: `removeAllNotices()` defaults to the `default` type and would leave the
+		// snackbar the save path creates, so it would leak into the next test.
+		dispatch( noticesStore ).removeAllNotices( 'snackbar' );
+		dispatch( noticesStore ).removeAllNotices( 'default' );
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( bootstrapBundle() );
 		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
@@ -795,6 +804,40 @@ describe( 'Email design editor entry point', () => {
 			);
 
 			expect( result.styles ).toEqual( { color: { background: '#ffffff' } } );
+		} );
+
+		it( 'tells the creator when the save kept nothing', async () => {
+			mockApiFetch.mockResolvedValueOnce( { blog_id: 1, design: null, discarded: true } );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
+				jest.fn()
+			);
+
+			// Without this the panel goes clean and the creator is told it saved, while the stored
+			// design no longer holds what they set.
+			expect( select( noticesStore ).getNotices() ).toEqual( [
+				expect.objectContaining( {
+					status: 'error',
+					content: expect.stringContaining( 'could not be saved' ),
+					type: 'snackbar',
+				} ),
+			] );
+		} );
+
+		it( 'stays quiet when the design was kept', async () => {
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 1,
+				design: { styles: { color: { background: '#c0ffee' } }, settings: {} },
+				discarded: false,
+			} );
+
+			await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: {} },
+				jest.fn()
+			);
+
+			expect( select( noticesStore ).getNotices() ).toEqual( [] );
 		} );
 
 		it( 'survives an envelope carrying no design', async () => {

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -173,6 +173,7 @@ describe( 'Email design editor entry point', () => {
 		// snackbar the save path creates, so it would leak into the next test.
 		dispatch( noticesStore ).removeAllNotices( 'snackbar' );
 		dispatch( noticesStore ).removeAllNotices( 'default' );
+		dispatch( noticesStore ).removeAllNotices( 'default', 'email-editor' );
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( bootstrapBundle() );
 		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
@@ -744,6 +745,46 @@ describe( 'Email design editor entry point', () => {
 			// The template is parsed on first render and resolved against the registry then, so
 			// registering afterwards leaves the same unsupported-block errors.
 			expect( order ).toEqual( [ 'register', 'render' ] );
+		} );
+	} );
+
+	describe( 'when the blog does not render through the email editor', () => {
+		const { reportInactiveEmailDesign } = jest.requireActual( '../src/index' );
+
+		const editorNotices = () => select( noticesStore ).getNotices( 'email-editor' );
+
+		it( 'warns, pinned, when WordPress.com says it does not', () => {
+			reportInactiveEmailDesign( { renders_through_email_editor: false } );
+
+			// Pinned rather than dismissible: the editor's own list splits on that, and this is a
+			// standing condition of the blog rather than something that just happened.
+			expect( editorNotices() ).toEqual( [
+				expect.objectContaining( {
+					status: 'warning',
+					type: 'default',
+					isDismissible: false,
+					content: expect.stringContaining( 'not active on this site' ),
+				} ),
+			] );
+		} );
+
+		// `null` is WordPress.com saying it could not determine this, which happens in a deploy
+		// window. Warning then tells a creator on a healthy blog something false.
+		it.each( [
+			[ 'it renders through the editor', { renders_through_email_editor: true } ],
+			[ 'the answer is null', { renders_through_email_editor: null } ],
+			[ 'the key is absent', {} ],
+			[ 'there is no bundle', undefined ],
+		] )( 'says nothing when %s', ( _label, bundle ) => {
+			reportInactiveEmailDesign( bundle );
+
+			expect( editorNotices() ).toEqual( [] );
+		} );
+
+		it( 'does not put the warning where the snackbars are', () => {
+			reportInactiveEmailDesign( { renders_through_email_editor: false } );
+
+			expect( select( noticesStore ).getNotices() ).toEqual( [] );
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -766,6 +766,73 @@ describe( 'Email design editor entry point', () => {
 		} );
 	} );
 
+	// Off Simple the bootstrap is proxied through `json_decode( …, true )`, so `{}` arrives as `[]`.
+	// The editor writes edits onto whatever it finds, and a property set on an array is dropped by
+	// JSON.stringify — the colour flashes and never persists. NL-871.
+	describe( 'the empty halves the proxy turns into arrays', () => {
+		const { buildPreloadMap, createDesignSaveMiddleware } = jest.requireActual( '../src/index' );
+		const ourId = 999999999;
+
+		const seed = design =>
+			dispatch( coreStore ).receiveEntityRecords( 'root', 'globalStyles', [
+				{ id: ourId, ...design },
+			] );
+
+		it( 'preloads them as objects the editor can write to', () => {
+			const preload = buildPreloadMap(
+				bootstrapBundle( {
+					global_styles: {
+						post_id: ourId,
+						can_edit: true,
+						record: { id: ourId, styles: [], settings: [] },
+					},
+				} ),
+				null
+			);
+
+			const body = preload[ `/wp/v2/global-styles/${ ourId }` ].body;
+
+			expect( Array.isArray( body.styles ) ).toBe( false );
+			expect( body.styles ).toEqual( {} );
+			expect( body.settings ).toEqual( {} );
+		} );
+
+		it( 'leaves a design that arrived intact alone', () => {
+			const styles = { color: { background: '#c0ffee' } };
+			const preload = buildPreloadMap(
+				bootstrapBundle( {
+					global_styles: {
+						post_id: ourId,
+						can_edit: true,
+						record: { id: ourId, styles, settings: {} },
+					},
+				} ),
+				null
+			);
+
+			expect( preload[ `/wp/v2/global-styles/${ ourId }` ].body.styles ).toEqual( styles );
+		} );
+
+		// The save response comes back through the same proxy, so a first save would otherwise hand
+		// core-data an array again and break every edit after it.
+		it( 'hands back objects after a save, not arrays', async () => {
+			mockApiFetch.mockResolvedValueOnce( {
+				blog_id: 1,
+				design: { styles: [], settings: [] },
+				discarded: false,
+			} );
+			seed( { styles: {}, settings: {} } );
+
+			const result = await createDesignSaveMiddleware( ourId )(
+				{ path: `/wp/v2/global-styles/${ ourId }`, method: 'PUT', data: { styles: {} } },
+				jest.fn()
+			);
+
+			expect( Array.isArray( result.styles ) ).toBe( false );
+			expect( result ).toEqual( { id: ourId, styles: {}, settings: {} } );
+		} );
+	} );
+
 	describe( 'when the blog does not render through the email editor', () => {
 		const { reportInactiveEmailDesign } = jest.requireActual( '../src/index' );
 

--- a/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
+++ b/projects/plugins/jetpack/modules/subscriptions/email-design-editor/test/index.test.jsx
@@ -282,7 +282,25 @@ describe( 'Email design editor entry point', () => {
 				styles: [ { css: 'body{}' } ],
 				allowedIframeStyleHandles: [ 'wp-block-library' ],
 				__unstableResolvedAssets: { styles: '' },
+				isFullScreenForced: true,
 			} );
+		} );
+
+		// Without it the admin menu stays, and its flyouts open over a full-viewport canvas that
+		// no z-index can sit both above and below. Forced last so neither half can turn it off.
+		it.each( [
+			[ 'WordPress.com', 'bundle' ],
+			[ 'the page', 'page' ],
+		] )( 'keeps fullscreen forced even when %s asks for it off', async ( _label, half ) => {
+			const off = { isFullScreenForced: false };
+			mockApiFetch.mockResolvedValue(
+				bootstrapBundle( 'bundle' === half ? { editor_settings: off } : {} )
+			);
+			window.JetpackEmailDesignEditor = pageData( 'page' === half ? { editorSettings: off } : {} );
+
+			await loadEntryPoint();
+
+			expect( mountedEditorProps().config.editorSettings.isFullScreenForced ).toBe( true );
 		} );
 
 		it( 'does not pass the bundle through in its own shape', async () => {

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
@@ -379,8 +379,10 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The editor paints notices and popovers against the viewport, so below #adminmenuwrap
-	 * (9990) they land behind the admin menu, and above #wpadminbar (100000) they cover it.
+	 * The editor paints notices and popovers against the viewport, so below the admin menu's
+	 * submenus (9999) they land behind them, and above #wpadminbar (99999) they cover it. The
+	 * bound that matters is the submenu one: #adminmenuwrap is 9990, and clearing only that left
+	 * every flyout painting over the editor.
 	 */
 	public function test_the_layout_lifts_the_editor_between_the_admin_menu_and_the_admin_bar() {
 		$css = $this->call_private( 'get_layout_css' );
@@ -388,8 +390,22 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 		preg_match( '/z-index:\s*(\d+)/', $css, $matches );
 
 		$this->assertNotEmpty( $matches );
-		$this->assertGreaterThan( 9990, (int) $matches[1] );
-		$this->assertLessThan( 100000, (int) $matches[1] );
+		$this->assertGreaterThan( 9999, (int) $matches[1] );
+		$this->assertLessThan( 99999, (int) $matches[1] );
+	}
+
+	/**
+	 * `wp-edit-post` carries the rule that pins this, and the screen does not enqueue it, so
+	 * without one of our own the snackbar renders in flow beside the header.
+	 */
+	public function test_the_layout_pins_the_snackbar_over_the_canvas() {
+		$css = $this->call_private( 'get_layout_css' );
+
+		$this->assertMatchesRegularExpression(
+			'/#' . Jetpack_Email_Design_Editor::HANDLE . '\s+\.components-editor-notices__snackbar\s*\{[^}]*position:\s*absolute/',
+			$css
+		);
+		$this->assertMatchesRegularExpression( '/inset-block-end:/', $css );
 	}
 
 	public function test_the_layout_is_rtl_aware() {

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Email_Design_Editor_Test.php
@@ -379,10 +379,9 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The editor paints notices and popovers against the viewport, so below the admin menu's
-	 * submenus (9999) they land behind them, and above #wpadminbar (99999) they cover it. The
-	 * bound that matters is the submenu one: #adminmenuwrap is 9990, and clearing only that left
-	 * every flyout painting over the editor.
+	 * The screen runs in fullscreen mode, so the admin menu is gone and #wpadminbar (99999) is
+	 * the only thing left to sit below. The floor matters less than it did, but stays pinned so
+	 * the container cannot drop under page chrome.
 	 */
 	public function test_the_layout_lifts_the_editor_between_the_admin_menu_and_the_admin_bar() {
 		$css = $this->call_private( 'get_layout_css' );
@@ -413,6 +412,43 @@ class Jetpack_Email_Design_Editor_Test extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'inset-inline', $css );
 		$this->assertDoesNotMatchRegularExpression( '/(?<!-)\b(left|right):/', $css );
+	}
+
+	/**
+	 * `wp-editor` hides the admin menu on this class. The editor also sets it from a React
+	 * component, but only once the bundle has loaded and the bootstrap has answered — so without
+	 * this the page spends a few seconds in the ordinary admin layout and then reflows.
+	 */
+	public function test_the_screen_asks_for_fullscreen_before_the_bundle_loads() {
+		$this->assertStringContainsString(
+			'is-fullscreen-mode',
+			Jetpack_Email_Design_Editor::add_fullscreen_body_class( 'existing-class' )
+		);
+	}
+
+	public function test_the_screen_actually_wires_the_fullscreen_class_up() {
+		Jetpack_Email_Design_Editor::on_load();
+
+		$this->assertNotFalse(
+			has_filter( 'admin_body_class', array( 'Jetpack_Email_Design_Editor', 'add_fullscreen_body_class' ) )
+		);
+	}
+
+	public function test_the_fullscreen_class_keeps_what_was_already_there() {
+		$this->assertStringContainsString(
+			'existing-class',
+			Jetpack_Email_Design_Editor::add_fullscreen_body_class( 'existing-class' )
+		);
+	}
+
+	/**
+	 * The admin menu is hidden, so an inset for it would leave a gap rather than clear anything.
+	 */
+	public function test_the_layout_leaves_no_room_for_the_admin_menu() {
+		$css = $this->call_private( 'get_layout_css' );
+
+		$this->assertStringNotContainsString( '160px', $css );
+		$this->assertStringNotContainsString( 'folded', $css );
 	}
 
 	public function test_nothing_is_enqueued_without_a_build() {


### PR DESCRIPTION
## Proposed changes

Routes the email design editor's Styles panel save to WordPress.com, where the design is actually stored. Also fixes the screen and notices on the save path.

### The save path (NL-873)

The editor writes a core-data `globalStyles` entity, but the design lives in a WordPress.com blog option rather than a post, so the write is re-addressed to the bootstrap route by an `apiFetch` middleware, installed only when the bundle named a global-styles id.

* **The whole design is sent, not the half that changed.** core-data strips unchanged keys from its edits, so an ordinary styles-only change arrives with no `settings` at all — and the store *replaces* rather than merges, so forwarding that half would wipe the other. The payload comes from `getEditedEntityRecord` instead: persisted record plus pending edits, which is what the creator means to save.
* **Only the two theme.json halves go.** core-data hands over its whole record, whose `id` is a sentinel standing in for a post that does not exist. `version` and `isGlobalStylesUserThemeJSON` are the store's to set.
* **The response envelope is unwrapped.** The route answers `{ blog_id, design, discarded }` around a read-back. core-data takes what comes back as the record itself, so returning the envelope would leave `styles` and `settings` undefined and snap the canvas to its pre-edit design.
* **A discarded save says so.** `discarded` means the write succeeded and kept none of it. Without the notice the panel goes clean while the stored design no longer holds the edit.

<img width="1446" height="748" alt="Screenshot 2026-09-11 at 10 01 01 AM" src="https://github.com/user-attachments/assets/6e1d4f22-0419-4d75-a030-f9bd3810f96e" />


### Telling a creator when the design will not apply (NL-864)

WordPress.com now reports `renders_through_email_editor`. On a blog the WooCommerce renderer does not serve, a design saves, stores, reads back, and changes no email anyone receives. A pinned notice now says so.
<img width="1249" height="250" alt="Screenshot 2026-09-11 at 10 00 17 AM" src="https://github.com/user-attachments/assets/3cf4bd69-c685-4c76-b023-d1e862f63a3e" />

### The screen it saves from (NL-839)

* **Fullscreen, via the package's own setting.** `isFullScreenForced` makes the package render core's `FullscreenMode`, which hides the admin menu — the same thing WooCommerce's editor gets at `post.php`. Also set server-side on `admin_body_class` so it applies at first paint rather than seconds in, once the bundle has loaded and the bootstrap has answered.
* **The layout that cleared the admin menu is gone**, since there is no menu left to clear: the 160px inset, the folded-menu rule and the mobile media query are removed.
* **The snackbar is positioned.** Nothing in `@wordpress/components`, `@wordpress/editor` or the package positions `.components-editor-notices__snackbar` — the rule that does lives in `wp-edit-post`, which this screen does not enqueue, so it rendered in flow beside the header.

### Worth a reviewer's attention

* **The path match is the safety property, and it is deliberately narrow.** One exact path, one id, write methods only, query string stripped so `?context=edit` cannot slip past. The editor also holds the *site's own* global-styles record — anything broader would push the site's design through the email endpoint, and would look correct doing it on Simple, where the site and shadow blog share a database. Tests pin both the match and the non-match, including a near-miss id.
* **The notice checks `=== false`, not falsiness.** `null` is WordPress.com saying it could not determine the answer during a deploy window; warning then tells a creator on a healthy blog something false. `null` and absent are treated alike.
* **Fullscreen leaves the admin bar alone on purpose.** If the editor fails to load, the body class is already set and the package's back button never renders — the admin bar is then the only way out.
* **`WRITE_METHODS` is `POST`, `PUT`, `PATCH`.** core-data picks its verb by whether it thinks it is creating, and the sentinel id makes that ambiguous. Worth a look at whether the list is right rather than merely sufficient.

## Related product discussion/links

* NL-873, NL-864, NL-839

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Needs the same setup as #52055 — the `email-design-editor` sticker on the connected blog and the `jetpack-email-design` flag on — plus the WordPress.com counterpart reporting the design as editable.

1. Open **Appearance → Email Design**. It should be fullscreen immediately, with no admin menu and no reflow a few seconds in. A back button top-left returns you to Appearance.
2. Change a background colour in the Styles panel and save. The network tab should show a `POST` to `/wpcom/v2/email-editor-bootstrap` carrying `{ design: { styles: …, settings: … } }` — **both halves**, even though only one changed — and **no** `PUT` to `/wp/v2/global-styles/…`.
3. The canvas should keep your change rather than snapping back. Snapping back means the envelope was not unwrapped.
4. Reload. The change should still be there.
5. The snackbar should appear bottom-left over the canvas.
7. Open the site editor (**Appearance → Editor → Styles**) and change a site colour. That save must still go to `/wp/v2/global-styles/…` and must not touch the email endpoint. On Simple a mistake here looks correct, so check the network tab rather than the result.
8. On a blog with `disable-wc-email-editor`, the screen should carry a pinned notice saying email design is not active. On a normal blog, no notice.
