### PR TITLE
PayPal Payment Buttons: Fix flat tax, payment link count, and list page size

### DIFF
--- a/projects/packages/paypal-payments/changelog/add-paypal-list-total-required
+++ b/projects/packages/paypal-payments/changelog/add-paypal-list-total-required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The payment links admin screen now shows how many links the account has, instead of how many fit on the page you are looking at.

--- a/projects/packages/paypal-payments/changelog/add-paypal-list-total-required
+++ b/projects/packages/paypal-payments/changelog/add-paypal-list-total-required
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-The payment links admin screen now shows how many links the account has, instead of how many fit on the page you are looking at.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-flat-tax
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-flat-tax
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop turning a flat tax into a percentage. A payment link carrying a fixed tax amount now saves with that amount intact instead of being rejected or rewritten, a tax with no name is kept rather than dropped, and a tax set to follow the PayPal profile always sends the profile setting instead of a stray rate.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-list-route-page-size
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-list-route-page-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-The payment links REST endpoint now returns up to 100 links per request by default instead of 10.
+Return up to 100 payment links per request instead of 10.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-list-route-page-size
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-list-route-page-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+The payment links REST endpoint now returns up to 100 links per request by default instead of 10.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-list-total-required
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-list-total-required
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show how many payment links the account has, not how many fit on the page you are looking at.

--- a/projects/packages/paypal-payments/docs/rest-api-reference.md
+++ b/projects/packages/paypal-payments/docs/rest-api-reference.md
@@ -175,17 +175,21 @@ List payment resources with pagination.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `page_size` | integer | No | `10` | Results per page (1–100) |
+| `page_size` | integer | No | `100` | Results per page (1–100) |
 | `page_token` | string | No | — | Pagination cursor |
 
 **Response (200):**
 
 ```json
 {
-  "items": [ ... ],
-  "total_items": 5
+  "resources": [ ... ],
+  "total_items": 5,
+  "total_pages": 1,
+  "links": [ { "rel": "next", "href": "..." } ]
 }
 ```
+
+PayPal's body is passed through as-is. `links` carries a `next` only when more pages remain.
 
 ---
 

--- a/projects/packages/paypal-payments/docs/rest-api-reference.md
+++ b/projects/packages/paypal-payments/docs/rest-api-reference.md
@@ -147,6 +147,9 @@ Create a payment resource via the PayPal API. Returns both a button-ready resour
 | `line_items[].unit_amount.value` | string | Yes | — | Price (positive, max 2 decimals) |
 | `line_items[].quantity` | string | No | `1` | Quantity |
 | `line_items[].image_url` | string | No | — | Product image URL |
+| `line_items[].taxes[].type` | string | No | `PERCENTAGE` | `PERCENTAGE`, `FLAT` or `PREFERENCE` |
+| `line_items[].taxes[].value` | string | No | `0` | Rate for `PERCENTAGE`, amount for `FLAT`. `PREFERENCE` always sends `PROFILE` |
+| `line_items[].taxes[].name` | string | No | — | Tax label. Sent only when set |
 | `return_url` | string | No | — | Post-payment redirect URL |
 | `name` | string | No | — | Display name for the resource |
 
@@ -189,7 +192,8 @@ List payment resources with pagination.
 }
 ```
 
-PayPal's body is passed through as-is. `links` carries a `next` only when more pages remain.
+> **Note:** PayPal's body is passed through as-is. `links` includes a `next` only when more
+> pages remain.
 
 ---
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
@@ -116,6 +116,9 @@ class PayPal_API_Client {
 	/**
 	 * List payment resources with optional pagination.
 	 *
+	 * The 10 is PayPal's own default when the parameter is omitted. Callers that
+	 * care state their own - the REST route asks for 100, the admin table PER_PAGE.
+	 *
 	 * @param int    $page_size  Number of results per page. Default 10.
 	 * @param string $page_token Pagination cursor from a previous response. Default empty.
 	 * @return array|\WP_Error Decoded response body on success (HTTP 200), WP_Error on failure.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
@@ -122,7 +122,9 @@ class PayPal_API_Client {
 	 */
 	public static function list_resources( $page_size = 10, $page_token = '' ) {
 		$query_args = array(
-			'page_size' => absint( $page_size ),
+			'page_size'      => absint( $page_size ),
+			// PayPal omits total_items and total_pages unless we ask for them.
+			'total_required' => 'true',
 		);
 
 		if ( ! empty( $page_token ) ) {

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
@@ -158,10 +158,17 @@ class PayPal_Payment_Links_List_Table extends \WP_List_Table {
 			}
 		}
 
-		// PayPal paginates by cursor and returns no total, so count what this page holds.
+		// PayPal sends the real total now; responses cached before that change do
+		// not have it, so fall back to this page's rows.
+		//
+		// total_pages stays 1 on purpose. Paging here is by cursor - the Next Page
+		// link the admin page draws from $next_page_token - and prepare_items()
+		// never reads `paged`, so core's numbered links would go nowhere. Leaving
+		// it to be computed from the real total is what makes them appear.
 		$this->set_pagination_args(
 			array(
-				'total_items' => count( $this->items ),
+				'total_items' => absint( $result['total_items'] ?? count( $this->items ) ),
+				'total_pages' => 1,
 				'per_page'    => self::PER_PAGE,
 			)
 		);

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-payment-links-list-table.php
@@ -158,13 +158,9 @@ class PayPal_Payment_Links_List_Table extends \WP_List_Table {
 			}
 		}
 
-		// PayPal sends the real total now; responses cached before that change do
-		// not have it, so fall back to this page's rows.
-		//
-		// total_pages stays 1 on purpose. Paging here is by cursor - the Next Page
-		// link the admin page draws from $next_page_token - and prepare_items()
-		// never reads `paged`, so core's numbered links would go nowhere. Leaving
-		// it to be computed from the real total is what makes them appear.
+		// Fall back to the row count when a response has no total.
+		// total_pages is 1 because this table pages by cursor: core's numbered
+		// links navigate by `paged`, which prepare_items() ignores.
 		$this->set_pagination_args(
 			array(
 				'total_items' => absint( $result['total_items'] ?? count( $this->items ) ),

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -226,22 +226,22 @@ class PayPal_REST_Controller {
 					'callback'            => array( __CLASS__, 'handle_list_buttons' ),
 					'permission_callback' => array( __CLASS__, 'manage_options_permission_check' ),
 					'args'                => array(
-						// PayPal cannot search or filter server-side, so a short page just
-						// hides links from whoever has to filter them. Send a full one.
 						'page_size'  => array(
-							'description' => __( 'Payment resources per page.', 'jetpack-paypal-payments' ),
 							'required'    => false,
 							'type'        => 'integer',
+							// PayPal has no server-side search, so callers filter
+							// client-side. Fetch a whole page by default.
 							'default'     => 100,
 							'minimum'     => 1,
 							'maximum'     => 100,
+							'description' => __( 'Payment resources per page.', 'jetpack-paypal-payments' ),
 						),
 						'page_token' => array(
-							'description'       => __( 'Cursor from the previous page\'s next link.', 'jetpack-paypal-payments' ),
 							'required'          => false,
 							'type'              => 'string',
 							'default'           => '',
 							'sanitize_callback' => 'sanitize_text_field',
+							'description'       => __( 'Cursor from the previous page\'s next link.', 'jetpack-paypal-payments' ),
 						),
 					),
 				),
@@ -1097,7 +1097,7 @@ class PayPal_REST_Controller {
 							// The rate comes from the merchant's PayPal profile.
 							$tax_value = 'PROFILE';
 						} elseif ( 'FLAT' === $tax_type ) {
-							// A flat tax is an amount, not a rate - keep the string as sent
+							// A flat tax is an amount, not a rate - keep a string as sent
 							// so '1.50' does not become 1.5. PayPal validates it itself.
 							$tax_value = trim( sanitize_text_field( (string) ( $tax['value'] ?? '0' ) ) );
 							if ( '' === $tax_value ) {

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -226,14 +226,18 @@ class PayPal_REST_Controller {
 					'callback'            => array( __CLASS__, 'handle_list_buttons' ),
 					'permission_callback' => array( __CLASS__, 'manage_options_permission_check' ),
 					'args'                => array(
+						// PayPal cannot search or filter server-side, so a short page just
+						// hides links from whoever has to filter them. Send a full one.
 						'page_size'  => array(
-							'required' => false,
-							'type'     => 'integer',
-							'default'  => 10,
-							'minimum'  => 1,
-							'maximum'  => 100,
+							'description' => __( 'Payment resources per page.', 'jetpack-paypal-payments' ),
+							'required'    => false,
+							'type'        => 'integer',
+							'default'     => 100,
+							'minimum'     => 1,
+							'maximum'     => 100,
 						),
 						'page_token' => array(
+							'description'       => __( 'Cursor from the previous page\'s next link.', 'jetpack-paypal-payments' ),
 							'required'          => false,
 							'type'              => 'string',
 							'default'           => '',

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -960,7 +960,7 @@ class PayPal_REST_Controller {
 									'name'  => array( 'type' => 'string' ),
 									'type'  => array(
 										'type' => 'string',
-										'enum' => array( 'PERCENTAGE', 'PREFERENCE' ),
+										'enum' => array( 'PERCENTAGE', 'PREFERENCE', 'FLAT' ),
 									),
 									'value' => array( 'type' => 'string' ),
 								),
@@ -1079,17 +1079,42 @@ class PayPal_REST_Controller {
 			// Tax configuration.
 			if ( ! empty( $item['taxes'] ) && is_array( $item['taxes'] ) ) {
 				$clean_taxes = array();
-				$valid_types = array( 'PERCENTAGE', 'PREFERENCE' );
+				$valid_types = array( 'PERCENTAGE', 'PREFERENCE', 'FLAT' );
 				foreach ( $item['taxes'] as $tax ) {
-					if ( is_array( $tax ) && ! empty( $tax['name'] ) ) {
-						$tax_type      = isset( $tax['type'] ) ? sanitize_text_field( $tax['type'] ) : 'PERCENTAGE';
-						$clean_taxes[] = array(
-							'name'  => sanitize_text_field( $tax['name'] ),
-							'type'  => in_array( $tax_type, $valid_types, true ) ? $tax_type : 'PERCENTAGE',
-							'value' => isset( $tax['value'] ) && 'PROFILE' !== $tax['value']
-							? (string) max( 0, floatval( $tax['value'] ) )
-							: ( 'PREFERENCE' === $tax_type ? 'PROFILE' : '0' ),
+					// No name: PayPal labels the tax itself, and requiring one here
+					// threw the whole tax away.
+					if ( is_array( $tax ) ) {
+						$tax_type = isset( $tax['type'] ) ? sanitize_text_field( $tax['type'] ) : 'PERCENTAGE';
+						if ( ! in_array( $tax_type, $valid_types, true ) ) {
+							$tax_type = 'PERCENTAGE';
+						}
+
+						if ( 'PREFERENCE' === $tax_type ) {
+							// The rate comes from the merchant's PayPal profile.
+							$tax_value = 'PROFILE';
+						} elseif ( 'FLAT' === $tax_type ) {
+							// A flat tax is an amount, not a rate - keep the string as sent
+							// so '1.50' does not become 1.5. PayPal validates it itself.
+							$tax_value = trim( sanitize_text_field( (string) ( $tax['value'] ?? '0' ) ) );
+							if ( '' === $tax_value ) {
+								$tax_value = '0';
+							}
+						} else {
+							$tax_value = (string) max( 0, floatval( $tax['value'] ?? 0 ) );
+						}
+
+						$clean_tax = array(
+							'type'  => $tax_type,
+							'value' => $tax_value,
 						);
+
+						// name is optional, so only send a real one - an empty string
+						// is not a name.
+						if ( ! empty( $tax['name'] ) ) {
+							$clean_tax['name'] = sanitize_text_field( $tax['name'] );
+						}
+
+						$clean_taxes[] = $clean_tax;
 					}
 				}
 				if ( ! empty( $clean_taxes ) ) {

--- a/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
@@ -604,6 +604,33 @@ class PayPal_API_Client_Test extends TestCase {
 	 * Test that list_resources sends correct URL with page_size query parameter.
 	 */
 	public function test_list_resources_pagination_params() {
+		$captured_url = $this->capture_list_url( 25, 'cursor_abc123' );
+
+		$this->assertNotNull( $captured_url );
+		$this->assertStringContainsString( 'page_size=25', $captured_url );
+		$this->assertStringContainsString( 'page_token=cursor_abc123', $captured_url );
+	}
+
+	/**
+	 * Test that list_resources asks PayPal for a total, which it omits unless asked.
+	 */
+	public function test_list_resources_asks_for_a_total() {
+		$captured_url = $this->capture_list_url();
+
+		$this->assertNotNull( $captured_url );
+
+		// The literal string 'true' - a boolean would arrive as total_required=1.
+		$this->assertStringContainsString( 'total_required=true', $captured_url );
+	}
+
+	/**
+	 * Call list_resources against a mocked PayPal and return the URL it built.
+	 *
+	 * @param int    $page_size  Number of results per page.
+	 * @param string $page_token Pagination cursor.
+	 * @return string|null The requested URL.
+	 */
+	private function capture_list_url( $page_size = 10, $page_token = '' ) {
 		$this->set_up_connected_state();
 
 		$captured_url = null;
@@ -611,8 +638,7 @@ class PayPal_API_Client_Test extends TestCase {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( &$captured_url ) {
-				if ( strpos( $url, '/v1/checkout/payment-resources' ) !== false
-					&& strpos( $url, '/v1/oauth2/token' ) === false ) {
+				if ( strpos( $url, '/v1/checkout/payment-resources' ) !== false ) {
 					$captured_url = $url;
 				}
 				return array(
@@ -620,18 +646,16 @@ class PayPal_API_Client_Test extends TestCase {
 						'code'    => 200,
 						'message' => 'OK',
 					),
-					'body'     => wp_json_encode( array( 'items' => array() ), JSON_UNESCAPED_SLASHES ),
+					'body'     => wp_json_encode( array( 'resources' => array() ), JSON_UNESCAPED_SLASHES ),
 				);
 			},
 			10,
 			3
 		);
 
-		PayPal_API_Client::list_resources( 25, 'cursor_abc123' );
+		PayPal_API_Client::list_resources( $page_size, $page_token );
 
-		$this->assertNotNull( $captured_url );
-		$this->assertStringContainsString( 'page_size=25', $captured_url );
-		$this->assertStringContainsString( 'page_token=cursor_abc123', $captured_url );
+		return $captured_url;
 	}
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
@@ -601,9 +601,9 @@ class PayPal_API_Client_Test extends TestCase {
 	}
 
 	/**
-	 * Test that list_resources sends correct URL with page_size query parameter.
+	 * Test that list_resources sends both page_size and page_token.
 	 */
-	public function test_list_resources_pagination_params() {
+	public function test_list_resources_sends_page_size_and_page_token() {
 		$captured_url = $this->capture_list_url( 25, 'cursor_abc123' );
 
 		$this->assertNotNull( $captured_url );
@@ -612,50 +612,16 @@ class PayPal_API_Client_Test extends TestCase {
 	}
 
 	/**
-	 * Test that list_resources asks PayPal for a total, which it omits unless asked.
+	 * Test that list_resources sends total_required, which PayPal needs before
+	 * it returns a count at all.
 	 */
-	public function test_list_resources_asks_for_a_total() {
+	public function test_list_resources_sends_total_required() {
 		$captured_url = $this->capture_list_url();
 
 		$this->assertNotNull( $captured_url );
 
-		// The literal string 'true' - a boolean would arrive as total_required=1.
+		// The literal string 'true' - a boolean would render as total_required=1.
 		$this->assertStringContainsString( 'total_required=true', $captured_url );
-	}
-
-	/**
-	 * Call list_resources against a mocked PayPal and return the URL it built.
-	 *
-	 * @param int    $page_size  Number of results per page.
-	 * @param string $page_token Pagination cursor.
-	 * @return string|null The requested URL.
-	 */
-	private function capture_list_url( $page_size = 10, $page_token = '' ) {
-		$this->set_up_connected_state();
-
-		$captured_url = null;
-
-		add_filter(
-			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( &$captured_url ) {
-				if ( strpos( $url, '/v1/checkout/payment-resources' ) !== false ) {
-					$captured_url = $url;
-				}
-				return array(
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'body'     => wp_json_encode( array( 'resources' => array() ), JSON_UNESCAPED_SLASHES ),
-				);
-			},
-			10,
-			3
-		);
-
-		PayPal_API_Client::list_resources( $page_size, $page_token );
-
-		return $captured_url;
 	}
 
 	/**
@@ -691,6 +657,41 @@ class PayPal_API_Client_Test extends TestCase {
 	}
 
 	// --- Helpers ---
+
+	/**
+	 * Call list_resources against a mocked PayPal and return the URL it built.
+	 *
+	 * @param int    $page_size  Number of results per page.
+	 * @param string $page_token Pagination cursor.
+	 * @return string|null The requested URL.
+	 */
+	private function capture_list_url( $page_size = 10, $page_token = '' ) {
+		$this->set_up_connected_state();
+
+		$captured_url = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_url ) {
+				if ( strpos( $url, '/v1/checkout/payment-resources' ) !== false ) {
+					$captured_url = $url;
+				}
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode( array( 'resources' => array() ), JSON_UNESCAPED_SLASHES ),
+				);
+			},
+			10,
+			3
+		);
+
+		PayPal_API_Client::list_resources( $page_size, $page_token );
+
+		return $captured_url;
+	}
 
 	/**
 	 * Set up a simulated connected state with credentials and a cached token.

--- a/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
@@ -140,6 +140,68 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 	}
 
 	/**
+	 * Test that prepare_items counts every link, not just the page on screen.
+	 *
+	 * The table pages by cursor, so counting its own rows told a merchant with
+	 * more links than fit on a page that they had one page's worth.
+	 */
+	public function test_prepare_items_uses_paypals_total() {
+		$this->set_up_connected_state();
+
+		$this->mock_http_response(
+			200,
+			array(
+				'resources'   => $this->get_sample_items(),
+				'total_items' => 40,
+			)
+		);
+
+		$table = new PayPal_Payment_Links_List_Table();
+		$table->prepare_items();
+
+		$this->assertSame( 40, $table->get_pagination_arg( 'total_items' ) );
+	}
+
+	/**
+	 * Test that the real total does not switch on core's numbered pagination.
+	 *
+	 * Paging is by cursor and prepare_items() never reads `paged`, so links
+	 * built from a computed page count would go nowhere.
+	 */
+	public function test_prepare_items_keeps_core_pagination_off() {
+		$this->set_up_connected_state();
+
+		$this->mock_http_response(
+			200,
+			array(
+				'resources'   => $this->get_sample_items(),
+				'total_items' => 40,
+			)
+		);
+
+		$table = new PayPal_Payment_Links_List_Table();
+		$table->prepare_items();
+
+		$this->assertSame( 1, $table->get_pagination_arg( 'total_pages' ) );
+	}
+
+	/**
+	 * Test that prepare_items falls back to the row count without a total.
+	 *
+	 * A response cached before the client started asking for one has no
+	 * total_items.
+	 */
+	public function test_prepare_items_falls_back_to_row_count() {
+		$this->set_up_connected_state();
+		$this->mock_list_response( $this->get_sample_items() );
+
+		$table = new PayPal_Payment_Links_List_Table();
+		$table->prepare_items();
+
+		$this->assertSame( 2, $table->get_pagination_arg( 'total_items' ) );
+	}
+
+	/**
 	 * Test column_name renders product name from line_items.
 	 */
 	public function test_column_name_renders_product_name() {

--- a/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Payment_Links_List_Table_Test.php
@@ -147,14 +147,7 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 	 */
 	public function test_prepare_items_uses_paypals_total() {
 		$this->set_up_connected_state();
-
-		$this->mock_http_response(
-			200,
-			array(
-				'resources'   => $this->get_sample_items(),
-				'total_items' => 40,
-			)
-		);
+		$this->mock_list_response( $this->get_sample_items(), 40 );
 
 		$table = new PayPal_Payment_Links_List_Table();
 		$table->prepare_items();
@@ -163,21 +156,15 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 	}
 
 	/**
-	 * Test that the real total does not switch on core's numbered pagination.
+	 * Test that prepare_items sets total_pages to 1, which keeps core's
+	 * numbered pagination off.
 	 *
-	 * Paging is by cursor and prepare_items() never reads `paged`, so links
-	 * built from a computed page count would go nowhere.
+	 * Paging is by cursor and prepare_items() ignores `paged`, so links built
+	 * from a computed page count would go nowhere.
 	 */
-	public function test_prepare_items_keeps_core_pagination_off() {
+	public function test_prepare_items_sets_total_pages_to_one() {
 		$this->set_up_connected_state();
-
-		$this->mock_http_response(
-			200,
-			array(
-				'resources'   => $this->get_sample_items(),
-				'total_items' => 40,
-			)
-		);
+		$this->mock_list_response( $this->get_sample_items(), 40 );
 
 		$table = new PayPal_Payment_Links_List_Table();
 		$table->prepare_items();
@@ -186,10 +173,10 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 	}
 
 	/**
-	 * Test that prepare_items falls back to the row count without a total.
+	 * Test that prepare_items falls back to the row count when the total is
+	 * missing.
 	 *
-	 * A response cached before the client started asking for one has no
-	 * total_items.
+	 * A cached or older response can come back with no total_items.
 	 */
 	public function test_prepare_items_falls_back_to_row_count() {
 		$this->set_up_connected_state();
@@ -400,9 +387,10 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 	/**
 	 * Mock a list_resources API response.
 	 *
-	 * @param array $items The items to return.
+	 * @param array    $items The items to return.
+	 * @param int|null $total Optional. The account total PayPal reports.
 	 */
-	private function mock_list_response( $items ) {
+	private function mock_list_response( $items, $total = null ) {
 		$this->mock_http_response(
 			200,
 			array(
@@ -413,7 +401,7 @@ class PayPal_Payment_Links_List_Table_Test extends TestCase {
 						'href' => 'https://api.paypal.com/v1/checkout/payment-resources?page_size=20',
 					),
 				),
-			)
+			) + ( null === $total ? array() : array( 'total_items' => $total ) )
 		);
 	}
 

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -13,6 +13,7 @@ namespace Automattic\Jetpack\PaypalPayments;
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1159,6 +1160,170 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$this->assertEquals( 'missing_variant_price', $result->get_error_code() );
 	}
 
+	// --- Tax types ---
+
+	/**
+	 * Test that a FLAT tax reaches PayPal unchanged.
+	 *
+	 * PayPal accepts FLAT even though its published enum omits it. The arg
+	 * schema and the sanitizer both used to turn $1.50 of tax into 1.5%.
+	 *
+	 * @param string $method HTTP method.
+	 * @param string $route  Route to dispatch against.
+	 * @param int    $status Status PayPal answers with, and the route returns.
+	 * @dataProvider write_routes_provider
+	 */
+	#[DataProvider( 'write_routes_provider' )]
+	public function test_write_routes_keep_flat_tax( $method, $route, $status ) {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'name'  => 'Sales Tax',
+					'type'  => 'FLAT',
+					'value' => '1.50',
+				),
+			),
+			$method,
+			$route,
+			$status
+		);
+
+		$this->assertCount( 1, $line_item['taxes'] );
+		$this->assertSame( 'Sales Tax', $line_item['taxes'][0]['name'] );
+		$this->assertSame( 'FLAT', $line_item['taxes'][0]['type'] );
+		$this->assertSame( '1.50', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Both write routes share one argument schema and the bug showed up on
+	 * update, so the FLAT case runs over each.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: int}>
+	 */
+	public static function write_routes_provider() {
+		return array(
+			'create' => array( 'POST', '/wpcom/v2/paypal/buttons', 201 ),
+			'update' => array( 'PUT', '/wpcom/v2/paypal/buttons/PLB-CREATED123', 200 ),
+		);
+	}
+
+	/**
+	 * Test that a PREFERENCE tax sends PROFILE instead of the rate it was given.
+	 *
+	 * Changed: a numeric value used to pass straight through.
+	 */
+	public function test_create_button_sends_profile_for_preference_tax() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'name'  => 'Sales Tax',
+					'type'  => 'PREFERENCE',
+					'value' => '5',
+				),
+			)
+		);
+
+		$this->assertSame( 'PREFERENCE', $line_item['taxes'][0]['type'] );
+		$this->assertSame( 'PROFILE', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Test that a tax with no name still reaches PayPal.
+	 *
+	 * `taxes[].name` is optional and never shown to the buyer, and the form
+	 * stopped sending one. Requiring a name here threw the whole tax away.
+	 */
+	public function test_create_button_keeps_tax_without_name() {
+		// PERCENTAGE, so the missing name is the only thing under test.
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'type'  => 'PERCENTAGE',
+					'value' => '7.5',
+				),
+			)
+		);
+
+		$this->assertCount( 1, $line_item['taxes'] );
+		$this->assertArrayNotHasKey( 'name', $line_item['taxes'][0] );
+		$this->assertSame( 'PERCENTAGE', $line_item['taxes'][0]['type'] );
+		$this->assertSame( '7.5', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Test that an empty tax name is left off rather than sent as an empty string.
+	 */
+	public function test_create_button_omits_empty_tax_name() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'name'  => '',
+					'type'  => 'PERCENTAGE',
+					'value' => '7.5',
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'name', $line_item['taxes'][0] );
+	}
+
+	/**
+	 * Test that a FLAT amount reaches PayPal exactly as sent.
+	 *
+	 * Deliberate: PayPal answers a negative or non-numeric amount with a
+	 * clearer message than a clamp would, and clamping would book a zero tax.
+	 */
+	public function test_create_button_does_not_clamp_flat_tax() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'type'  => 'FLAT',
+					'value' => '-5.00',
+				),
+			)
+		);
+
+		$this->assertSame( '-5.00', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Test that an empty FLAT amount lands on zero rather than an empty string.
+	 *
+	 * PERCENTAGE and a missing value both give '0'; PayPal rejects ''.
+	 */
+	public function test_create_button_zeroes_empty_flat_tax() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'type'  => 'FLAT',
+					'value' => '',
+				),
+			)
+		);
+
+		$this->assertSame( '0', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Test that a percentage rate is still clamped and normalized.
+	 *
+	 * Unchanged behavior - this guards the split into per-type branches.
+	 */
+	public function test_create_button_clamps_negative_percentage_tax_rate() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'name'  => 'Sales Tax',
+					'type'  => 'PERCENTAGE',
+					'value' => '-7.500',
+				),
+			)
+		);
+
+		$this->assertSame( 'PERCENTAGE', $line_item['taxes'][0]['type'] );
+		$this->assertSame( '0', $line_item['taxes'][0]['value'] );
+	}
+
 	/**
 	 * Build a variants structure with a single primary dimension.
 	 *
@@ -1189,19 +1354,73 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
+	 * Dispatch a write through the REST server rather than calling the handler,
+	 * so the argument schema runs, and return the line item sent to PayPal.
+	 *
+	 * @param array  $taxes  Taxes to attach to the line item.
+	 * @param string $method HTTP method.
+	 * @param string $route  Route to dispatch against.
+	 * @param int    $status Status PayPal answers with, and the route returns.
+	 * @return array The line item as sent to PayPal.
+	 */
+	private function capture_sent_line_item( array $taxes, $method = 'POST', $route = '/wpcom/v2/paypal/buttons', $status = 201 ) {
+		$this->set_up_connected_admin_state();
+		$this->register_paypal_routes();
+
+		$sent = null;
+		$this->mock_http_response( $status, array( 'id' => 'PLB-CREATED123' ), $sent );
+
+		$request = new \WP_REST_Request( $method, $route );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'line_items' => array(
+						array(
+							'name'        => 'Widget',
+							'unit_amount' => array(
+								'currency_code' => 'USD',
+								'value'         => '10.00',
+							),
+							'taxes'       => $taxes,
+						),
+					),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame(
+			$status,
+			$response->get_status(),
+			'The route rejected the request: ' . wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+		$this->assertNotNull( $sent, 'No request reached PayPal.' );
+
+		$body = json_decode( $sent, true );
+
+		return $body['line_items'][0];
+	}
+
+	/**
 	 * Mock an HTTP response for the next wp_remote_request call.
 	 *
 	 * @param int          $status_code HTTP status code.
 	 * @param array|string $body        Response body (will be JSON-encoded if array).
+	 * @param string|null  $sent_body   Set to the request body that reached PayPal.
 	 */
-	private function mock_http_response( $status_code, $body ) {
+	private function mock_http_response( $status_code, $body, &$sent_body = null ) {
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( $status_code, $body ) {
+			function ( $preempt, $args, $url ) use ( $status_code, $body, &$sent_body ) {
 				// Skip the OAuth token endpoint mock — we use a cached token.
 				if ( strpos( $url, '/v1/oauth2/token' ) !== false ) {
 					return $preempt;
 				}
+
+				$sent_body = $args['body'] ?? null;
 
 				return array(
 					'response' => array(

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -977,6 +977,23 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
+	 * A list request with no page size asks PayPal for a full page.
+	 *
+	 * PayPal cannot search server-side, so a short page silently hides links from
+	 * whoever has to filter them.
+	 */
+	public function test_list_route_defaults_to_a_full_page() {
+		$this->assertStringContainsString( 'page_size=100', $this->capture_list_route_url() );
+	}
+
+	/**
+	 * An explicit page size overrides the default.
+	 */
+	public function test_list_route_honors_an_explicit_page_size() {
+		$this->assertStringContainsString( 'page_size=25', $this->capture_list_route_url( array( 'page_size' => 25 ) ) );
+	}
+
+	/**
 	 * The site must never proxy to a route it serves itself.
 	 *
 	 * The Jetpack plugin registers wpcom/v2/paypal/platform/signup-link for the
@@ -1402,6 +1419,50 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$body = json_decode( $sent, true );
 
 		return $body['line_items'][0];
+	}
+
+	/**
+	 * Dispatch a list request against a mocked PayPal and return the URL it built.
+	 *
+	 * @param array $params Query parameters to set on the request.
+	 * @return string The URL that reached PayPal.
+	 */
+	private function capture_list_route_url( array $params = array() ) {
+		$this->set_up_connected_admin_state();
+		$this->register_paypal_routes();
+
+		$captured_url = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$captured_url ) {
+				$captured_url = $url;
+
+				return $preempt;
+			},
+			9,
+			3
+		);
+
+		$this->mock_http_routes(
+			array( '/v1/checkout/payment-resources' => $this->http_response( 200, array( 'resources' => array() ) ) )
+		);
+
+		$request = new \WP_REST_Request( 'GET', '/wpcom/v2/paypal/buttons' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame(
+			200,
+			$response->get_status(),
+			'The route rejected the request: ' . wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+		$this->assertStringContainsString( '/v1/checkout/payment-resources', (string) $captured_url, 'No list request reached PayPal.' );
+
+		return $captured_url;
 	}
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -64,12 +64,20 @@ class PayPal_REST_Controller_Test extends TestCase {
 	/**
 	 * Route mocked HTTP responses by URL fragment.
 	 *
-	 * @param array $routes Map of URL fragment => response array or WP_Error.
+	 * @param array $routes   Map of URL fragment => response array or WP_Error.
+	 * @param array $requests Optional. Collected by reference as [ url, args ] pairs.
 	 */
-	private function mock_http_routes( array $routes ) {
+	private function mock_http_routes( array $routes, &$requests = null ) {
+		$requests = array();
+
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( $routes ) {
+			function ( $preempt, $args, $url ) use ( $routes, &$requests ) {
+				$requests[] = array(
+					'url'  => $url,
+					'args' => $args,
+				);
+
 				foreach ( $routes as $fragment => $response ) {
 					if ( false !== strpos( $url, $fragment ) ) {
 						return $response;
@@ -695,6 +703,9 @@ class PayPal_REST_Controller_Test extends TestCase {
 
 	/**
 	 * Test that listing buttons passes the API payload straight through.
+	 *
+	 * The fixture is PayPal's real list shape, so this also covers the count
+	 * that total_required adds.
 	 */
 	public function test_list_buttons_returns_api_payload() {
 		$this->set_up_connected_admin_state();
@@ -703,8 +714,10 @@ class PayPal_REST_Controller_Test extends TestCase {
 				'/v1/checkout/payment-resources' => $this->http_response(
 					200,
 					array(
-						'items'           => array( array( 'id' => 'PLB-1' ) ),
-						'next_page_token' => 'token123',
+						'resources'   => array( array( 'id' => 'PLB-1' ) ),
+						'total_items' => 40,
+						'total_pages' => 1,
+						'links'       => array( array( 'rel' => 'next' ) ),
 					)
 				),
 			)
@@ -717,8 +730,9 @@ class PayPal_REST_Controller_Test extends TestCase {
 
 		$this->assertInstanceOf( \WP_REST_Response::class, $result );
 		$this->assertSame( 200, $result->get_status() );
-		$this->assertSame( 'PLB-1', $result->get_data()['items'][0]['id'] );
-		$this->assertSame( 'token123', $result->get_data()['next_page_token'] );
+		$this->assertSame( 'PLB-1', $result->get_data()['resources'][0]['id'] );
+		$this->assertSame( 40, $result->get_data()['total_items'] );
+		$this->assertSame( 'next', $result->get_data()['links'][0]['rel'] );
 	}
 
 	/**
@@ -976,20 +990,25 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$this->assertTrue( $create_args['line_items']['required'], 'line_items should be required.' );
 	}
 
+	// --- List route ---
+
 	/**
-	 * A list request with no page size asks PayPal for a full page.
+	 * A list request with no page size asks PayPal for 100 results.
 	 *
-	 * PayPal cannot search server-side, so a short page silently hides links from
-	 * whoever has to filter them.
+	 * PayPal has no server-side search, so callers filter client-side and a
+	 * short page silently hides links from them.
 	 */
-	public function test_list_route_defaults_to_a_full_page() {
+	public function test_list_route_defaults_to_100_results() {
 		$this->assertStringContainsString( 'page_size=100', $this->capture_list_route_url() );
 	}
 
 	/**
 	 * An explicit page size overrides the default.
+	 *
+	 * Unchanged behavior - it guards against the handler being simplified to a
+	 * literal 100.
 	 */
-	public function test_list_route_honors_an_explicit_page_size() {
+	public function test_list_route_uses_an_explicit_page_size() {
 		$this->assertStringContainsString( 'page_size=25', $this->capture_list_route_url( array( 'page_size' => 25 ) ) );
 	}
 
@@ -1180,10 +1199,9 @@ class PayPal_REST_Controller_Test extends TestCase {
 	// --- Tax types ---
 
 	/**
-	 * Test that a FLAT tax reaches PayPal unchanged.
+	 * Test that create and update both forward a FLAT tax verbatim.
 	 *
-	 * PayPal accepts FLAT even though its published enum omits it. The arg
-	 * schema and the sanitizer both used to turn $1.50 of tax into 1.5%.
+	 * PayPal accepts FLAT even though its published enum omits it.
 	 *
 	 * @param string $method HTTP method.
 	 * @param string $route  Route to dispatch against.
@@ -1191,7 +1209,7 @@ class PayPal_REST_Controller_Test extends TestCase {
 	 * @dataProvider write_routes_provider
 	 */
 	#[DataProvider( 'write_routes_provider' )]
-	public function test_write_routes_keep_flat_tax( $method, $route, $status ) {
+	public function test_create_and_update_forward_flat_tax_verbatim( $method, $route, $status ) {
 		$line_item = $this->capture_sent_line_item(
 			array(
 				array(
@@ -1212,8 +1230,8 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Both write routes share one argument schema and the bug showed up on
-	 * update, so the FLAT case runs over each.
+	 * Create and update share one argument schema, so the FLAT case runs over
+	 * both.
 	 *
 	 * @return array<string, array{0: string, 1: string, 2: int}>
 	 */
@@ -1227,7 +1245,8 @@ class PayPal_REST_Controller_Test extends TestCase {
 	/**
 	 * Test that a PREFERENCE tax sends PROFILE instead of the rate it was given.
 	 *
-	 * Changed: a numeric value used to pass straight through.
+	 * A rate typed into the form is ignored - PREFERENCE means the rate on the
+	 * merchant's PayPal profile.
 	 */
 	public function test_create_button_sends_profile_for_preference_tax() {
 		$line_item = $this->capture_sent_line_item(
@@ -1245,12 +1264,12 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Test that a tax with no name still reaches PayPal.
+	 * Test that a tax with no name is still sent.
 	 *
-	 * `taxes[].name` is optional and never shown to the buyer, and the form
-	 * stopped sending one. Requiring a name here threw the whole tax away.
+	 * `taxes[].name` is optional and never shown to the buyer, so a tax without
+	 * one must still go through.
 	 */
-	public function test_create_button_keeps_tax_without_name() {
+	public function test_create_button_sends_tax_with_no_name() {
 		// PERCENTAGE, so the missing name is the only thing under test.
 		$line_item = $this->capture_sent_line_item(
 			array(
@@ -1263,6 +1282,26 @@ class PayPal_REST_Controller_Test extends TestCase {
 
 		$this->assertCount( 1, $line_item['taxes'] );
 		$this->assertArrayNotHasKey( 'name', $line_item['taxes'][0] );
+		$this->assertSame( 'PERCENTAGE', $line_item['taxes'][0]['type'] );
+		$this->assertSame( '7.5', $line_item['taxes'][0]['value'] );
+	}
+
+	/**
+	 * Test that a tax with no type is sent as PERCENTAGE.
+	 *
+	 * The only type branch still reachable through the route - the arg schema
+	 * rejects an unknown type before the sanitizer runs.
+	 */
+	public function test_create_button_sends_percentage_for_tax_with_no_type() {
+		$line_item = $this->capture_sent_line_item(
+			array(
+				array(
+					'name'  => 'Sales Tax',
+					'value' => '7.5',
+				),
+			)
+		);
+
 		$this->assertSame( 'PERCENTAGE', $line_item['taxes'][0]['type'] );
 		$this->assertSame( '7.5', $line_item['taxes'][0]['value'] );
 	}
@@ -1285,12 +1324,12 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Test that a FLAT amount reaches PayPal exactly as sent.
+	 * Test that a negative FLAT amount is forwarded verbatim.
 	 *
-	 * Deliberate: PayPal answers a negative or non-numeric amount with a
-	 * clearer message than a clamp would, and clamping would book a zero tax.
+	 * PayPal rejects it with a message the merchant can act on. Forcing it to
+	 * zero instead would save a zero tax and say nothing.
 	 */
-	public function test_create_button_does_not_clamp_flat_tax() {
+	public function test_create_button_forwards_negative_flat_tax_verbatim() {
 		$line_item = $this->capture_sent_line_item(
 			array(
 				array(
@@ -1304,11 +1343,11 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Test that an empty FLAT amount lands on zero rather than an empty string.
+	 * Test that an empty FLAT amount is sent as zero, not an empty string.
 	 *
-	 * PERCENTAGE and a missing value both give '0'; PayPal rejects ''.
+	 * PERCENTAGE and a missing value both produce '0'; PayPal rejects ''.
 	 */
-	public function test_create_button_zeroes_empty_flat_tax() {
+	public function test_create_button_sends_zero_for_empty_flat_tax() {
 		$line_item = $this->capture_sent_line_item(
 			array(
 				array(
@@ -1322,11 +1361,11 @@ class PayPal_REST_Controller_Test extends TestCase {
 	}
 
 	/**
-	 * Test that a percentage rate is still clamped and normalized.
+	 * Test that a negative percentage rate is sent as zero.
 	 *
-	 * Unchanged behavior - this guards the split into per-type branches.
+	 * Unchanged behavior - only FLAT keeps the raw string.
 	 */
-	public function test_create_button_clamps_negative_percentage_tax_rate() {
+	public function test_create_button_sends_zero_for_negative_percentage_tax() {
 		$line_item = $this->capture_sent_line_item(
 			array(
 				array(
@@ -1384,8 +1423,11 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$this->set_up_connected_admin_state();
 		$this->register_paypal_routes();
 
-		$sent = null;
-		$this->mock_http_response( $status, array( 'id' => 'PLB-CREATED123' ), $sent );
+		$requests = array();
+		$this->mock_http_routes(
+			array( '/v1/checkout/payment-resources' => $this->http_response( $status, array( 'id' => 'PLB-CREATED123' ) ) ),
+			$requests
+		);
 
 		$request = new \WP_REST_Request( $method, $route );
 		$request->set_header( 'content-type', 'application/json' );
@@ -1414,38 +1456,31 @@ class PayPal_REST_Controller_Test extends TestCase {
 			$response->get_status(),
 			'The route rejected the request: ' . wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
 		);
-		$this->assertNotNull( $sent, 'No request reached PayPal.' );
+		$this->assertNotEmpty( $requests, 'No request was sent to PayPal.' );
 
-		$body = json_decode( $sent, true );
+		$body = (array) json_decode( (string) $requests[0]['args']['body'], true );
+		$this->assertArrayHasKey( 'line_items', $body );
 
-		return $body['line_items'][0];
+		$line_item = $body['line_items'][0];
+		$this->assertArrayHasKey( 'taxes', $line_item, 'The taxes were dropped on the way to PayPal.' );
+
+		return $line_item;
 	}
 
 	/**
 	 * Dispatch a list request against a mocked PayPal and return the URL it built.
 	 *
 	 * @param array $params Query parameters to set on the request.
-	 * @return string The URL that reached PayPal.
+	 * @return string The URL sent to PayPal.
 	 */
 	private function capture_list_route_url( array $params = array() ) {
 		$this->set_up_connected_admin_state();
 		$this->register_paypal_routes();
 
-		$captured_url = null;
-
-		add_filter(
-			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( &$captured_url ) {
-				$captured_url = $url;
-
-				return $preempt;
-			},
-			9,
-			3
-		);
-
+		$requests = array();
 		$this->mock_http_routes(
-			array( '/v1/checkout/payment-resources' => $this->http_response( 200, array( 'resources' => array() ) ) )
+			array( '/v1/checkout/payment-resources' => $this->http_response( 200, array( 'resources' => array() ) ) ),
+			$requests
 		);
 
 		$request = new \WP_REST_Request( 'GET', '/wpcom/v2/paypal/buttons' );
@@ -1460,9 +1495,9 @@ class PayPal_REST_Controller_Test extends TestCase {
 			$response->get_status(),
 			'The route rejected the request: ' . wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
 		);
-		$this->assertStringContainsString( '/v1/checkout/payment-resources', (string) $captured_url, 'No list request reached PayPal.' );
+		$this->assertNotEmpty( $requests, 'No list request was sent to PayPal.' );
 
-		return $captured_url;
+		return (string) $requests[0]['url'];
 	}
 
 	/**
@@ -1470,18 +1505,15 @@ class PayPal_REST_Controller_Test extends TestCase {
 	 *
 	 * @param int          $status_code HTTP status code.
 	 * @param array|string $body        Response body (will be JSON-encoded if array).
-	 * @param string|null  $sent_body   Set to the request body that reached PayPal.
 	 */
-	private function mock_http_response( $status_code, $body, &$sent_body = null ) {
+	private function mock_http_response( $status_code, $body ) {
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( $status_code, $body, &$sent_body ) {
+			function ( $preempt, $args, $url ) use ( $status_code, $body ) {
 				// Skip the OAuth token endpoint mock — we use a cached token.
 				if ( strpos( $url, '/v1/oauth2/token' ) !== false ) {
 					return $preempt;
 				}
-
-				$sent_body = $args['body'] ?? null;
 
 				return array(
 					'response' => array(


### PR DESCRIPTION
Resolves WOOPTP-489

## Proposed changes

Three fixes in the PayPal Payments REST layer, one commit each.

* `FLAT` added to both the route's arg-schema enum and the `sanitize_line_items()` whitelist, with the value handled per type - `PREFERENCE` sends `PROFILE`, `FLAT` passes through as a string, `PERCENTAGE` keeps its clamp.
* A tax with no name is kept, and `name` is sent only when set. Groundwork for #52022, which removes the block's `taxEnabled && taxName` check.
* `list_resources()` sends `total_required=true`, and the payment links screen reads `total_items` instead of counting its own rows.
* `GET /wpcom/v2/paypal/buttons` defaults to 100 results instead of 10.

## Why are these changes being made?

The payment-link library needs three server-side bugs fixed before it can be built: flat-amount taxes were rejected outright and silently rewritten as percentages, and the list endpoint couldn't report a total or return more than 10 links at a time.

| | Before | After |
|---|---|---|
| Save a payment link with a fixed tax | 400 `rest_not_in_enum`, and behind that a $1.50 fee stored as 1.5% | saves as `{"type":"FLAT","value":"1.50"}` |
| Admin screen, merchant with 40 links | "20 items" | "40 items" |
| List route with no `page_size` | 10 links | up to 100 |

A `FLAT` link created outside the block opens in the editor looking normal, then Update either 400s or writes a percentage. The arg schema and `sanitize_line_items()` had the same two-value whitelist, so both needed the fix.

PayPal has no server-side search - `name`, `status`, `q` and `sort_by` are accepted and ignored - so search filters in the browser over what was already fetched. A default of 10 gives a merchant with 40 links a search over 10 of them.

Both deliberate: **`total_pages => 1`** keeps core's `paged` pager off, since this table pages by cursor. **FLAT goes out as typed**, because PayPal 422s a bad amount visibly and clamping would book a zero tax.


## Testing instructions

Needs a site with PayPal Payments connected in sandbox mode.

```
cd projects/packages/paypal-payments
composer test-php
```

**Fixed tax** - create a payment link with this on the line item:

```json
{"name":"Sales Tax","type":"FLAT","value":"1.50"}
```

| | Result |
|---|---|
| Trunk | 400 `line_items[0][taxes][0][type] is not one of PERCENTAGE and PREFERENCE` |
| This branch | 201, and a GET returns `"value":"1.50"` |

Check the GET, not the 201 - PayPal drops unknown fields silently. Then Update the block and re-read: the amount survives, and it is `1.50`, not `1.5`.

**Admin count** - `wp-admin/admin.php?page=paypal-payment-links`

Needs more links than `PayPal_Payment_Links_List_Table::PER_PAGE`, which is 20. Create 21+, or set `PER_PAGE` to 2 for one page load.

| At `PER_PAGE = 2`, 6 links | Trunk | This branch |
|---|---|---|
| Count shown | "2 items" | "6 items" |
| Core pager `«  ‹  Next page›  Last page»` | present | absent |

The screen's own Next Page button works either way.

**Page size** - browser console on any admin page:

```js
await wp.apiFetch( { path: '/wpcom/v2/paypal/buttons' } )
```

| Path | Expect |
|---|---|
| no `page_size` | up to 100 resources |
| `?page_size=10` | 10 resources and a `next` link - cursor path unchanged |
| `?page_size=101` or `?page_size=0` | `rest_invalid_param` |

Under 10 links trunk and this branch return the same rows, so create enough to pass 10.

## Does this pull request change what data or activity we track or use?

No.


