### PR TITLE
Premium Analytics: remove the date controls from the Insights section header

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2012-insights-header-date-control
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2012-insights-header-date-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: remove the year filter and interval dropdown from the section header.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -588,6 +588,18 @@ describe( 'Dashboard header date control', () => {
 		expect( screen.getByText( 'offers comparison' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders neither the year surface nor the interval when a year section hands them over', () => {
+		useSectionDateFilterMock.mockReturnValue( DATE_FILTER_YEAR );
+		mockSection( {
+			date_filter_options: { with_date_comparison: false, with_header_date_control: false },
+		} );
+
+		render( <Dashboard /> );
+
+		expect( screen.queryByText( /^year surface/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /^interval/ ) ).not.toBeInTheDocument();
+	} );
+
 	// A payload served before the field existed carries no placement.
 	it( 'keeps the control for a section that carries no placement', () => {
 		mockSection( {

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -303,11 +303,13 @@ function register_default_dashboard_sections() {
 			'label'               => __( 'Insights', 'jetpack-premium-analytics-pkg' ),
 			'title'               => __( 'Activity insights', 'jetpack-premium-analytics-pkg' ),
 			'order'               => 20,
-			// Insights reads whole history: all time and single years instead of
-			// the rolling picker, with nothing to compare them against.
+			// Insights reads whole history: all time and single years, with nothing
+			// to compare them against. Most widgets have fixed periods of their own,
+			// so no header control; Highlights hosts the only year control.
 			'date_filter'         => Dashboard_Section::DATE_FILTER_YEAR,
 			'date_filter_options' => array(
-				'with_date_comparison' => false,
+				'with_date_comparison'     => false,
+				'with_header_date_control' => false,
 			),
 			'default_layout'      => static function () {
 				return get_dashboard_default_layout_for( 'analytics/insights' );

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -430,7 +430,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Ads alone moves its date control to widgets; Ads and Insights disable comparison.
+	 * Ads and Insights move their date control to widgets and disable comparison.
 	 */
 	public function test_built_in_sections_declare_their_date_filter_options() {
 		// Store needs both gates: the filter stands in for WooCommerce being active,
@@ -448,7 +448,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 				),
 				'insights'    => array(
 					'with_date_comparison'     => false,
-					'with_header_date_control' => true,
+					'with_header_date_control' => false,
 				),
 				'subscribers' => array(
 					'with_date_comparison'     => true,
@@ -874,7 +874,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'date_filter'         => 'year',
 					'date_filter_options' => array(
 						'with_date_comparison'     => false,
-						'with_header_date_control' => true,
+						'with_header_date_control' => false,
 					),
 					'requires_sync'       => false,
 				),

--- a/projects/plugins/jetpack/changelog/wooa7s-2012-insights-header-date-control
+++ b/projects/plugins/jetpack/changelog/wooa7s-2012-insights-header-date-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: remove the year filter and interval dropdown from the Insights header.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2012-insights-header-date-control
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2012-insights-header-date-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: remove the year filter and interval dropdown from the section header.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2012-insights-header-date-control
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2012-insights-header-date-control
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: remove the year filter and interval dropdown from the Insights header.


### PR DESCRIPTION
Fixes WOOA7S-2012



## Proposed changes
* The Insights header renders only its title; the year filter and interval dropdown are gone.
* Insights opts out through the existing `with_header_date_control` section option that the Ads tab already uses; no new surface or schema field.
* Insights keeps `date_filter => year`, so a rolling preset carried over from Traffic still collapses to all-time, as today.
* The Highlights widget's own year dropdown is now the only year control on the tab.
* Traffic, Subscribers, Store and Ads are unchanged.


Out of scope: the six widgets that still read the section's date state (Total views, Total visitors, Popular days, Popular hours, Posting activity, Traffic views activity) sit at all-time with no period label until WOOA7S-2014, WOOA7S-2015 and WOOA7S-2020 land. A stale `?preset=year-2025` deep link still applies to them silently in the meantime; that was accepted over a `DATE_FILTER_NONE` surface because Insights still hosts a widget-level year control.

## Related product discussion/links
* WOOA7S-2008 (parent), decided in the Jetpack Stats Slack channel with Eder's prototype.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open Stats v2 and switch to the Insights tab. The header should show only "Activity insights", with no year pills and no interval dropdown.
* Traffic still shows the date range, Compare and interval controls; Ads still has no header control.
* On Insights, change the year in the Year in review widget. The widget updates and the URL preset stays `all-time`.

### Before / after

Same site, data and URL. Only the header changes; the widgets below, including the Year in review dropdown, are identical.

| Before | After |
| --- | --- |
| ![Insights header with year pills and interval dropdown](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/wooa7s-2012-insights-header-date-control/before-insights-header-year-pills-and-interval.jpg) | ![Insights header with no date controls](https://raw.githubusercontent.com/Automattic/jetpack/screenshots/wooa7s-2012-insights-header-date-control/after-insights-header-no-date-controls.jpg) |

<!-- pr-draft
Verified: UI tier on chi.jurassic.tube (real data, filter-enabled PA, jetpack-dev off) - Insights header empty, Traffic/Ads unchanged, Highlights year dropdown works, REST record false on insights only, before/after on same data by flipping the flag; console clean
Fixed in review: changelog wording no longer claims every widget owns its period
Skipped: WordPress.com Simple not exercised; field has shipped there since 0.5.0 and the frontend defaults it to true when absent
Risk: Low - one section option that the Ads tab already exercises, internal-only tab, one-line revert
-->
