### PR TITLE
PayPal Payment Buttons: Fix updates that destroy merchant configuration

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-description-length
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-description-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow product descriptions up to PayPal's real 2048-character limit, instead of cutting them off at 256.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-tax-name-gate
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-tax-name-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix tax collection turning itself off. An empty tax name made the block and then the REST route throw the whole tax away.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-update-reports-204-as-error
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-update-reports-204-as-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix editing a payment button reporting an error after the edit saved. PayPal answers a successful update with 204 No Content and the API client expected 200.

--- a/projects/packages/paypal-payments/changelog/fix-paypal-update-wipes-unmodelled-fields
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-update-wipes-unmodelled-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Update deleting payment configuration set outside the block. An update is a full replacement at PayPal, so a SKU, shipping rate, handling fee or discount set anywhere else was silently dropped, and address collection was forced back on.

--- a/projects/packages/paypal-payments/docs/rest-api-reference.md
+++ b/projects/packages/paypal-payments/docs/rest-api-reference.md
@@ -142,7 +142,7 @@ Create a payment resource via the PayPal API. Returns both a button-ready resour
 | `reusable` | string | No | `MULTIPLE` | `MULTIPLE` or `SINGLE` |
 | `line_items` | array | Yes | — | Array of line item objects (min 1) |
 | `line_items[].name` | string | Yes | — | Product name (max 127 chars) |
-| `line_items[].description` | string | No | — | Product description (max 256 chars) |
+| `line_items[].description` | string | No | — | Product description (max 2048 chars) |
 | `line_items[].unit_amount.currency_code` | string | Yes | — | ISO currency code |
 | `line_items[].unit_amount.value` | string | Yes | — | Price (positive, max 2 decimals) |
 | `line_items[].quantity` | string | No | `1` | Quantity |
@@ -211,7 +211,9 @@ Get a single payment resource.
 
 Full replacement update of a payment resource. Same request body as create.
 
-**Response (200):** Updated resource object.
+**Response (200):** The request body echoed back, plus `id`. PayPal answers a successful update with
+`204 No Content`, so `status`, `payment_link` and `links` are absent - use the GET route to read
+PayPal's actual state.
 
 ---
 

--- a/projects/packages/paypal-payments/docs/support-pay-with-paypal.md
+++ b/projects/packages/paypal-payments/docs/support-pay-with-paypal.md
@@ -64,7 +64,7 @@ Once connected:
 1. Enter a **Product Name** (max 127 characters)
 2. Enter a **Price** (positive number, up to 2 decimal places)
 3. Select a **Currency** from the dropdown (26 supported)
-4. Optionally add a **Description** (max 256 characters)
+4. Optionally add a **Description** (max 2048 characters)
 5. Click **Create New**
 
 A live preview appears showing exactly how your button will look on the published page.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/block.json
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/block.json
@@ -113,7 +113,7 @@
 		},
 		"collectShippingAddress": {
 			"type": "boolean",
-			"default": false
+			"default": true
 		},
 		"shippingEnabled": {
 			"type": "boolean",

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
@@ -645,7 +645,9 @@ class PayPal_Admin_Page {
 			if ( ! empty( $line_item['taxes'] ) ) {
 				$tax_parts = array();
 				foreach ( $line_item['taxes'] as $tax ) {
-					$tax_parts[] = sprintf( '%s: %s (%s)', $tax['name'] ?? '', $tax['value'] ?? '', $tax['type'] ?? '' );
+					// PayPal labels the tax itself, so most payments leave the name empty.
+					$detail      = sprintf( '%s (%s)', $tax['value'] ?? '', $tax['type'] ?? '' );
+					$tax_parts[] = empty( $tax['name'] ) ? $detail : sprintf( '%s: %s', $tax['name'], $detail );
 				}
 				self::render_detail_row( __( 'Taxes', 'jetpack-paypal-payments' ), implode( ', ', $tax_parts ) );
 			}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-api-client.php
@@ -179,9 +179,14 @@ class PayPal_API_Client {
 	/**
 	 * Update a payment resource (full replacement via PUT).
 	 *
+	 * PayPal answers a successful PUT with an empty 204, so this echoes the request
+	 * back with the id. Call get_resource() for the payment's actual state, which a
+	 * full replacement can move. 200 counts as success too, in case PayPal ever
+	 * answers with a body; the body is discarded either way.
+	 *
 	 * @param string $resource_id   PayPal resource ID (format: PLB-XXXXXXXXXXXX).
 	 * @param array  $resource_data Complete updated resource data (same schema as create).
-	 * @return array|\WP_Error Decoded response body on success (HTTP 200), WP_Error on failure.
+	 * @return array|\WP_Error The data that was sent, plus the resource id, or WP_Error on failure.
 	 */
 	public static function update_resource( $resource_id, $resource_data ) {
 		$resource_id = self::sanitize_resource_id( $resource_id );
@@ -193,25 +198,14 @@ class PayPal_API_Client {
 			'PUT',
 			self::RESOURCES_ENDPOINT . '/' . $resource_id,
 			$resource_data,
-			200
+			array( 204, 200 )
 		);
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		// Extract payment_link from HATEOAS links array to top-level field.
-		$result = self::extract_payment_link( $result );
-
-		// Validate payment_link domain if present.
-		if ( ! empty( $result['payment_link'] ) ) {
-			$validation = self::validate_paypal_url( $result['payment_link'] );
-			if ( is_wp_error( $validation ) ) {
-				return $validation;
-			}
-		}
-
-		return $result;
+		return array_merge( $resource_data, array( 'id' => $resource_id ) );
 	}
 
 	/**
@@ -251,7 +245,7 @@ class PayPal_API_Client {
 	 * @param string     $method          HTTP method (GET, POST, PUT, DELETE).
 	 * @param string     $endpoint        API endpoint path.
 	 * @param array|null $body            Request body data.
-	 * @param int        $expected_status Expected HTTP status code for success.
+	 * @param int|array  $expected_status Status code, or codes, that count as success.
 	 * @return array|null|\WP_Error Decoded response body, null for 204, or WP_Error.
 	 */
 	private static function make_request_with_retry( $method, $endpoint, $body, $expected_status ) {
@@ -347,7 +341,7 @@ class PayPal_API_Client {
 	 * @param string     $method          HTTP method (GET, POST, PUT, DELETE).
 	 * @param string     $endpoint        API endpoint path (appended to base URL).
 	 * @param array|null $body            Request body data (JSON-encoded for POST/PUT).
-	 * @param int        $expected_status Expected HTTP status code for success.
+	 * @param int|array  $expected_status Status code, or codes, that count as success.
 	 * @param string     $request_id      Optional. Idempotency key. Auto-generated if empty.
 	 * @return array|null|\WP_Error Decoded response body, null for 204, or WP_Error.
 	 */
@@ -404,8 +398,8 @@ class PayPal_API_Client {
 		$status_code = wp_remote_retrieve_response_code( $response );
 
 		// Success path.
-		if ( $status_code === $expected_status ) {
-			// 204 No Content has no body.
+		if ( in_array( $status_code, (array) $expected_status, true ) ) {
+			// A 204 is empty. Ignore a body if PayPal ever sends one.
 			if ( 204 === $status_code ) {
 				return null;
 			}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-attribute-mapper.php
@@ -91,9 +91,12 @@ class PayPal_Attribute_Mapper {
 	/**
 	 * Maximum description length.
 	 *
+	 * Anything longer is a 400 `INVALID_STRING_LENGTH` from PayPal. Mirrored in
+	 * `utils/validation.js`; change both together.
+	 *
 	 * @var int
 	 */
-	const MAX_DESCRIPTION_LENGTH = 256;
+	const MAX_DESCRIPTION_LENGTH = 2048;
 
 	/**
 	 * Maximum button text length.
@@ -294,9 +297,9 @@ class PayPal_Attribute_Mapper {
 				$attributes['shippingValue']   = 'PREFERENCE' === $attributes['shippingType'] ? '' : sanitize_text_field( $shipping['value'] ?? '' );
 			}
 
-			if ( ! empty( $line_item['collect_shipping_address'] ) ) {
-				$attributes['collectShippingAddress'] = true;
-			}
+			// Map it even when the key is absent: the block attribute defaults to
+			// on, so a missing key has to read as off.
+			$attributes['collectShippingAddress'] = ! empty( $line_item['collect_shipping_address'] );
 		}
 
 		// Extract return_url if present.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -830,6 +830,20 @@ class PayPal_REST_Controller {
 	 * @return array REST API args definition.
 	 */
 	private static function get_button_create_args() {
+		// Shipping, handling and discounts take the same fields.
+		$amount_list = array(
+			'type'     => 'array',
+			'required' => false,
+			'items'    => array(
+				'type'       => 'object',
+				'properties' => array(
+					'type'                  => array( 'type' => 'string' ),
+					'value'                 => array( 'type' => 'string' ),
+					'additional_unit_value' => array( 'type' => 'string' ),
+				),
+			),
+		);
+
 		return array(
 			'name'             => array(
 				'required'          => false,
@@ -876,17 +890,17 @@ class PayPal_REST_Controller {
 				'items'       => array(
 					'type'       => 'object',
 					'properties' => array(
-						'name'                => array(
+						'name'                     => array(
 							'type'     => 'string',
 							'required' => true,
 						),
-						'description'         => array(
+						'description'              => array(
 							'type'     => 'string',
 							'required' => false,
 						),
 						// Not required: omitted when the product options carry
 						// their own per-option prices.
-						'unit_amount'         => array(
+						'unit_amount'              => array(
 							'type'       => 'object',
 							'required'   => false,
 							'properties' => array(
@@ -900,12 +914,12 @@ class PayPal_REST_Controller {
 								),
 							),
 						),
-						'quantity'            => array(
+						'quantity'                 => array(
 							'type'     => 'string',
 							'required' => false,
 							'default'  => '1',
 						),
-						'variants'            => array(
+						'variants'                 => array(
 							'type'       => 'object',
 							'required'   => false,
 							'properties' => array(
@@ -937,14 +951,14 @@ class PayPal_REST_Controller {
 								),
 							),
 						),
-						'adjustable_quantity' => array(
+						'adjustable_quantity'      => array(
 							'type'       => 'object',
 							'required'   => false,
 							'properties' => array(
 								'maximum' => array( 'type' => 'integer' ),
 							),
 						),
-						'customer_notes'      => array(
+						'customer_notes'           => array(
 							'type'     => 'array',
 							'required' => false,
 							'items'    => array(
@@ -955,7 +969,7 @@ class PayPal_REST_Controller {
 								),
 							),
 						),
-						'taxes'               => array(
+						'taxes'                    => array(
 							'type'     => 'array',
 							'required' => false,
 							'items'    => array(
@@ -969,6 +983,19 @@ class PayPal_REST_Controller {
 									'value' => array( 'type' => 'string' ),
 								),
 							),
+						),
+						// Set outside the form, but a PUT replaces the whole resource,
+						// so the editor sends them back.
+						'product_id'               => array(
+							'type'     => 'string',
+							'required' => false,
+						),
+						'shipping'                 => $amount_list,
+						'handling'                 => $amount_list,
+						'discounts'                => $amount_list,
+						'collect_shipping_address' => array(
+							'type'     => 'boolean',
+							'required' => false,
 						),
 					),
 				),
@@ -1126,10 +1153,64 @@ class PayPal_REST_Controller {
 				}
 			}
 
+			// Copied back from the payment by the editor. Drop one here and Update
+			// deletes it at PayPal.
+			if ( isset( $item['product_id'] ) && '' !== $item['product_id'] ) {
+				$clean_item['product_id'] = sanitize_text_field( $item['product_id'] );
+			}
+			foreach ( array( 'shipping', 'handling', 'discounts' ) as $field ) {
+				if ( ! empty( $item[ $field ] ) && is_array( $item[ $field ] ) ) {
+					$clean_amounts = self::sanitize_amount_list( $item[ $field ] );
+					if ( ! empty( $clean_amounts ) ) {
+						$clean_item[ $field ] = $clean_amounts;
+					}
+				}
+			}
+
+			// Send it even when off - omit it and PayPal turns address collection back on.
+			if ( isset( $item['collect_shipping_address'] ) ) {
+				$clean_item['collect_shipping_address'] = (bool) $item['collect_shipping_address'];
+			}
+
 			$sanitized[] = $clean_item;
 		}
 
 		return $sanitized;
+	}
+
+	/**
+	 * Sanitize a shipping, handling or discount list for PayPal API submission.
+	 *
+	 * All three take a type, a value, and for per-unit shipping a rate for each
+	 * extra unit. The type passes straight through: these come back off the payment,
+	 * so anything PayPal accepted must survive the round trip.
+	 *
+	 * @param array $amounts Raw entries from the REST request.
+	 * @return array Sanitized entries.
+	 */
+	private static function sanitize_amount_list( $amounts ) {
+		$clean = array();
+
+		foreach ( $amounts as $amount ) {
+			// A zero is a legitimate amount, and in a zero-decimal currency it is
+			// written "0", which empty() would throw away.
+			if ( ! is_array( $amount ) || ! isset( $amount['value'] ) || '' === (string) $amount['value'] ) {
+				continue;
+			}
+
+			$clean_amount = array(
+				'type'  => isset( $amount['type'] ) ? sanitize_text_field( $amount['type'] ) : 'FLAT',
+				'value' => sanitize_text_field( (string) $amount['value'] ),
+			);
+
+			if ( isset( $amount['additional_unit_value'] ) && '' !== (string) $amount['additional_unit_value'] ) {
+				$clean_amount['additional_unit_value'] = sanitize_text_field( (string) $amount['additional_unit_value'] );
+			}
+
+			$clean[] = $clean_amount;
+		}
+
+		return $clean;
 	}
 
 	/**

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/hooks/use-paypal-resource.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/hooks/use-paypal-resource.js
@@ -14,8 +14,47 @@ import { getResourceAttributeUpdates, withCurrency } from '../utils/resource-syn
 import { getUserFriendlyError } from '../utils/validation';
 
 /**
+ * Line-item fields set outside the block form.
+ *
+ * A PUT is a full replacement, so a field the request leaves out is one the
+ * merchant deletes by pressing Update. These ride back out from the payment itself.
+ */
+const PAYPAL_ONLY_LINE_ITEM_FIELDS = [
+	'product_id',
+	'shipping',
+	'handling',
+	'discounts',
+	'collect_shipping_address',
+];
+
+/**
+ * Put the fields set outside the form back into an update request.
+ *
+ * @param {object} data     - The request built from the block's attributes.
+ * @param {object} resource - The payment as it currently stands at PayPal.
+ * @return {object} The request with those fields copied in.
+ */
+function keepPayPalOnlyFields( data, resource ) {
+	const stored = resource?.line_items?.[ 0 ];
+	if ( ! stored ) {
+		return data;
+	}
+
+	const kept = {};
+	PAYPAL_ONLY_LINE_ITEM_FIELDS.forEach( key => {
+		if ( stored[ key ] !== undefined && stored[ key ] !== null ) {
+			kept[ key ] = stored[ key ];
+		}
+	} );
+
+	// PayPal's stored value wins: for these the form only ever sends its own
+	// defaults.
+	return { ...data, line_items: [ { ...data.line_items[ 0 ], ...kept } ] };
+}
+
+/**
  * The PayPal payment resource this block points at: creating it, updating it,
- * deleting it, and reading back what PayPal holds.
+ * deleting it, and reading it back.
  *
  * @param {object}   props                      - Hook props.
  * @param {object}   props.attributes           - Block attributes.
@@ -41,7 +80,6 @@ export function usePayPalResource( {
 	const {
 		isApiManaged,
 		resourceId,
-		paymentLink,
 		productName,
 		price,
 		currencyCode,
@@ -56,6 +94,7 @@ export function usePayPalResource( {
 		taxType,
 		taxName,
 		taxValue,
+		collectShippingAddress,
 	} = attributes;
 
 	// Form state.
@@ -141,17 +180,24 @@ export function usePayPalResource( {
 					...( customerNotes?.length > 0
 						? { customer_notes: customerNotes.filter( n => n.label?.trim() ) }
 						: {} ),
-					...( taxEnabled && taxName
+					...( taxEnabled
 						? {
 								taxes: [
 									{
-										name: taxName,
+										// PayPal supplies the label, so the name is
+										// its own only when the payment already has
+										// one. Sending an empty one would overwrite it.
+										...( taxName ? { name: taxName } : {} ),
 										type: taxType || 'PERCENTAGE',
 										value: taxType === 'PREFERENCE' ? 'PROFILE' : taxValue || '0',
 									},
 								],
 						  }
 						: {} ),
+					// Omitting this makes PayPal collect an address whatever the
+					// payment said before, so it goes out on every request. On an
+					// update the payment's own value replaces this one.
+					collect_shipping_address: !! collectShippingAddress,
 				},
 			],
 			...( returnUrl ? { return_url: returnUrl } : {} ),
@@ -172,6 +218,7 @@ export function usePayPalResource( {
 			taxType,
 			taxName,
 			taxValue,
+			collectShippingAddress,
 		]
 	);
 
@@ -246,23 +293,28 @@ export function usePayPalResource( {
 
 		let isRecreating = false;
 
-		apiFetch( {
-			path: `${ API_BASE }/buttons/${ resourceId }`,
-			method: 'PUT',
-			data: buildRequestData(),
-		} )
-			.then( response => {
-				setAttributes( {
-					paymentLink: response.payment_link || paymentLink,
-				} );
+		// Read the payment first, and let a failed read stop the save: a blind PUT
+		// would delete the fields the read was there to copy.
+		apiFetch( { path: `${ API_BASE }/buttons/${ resourceId }` } )
+			.then( resource =>
+				apiFetch( {
+					path: `${ API_BASE }/buttons/${ resourceId }`,
+					method: 'PUT',
+					data: keepPayPalOnlyFields( buildRequestData(), resource ),
+				} )
+			)
+			.then( () => {
+				// An update answers 204, so the route echoes the request back and the
+				// payment link stays as it was.
 				setSuccessMessage( __( 'PayPal button updated successfully!', 'jetpack-paypal-payments' ) );
 				setIsEditing( false );
 				setTouchedFields( {} );
 			} )
 			.catch( err => {
-				// If the resource was deleted from PayPal (404), automatically
-				// re-create it as a new button with the same product data.
-				// This handles demo/playground blocks and buttons deleted outside WordPress.
+				// If the resource was deleted from PayPal (404 on either the read or
+				// the write), automatically re-create it as a new button with the same
+				// product data. This handles demo/playground blocks and buttons deleted
+				// outside WordPress.
 				if ( err.code === 'paypal_api_resource_not_found' || err.data?.status === 404 ) {
 					isRecreating = true;
 					apiFetch( {
@@ -301,15 +353,7 @@ export function usePayPalResource( {
 					setIsCreating( false );
 				}
 			} );
-	}, [
-		resourceId,
-		buildRequestData,
-		paymentLink,
-		setAttributes,
-		isFormValid,
-		setIsEditing,
-		setTouchedFields,
-	] );
+	}, [ resourceId, buildRequestData, setAttributes, isFormValid, setIsEditing, setTouchedFields ] );
 
 	/**
 	 * Request delete confirmation via ConfirmDialog.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/resource-sync.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/resource-sync.js
@@ -30,6 +30,7 @@ export const RESOURCE_ATTRIBUTES = [
 	'taxName',
 	'taxValue',
 	'returnUrl',
+	'collectShippingAddress',
 ];
 
 let nextKey = 1;

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/validation.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/validation.js
@@ -14,10 +14,11 @@ import { VALID_CURRENCY_CODES } from './currencies';
 import { ZERO_DECIMAL_CURRENCIES } from './currency-symbols';
 
 /**
- * Validation constants — match server-side limits.
+ * Validation constants - PayPal's own limits, mirrored in `PayPal_Attribute_Mapper`.
+ * Change both together. A character over either is a 400 `INVALID_STRING_LENGTH`.
  */
 export const MAX_NAME_LENGTH = 127;
-export const MAX_DESCRIPTION_LENGTH = 256;
+export const MAX_DESCRIPTION_LENGTH = 2048;
 // PayPal rejects a third custom checkout field with a 400.
 export const MAX_CUSTOMER_NOTES = 2;
 

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
@@ -301,6 +301,17 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			/>
 		);
 
+	/**
+	 * Open the block's edit form and press Save.
+	 *
+	 * @param {object} user - The userEvent instance driving the clicks.
+	 */
+	async function saveFromEditForm( user ) {
+		await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
+		await user.click( screen.getByTestId( 'toolbar-Edit' ) );
+		await user.click( screen.getByText( 'Save' ) );
+	}
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		// Clear persisted wizard step to ensure tests start from 'welcome'.
@@ -1455,8 +1466,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( /Create Button/ ) ).resolves.toBeInTheDocument();
-			expect( screen.getByText( /Create Button/ ) ).toBeEnabled();
+			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( 'Create New' ) ).toBeEnabled();
 		} );
 
 		it( 'submits create request with correct data', async () => {
@@ -2405,6 +2416,89 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			expect( screen.queryByText( missingRate ) ).not.toBeInTheDocument();
 			expect( screen.getByText( 'Save' ) ).toBeEnabled();
 		} );
+
+		/**
+		 * The taxes the update request sent.
+		 *
+		 * @return {Array|undefined} The taxes array from the PUT.
+		 */
+		function taxesFromUpdate() {
+			const put = apiFetch.mock.calls.find( ( [ options ] ) => options.method === 'PUT' );
+			return put?.[ 0 ]?.data?.line_items?.[ 0 ]?.taxes;
+		}
+
+		// PayPal renders its own label to the buyer, so the merchant's string goes
+		// nowhere - and requiring one threw the whole tax away.
+		it( 'collects tax on a payment without a tax name', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [ { type: 'PERCENTAGE', value: '8.25' } ] )
+			);
+		} );
+
+		it( 'leaves taxes out of the request when tax collection is off', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxEnabled: false } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { method: 'PUT' } ) )
+			);
+			expect( taxesFromUpdate() ).toBeUndefined();
+		} );
+
+		it( 'sends PayPal’s own profile rate as PROFILE', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxType: 'PREFERENCE' } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [ { type: 'PREFERENCE', value: 'PROFILE' } ] )
+			);
+		} );
+
+		// A payment made in PayPal's dashboard can have one. Sending an empty name
+		// back would overwrite it, so the key rides along only when there is one.
+		it( 'sends a tax name the payment already has', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxName: 'ZZ Custom VAT Label' } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [
+					{ name: 'ZZ Custom VAT Label', type: 'PERCENTAGE', value: '8.25' },
+				] )
+			);
+		} );
 	} );
 
 	describe( 'Custom checkout fields', () => {
@@ -2735,8 +2829,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 
 		it( 'shows the description error once the field is left', async () => {
 			const user = userEvent.setup();
-			const tooLong = 'Description must be 256 characters or fewer.';
-			renderForm( { productDescription: 'x'.repeat( 257 ) } );
+			const tooLong = 'Description must be 2048 characters or fewer.';
+			renderForm( { productDescription: 'x'.repeat( 2049 ) } );
 
 			const field = await screen.findByLabelText( 'Description (optional)' );
 			expect( screen.queryByText( tooLong ) ).not.toBeInTheDocument();
@@ -2818,9 +2912,9 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				visit: 'Price',
 			},
 			productDescription: {
-				attributes: { productDescription: 'x'.repeat( 257 ) },
+				attributes: { productDescription: 'x'.repeat( 2049 ) },
 				testId: 'control-Description (optional)',
-				message: 'Description must be 256 characters or fewer.',
+				message: 'Description must be 2048 characters or fewer.',
 				visit: 'Description (optional)',
 			},
 			currencyCode: {
@@ -3212,17 +3306,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			collect_shipping_address: true,
 		};
 
-		/**
-		 * Open the block's edit form and press Update Button.
-		 *
-		 * @param {object} user - The userEvent instance driving the clicks.
-		 */
-		async function saveFromEditForm( user ) {
-			await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
-			await user.click( screen.getByTestId( 'toolbar-Edit' ) );
-			await user.click( screen.getByText( /Update Button/ ) );
-		}
-
 		it( 'keeps the fields set outside the form', async () => {
 			const user = userEvent.setup();
 
@@ -3314,130 +3397,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				expect( setAttributes ).toHaveBeenCalledWith(
 					expect.objectContaining( { resourceId: 'PLB-NEW1' } )
 				)
-			);
-		} );
-	} );
-
-	describe( 'Tax', () => {
-		const resourcePath = '/wpcom/v2/paypal/buttons/PLB-TAX1';
-		const attributes = {
-			isApiManaged: true,
-			resourceId: 'PLB-TAX1',
-			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-TAX1',
-			productName: 'Test Widget',
-			price: '29.99',
-			currencyCode: 'USD',
-			taxEnabled: true,
-			taxType: 'PERCENTAGE',
-			taxValue: '8.25',
-		};
-
-		/**
-		 * Mock the connection check and the pre-update read.
-		 */
-		function mockConnected() {
-			apiFetch.mockImplementation( ( { path, method } ) => {
-				if ( path.endsWith( '/connection' ) ) {
-					return Promise.resolve( { connected: true, environment: 'sandbox' } );
-				}
-				if ( path === resourcePath && method === undefined ) {
-					return Promise.resolve( { id: 'PLB-TAX1', line_items: [ {} ] } );
-				}
-				return Promise.resolve( {} );
-			} );
-		}
-
-		/**
-		 * Open the block's edit form and press Update Button.
-		 *
-		 * @param {object} user - The userEvent instance driving the clicks.
-		 */
-		async function saveFromEditForm( user ) {
-			await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
-			await user.click( screen.getByTestId( 'toolbar-Edit' ) );
-			await user.click( screen.getByText( /Update Button/ ) );
-		}
-
-		/**
-		 * The taxes the update request sent.
-		 *
-		 * @return {Array|undefined} The taxes array from the PUT.
-		 */
-		function taxesFromUpdate() {
-			const put = apiFetch.mock.calls.find( ( [ options ] ) => options.method === 'PUT' );
-			return put?.[ 0 ]?.data?.line_items?.[ 0 ]?.taxes;
-		}
-
-		// PayPal renders its own label to the buyer, so the merchant's string goes
-		// nowhere - and requiring one threw the whole tax away.
-		it( 'collects tax on a payment without a tax name', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [ { type: 'PERCENTAGE', value: '8.25' } ] )
-			);
-		} );
-
-		it( 'leaves taxes out of the request when tax collection is off', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxEnabled: false } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { method: 'PUT' } ) )
-			);
-			expect( taxesFromUpdate() ).toBeUndefined();
-		} );
-
-		it( 'sends PayPal’s own profile rate as PROFILE', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxType: 'PREFERENCE' } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [ { type: 'PREFERENCE', value: 'PROFILE' } ] )
-			);
-		} );
-
-		// A payment made in PayPal's dashboard can have one. Sending an empty name
-		// back would overwrite it, so the key rides along only when there is one.
-		it( 'sends a tax name the payment already has', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxName: 'ZZ Custom VAT Label' } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [
-					{ name: 'ZZ Custom VAT Label', type: 'PERCENTAGE', value: '8.25' },
-				] )
 			);
 		} );
 	} );

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
@@ -1431,7 +1431,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 						productName: 'Test Widget',
 						price: '29.99',
 						currencyCode: 'USD',
-						productDescription: 'x'.repeat( 257 ),
+						productDescription: 'x'.repeat( 2049 ),
 					} }
 					setAttributes={ setAttributes }
 				/>
@@ -1440,6 +1440,23 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
 			const createButton = screen.getByText( 'Create New' );
 			expect( createButton ).toBeDisabled();
+		} );
+
+		it( 'accepts a description past the old 256 limit', async () => {
+			render(
+				<Edit
+					attributes={ {
+						productName: 'Test Widget',
+						price: '29.99',
+						currencyCode: 'USD',
+						productDescription: 'x'.repeat( 500 ),
+					} }
+					setAttributes={ setAttributes }
+				/>
+			);
+
+			await expect( screen.findByText( /Create Button/ ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( /Create Button/ ) ).toBeEnabled();
 		} );
 
 		it( 'submits create request with correct data', async () => {
@@ -1459,6 +1476,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 						productName: 'Test Widget',
 						price: '29.99',
 						currencyCode: 'USD',
+						collectShippingAddress: false,
 					} }
 					setAttributes={ setAttributes }
 				/>
@@ -1480,6 +1498,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 							expect.objectContaining( {
 								name: 'Test Widget',
 								unit_amount: { currency_code: 'USD', value: '29.99' },
+								// Sent even when off: omit it and PayPal turns address collection on.
+								collect_shipping_address: false,
 							} ),
 						] ),
 					} ),
@@ -3163,6 +3183,262 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 
 			await expect( screen.findByText( /Get Your API Credentials/ ) ).resolves.toBeInTheDocument();
 			expect( screen.queryByTestId( 'paypal-button-preview' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Updating a payment', () => {
+		const attributes = {
+			isApiManaged: true,
+			resourceId: 'PLB-KEEP1',
+			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-KEEP1',
+			productName: 'Test Widget',
+			price: '29.99',
+			currencyCode: 'USD',
+			collectShippingAddress: false,
+		};
+		const resourcePath = '/wpcom/v2/paypal/buttons/PLB-KEEP1';
+
+		// A payment configured beyond what the block form covers - set in PayPal's
+		// own dashboard, or by the admin page.
+		const storedLineItem = {
+			name: 'Test Widget',
+			unit_amount: { currency_code: 'USD', value: '29.99' },
+			product_id: 'SKU-12345',
+			shipping: [ { type: 'FLAT', value: '5.00', additional_unit_value: '2.00' } ],
+			handling: [ { type: 'FLAT', value: '4.00' } ],
+			discounts: [ { type: 'FLAT', value: '2.00' } ],
+			// The block sends false, so a true in the PUT can only have come from
+			// the payment.
+			collect_shipping_address: true,
+		};
+
+		/**
+		 * Open the block's edit form and press Update Button.
+		 *
+		 * @param {object} user - The userEvent instance driving the clicks.
+		 */
+		async function saveFromEditForm( user ) {
+			await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
+			await user.click( screen.getByTestId( 'toolbar-Edit' ) );
+			await user.click( screen.getByText( /Update Button/ ) );
+		}
+
+		it( 'keeps the fields set outside the form', async () => {
+			const user = userEvent.setup();
+
+			apiFetch.mockImplementation( ( { path, method } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				if ( path === resourcePath && method === undefined ) {
+					return Promise.resolve( { id: 'PLB-KEEP1', line_items: [ storedLineItem ] } );
+				}
+				return Promise.resolve( {} );
+			} );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						path: resourcePath,
+						method: 'PUT',
+						data: expect.objectContaining( {
+							line_items: [
+								expect.objectContaining( {
+									product_id: 'SKU-12345',
+									shipping: storedLineItem.shipping,
+									handling: storedLineItem.handling,
+									discounts: storedLineItem.discounts,
+									collect_shipping_address: true,
+								} ),
+							],
+						} ),
+					} )
+				)
+			);
+		} );
+
+		it( 'sends the form’s own values over the payment’s', async () => {
+			const user = userEvent.setup();
+
+			apiFetch.mockImplementation( ( { path, method } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				if ( path === resourcePath && method === undefined ) {
+					return Promise.resolve( {
+						id: 'PLB-KEEP1',
+						line_items: [ { ...storedLineItem, name: 'Stale name' } ],
+					} );
+				}
+				return Promise.resolve( {} );
+			} );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						method: 'PUT',
+						data: expect.objectContaining( {
+							line_items: [ expect.objectContaining( { name: 'Test Widget' } ) ],
+						} ),
+					} )
+				)
+			);
+		} );
+
+		it( 're-creates a payment that has been deleted from PayPal', async () => {
+			const user = userEvent.setup();
+
+			apiFetch.mockImplementation( ( { path } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				if ( path === resourcePath ) {
+					return Promise.reject( { code: 'paypal_api_resource_not_found', data: { status: 404 } } );
+				}
+				return Promise.resolve( {
+					id: 'PLB-NEW1',
+					payment_link: 'https://www.paypal.com/ncp/payment/PLB-NEW1',
+				} );
+			} );
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( setAttributes ).toHaveBeenCalledWith(
+					expect.objectContaining( { resourceId: 'PLB-NEW1' } )
+				)
+			);
+		} );
+	} );
+
+	describe( 'Tax', () => {
+		const resourcePath = '/wpcom/v2/paypal/buttons/PLB-TAX1';
+		const attributes = {
+			isApiManaged: true,
+			resourceId: 'PLB-TAX1',
+			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-TAX1',
+			productName: 'Test Widget',
+			price: '29.99',
+			currencyCode: 'USD',
+			taxEnabled: true,
+			taxType: 'PERCENTAGE',
+			taxValue: '8.25',
+		};
+
+		/**
+		 * Mock the connection check and the pre-update read.
+		 */
+		function mockConnected() {
+			apiFetch.mockImplementation( ( { path, method } ) => {
+				if ( path.endsWith( '/connection' ) ) {
+					return Promise.resolve( { connected: true, environment: 'sandbox' } );
+				}
+				if ( path === resourcePath && method === undefined ) {
+					return Promise.resolve( { id: 'PLB-TAX1', line_items: [ {} ] } );
+				}
+				return Promise.resolve( {} );
+			} );
+		}
+
+		/**
+		 * Open the block's edit form and press Update Button.
+		 *
+		 * @param {object} user - The userEvent instance driving the clicks.
+		 */
+		async function saveFromEditForm( user ) {
+			await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
+			await user.click( screen.getByTestId( 'toolbar-Edit' ) );
+			await user.click( screen.getByText( /Update Button/ ) );
+		}
+
+		/**
+		 * The taxes the update request sent.
+		 *
+		 * @return {Array|undefined} The taxes array from the PUT.
+		 */
+		function taxesFromUpdate() {
+			const put = apiFetch.mock.calls.find( ( [ options ] ) => options.method === 'PUT' );
+			return put?.[ 0 ]?.data?.line_items?.[ 0 ]?.taxes;
+		}
+
+		// PayPal renders its own label to the buyer, so the merchant's string goes
+		// nowhere - and requiring one threw the whole tax away.
+		it( 'collects tax on a payment without a tax name', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [ { type: 'PERCENTAGE', value: '8.25' } ] )
+			);
+		} );
+
+		it( 'leaves taxes out of the request when tax collection is off', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxEnabled: false } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { method: 'PUT' } ) )
+			);
+			expect( taxesFromUpdate() ).toBeUndefined();
+		} );
+
+		it( 'sends PayPal’s own profile rate as PROFILE', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxType: 'PREFERENCE' } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [ { type: 'PREFERENCE', value: 'PROFILE' } ] )
+			);
+		} );
+
+		// A payment made in PayPal's dashboard can have one. Sending an empty name
+		// back would overwrite it, so the key rides along only when there is one.
+		it( 'sends a tax name the payment already has', async () => {
+			const user = userEvent.setup();
+			mockConnected();
+
+			render(
+				<Edit
+					attributes={ { ...attributes, taxName: 'ZZ Custom VAT Label' } }
+					setAttributes={ setAttributes }
+					clientId="a"
+				/>
+			);
+			await saveFromEditForm( user );
+
+			await waitFor( () =>
+				expect( taxesFromUpdate() ).toEqual( [
+					{ name: 'ZZ Custom VAT Label', type: 'PERCENTAGE', value: '8.25' },
+				] )
+			);
 		} );
 	} );
 

--- a/projects/packages/paypal-payments/tests/js/resource-sync.test.js
+++ b/projects/packages/paypal-payments/tests/js/resource-sync.test.js
@@ -28,6 +28,7 @@ const blockAttributes = {
 	taxName: 'Sales Tax',
 	taxValue: '',
 	returnUrl: '',
+	collectShippingAddress: true,
 	imageUrl: 'https://example.com/widget.jpg',
 	format: 'QR',
 };
@@ -76,6 +77,15 @@ describe( 'getResourceAttributeUpdates', () => {
 				resourceAttributes
 			)
 		).toEqual( { productDescription: '', returnUrl: '' } );
+	} );
+
+	it( 'reads address collection back from the payment', () => {
+		expect(
+			getResourceAttributeUpdates( blockAttributes, {
+				...resourceAttributes,
+				collectShippingAddress: false,
+			} )
+		).toEqual( { collectShippingAddress: false } );
 	} );
 
 	it( 'clears a leftover product price when the payment prices per option', () => {

--- a/projects/packages/paypal-payments/tests/js/validation.test.js
+++ b/projects/packages/paypal-payments/tests/js/validation.test.js
@@ -124,14 +124,14 @@ describe( 'validateDescription', () => {
 	} );
 
 	it( 'returns an error when value exceeds MAX_DESCRIPTION_LENGTH', () => {
-		const longDesc = 'a'.repeat( 257 );
+		const longDesc = 'a'.repeat( 2049 );
 		expect( validateDescription( longDesc ) ).toBe(
 			`Description must be ${ MAX_DESCRIPTION_LENGTH } characters or fewer.`
 		);
 	} );
 
 	it( 'returns null for a description at exactly MAX_DESCRIPTION_LENGTH', () => {
-		const maxDesc = 'a'.repeat( 256 );
+		const maxDesc = 'a'.repeat( 2048 );
 		expect( validateDescription( maxDesc ) ).toBeNull();
 	} );
 } );

--- a/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_API_Client_Test.php
@@ -268,18 +268,12 @@ class PayPal_API_Client_Test extends TestCase {
 	}
 
 	/**
-	 * Test update_resource returns parsed response on 200.
+	 * Test update_resource treats PayPal's 204 as success and echoes the saved resource.
 	 */
 	public function test_update_resource_success() {
 		$this->set_up_connected_state();
 
-		$expected_response = array(
-			'id'     => 'PLB-UPDATE123',
-			'type'   => 'BUY_NOW',
-			'status' => 'ACTIVE',
-		);
-
-		$this->mock_http_response( 200, $expected_response );
+		$this->mock_http_response( 204, '' );
 
 		$result = PayPal_API_Client::update_resource(
 			'PLB-UPDATE123',
@@ -298,6 +292,57 @@ class PayPal_API_Client_Test extends TestCase {
 		);
 
 		$this->assertIsArray( $result );
+		$this->assertEquals( 'PLB-UPDATE123', $result['id'] );
+		$this->assertEquals( 'Updated Widget', $result['line_items'][0]['name'] );
+	}
+
+	/**
+	 * Test a 200 on the update counts as success.
+	 *
+	 * PayPal may answer with a confirmation body instead of a bare 204.
+	 */
+	public function test_update_resource_accepts_200() {
+		$this->set_up_connected_state();
+
+		$this->mock_http_response(
+			200,
+			array(
+				'id'     => 'PLB-UPDATE123',
+				'status' => 'ACTIVE',
+			)
+		);
+
+		$result = PayPal_API_Client::update_resource(
+			'PLB-UPDATE123',
+			array( 'type' => 'BUY_NOW' )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'PLB-UPDATE123', $result['id'] );
+		$this->assertEquals( 'BUY_NOW', $result['type'] );
+	}
+
+	/**
+	 * Test a body on a 204 is discarded and the update still succeeds.
+	 */
+	public function test_update_resource_discards_a_confirmation_body() {
+		$this->set_up_connected_state();
+
+		$this->mock_http_response(
+			204,
+			array(
+				'id'     => 'PLB-SOMETHINGELSE',
+				'status' => 'ACTIVE',
+			)
+		);
+
+		$result = PayPal_API_Client::update_resource(
+			'PLB-UPDATE123',
+			array( 'type' => 'BUY_NOW' )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'status', $result );
 		$this->assertEquals( 'PLB-UPDATE123', $result['id'] );
 	}
 
@@ -585,10 +630,10 @@ class PayPal_API_Client_Test extends TestCase {
 				}
 				return array(
 					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
+						'code'    => 204,
+						'message' => 'No Content',
 					),
-					'body'     => wp_json_encode( array( 'id' => 'PLB-UPD123' ), JSON_UNESCAPED_SLASHES ),
+					'body'     => '',
 				);
 			},
 			10,

--- a/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
@@ -633,6 +633,37 @@ class PayPal_Admin_Page_Test extends TestCase {
 	}
 
 	/**
+	 * Test detail view labels a tax without a name.
+	 *
+	 * PayPal labels the tax itself, so the block leaves the name empty and the row
+	 * shows the amount alone.
+	 */
+	public function test_detail_view_shows_a_tax_without_a_name() {
+		$admin = $this->create_admin_user();
+		wp_set_current_user( $admin );
+
+		$this->set_up_connected_state();
+		$resource                           = $this->get_sample_resource();
+		$resource['line_items'][0]['taxes'] = array(
+			array(
+				'type'  => 'PERCENTAGE',
+				'value' => '8.25',
+			),
+		);
+		$this->mock_get_resource_response( $resource );
+
+		$_GET['action']      = 'view';
+		$_GET['resource_id'] = 'PLB-ABC123';
+
+		ob_start();
+		PayPal_Admin_Page::render_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '8.25 (PERCENTAGE)', $output );
+		$this->assertStringNotContainsString( ': 8.25', $output );
+	}
+
+	/**
 	 * Test detail view shows adjustable quantity.
 	 */
 	public function test_detail_view_shows_adjustable_quantity() {

--- a/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Attribute_Mapper_Test.php
@@ -356,7 +356,7 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 	// --- validate_attributes: optional field length limits ---
 
 	/**
-	 * Test that description exceeding 256 characters is rejected.
+	 * Test that description exceeding 2048 characters is rejected.
 	 */
 	public function test_validate_rejects_description_too_long() {
 		$result = PayPal_Attribute_Mapper::validate_attributes(
@@ -364,12 +364,28 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 				'productName'        => 'Widget',
 				'price'              => '10.00',
 				'currencyCode'       => 'USD',
-				'productDescription' => str_repeat( 'D', 257 ),
+				'productDescription' => str_repeat( 'D', 2049 ),
 			)
 		);
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertEquals( 'description_too_long', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a description at PayPal's 2048 limit is accepted.
+	 */
+	public function test_validate_accepts_description_at_max_length() {
+		$result = PayPal_Attribute_Mapper::validate_attributes(
+			array(
+				'productName'        => 'Widget',
+				'price'              => '10.00',
+				'currencyCode'       => 'USD',
+				'productDescription' => str_repeat( 'D', 2048 ),
+			)
+		);
+
+		$this->assertTrue( $result );
 	}
 
 	/**
@@ -539,6 +555,59 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 		$this->assertSame( '49.99', $attributes['price'] );
 		$this->assertEquals( 'A very fancy widget.', $attributes['productDescription'] );
 		$this->assertEquals( 'https://example.com/thanks', $attributes['returnUrl'] );
+	}
+
+	/**
+	 * Test that api_response_to_attributes reports address collection both ways.
+	 *
+	 * The block attribute defaults to on, so an absent key has to come back as off.
+	 * Otherwise a payment that skips address collection reads as one that asks for it.
+	 */
+	public function test_api_response_to_attributes_maps_address_collection_both_ways() {
+		$on  = PayPal_Attribute_Mapper::api_response_to_attributes(
+			array(
+				'id'         => 'PLB-ON',
+				'line_items' => array( array( 'collect_shipping_address' => true ) ),
+			)
+		);
+		$off = PayPal_Attribute_Mapper::api_response_to_attributes(
+			array(
+				'id'         => 'PLB-OFF',
+				'line_items' => array( array( 'name' => 'Widget' ) ),
+			)
+		);
+
+		$this->assertTrue( $on['collectShippingAddress'] );
+		$this->assertFalse( $off['collectShippingAddress'] );
+	}
+
+	/**
+	 * Test that api_response_to_attributes reads back a tax without a name.
+	 *
+	 * The block leaves the tax name empty, so the mapper fills in the default label.
+	 */
+	public function test_api_response_to_attributes_reads_a_tax_without_a_name() {
+		$attributes = PayPal_Attribute_Mapper::api_response_to_attributes(
+			array(
+				'id'         => 'PLB-TAX',
+				'line_items' => array(
+					array(
+						'name'  => 'Widget',
+						'taxes' => array(
+							array(
+								'type'  => 'PERCENTAGE',
+								'value' => '8.25',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $attributes['taxEnabled'] );
+		$this->assertSame( 'PERCENTAGE', $attributes['taxType'] );
+		$this->assertSame( '8.25', $attributes['taxValue'] );
+		$this->assertSame( 'Sales Tax', $attributes['taxName'] );
 	}
 
 	/**
@@ -1008,7 +1077,7 @@ class PayPal_Attribute_Mapper_Test extends TestCase {
 	 */
 	public function test_length_constants() {
 		$this->assertEquals( 127, PayPal_Attribute_Mapper::MAX_NAME_LENGTH );
-		$this->assertEquals( 256, PayPal_Attribute_Mapper::MAX_DESCRIPTION_LENGTH );
+		$this->assertEquals( 2048, PayPal_Attribute_Mapper::MAX_DESCRIPTION_LENGTH );
 		$this->assertEquals( 50, PayPal_Attribute_Mapper::MAX_BUTTON_TEXT_LENGTH );
 	}
 }

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -1084,7 +1084,9 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$result = PayPal_REST_Controller::handle_update_button( $request );
 
 		$this->assertInstanceOf( \WP_REST_Response::class, $result );
-		$this->assertSame(
+		// assertEquals, not assertSame: the whole array is the point - nothing
+		// vanished - but the key order is the sanitizer's business, not the test's.
+		$this->assertEquals(
 			array(
 				array(
 					'name'  => 'ZZ Custom VAT Label',

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -849,6 +849,291 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$this->assertEquals( 'missing_line_items', $result->get_error_code() );
 	}
 
+	/**
+	 * Test that an update keeps the fields set outside the block form.
+	 *
+	 * A PUT replaces the whole resource at PayPal, so anything the route drops
+	 * here the merchant loses by pressing Update.
+	 */
+	public function test_update_keeps_fields_set_outside_the_form() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'                     => 'Widget',
+					'unit_amount'              => array(
+						'currency_code' => 'USD',
+						'value'         => '29.99',
+					),
+					'product_id'               => 'SKU-12345',
+					'shipping'                 => array(
+						array(
+							'type'                  => 'FLAT',
+							'value'                 => '5.00',
+							'additional_unit_value' => '2.00',
+						),
+					),
+					'handling'                 => array(
+						array(
+							'type'  => 'FLAT',
+							'value' => '4.00',
+						),
+					),
+					'discounts'                => array(
+						array(
+							'type'  => 'FLAT',
+							'value' => '2.00',
+						),
+					),
+					'collect_shipping_address' => false,
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$sent = $result->get_data()['line_items'][0];
+		$this->assertSame( 'SKU-12345', $sent['product_id'] );
+		$this->assertSame(
+			array(
+				'type'                  => 'FLAT',
+				'value'                 => '5.00',
+				'additional_unit_value' => '2.00',
+			),
+			$sent['shipping'][0]
+		);
+		$this->assertSame(
+			array(
+				'type'  => 'FLAT',
+				'value' => '4.00',
+			),
+			$sent['handling'][0]
+		);
+		$this->assertSame(
+			array(
+				'type'  => 'FLAT',
+				'value' => '2.00',
+			),
+			$sent['discounts'][0]
+		);
+		$this->assertFalse( $sent['collect_shipping_address'] );
+	}
+
+	/**
+	 * Test that an address-collecting payment stays one across an update.
+	 */
+	public function test_update_sends_address_collection_when_on() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'                     => 'Widget',
+					'unit_amount'              => array(
+						'currency_code' => 'USD',
+						'value'         => '29.99',
+					),
+					'collect_shipping_address' => true,
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertTrue( $result->get_data()['line_items'][0]['collect_shipping_address'] );
+	}
+
+	/**
+	 * Test that a zero amount survives an update.
+	 *
+	 * Zero-decimal currencies write a zero as "0", which PHP treats as empty - and
+	 * a dropped field is a deleted field once PayPal replaces the resource.
+	 */
+	public function test_update_keeps_a_zero_amount() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'        => 'Widget',
+					'unit_amount' => array(
+						'currency_code' => 'JPY',
+						'value'         => '1000',
+					),
+					'product_id'  => '0',
+					'handling'    => array(
+						array(
+							'type'  => 'FLAT',
+							'value' => '0',
+						),
+					),
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$sent = $result->get_data()['line_items'][0];
+		$this->assertSame( '0', $sent['product_id'] );
+		$this->assertSame( '0', $sent['handling'][0]['value'] );
+	}
+
+	/**
+	 * Test that a tax without a name survives an update.
+	 *
+	 * PayPal supplies the label, so the block leaves the name empty and the
+	 * sanitizer must keep the tax anyway.
+	 */
+	public function test_update_keeps_a_tax_without_a_name() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'        => 'Widget',
+					'unit_amount' => array(
+						'currency_code' => 'USD',
+						'value'         => '29.99',
+					),
+					'taxes'       => array(
+						array(
+							'type'  => 'PERCENTAGE',
+							'value' => '8.25',
+						),
+					),
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame(
+			array(
+				array(
+					'type'  => 'PERCENTAGE',
+					'value' => '8.25',
+				),
+			),
+			$result->get_data()['line_items'][0]['taxes']
+		);
+	}
+
+	/**
+	 * Test that an update keeps a tax name the payment already has.
+	 *
+	 * A payment made in PayPal's dashboard can carry one, and a PUT is a full
+	 * replacement, so leaving the key out would delete it.
+	 */
+	public function test_update_keeps_a_tax_name_the_payment_already_has() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'        => 'Widget',
+					'unit_amount' => array(
+						'currency_code' => 'USD',
+						'value'         => '29.99',
+					),
+					'taxes'       => array(
+						array(
+							'name'  => 'ZZ Custom VAT Label',
+							'type'  => 'PERCENTAGE',
+							'value' => '8.25',
+						),
+					),
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame(
+			array(
+				array(
+					'name'  => 'ZZ Custom VAT Label',
+					'type'  => 'PERCENTAGE',
+					'value' => '8.25',
+				),
+			),
+			$result->get_data()['line_items'][0]['taxes']
+		);
+	}
+
+	/**
+	 * Test that a PayPal-profile tax without a name survives an update.
+	 */
+	public function test_update_keeps_a_paypal_profile_tax_without_a_name() {
+		$this->set_up_connected_admin_state();
+		$this->mock_http_response( 204, '' );
+
+		$request = new \WP_REST_Request( 'PUT', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'type', 'BUY_NOW' );
+		$request->set_param( 'integration_mode', 'LINK' );
+		$request->set_param(
+			'line_items',
+			array(
+				array(
+					'name'        => 'Widget',
+					'unit_amount' => array(
+						'currency_code' => 'USD',
+						'value'         => '29.99',
+					),
+					'taxes'       => array(
+						array(
+							'type'  => 'PREFERENCE',
+							'value' => 'PROFILE',
+						),
+					),
+				),
+			)
+		);
+
+		$result = PayPal_REST_Controller::handle_update_button( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$sent = $result->get_data()['line_items'][0]['taxes'][0];
+		$this->assertSame( 'PREFERENCE', $sent['type'] );
+		$this->assertSame( 'PROFILE', $sent['value'] );
+	}
+
 	// --- Constants ---
 
 	/**

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-description-length
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-description-length
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Allow product descriptions up to PayPal's real 2048-character limit, instead of cutting them off at 256.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-tax-name-gate
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-tax-name-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix tax collection turning itself off. An empty tax name made the block and then the REST route throw the whole tax away.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-update-reports-204-as-error
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-update-reports-204-as-error
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix editing a payment button reporting an error after the edit saved. PayPal answers a successful update with 204 No Content and the API client expected 200.

--- a/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-update-wipes-unmodelled-fields
+++ b/projects/plugins/paypal-payment-buttons/changelog/fix-paypal-update-wipes-unmodelled-fields
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix Update deleting payment configuration set outside the block. An update is a full replacement at PayPal, so a SKU, shipping rate, handling fee or discount set anywhere else was silently dropped, and address collection was forced back on.

--- a/projects/plugins/paypal-payment-buttons/tests/e2e/helpers/paypal-api-mock.js
+++ b/projects/plugins/paypal-payment-buttons/tests/e2e/helpers/paypal-api-mock.js
@@ -48,13 +48,13 @@ const MOCK_RESPONSES = {
 			},
 		],
 	},
+	// A successful update is an empty 204, so the route echoes the request back with
+	// the id alone. See PayPal_API_Client.
 	updateButton: {
 		id: 'PLB-TESTMOCK001',
 		type: 'BUY_NOW',
 		integration_mode: 'LINK',
 		reusable: 'MULTIPLE',
-		status: 'ACTIVE',
-		payment_link: 'https://www.sandbox.paypal.com/ncp/payment/TESTMOCK001',
 		line_items: [
 			{
 				name: 'Updated Product',


### PR DESCRIPTION
Fixes WOOPTP-490

The server and payload half of #52022. No editor UI here.

## Proposed changes

* **Update destroyed the configuration the form has no controls for.** A PUT replaces the whole resource and `buildRequestData` only sent what the form models, so PayPal deleted the rest. Silently, reported as success, on any payment link the block did not create.
* **A successful edit reported an error.** PayPal answers `204` to a PUT and `update_resource()` only accepted 200.
* **Tax vanished when its name was blank** - dropped by the block, then again by the REST route. Both checks are gone. A name the payment already has still goes back out, so a link made in PayPal's dashboard keeps it.
* **Description limit was 256.** PayPal's is 2048, and it rejects rather than truncates.

| Field | Before | After one Update | Now |
|---|---|---|---|
| `product_id` | `SKU-1` | gone | survives |
| `shipping` | FLAT 5.00, +2.00 per extra unit | gone | survives |
| `handling` | FLAT 4.00 | gone | survives |
| `discounts` | FLAT 2.00 | gone | survives |
| `collect_shipping_address` | `false` | `true` | survives |

`handleUpdateButton` reads the payment first and merges those five into the request - one extra GET per save. A failed read stops the save, because a blind PUT would delete them. `sanitize_line_items()` had to stop rebuilding line items from an allowlist too, or the route dropped them again on the way out.

`collect_shipping_address` now goes out on every request. On trunk the block left the key out, so PayPal applied its own default of `true` and asked for an address whatever the block attribute said; `block.json` flips the default to match what was already happening.

**Before anyone adds a shipping-address control:** a new toggle would render, save cleanly, and change nothing on an update. Take `collect_shipping_address` out of `PAYPAL_ONLY_LINE_ITEM_FIELDS` in the same change.

## Related product discussion/links

* WOOPTP-490
* #52022 carries the editor half of this work.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Build `packages/paypal-payments` and load the branch. The block has no shipping, handling, discount
or SKU controls, so make the payment through the REST route. In the browser console on a post edit
screen:

```js
const made = await wp.apiFetch( { path: '/wpcom/v2/paypal/buttons', method: 'POST', data: {
  type: 'BUY_NOW', integration_mode: 'LINK', reusable: 'MULTIPLE',
  line_items: [ {
    name: 'split check', unit_amount: { currency_code: 'USD', value: '10.00' },
    product_id: 'SKU-1',
    shipping: [ { type: 'FLAT', value: '5.00', additional_unit_value: '2.00' } ],
    handling: [ { type: 'FLAT', value: '4.00' } ],
    discounts: [ { type: 'FLAT', value: '2.00' } ],
    collect_shipping_address: false,
    taxes: [ { name: 'ZZ Custom VAT Label', type: 'PERCENTAGE', value: '8.25' } ],
  } ],
} } );
wp.data.dispatch( 'core/block-editor' ).insertBlock(
  wp.blocks.createBlock( 'jetpack/paypal-payment-buttons', {
    isApiManaged: true, resourceId: made.id, productName: 'split check',
    price: '10.00', currencyCode: 'USD',
    paymentLink: `https://www.sandbox.paypal.com/ncp/payment/${ made.id }`,
  } )
);
made.id;
```

Select the block, click **Edit** in the block toolbar, change **Product Name** in the **Details**
panel, then **Save**. Read it back with
`await wp.apiFetch( { path: '/wpcom/v2/paypal/buttons/<id>' } )`.

* The notice reads **PayPal button updated successfully!** Before this branch it read "An unexpected
  error occurred..." while PayPal saved the edit anyway.
* All five fields survive and `collect_shipping_address` is still `false`. Without this branch they
  are gone and the flag reads `true`.
* `taxes` still carries `ZZ Custom VAT Label`. The Tax name field was removed in #52022, so the
  attribute round-trips without a control - the name a payment link arrived with is kept.
* Paste 2048 characters into **Description**: `2048 / 2048 characters`, **Save** stays enabled, and
  it reads back at 2048. 2049 gives the length error.

A tax with no name has no field to clear, so drive that one from the console with the block
selected, then **Save** again:

```js
wp.data.dispatch( 'core/block-editor' ).updateBlockAttributes(
  wp.data.select( 'core/block-editor' ).getSelectedBlockClientId(),
  { taxName: '' }
);
```

`taxes` reads back as `[ { type: 'PERCENTAGE', value: '8.25' } ]`. Before this branch a blank name
threw the whole tax away.
