### PR TITLE
Premium Analytics: hide the dashboard date controls while customizing

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: hide the date controls while customizing the layout, instead of disabling them.

--- a/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/section-header/section-header.module.scss
@@ -107,6 +107,11 @@ $section-header-condense-distance: 40px;
 	display: flex;
 	flex-direction: column;
 	min-inline-size: 0;
+	// The resting title's line box, so the row keeps its height when the
+	// controls beside it are gone and the pinned title has condensed.
+	min-block-size: var(--wpds-typography-line-height-2xl);
+	// Centred, as the row centred it before the floor filled the row.
+	justify-content: center;
 }
 
 .withVisual .text {
@@ -216,7 +221,7 @@ $section-header-condense-distance: 40px;
 		animation-timeline: --section-header-pin;
 		animation-range: exit;
 
-		// Buys no height: the row is floored by the date controls beside it.
+		// Buys no height: `.text` is floored at the resting line box.
 		// What changes is what the pinned band reads as.
 		.title {
 			animation: condense-title linear both;

--- a/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.test.tsx
@@ -66,21 +66,11 @@ jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/ui', () => ( {
-	DateFiltersPanel: ( { disabled }: { disabled?: boolean } ) => (
-		<MockHeaderScopeProbe disabled={ disabled } />
-	),
-	DateIntervalDropdown: ( { disabled }: { disabled?: boolean } ) => (
-		<span>{ disabled ? 'interval disabled' : 'interval enabled' }</span>
-	),
-	DateYearFilter: ( {
-		containerElement,
-		disabled,
-	}: {
-		containerElement?: HTMLElement | null;
-		disabled?: boolean;
-	} ) => (
+	DateFiltersPanel: () => <MockHeaderScopeProbe />,
+	DateIntervalDropdown: () => <span>interval control</span>,
+	DateYearFilter: ( { containerElement }: { containerElement?: HTMLElement | null } ) => (
 		<>
-			<span>{ disabled ? 'year surface disabled' : 'year surface enabled' }</span>
+			<span>year surface</span>
 			<span>{ containerElement ? 'measuring header' : 'measuring body' }</span>
 		</>
 	),
@@ -132,18 +122,13 @@ jest.mock( '@wordpress/data', () => ( { useSelect: () => [] } ) );
  * render. Both halves derive from the one declaration, so the header reads it
  * rather than being handed a prop.
  *
- * @param props          - The props the stage hands the panel.
- * @param props.disabled - Whether the stage greyed the controls out.
- * @return The declared scope, as text, with the disabled state appended.
+ * @return The declared scope, as text.
  */
-function MockHeaderScopeProbe( { disabled = false }: { disabled?: boolean } ) {
+function MockHeaderScopeProbe() {
 	const { offersComparison } = useReportScope();
 
 	return (
-		<span>
-			{ offersComparison ? 'header offers comparison' : 'header offers no comparison' }
-			{ disabled ? ', disabled' : '' }
-		</span>
+		<span>{ offersComparison ? 'header offers comparison' : 'header offers no comparison' }</span>
 	);
 }
 
@@ -662,38 +647,37 @@ describe( 'Dashboard customizing', () => {
 		mockSection( { slug: 'traffic', date_filter: DATE_FILTER_RANGE } );
 	} );
 
-	// The layout has to be saved or dropped before the page is used again, so
-	// the controls stay in view naming the range but take nothing until then.
-	it( 'greys the date controls out while customizing', async () => {
+	it( 'hides the date controls while customizing', async () => {
 		render( <Dashboard /> );
 		expect( screen.getByText( 'header offers comparison' ) ).toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Customize' } ) );
 
-		expect( screen.getByText( 'header offers comparison, disabled' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /^header offers/ ) ).not.toBeInTheDocument();
 		// The widgets keep reporting over the same range meanwhile.
 		expect( screen.getByText( 'offers comparison' ) ).toBeInTheDocument();
 	} );
 
-	it( 'greys the year surface out too', async () => {
+	it( 'hides the year surface too', async () => {
 		useActiveSectionMock.mockReturnValue( [ 'insights', jest.fn() ] );
 		mockActiveSectionSlug = 'insights';
 		useSectionDateFilterMock.mockReturnValue( DATE_FILTER_YEAR );
 		mockSection();
 
 		render( <Dashboard /> );
-		expect( screen.getByText( 'year surface enabled' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'year surface' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'interval control' ) ).toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Customize' } ) );
 
-		expect( screen.getByText( 'year surface disabled' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'interval disabled' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'year surface' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'interval control' ) ).not.toBeInTheDocument();
 	} );
 
-	it.each( [ 'Done', 'Cancel' ] )( 'enables the date controls again on %s', async action => {
+	it.each( [ 'Done', 'Cancel' ] )( 'brings the date controls back on %s', async action => {
 		render( <Dashboard /> );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Customize' } ) );
-		expect( screen.getByText( 'header offers comparison, disabled' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /^header offers/ ) ).not.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: action } ) );
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -210,12 +210,12 @@ function Dashboard(): JSX.Element {
 	/*
 	 * Tab panels unmount when unfocused, so only the active section's header renders
 	 * and one set of controls suffices; an opted-out section renders none at all.
-	 * Greyed out while customizing: the layout has to be saved or dropped before the
-	 * page is used again, and the range stays readable meanwhile.
+	 * Gone while customizing: reading controls take no part in arranging a layout,
+	 * and Done or Cancel bring them back over the applied range.
 	 */
 	let dateControls: JSX.Element | null = null;
 
-	if ( showHeaderDateControl ) {
+	if ( showHeaderDateControl && ! editMode ) {
 		dateControls =
 			dateFilterSurface === DATE_FILTER_YEAR ? (
 				/*
@@ -232,13 +232,11 @@ function Dashboard(): JSX.Element {
 						onSelect={ selectYear }
 						timeZone={ dateFilters.timeZone }
 						containerElement={ headerElement }
-						disabled={ editMode }
 					/>
 
 					<DateIntervalDropdown
 						options={ dateFilters.intervalOptions }
 						value={ dateFilters.interval }
-						disabled={ editMode }
 						onChange={ dateFilters.onIntervalChange }
 					/>
 				</Stack>
@@ -247,7 +245,7 @@ function Dashboard(): JSX.Element {
 				 * Report pages mount this same panel over records tables, which have no
 				 * interval, so the control is asked for rather than implied.
 				 */
-				<DateFiltersPanel { ...dateFilters } withIntervalControl disabled={ editMode } />
+				<DateFiltersPanel { ...dateFilters } withIntervalControl />
 			);
 	}
 

--- a/projects/plugins/jetpack/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
+++ b/projects/plugins/jetpack/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: hide the dashboard's date controls while customizing its layout, instead of disabling them.

--- a/projects/plugins/premium-analytics/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
+++ b/projects/plugins/premium-analytics/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: hide the date controls while customizing the layout, instead of disabling them.

--- a/projects/plugins/wpcomsh/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
+++ b/projects/plugins/wpcomsh/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Premium Analytics: hide the dashboard's date controls while customizing its layout, instead of disabling them.

--- a/projects/plugins/wpcomsh/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
+++ b/projects/plugins/wpcomsh/changelog/change-wooa7s-2101-hide-date-controls-while-customizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: hide the dashboard's date controls while customizing its layout, instead of disabling them.


### PR DESCRIPTION
Fixes WOOA7S-2101

#52024 greyed the dashboard's date controls out while customizing; the intended state is hidden. Clicking Customize now removes the date controls from the section header, and Cancel or Done brings them back with the range that was applied before.

## Proposed changes
* Render no date controls while `editMode` is on, instead of passing `disabled` to them.
* Floor the section header's text cell at the resting title line height (40px), so the pinned band keeps its height without the controls that used to hold it, and centre the title in that cell so the condensed title stays aligned with the controls in reading mode.
* Stage tests assert the controls are absent while customizing and back after Done and Cancel.
* Changelog entries for the package and for the Jetpack and Premium Analytics plugins.


## Related product discussion/links
* WOOA7S-2101, WOOA7S-2055 (the Customise demo), UNI-742.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open **Stats v2** on a site with the new dashboard.
* Click **Customize**: the date controls beside the section title disappear; the title and the tab row do not move.
* Click **Cancel**: the controls return with the same range. Move a widget and click **Done**: same.
* Scroll until the header pins, then Customize and Cancel again: the band keeps its height and the condensed title does not move.
* Narrow the window until the controls drop under the title, then Customize: the controls row goes away and the widgets move up (expected).
* Remove every widget on a tab and click **Done**, then reload: the tab opens in edit mode with the title alone, and **Cancel** brings the controls back.

### Before / after

At rest, after clicking Customize. Only the date controls change.

| Before (trunk) | After (this PR) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/Automattic/jetpack/690cb7455423777d258e950c8680bf5e19886521/before-rest-customize-controls-greyed.jpg) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/690cb7455423777d258e950c8680bf5e19886521/after-rest-customize-controls-gone.jpg) |

Pinned, after clicking Customize. The band keeps its height in both.

| Before (trunk) | After (this PR) |
| --- | --- |
| ![before pinned](https://raw.githubusercontent.com/Automattic/jetpack/690cb7455423777d258e950c8680bf5e19886521/before-pinned-customize-controls-greyed.jpg) | ![after pinned](https://raw.githubusercontent.com/Automattic/jetpack/690cb7455423777d258e950c8680bf5e19886521/after-pinned-customize-controls-gone.jpg) |

