### PR TITLE
JITM: remove a dead rule for the retired Forms dashboard

### DIFF
--- a/projects/packages/jitm/changelog/fix-jitm-card-margin-forms-screen
+++ b/projects/packages/jitm/changelog/fix-jitm-card-margin-forms-screen
@@ -1,0 +1,5 @@
+Significance: patch
+Type: removed
+Comment: Remove a CSS rule targeting a body class no longer produced by any page.
+
+

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -535,7 +535,3 @@ $jp-gray-20:             #a7aaad;
 #dolly + .jitm-card {
 	margin: 3rem 1rem 0 auto;
 }
-
-.jetpack_page_jetpack-forms-admin .jitm-card {
-	margin-left: 1.25rem;
-}


### PR DESCRIPTION
See FORMS-801

## Proposed changes

* Remove `.jetpack_page_jetpack-forms-admin .jitm-card` from `jetpack-admin-jitm.scss`. It has matched nothing since Forms moved to the wp-build dashboard.

The rule arrived in #43783, when `jetpack-forms-admin` was the Forms menu slug. Forms now registers as `jetpack-forms-responses-wp-admin`, and `?page=jetpack-forms-admin` redirects rather than rendering, so no page produces that body class any more.

Repointing it at the live slug would not have restored the margin, which is why this deletes instead. The wp-build page inlines its own critical CSS:

```css
body.js #wpbody-content > div:not(#jetpack-forms-responses-wp-admin-app):not(#screen-meta) {
    display: none;
}
```

The JITM card lands as a direct child of `#wpbody-content`, because Forms renders no in-app `<div id="jp-admin-notices">` for it to go inside the way Backup, Newsletter, Social, Search, VideoPress, Boost, Protect and My Jetpack all do. That selector carries three IDs, `.jitm-card` sets `display` off one class, and there is no `!important` anywhere in the file, so the card is hidden on that screen regardless of any margin.

That underlying gap is FORMS-801 and is not addressed here. This PR only removes the dead rule.

## Related product discussion/links

* FORMS-801 — the reason a margin there would not have helped
* JETPACK-2580 — where this turned up, since cancelled

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is dead CSS, so the point of testing is confirming nothing else moved.

* Check out the branch and run `jetpack build packages/jitm`.
* Confirm `projects/packages/jitm/build/index.css` no longer contains `jetpack-forms-admin`, and that the neighbouring `#dolly + .jitm-card` rule is still present. Same for `index.rtl.css`.
* Load any admin screen that shows a JITM — My Jetpack is the easiest, since it renders `#jp-admin-notices` in-app — and confirm the card looks unchanged.
* For the "before" state, visit the Forms dashboard on trunk with a connected site. The JITM card is already absent there, which is the bug this PR does not fix.
