### PR TITLE
Premium Analytics: draw the post and video detail charts as bars by default

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2048-detail-bar-chart-default
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2048-detail-bar-chart-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post and video detail pages: draw the Post views and Video performance charts as bars by default.

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -2,7 +2,7 @@ import { PA_COLUMN_COUNT } from '../../grid';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as full-width highlights and Post views rows, Likes, Comments and UTM side by side, then a full-width All-time traffic', () => {
+	it( 'composes Post traffic as full-width highlights and Post views bar chart rows, Likes, Comments and UTM side by side, then a full-width All-time traffic', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
@@ -12,6 +12,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'post-views',
 				type: 'jpa/post-views',
+				attributes: { chartType: 'bar' },
 				placement: { width: PA_COLUMN_COUNT, height: 2, order: 2 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -18,6 +18,9 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		{
 			uuid: 'post-views',
 			type: 'jpa/post-views',
+			// Bars: a post's exposure peaks right after publishing, so its chart is
+			// mostly read over short windows, where a line adds little.
+			attributes: { chartType: 'bar' },
 			placement: { width: PA_COLUMN_COUNT, height: 2, order: 2 },
 		},
 		{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -18,8 +18,6 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		{
 			uuid: 'post-views',
 			type: 'jpa/post-views',
-			// Bars: a post's exposure peaks right after publishing, so its chart is
-			// mostly read over short windows, where a line adds little.
 			attributes: { chartType: 'bar' },
 			placement: { width: PA_COLUMN_COUNT, height: 2, order: 2 },
 		},

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.test.ts
@@ -16,11 +16,12 @@ describe( 'video detail layout', () => {
 
 	// The composition is fixed (WOOA7S-1625): assert the exact arrangement so an
 	// accidental reshuffle surfaces here, not in the rendered dashboard.
-	it( 'composes the full-width performance chart above the full-width embeds list', () => {
+	it( 'composes the full-width bar performance chart above the full-width embeds list', () => {
 		expect( VIDEO_DETAIL_LAYOUT ).toEqual( [
 			{
 				uuid: 'video-detail-views-performance',
 				type: 'jpa/video-detail-views-performance',
+				attributes: { chartType: 'bar' },
 				placement: { width: PA_COLUMN_COUNT, height: 2, order: 1 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
@@ -9,8 +9,6 @@ export const VIDEO_DETAIL_LAYOUT: DashboardWidget[] = [
 	{
 		uuid: 'video-detail-views-performance',
 		type: 'jpa/video-detail-views-performance',
-		// Bars: a video's exposure peaks right after upload, so its chart is
-		// mostly read over short windows, where a line adds little.
 		attributes: { chartType: 'bar' },
 		placement: { width: PA_COLUMN_COUNT, height: 2, order: 1 },
 	},

--- a/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/config/layout.ts
@@ -9,6 +9,9 @@ export const VIDEO_DETAIL_LAYOUT: DashboardWidget[] = [
 	{
 		uuid: 'video-detail-views-performance',
 		type: 'jpa/video-detail-views-performance',
+		// Bars: a video's exposure peaks right after upload, so its chart is
+		// mostly read over short windows, where a line adds little.
+		attributes: { chartType: 'bar' },
 		placement: { width: PA_COLUMN_COUNT, height: 2, order: 1 },
 	},
 	{

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -120,9 +120,9 @@ describe( 'PostViewsWidget', () => {
 		// two in-window days; the 6/25 day falls outside the window.
 		expect( metrics[ 0 ].values ).toEqual( [ 0, 5, 0, 7, 0, 0, 0 ] );
 		// The metric headline is the window total, and the chart type
-		// defaults to line.
+		// defaults to bars.
 		expect( metrics[ 0 ].value ).toBe( 12 );
-		expect( chart ).toHaveAttribute( 'data-chart-type', 'line' );
+		expect( chart ).toHaveAttribute( 'data-chart-type', 'bar' );
 
 		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
 		expect( requestedPath ).toContain( 'stats/post/779' );
@@ -161,13 +161,13 @@ describe( 'PostViewsWidget', () => {
 		expect( chartedMetrics( chart )[ 0 ].values ).toEqual( [ 9, 12, 0, 0 ] );
 	} );
 
-	it( 'draws bars when the chartType attribute says so', async () => {
+	it( 'draws a line when the chartType attribute says so', async () => {
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 
-		render( <PostViewsWidget attributes={ { reportParams: WINDOW_PARAMS, chartType: 'bar' } } /> );
+		render( <PostViewsWidget attributes={ { reportParams: WINDOW_PARAMS, chartType: 'line' } } /> );
 
 		const chart = await screen.findByTestId( 'metric-tabs-chart' );
-		expect( chart ).toHaveAttribute( 'data-chart-type', 'bar' );
+		expect( chart ).toHaveAttribute( 'data-chart-type', 'line' );
 	} );
 
 	it( 'ignores comparison report params: one request, single series', async () => {

--- a/projects/packages/premium-analytics/widgets/post-views/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/render.tsx
@@ -102,7 +102,7 @@ function PostViewsInner( { chartType }: PostViewsInnerProps ) {
 
 export default function PostViews( { attributes = {} }: PostViewsWidgetProps ) {
 	// Coerce unknown persisted values to the default.
-	const chartType = attributes?.chartType === 'bar' ? 'bar' : 'line';
+	const chartType = attributes?.chartType === 'line' ? 'line' : 'bar';
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
@@ -95,7 +95,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"Post views\" widget: the scoped post's view trend over the dashboard date range as a line chart — the legacy Calypso post summary chart. The view series comes from `stats/post`'s full daily history, zero-filled and bucketed client-side at the page's chart interval. The post detail page has no comparison control, so comparison report params are ignored. Without a post scope the widget renders a scopeless empty state.",
+					"The \"Post views\" widget: the scoped post's view trend over the dashboard date range as a bar chart by default. The view series comes from `stats/post`'s full daily history, zero-filled and bucketed client-side at the page's chart interval. The post detail page has no comparison control, so comparison report params are ignored. Without a post scope the widget renders a scopeless empty state.",
 			},
 		},
 	},
@@ -106,8 +106,7 @@ export default meta;
 type Story = StoryObj< PostViewsStoryControls >;
 
 /**
- * Default — the scoped post's views for the selected period: a single
- * "Views" line.
+ * Default — the scoped post's views for the selected period as bars.
  */
 export const Default: Story = {
 	render: renderPostViews,

--- a/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
@@ -111,7 +111,7 @@ type Story = StoryObj< PostViewsStoryControls >;
  */
 export const Default: Story = {
 	render: renderPostViews,
-	args: { hasPostScope: true, interval: 'day', chartType: 'line' },
+	args: { hasPostScope: true, interval: 'day', chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -122,7 +122,7 @@ export const Default: Story = {
  */
 export const NoPostScope: Story = {
 	render: renderPostViews,
-	args: { hasPostScope: false, interval: 'day', chartType: 'line' },
+	args: { hasPostScope: false, interval: 'day', chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 

--- a/projects/packages/premium-analytics/widgets/post-views/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/widget.ts
@@ -36,7 +36,7 @@ export default {
 	attributes: [ chartTypeAttributeField() ] as WidgetAttributeField< PostViewsAttributes >[],
 	example: {
 		attributes: {
-			chartType: 'line',
+			chartType: 'bar',
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/__tests__/video-detail-views-performance.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/__tests__/video-detail-views-performance.test.tsx
@@ -168,7 +168,7 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 			'Hours watched',
 			'Retention rate',
 		] );
-		expect( chart ).toHaveAttribute( 'data-chart-type', 'line' );
+		expect( chart ).toHaveAttribute( 'data-chart-type', 'bar' );
 
 		// One point per calendar day of the 7-day window, zero-filled around the
 		// two returned days; the headline is the response's canonical total.
@@ -248,17 +248,17 @@ describe( 'VideoDetailViewsPerformanceWidget', () => {
 		expect( retention.values[ 2 ] ).toBe( 0 );
 	} );
 
-	it( 'draws bars when the chartType attribute says so', async () => {
+	it( 'draws a line when the chartType attribute says so', async () => {
 		mockApiFetch.mockImplementation( respondByWindow( { '2026-07-01': PRIMARY_WINDOW_RESPONSE } ) );
 
 		render(
 			<VideoDetailViewsPerformanceWidget
-				attributes={ { reportParams: WINDOW_PARAMS, chartType: 'bar' } }
+				attributes={ { reportParams: WINDOW_PARAMS, chartType: 'line' } }
 			/>
 		);
 
 		const chart = await screen.findByTestId( 'metric-tabs-chart' );
-		expect( chart ).toHaveAttribute( 'data-chart-type', 'bar' );
+		expect( chart ).toHaveAttribute( 'data-chart-type', 'line' );
 	} );
 
 	it( 'ignores comparison report params: one request, single-period series', async () => {

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/render.tsx
@@ -96,7 +96,7 @@ export default function VideoDetailViewsPerformance( {
 	attributes = {},
 }: VideoDetailViewsPerformanceWidgetProps ) {
 	// Coerce unknown persisted values to the default.
-	const chartType = attributes?.chartType === 'bar' ? 'bar' : 'line';
+	const chartType = attributes?.chartType === 'line' ? 'line' : 'bar';
 
 	return (
 		<WidgetRoot attributes={ attributes }>

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/stories/video-detail-views-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/stories/video-detail-views-performance-widget.stories.tsx
@@ -119,7 +119,7 @@ type Story = StoryObj< VideoDetailViewsPerformanceStoryControls >;
  */
 export const Default: Story = {
 	render: renderVideoDetailViewsPerformance,
-	args: { hasVideoScope: true, interval: 'day', chartType: 'line' },
+	args: { hasVideoScope: true, interval: 'day', chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -130,7 +130,7 @@ export const Default: Story = {
  */
 export const NoVideoScope: Story = {
 	render: renderVideoDetailViewsPerformance,
-	args: { hasVideoScope: false, interval: 'day', chartType: 'line' },
+	args: { hasVideoScope: false, interval: 'day', chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 

--- a/projects/packages/premium-analytics/widgets/video-detail-views-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-views-performance/widget.ts
@@ -21,7 +21,7 @@ export type VideoDetailViewsPerformanceChartType = ChartDisplayChartType;
 /**
  * `post_id` (video scope) and report params reach the widget via WidgetRoot.
  *
- * @property chartType - How to draw the selected metric. Defaults to `line`.
+ * @property chartType - How to draw the selected metric. Defaults to `bar`.
  */
 export type VideoDetailViewsPerformanceAttributes = {
 	chartType?: VideoDetailViewsPerformanceChartType;
@@ -38,7 +38,7 @@ export default {
 	] as WidgetAttributeField< VideoDetailViewsPerformanceAttributes >[],
 	example: {
 		attributes: {
-			chartType: 'line',
+			chartType: 'bar',
 		},
 	},
 };

--- a/projects/plugins/jetpack/changelog/wooa7s-2048-detail-bar-chart-default
+++ b/projects/plugins/jetpack/changelog/wooa7s-2048-detail-bar-chart-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: draw the Post views and Video performance charts on the detail pages as bars by default.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2048-detail-bar-chart-default
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2048-detail-bar-chart-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post and video detail pages: draw the Post views and Video performance charts as bars by default.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2048-detail-bar-chart-default
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2048-detail-bar-chart-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: draw the Post views and Video performance charts on the detail pages as bars by default.


### PR DESCRIPTION
Fixes WOOA7S-2045, WOOA7S-2048


## Proposed changes

The Post views chart on the post detail page and the Video performance chart on the video detail page opened as line charts; they now open as bar charts. A post or video gets most of its exposure right after publishing, so the chart is usually read over a short window, where bars read better than a line.


* Give the `post-views` tile in `POST_DETAIL_TAB_LAYOUTS` and the `video-detail-views-performance` tile in `VIDEO_DETAIL_LAYOUT` a fixed `attributes: { chartType: 'bar' }`, so both cards open as bars and the Chart type control shows Bars selected.
* A reader who already rearranged either page without touching Chart type also gets bars: `useStoredDetailLayout` stores only the attributes the reader changed and layers them over the fixed composition, so the new default reaches every untouched card. A reader who had explicitly picked Lines keeps Lines.
* The two widgets are bar-first on every surface too: `example.attributes`, the render fallback and the Storybook defaults flip to `bar`, so a card inserted from the picker (once inserting is re-enabled) opens the same way as the composition's copy.


## Related product discussion/links

* Linear: WOOA7S-2045, WOOA7S-2048 (spec: Eder's 29 August recap on the Unified Analytics P2, "Detailed instances")
* Follow-up: WOOA7S-2047

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jetpack build packages/premium-analytics --deps`, then open the Premium Analytics dashboard (`wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`) as a user who has not customized the detail pages.
* Open a post's detail page from Top posts: the Post views card draws bars, and its Chart type control (card settings) shows Bars selected. Switch through the date presets; it stays bars.
* Open a video's detail page from the Videos report: the Video performance card draws bars across the Views, Impressions, Hours watched and Retention rate tabs.
* Switch one card to Lines and reload: it is still Lines. Choose Reset layout from the page options menu: it is Bars again.
* Upgrade path: with a customized arrangement saved on trunk (rearrange a card, Done), check out this branch and reload: the chart is Bars. If you had switched a card to Lines on trunk, it stays Lines here.

* `pnpm run test` in `projects/packages/premium-analytics` passes.



### Before / after

First open, Last 30 days, same fixture data. Only the chart mark changes; the metric tabs, totals, and date control stay the same.

| | Before (trunk) | After (this PR) |
| --- | --- | --- |
| Video detail | <img alt="Video detail on trunk: line chart" src="https://raw.githubusercontent.com/Automattic/jetpack/67df0518176564c14082d8d1ee03ec077820e137/video-detail-first-open-line-before.jpg" /> | <img alt="Video detail on this PR: bar chart" src="https://raw.githubusercontent.com/Automattic/jetpack/67df0518176564c14082d8d1ee03ec077820e137/video-detail-first-open-bars-after.jpg" /> |
| Post detail | <img alt="Post detail on trunk: line chart" src="https://raw.githubusercontent.com/Automattic/jetpack/67df0518176564c14082d8d1ee03ec077820e137/post-detail-first-open-line-before.jpg" /> | <img alt="Post detail on this PR: bar chart" src="https://raw.githubusercontent.com/Automattic/jetpack/67df0518176564c14082d8d1ee03ec077820e137/post-detail-first-open-bars-after.jpg" /> |


