### PR TITLE
Premium Analytics: anchor the activity heatmaps' window fallback on the site's today

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2111-heatmap-window-site-today
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2111-heatmap-window-site-today
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Anchor the activity heatmaps' window fallback on the site's today instead of the viewer's.

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/posting-activity.test.tsx
@@ -2,13 +2,17 @@
  * External dependencies
  */
 import { useStatsStreak } from '@jetpack-premium-analytics/data';
+import {
+	resolveCalendarHeatmapWindow,
+	type HeatmapTooltipData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
 import PostingActivityRender from '../render';
 import type { ReportParams } from '@jetpack-premium-analytics/data';
-import type { HeatmapTooltipData } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
@@ -61,6 +65,17 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/data' ),
 	useStatsStreak: jest.fn(),
 } ) );
+
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => {
+	const actual = jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' );
+
+	return {
+		...actual,
+		resolveCalendarHeatmapWindow: jest.fn( actual.resolveCalendarHeatmapWindow ),
+	};
+} );
+
+const mockResolveCalendarHeatmapWindow = jest.mocked( resolveCalendarHeatmapWindow );
 
 const mockUseStatsStreak = jest.mocked( useStatsStreak );
 const REPORT_PARAMS = {
@@ -177,6 +192,30 @@ describe( 'PostingActivityWidget', () => {
 			startDate: '2021-06-28',
 			endDate: '2025-06-30',
 		} );
+	} );
+
+	// 10:00 UTC on the 9th is already the 10th at UTC+14 and still the 9th in every
+	// other zone, so the guard holds whatever the process zone is.
+	it( "anchors the window fallback on the site's today, not the viewer's", () => {
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { string: 'Pacific/Kiritimati', offset: 14, offsetFormatted: '14', abbr: 'LINT' },
+		} );
+		jest.useFakeTimers().setSystemTime( new Date( '2026-09-09T10:00:00Z' ) );
+		mockResolveCalendarHeatmapWindow.mockClear();
+
+		try {
+			renderWidget();
+
+			expect( mockResolveCalendarHeatmapWindow ).toHaveBeenCalled();
+			for ( const call of mockResolveCalendarHeatmapWindow.mock.calls ) {
+				expect( call[ 2 ] ).toBe( '2026-09-10' );
+			}
+		} finally {
+			jest.useRealTimers();
+			setSettings( settings );
+		}
 	} );
 
 	describe( 'empty state', () => {

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useStatsStreak } from '@jetpack-premium-analytics/data';
-import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
+import { localTZDate, parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { formatDate } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
@@ -73,7 +73,7 @@ function PostingActivityInner() {
 
 	// One reading for both windows below, so a render across midnight cannot resolve
 	// them against different days.
-	const today = format( new Date(), 'yyyy-MM-dd' );
+	const today = format( localTZDate(), 'yyyy-MM-dd' );
 
 	// Both the request window and the range the heatmap draws and pages through:
 	// without a floor the two coincide, so paging can never leave the selection.

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/__tests__/traffic-views-activity.test.tsx
@@ -2,13 +2,17 @@
  * External dependencies
  */
 import { useStatsVisits } from '@jetpack-premium-analytics/data';
+import {
+	resolveCalendarHeatmapWindow,
+	type HeatmapTooltipData,
+} from '@jetpack-premium-analytics/widgets-toolkit';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { getSettings, setSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
 import TrafficViewsActivityRender from '../render';
 import type { ReportParams } from '@jetpack-premium-analytics/data';
-import type { HeatmapTooltipData } from '@jetpack-premium-analytics/widgets-toolkit';
 import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
@@ -80,6 +84,17 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	useStatsVisits: jest.fn(),
 } ) );
 
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => {
+	const actual = jest.requireActual( '@jetpack-premium-analytics/widgets-toolkit' );
+
+	return {
+		...actual,
+		resolveCalendarHeatmapWindow: jest.fn( actual.resolveCalendarHeatmapWindow ),
+	};
+} );
+
+const mockResolveCalendarHeatmapWindow = jest.mocked( resolveCalendarHeatmapWindow );
+
 const mockUseStatsVisits = jest.mocked( useStatsVisits );
 
 const REPORT_PARAMS = {
@@ -147,6 +162,30 @@ describe( 'TrafficViewsActivityWidget', () => {
 
 	afterEach( () => {
 		setViewportWidth( originalInnerWidth );
+	} );
+
+	// 10:00 UTC on the 9th is already the 10th at UTC+14 and still the 9th in every
+	// other zone, so the guard holds whatever the process zone is.
+	it( "anchors the window fallback on the site's today, not the viewer's", () => {
+		const settings = getSettings();
+		setSettings( {
+			...settings,
+			timezone: { string: 'Pacific/Kiritimati', offset: 14, offsetFormatted: '14', abbr: 'LINT' },
+		} );
+		jest.useFakeTimers().setSystemTime( new Date( '2026-09-09T10:00:00Z' ) );
+		mockResolveCalendarHeatmapWindow.mockClear();
+
+		try {
+			renderWidget();
+
+			expect( mockResolveCalendarHeatmapWindow ).toHaveBeenCalled();
+			for ( const call of mockResolveCalendarHeatmapWindow.mock.calls ) {
+				expect( call[ 2 ] ).toBe( '2026-09-10' );
+			}
+		} finally {
+			jest.useRealTimers();
+			setSettings( settings );
+		}
 	} );
 
 	describe( 'request parameters', () => {

--- a/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-views-activity/render.tsx
@@ -6,7 +6,7 @@ import {
 	useStatsVisits,
 	withoutComparison,
 } from '@jetpack-premium-analytics/data';
-import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
+import { localTZDate, parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { formatDate } from '@jetpack-premium-analytics/formatters';
 import {
 	AdaptiveCalendarHeatmap,
@@ -58,7 +58,7 @@ function TrafficViewsActivityInner() {
 
 	// One reading for both windows below, so a render across midnight cannot resolve
 	// them against different days.
-	const today = format( new Date(), 'yyyy-MM-dd' );
+	const today = format( localTZDate(), 'yyyy-MM-dd' );
 
 	// A ceiling only — a floor would leak years outside the selection into the
 	// card's heading (WOOA7S-1963); it also bounds paging, so paging can't escape the selection.


### PR DESCRIPTION
Fixes WOOA7S-2111

## Proposed changes
* Use the site’s timezone for the fallback date in the Posting activity and Traffic views activity heatmaps. This ensures callers without `reportParams.to` get the site’s current day.
* Add regression tests for both widgets where the site’s day is ahead of the viewer’s.

There is no visible change: `WidgetRoot` always supplies `reportParams.to`, so the dashboard does not use this fallback.

## Related product discussion/links
* WOOA7S-2111
* WOOA7S-2065: Related fix for the Posting activity widget’s published day.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* From `projects/packages/premium-analytics`, run `PA_TEST_GROUPS=1 TZ=UTC pnpm exec jest --config=tests/jest.config.cjs widgets/posting-activity widgets/traffic-views-activity`. Expect 43 tests to pass.
* Repeat with `TZ=Asia/Tokyo`. Expect 43 tests to pass.
* To verify the regression test, temporarily replace `localTZDate()` with `new Date()` in either widget’s `render.tsx` and rerun with `TZ=Asia/Tokyo`. Expect a failure: expected `2026-09-10`, received `2026-09-09`. Restore the change afterward.
* Open Insights with any preset selected. Both heatmaps should show the same window and caption as before.
