### PR TITLE
Boost: Mount the modern Overview dashboard

### DIFF
--- a/projects/plugins/boost/_inc/overview/history-chart-card.tsx
+++ b/projects/plugins/boost/_inc/overview/history-chart-card.tsx
@@ -198,7 +198,9 @@ export default function HistoryChartCard( {
 		content = (
 			<Notice.Root
 				intent="error"
-				spokenMessage={ __( 'Failed to load performance history', 'jetpack-boost' ) }
+				spokenMessage={
+					isVisible ? __( 'Failed to load performance history', 'jetpack-boost' ) : ''
+				}
 			>
 				<Notice.Title>{ __( 'Failed to load performance history', 'jetpack-boost' ) }</Notice.Title>
 				<Notice.Description>{ error?.message }</Notice.Description>

--- a/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
+++ b/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
@@ -105,7 +105,7 @@ it( 'preserves Overview dismissals when the separate legacy client dismisses a n
 	}
 } );
 
-it.each( [ 'success', 'failure' ] )(
+it.each( [ 'success', 'failure', 'both failures' ] )(
 	'queues a second legacy dismissal until the first delayed %s settles',
 	async outcome => {
 		let stored: Record< string, boolean > = { performance_history_fresh_start: true };
@@ -121,9 +121,12 @@ it.each( [ 'success', 'failure' ] )(
 			const update = ( data as { JSON: Record< string, boolean > } ).JSON;
 			if ( update.score_increase ) {
 				await firstResponse;
-				if ( outcome === 'failure' ) {
+				if ( outcome !== 'success' ) {
 					throw new Error( 'Dismissal failed' );
 				}
+			}
+			if ( outcome === 'both failures' ) {
+				throw new Error( 'Second dismissal failed' );
 			}
 			stored = { ...stored, ...update };
 			return { status: 'success', JSON: { ...stored } };
@@ -155,7 +158,7 @@ it.each( [ 'success', 'failure' ] )(
 			const expected = {
 				performance_history_fresh_start: true,
 				...( outcome === 'success' ? { score_increase: true } : {} ),
-				legacy_minify_notice: true,
+				...( outcome === 'both failures' ? {} : { legacy_minify_notice: true } ),
 			};
 			expect( stored ).toEqual( expected );
 			expect( legacyClient.getQueryData( [ 'dismissed_alerts' ] ) ).toEqual( expected );

--- a/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
+++ b/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
@@ -1,0 +1,106 @@
+import { queryClient as legacyClient } from '@automattic/jetpack-react-data-sync-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type PropsWithChildren } from 'react';
+import { useDismissibleAlertState as useLegacyDismissal } from '../../../app/assets/src/js/features/performance-history/lib/hooks';
+import { useDismissibleAlertState as useOverviewDismissal } from './use-performance-history';
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: jest.fn() } ) );
+
+it( 'preserves Overview dismissals when the separate legacy client dismisses a notice', async () => {
+	const overviewClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+	} );
+	const hadFetch = Object.hasOwn( globalThis, 'fetch' );
+	if ( ! hadFetch ) {
+		Object.defineProperty( globalThis, 'fetch', {
+			configurable: true,
+			writable: true,
+			value: jest.fn(),
+		} );
+	}
+	let stored: Record< string, boolean > = { performance_history_fresh_start: true };
+	const writes: { url: string; value: Record< string, boolean > }[] = [];
+	let releaseLegacyWrite: () => void;
+	const legacyWrite = new Promise< void >( resolve => {
+		releaseLegacyWrite = resolve;
+	} );
+	const respond = ( url: string, method?: string, value?: Record< string, boolean > ) => {
+		if ( method === 'POST' ) {
+			writes.push( { url, value } );
+			stored = url.endsWith( '/merge' ) ? { ...stored, ...value } : { ...value };
+		}
+		return { status: 'success', JSON: { ...stored } };
+	};
+	Object.defineProperty( globalThis, 'Jetpack_Boost', {
+		configurable: true,
+		value: { site: { online: true } },
+	} );
+	window.jetpack_boost_ds = {
+		rest_api: { nonce: 'rest-nonce', value: 'https://example.org/wp-json/jetpack-boost-ds' },
+		dismissed_alerts: { nonce: 'alerts-nonce', value: { ...stored } },
+	};
+	jest.mocked( apiFetch ).mockImplementation( async ( { url, method, data } ) => {
+		const value = ( data as { JSON: Record< string, boolean > } )?.JSON;
+		if ( value?.legacy_minify_notice ) {
+			await legacyWrite;
+		}
+		return respond( url, method, value );
+	} );
+	const fetchSpy = jest.spyOn( globalThis, 'fetch' ).mockImplementation( async ( url, options ) => {
+		if ( options.method === 'POST' ) {
+			await legacyWrite;
+		}
+		const response = respond(
+			String( url ),
+			options.method,
+			options.body ? JSON.parse( options.body as string ).JSON : undefined
+		);
+		return { ok: true, text: async () => JSON.stringify( response ) } as Response;
+	} );
+	const wrapperFor =
+		( client: QueryClient ) =>
+		( { children }: PropsWithChildren ) =>
+			createElement( QueryClientProvider, { client }, children );
+	try {
+		const { result: legacy } = renderHook( () => useLegacyDismissal( 'legacy_minify_notice' ), {
+			wrapper: wrapperFor( legacyClient ),
+		} );
+		const { result: overview } = renderHook( () => useOverviewDismissal( 'score_decrease' ), {
+			wrapper: wrapperFor( overviewClient ),
+		} );
+		await waitFor( () => expect( overviewClient.isFetching() ).toBe( 0 ) );
+		act( () => overview.current[ 1 ]() );
+		await waitFor( () => expect( stored.score_decrease ).toBe( true ) );
+		expect( legacyClient.getQueryData( [ 'dismissed_alerts' ] ) ).toEqual( {
+			performance_history_fresh_start: true,
+		} );
+		act( () => legacy.current[ 1 ]() );
+		await waitFor( () => expect( legacy.current[ 0 ] ).toBe( true ) );
+		expect( legacyClient.getQueryData( [ 'dismissed_alerts' ] ) ).toEqual( {
+			performance_history_fresh_start: true,
+			legacy_minify_notice: true,
+		} );
+		await act( async () => releaseLegacyWrite() );
+		await waitFor( () => expect( legacyClient.isMutating() ).toBe( 0 ) );
+		expect( writes ).toEqual( [
+			{ url: expect.stringMatching( /\/merge$/ ), value: { score_decrease: true } },
+			{ url: expect.stringMatching( /\/merge$/ ), value: { legacy_minify_notice: true } },
+		] );
+		expect( stored ).toEqual( {
+			performance_history_fresh_start: true,
+			score_decrease: true,
+			legacy_minify_notice: true,
+		} );
+	} finally {
+		releaseLegacyWrite();
+		legacyClient.clear();
+		overviewClient.clear();
+		fetchSpy.mockRestore();
+		if ( ! hadFetch ) {
+			Reflect.deleteProperty( globalThis, 'fetch' );
+		}
+		jest.mocked( apiFetch ).mockReset();
+	}
+} );

--- a/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
+++ b/projects/plugins/boost/_inc/overview/lib/dismissed-alerts-integration.test.tsx
@@ -104,3 +104,65 @@ it( 'preserves Overview dismissals when the separate legacy client dismisses a n
 		jest.mocked( apiFetch ).mockReset();
 	}
 } );
+
+it.each( [ 'success', 'failure' ] )(
+	'queues a second legacy dismissal until the first delayed %s settles',
+	async outcome => {
+		let stored: Record< string, boolean > = { performance_history_fresh_start: true };
+		let releaseFirst: () => void;
+		const firstResponse = new Promise< void >( resolve => {
+			releaseFirst = resolve;
+		} );
+		window.jetpack_boost_ds = {
+			rest_api: { nonce: 'rest-nonce', value: 'https://example.org/wp-json/jetpack-boost-ds' },
+			dismissed_alerts: { nonce: 'alerts-nonce', value: { ...stored } },
+		};
+		jest.mocked( apiFetch ).mockImplementation( async ( { data } ) => {
+			const update = ( data as { JSON: Record< string, boolean > } ).JSON;
+			if ( update.score_increase ) {
+				await firstResponse;
+				if ( outcome === 'failure' ) {
+					throw new Error( 'Dismissal failed' );
+				}
+			}
+			stored = { ...stored, ...update };
+			return { status: 'success', JSON: { ...stored } };
+		} );
+		const wrapper = ( { children }: PropsWithChildren ) =>
+			createElement( QueryClientProvider, { client: legacyClient }, children );
+		try {
+			const { result } = renderHook(
+				() => ( {
+					first: useLegacyDismissal( 'score_increase' ),
+					second: useLegacyDismissal( 'legacy_minify_notice' ),
+				} ),
+				{ wrapper }
+			);
+			act( () => result.current.first[ 1 ]() );
+			await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+			await act( async () => result.current.second[ 1 ]() );
+			expect( legacyClient.isMutating() ).toBe( 2 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+			await act( async () => releaseFirst() );
+			await waitFor( () => expect( legacyClient.isMutating() ).toBe( 0 ) );
+			expect( apiFetch ).toHaveBeenNthCalledWith(
+				2,
+				expect.objectContaining( {
+					url: expect.stringMatching( /\/merge$/ ),
+					data: { JSON: { legacy_minify_notice: true } },
+				} )
+			);
+			const expected = {
+				performance_history_fresh_start: true,
+				...( outcome === 'success' ? { score_increase: true } : {} ),
+				legacy_minify_notice: true,
+			};
+			expect( stored ).toEqual( expected );
+			expect( legacyClient.getQueryData( [ 'dismissed_alerts' ] ) ).toEqual( expected );
+		} finally {
+			releaseFirst();
+			legacyClient.clear();
+			jest.mocked( apiFetch ).mockReset();
+		}
+	}
+);

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.test.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.test.ts
@@ -23,6 +23,7 @@ test.each( [ 'modules_state', 'critical_css_state', 'lcp_state' ] )(
 	key => {
 		client.setQueryData( [ key ], {} );
 		expect( onChange ).toHaveBeenCalledTimes( 1 );
+		expect( onChange ).toHaveBeenCalledWith( expect.objectContaining( { detail: key } ) );
 	}
 );
 

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.test.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.test.ts
@@ -1,0 +1,39 @@
+import { QueryClient } from '@tanstack/react-query';
+import { observeLegacyModulesState, OVERVIEW_MODULES_CHANGE_EVENT } from './modules-state-bridge';
+
+let client: QueryClient;
+let unsubscribe: () => void;
+const onChange = jest.fn();
+
+beforeEach( () => {
+	client = new QueryClient();
+	onChange.mockClear();
+	window.addEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onChange );
+	unsubscribe = observeLegacyModulesState( client );
+} );
+
+afterEach( () => {
+	unsubscribe();
+	window.removeEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onChange );
+	client.clear();
+} );
+
+test.each( [ 'modules_state', 'critical_css_state', 'lcp_state' ] )(
+	'relays successful updates to %s',
+	key => {
+		client.setQueryData( [ key ], {} );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	}
+);
+
+test( 'does not relay updates to unrelated keys', () => {
+	client.setQueryData( [ 'performance_history' ], {} );
+	expect( onChange ).not.toHaveBeenCalled();
+} );
+
+test( 'does not relay non-success updates', () => {
+	client.setQueryData( [ 'modules_state' ], {} );
+	onChange.mockClear();
+	client.invalidateQueries( { queryKey: [ 'modules_state' ] } );
+	expect( onChange ).not.toHaveBeenCalled();
+} );

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
@@ -1,0 +1,16 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+export const OVERVIEW_MODULES_CHANGE_EVENT = 'jetpack-boost-overview-modules-change';
+
+// Register in the legacy bundle, whose Data Sync cache is separate from the route bundle's cache.
+export function observeLegacyModulesState( client: QueryClient ) {
+	return client.getQueryCache().subscribe( event => {
+		if (
+			event.type === 'updated' &&
+			event.action.type === 'success' &&
+			event.query.queryKey[ 0 ] === 'modules_state'
+		) {
+			window.dispatchEvent( new Event( OVERVIEW_MODULES_CHANGE_EVENT ) );
+		}
+	} );
+}

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
@@ -2,7 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 
 export const OVERVIEW_MODULES_CHANGE_EVENT = 'jetpack-boost-overview-modules-change';
 
-const relayedQueryKeys = [ 'modules_state', 'critical_css_state', 'lcp_state' ];
+export const relayedQueryKeys = [ 'modules_state', 'critical_css_state', 'lcp_state' ];
 
 // Register in the legacy bundle, whose Data Sync cache is separate from the route bundle's cache.
 export function observeLegacyModulesState( client: QueryClient ) {

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
@@ -2,13 +2,15 @@ import type { QueryClient } from '@tanstack/react-query';
 
 export const OVERVIEW_MODULES_CHANGE_EVENT = 'jetpack-boost-overview-modules-change';
 
+const relayedQueryKeys = [ 'modules_state', 'critical_css_state', 'lcp_state' ];
+
 // Register in the legacy bundle, whose Data Sync cache is separate from the route bundle's cache.
 export function observeLegacyModulesState( client: QueryClient ) {
 	return client.getQueryCache().subscribe( event => {
 		if (
 			event.type === 'updated' &&
 			event.action.type === 'success' &&
-			event.query.queryKey[ 0 ] === 'modules_state'
+			relayedQueryKeys.some( key => event.query.queryKey[ 0 ] === key )
 		) {
 			window.dispatchEvent( new Event( OVERVIEW_MODULES_CHANGE_EVENT ) );
 		}

--- a/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
+++ b/projects/plugins/boost/_inc/overview/lib/modules-state-bridge.ts
@@ -10,9 +10,12 @@ export function observeLegacyModulesState( client: QueryClient ) {
 		if (
 			event.type === 'updated' &&
 			event.action.type === 'success' &&
+			event.action.manual &&
 			relayedQueryKeys.some( key => event.query.queryKey[ 0 ] === key )
 		) {
-			window.dispatchEvent( new Event( OVERVIEW_MODULES_CHANGE_EVENT ) );
+			window.dispatchEvent(
+				new CustomEvent( OVERVIEW_MODULES_CHANGE_EVENT, { detail: event.query.queryKey[ 0 ] } )
+			);
 		}
 	} );
 }

--- a/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
+++ b/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
@@ -87,7 +87,7 @@ export function parseModulesState( value: unknown ): ModulesState {
 	return modulesStateSchema.parse( value );
 }
 
-export const modulesStateQueryKey = [ 'modules_state' ] as const;
+const modulesStateQueryKey = [ 'modules_state' ] as const;
 
 export function useModulesState() {
 	const initial = modulesStateSchema.safeParse( window.jetpack_boost_ds?.modules_state?.value );

--- a/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
+++ b/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
@@ -54,7 +54,11 @@ export function isSiteOnline(): boolean {
 	return typeof Jetpack_Boost !== 'undefined' && Jetpack_Boost.site.online;
 }
 
-export async function requestDataSync( key: DataSyncKey, value?: unknown ): Promise< unknown > {
+export async function requestDataSync(
+	key: DataSyncKey,
+	value?: unknown,
+	action: 'set' | 'merge' = 'set'
+): Promise< unknown > {
 	if ( ! isSiteOnline() ) {
 		throw new Error( 'The site is not publicly available.' );
 	}
@@ -66,7 +70,7 @@ export async function requestDataSync( key: DataSyncKey, value?: unknown ): Prom
 	const route = key.replace( /_/g, '-' );
 	const response = await apiFetch( {
 		url: `${ config.rest_api.value.replace( /\/$/, '' ) }/${ route }${
-			value === undefined ? '' : '/set'
+			value === undefined ? '' : `/${ action }`
 		}`,
 		method: value === undefined ? 'GET' : 'POST',
 		credentials: 'same-origin',

--- a/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
+++ b/projects/plugins/boost/_inc/overview/lib/use-modules-state.ts
@@ -87,10 +87,12 @@ export function parseModulesState( value: unknown ): ModulesState {
 	return modulesStateSchema.parse( value );
 }
 
+export const modulesStateQueryKey = [ 'modules_state' ] as const;
+
 export function useModulesState() {
 	const initial = modulesStateSchema.safeParse( window.jetpack_boost_ds?.modules_state?.value );
 	return useQuery( {
-		queryKey: [ 'modules_state' ],
+		queryKey: modulesStateQueryKey,
 		queryFn: async () => parseModulesState( await requestDataSync( 'modules_state' ) ),
 		initialData: initial.success ? initial.data : undefined,
 		enabled: isSiteOnline(),

--- a/projects/plugins/boost/_inc/overview/lib/use-performance-history.test.tsx
+++ b/projects/plugins/boost/_inc/overview/lib/use-performance-history.test.tsx
@@ -132,11 +132,11 @@ it( 'persists fresh-start dismissal and preserves other alert dismissals', async
 	act( () => result.current[ 1 ]() );
 	await waitFor( () => expect( result.current[ 0 ] ).toBe( true ) );
 	expect( fetchMock ).toHaveBeenLastCalledWith( {
-		url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/set',
+		url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/merge',
 		method: 'POST',
 		credentials: 'same-origin',
 		headers: { 'X-WP-Nonce': 'rest-nonce', 'X-Jetpack-WP-JS-Sync-Nonce': 'alerts-nonce' },
-		data: { JSON: { score_increase: true, performance_history_fresh_start: true } },
+		data: { JSON: { performance_history_fresh_start: true } },
 	} );
 } );
 
@@ -199,8 +199,6 @@ it.each( [ false, true ] )(
 				credentials: 'same-origin',
 				data: {
 					JSON: {
-						...initial,
-						...( fails ? {} : { performance_history_fresh_start: true } ),
 						score_decrease: true,
 					},
 				},

--- a/projects/plugins/boost/_inc/overview/lib/use-performance-history.ts
+++ b/projects/plugins/boost/_inc/overview/lib/use-performance-history.ts
@@ -51,12 +51,8 @@ export function useDismissibleAlertState(
 		},
 		mutationFn: async () => {
 			await queryClient.cancelQueries( { queryKey: dismissedAlertsQueryKey } );
-			const dismissed =
-				queryClient.getQueryData< z.infer< typeof dismissedAlertsSchema > >(
-					dismissedAlertsQueryKey
-				) ?? {};
 			return dismissedAlertsSchema.parse(
-				await requestDataSync( 'dismissed_alerts', { ...dismissed, [ alertId ]: true } )
+				await requestDataSync( 'dismissed_alerts', { [ alertId ]: true }, 'merge' )
 			);
 		},
 		onError: ( _error, _variables, context ) => {

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -15,6 +15,7 @@ import { useSingleModuleState } from '../../app/assets/src/js/features/module/li
 import { useDismissibleAlertState as useLegacyAlertState } from '../../app/assets/src/js/features/performance-history/lib/hooks';
 import PopOut from '../../app/assets/src/js/features/speed-score/pop-out/pop-out';
 import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
+import { observeLegacyModulesState } from './lib/modules-state-bridge';
 import * as speedScores from './lib/use-speed-scores';
 import Overview from './overview';
 import ScoreCard from './score-card';
@@ -151,6 +152,7 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 	let savedModules = initialModules;
 	window.jetpack_boost_ds!.modules_state!.value = initialModules;
 	legacyQueryClient.clear();
+	const stopObserving = observeLegacyModulesState( legacyQueryClient );
 	const originalFetch = globalThis.fetch;
 	globalThis.fetch = jest.fn().mockImplementation( async ( url, options ) => {
 		if ( options.method === 'POST' ) {
@@ -211,6 +213,7 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 			wpApiSettings.nonce
 		);
 	} finally {
+		stopObserving();
 		view.unmount();
 		client.clear();
 		legacyQueryClient.clear();

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -144,6 +144,42 @@ test( 'loads online scores and regenerates them with refresh tracking and histor
 	);
 } );
 
+test( 'refetches Overview generation state after a legacy critical CSS update', async () => {
+	window.jetpack_boost_ds!.modules_state!.value = {
+		critical_css: { available: true, active: true },
+		performance_history: { available: true, active: true },
+	};
+	window.jetpack_boost_ds!.critical_css_state = { nonce: 'css-nonce', value: undefined };
+	const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
+	jest
+		.mocked( apiFetch )
+		.mockImplementation( options =>
+			options.url?.endsWith( '/critical-css-state' )
+				? Promise.resolve( { status: 'success', JSON: { status: 'generated', updated: 1 } } )
+				: fetch( options )
+		);
+	legacyQueryClient.clear();
+	const stopObserving = observeLegacyModulesState( legacyQueryClient );
+	const { client } = renderOverview();
+	try {
+		await waitFor( () =>
+			expect( client.getQueryState( [ 'critical_css_state' ] )?.dataUpdateCount ).toBe( 1 )
+		);
+		act( () => {
+			legacyQueryClient.setQueryData( [ 'critical_css_state' ], {
+				status: 'generated',
+				updated: 2,
+			} );
+		} );
+		await waitFor( () =>
+			expect( client.getQueryState( [ 'critical_css_state' ] )?.dataUpdateCount ).toBe( 2 )
+		);
+	} finally {
+		stopObserving();
+		legacyQueryClient.clear();
+	}
+} );
+
 test( 'regenerates scores after a Settings toggle and return to the mounted Overview', async () => {
 	const initialModules = {
 		performance_history: { available: true, active: true },

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable testing-library/prefer-user-event */
 import { requestSpeedScores } from '@automattic/jetpack-boost-score-api';
-import { queryClient as legacyQueryClient } from '@automattic/jetpack-react-data-sync-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
 	act,
@@ -25,6 +24,14 @@ jest.mock( '@automattic/jetpack-boost-score-api', () => ( {
 	...jest.requireActual( '@automattic/jetpack-boost-score-api' ),
 	requestSpeedScores: jest.fn(),
 } ) );
+// The dashboard route and legacy Settings bundle have separate Data Sync singletons.
+jest.mock( '@automattic/jetpack-react-data-sync-client', () => ( {
+	...jest.requireActual( '@automattic/jetpack-react-data-sync-client' ),
+	queryClient: new ( jest.requireActual( '@tanstack/react-query' ).QueryClient )(),
+} ) );
+const { queryClient: legacyQueryClient } = jest.requireActual(
+	'@automattic/jetpack-react-data-sync-client'
+);
 jest.mock( '@wordpress/api-fetch' );
 jest.mock( '../../app/assets/src/js/features/performance-history/lib/hooks', () => ( {
 	...jest.requireActual( '../../app/assets/src/js/features/performance-history/lib/hooks' ),

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -400,6 +400,7 @@ test( 'shows the free history upgrade without requesting history', async () => {
 	};
 	renderOverview();
 	await expect( screen.findByRole( 'button', { name: 'Upgrade now' } ) ).resolves.toBeTruthy();
+	await expect( screen.findByText( '91' ) ).resolves.toBeVisible();
 	expect( apiFetch ).not.toHaveBeenCalledWith(
 		expect.objectContaining( {
 			url: 'https://example.org/wp-json/jetpack-boost-ds/performance-history',
@@ -569,12 +570,15 @@ test( 'reports module request errors independently and retries only modules', as
 		}
 		return { status: 'success', JSON: null };
 	} );
-	renderOverview();
+	const { container } = renderOverview();
 	await expect( screen.findByText( 'Module settings unavailable' ) ).resolves.toBeTruthy();
 	expect(
 		screen.getByText( 'Failed to load module settings', { selector: 'span' } )
 	).toBeInTheDocument();
 	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).not.toBeInTheDocument();
+	expect( screen.getByText( /Performance history will appear/ ) ).toBeVisible();
+	// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+	expect( container.querySelector( '.jetpack-boost-overview__chart-loading' ) ).toBeNull();
 	jest.mocked( apiFetch ).mockClear();
 	fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
 	await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -122,6 +122,7 @@ test( 'contains a render failure with the Overview error fallback', () => {
 test.each( [
 	[ 'score', 'Failed to load Speed Scores' ],
 	[ 'performance-history', 'Failed to load performance history' ],
+	[ 'modules-state', 'Failed to load module settings' ],
 ] )( 'keeps %s errors silent while the Overview is hidden', async ( source, message ) => {
 	/* eslint-disable testing-library/no-node-access */
 	const region =

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -144,7 +144,7 @@ test( 'loads online scores and regenerates them with refresh tracking and histor
 	);
 } );
 
-test( 'refetches Overview generation state after a legacy critical CSS update', async () => {
+test( 'ignores legacy polls and refetches only the key written by the legacy cache', async () => {
 	window.jetpack_boost_ds!.modules_state!.value = {
 		critical_css: { available: true, active: true },
 		performance_history: { available: true, active: true },
@@ -159,12 +159,23 @@ test( 'refetches Overview generation state after a legacy critical CSS update', 
 				: fetch( options )
 		);
 	legacyQueryClient.clear();
+	legacyQueryClient.setQueryData( [ 'critical_css_state' ], { status: 'generated', updated: 1 } );
 	const stopObserving = observeLegacyModulesState( legacyQueryClient );
 	const { client } = renderOverview();
 	try {
 		await waitFor( () =>
 			expect( client.getQueryState( [ 'critical_css_state' ] )?.dataUpdateCount ).toBe( 1 )
 		);
+		await waitFor( () => expect( client.isFetching() ).toBe( 0 ) );
+		jest.mocked( apiFetch ).mockClear();
+		await act( async () => {
+			await legacyQueryClient.fetchQuery( {
+				queryKey: [ 'critical_css_state' ],
+				queryFn: async () => ( { status: 'generated', updated: 1 } ),
+			} );
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+
 		act( () => {
 			legacyQueryClient.setQueryData( [ 'critical_css_state' ], {
 				status: 'generated',
@@ -173,6 +184,10 @@ test( 'refetches Overview generation state after a legacy critical CSS update', 
 		} );
 		await waitFor( () =>
 			expect( client.getQueryState( [ 'critical_css_state' ] )?.dataUpdateCount ).toBe( 2 )
+		);
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { url: expect.stringContaining( '/critical-css-state' ) } )
 		);
 	} finally {
 		stopObserving();

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -314,15 +314,17 @@ test.each( [
 	);
 	expect( screen.getByText( String( score ) ) ).toBeInTheDocument();
 	expect( screen.getByRole( 'progressbar', { name: 'Desktop' } ) ).toHaveValue( score );
-	expect( screen.getByText( '+10 points compared to without Boost' ) ).toBeInTheDocument();
+	expect( screen.getByText( '+10 points compared with Boost disabled' ) ).toBeInTheDocument();
 	expect( screen.getByText( tier ) ).toBeInTheDocument();
 } );
 
 test( 'opens the overall grade explanation and dismisses it with Escape', async () => {
 	render( <ScoreCards scores={ scores } /> );
 	expect(
-		within( screen.getByRole( 'region', { name: 'Overall grade' } ) ).getByText( 'Good' )
-	).toBeInTheDocument();
+		within( screen.getByRole( 'region', { name: 'Overall grade' } ) ).queryByText(
+			/Good|Could be improved|Poor/
+		)
+	).not.toBeInTheDocument();
 	const trigger = within( screen.getByRole( 'region', { name: 'Overall grade' } ) ).getByRole(
 		'button',
 		{ name: 'How the overall grade is calculated' }
@@ -339,10 +341,10 @@ test( 'opens the overall grade explanation and dismisses it with Escape', async 
 	expect( trigger ).toHaveFocus();
 } );
 
-test( 'renders a negative baseline delta alongside the current measured bar', () => {
+test( 'hides a negative baseline delta while preserving the current measured bar', () => {
 	render( <ScoreCard icon={ null } label="Mobile" value={ 40 } score={ 40 } noBoost={ 60 } /> );
 	expect( screen.getByRole( 'progressbar', { name: 'Mobile' } ) ).toHaveValue( 40 );
-	expect( screen.getByText( '−20 points compared to without Boost' ) ).toBeInTheDocument();
+	expect( screen.queryByText( /compared with Boost disabled/ ) ).not.toBeInTheDocument();
 	expect( screen.getByText( 'Poor' ) ).toBeInTheDocument();
 } );
 
@@ -350,10 +352,10 @@ test( 'hides stale and absent baselines while preserving measured scores', () =>
 	const { rerender } = render( <ScoreCards scores={ scores } /> );
 	expect( screen.getByText( /\+10 points/ ) ).toBeInTheDocument();
 	rerender( <ScoreCards scores={ { ...scores, isStale: true } } /> );
-	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( /compared with Boost disabled/ ) ).not.toBeInTheDocument();
 	expect( screen.getByText( '91' ) ).toBeInTheDocument();
 	rerender( <ScoreCards scores={ { ...scores, noBoost: null } } /> );
-	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( /compared with Boost disabled/ ) ).not.toBeInTheDocument();
 } );
 
 test( 'selects the free history upgrade using module availability', async () => {
@@ -541,15 +543,15 @@ test( 'reports module request errors independently and retries only modules', as
 } );
 
 test.each( [
-	[ 100, 'A', 'Good', 'good' ],
-	[ 90, 'B', 'Good', 'good' ],
-	[ 76, 'B', 'Good', 'good' ],
-	[ 75, 'C', 'Could be improved', 'medium' ],
-	[ 71, 'C', 'Could be improved', 'medium' ],
-	[ 50, 'D', 'Poor', 'poor' ],
-	[ 30, 'E', 'Poor', 'poor' ],
-	[ 0, 'F', 'Poor', 'poor' ],
-] )( 'keeps the Overall letter and tier aligned at score %s', ( score, grade, word, tier ) => {
+	[ 100, 'A' ],
+	[ 90, 'B' ],
+	[ 76, 'B' ],
+	[ 75, 'C' ],
+	[ 71, 'C' ],
+	[ 50, 'D' ],
+	[ 30, 'E' ],
+	[ 0, 'F' ],
+] )( 'shows the Overall letter without a tier at score %s', ( score, grade ) => {
 	render(
 		<ScoreCards
 			scores={ {
@@ -561,12 +563,10 @@ test.each( [
 	);
 	const overall = within( screen.getByRole( 'region', { name: 'Overall grade' } ) );
 	expect( overall.getByText( String( grade ) ) ).toBeInTheDocument();
-	expect( overall.getByText( String( word ) ) ).toHaveClass(
-		`jetpack-boost-overview__tier--${ tier }`
-	);
+	expect( overall.queryByText( /Good|Could be improved|Poor/ ) ).not.toBeInTheDocument();
 } );
 
-test( 'keeps numeric device tiers when the Overall letter uses a different tier', () => {
+test( 'keeps numeric device tiers when the Overall letter is C', () => {
 	render(
 		<ScoreCards
 			scores={ { current: { desktop: 71, mobile: 71 }, noBoost: null, isStale: false } }

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -153,6 +153,14 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 	window.jetpack_boost_ds!.modules_state!.value = initialModules;
 	legacyQueryClient.clear();
 	const stopObserving = observeLegacyModulesState( legacyQueryClient );
+	const hadFetch = Object.hasOwn( globalThis, 'fetch' );
+	if ( ! hadFetch ) {
+		Object.defineProperty( globalThis, 'fetch', {
+			configurable: true,
+			writable: true,
+			value: jest.fn(),
+		} );
+	}
 	const fetchSpy = jest.spyOn( globalThis, 'fetch' ).mockImplementation( async ( url, options ) => {
 		if ( options.method === 'POST' ) {
 			savedModules = JSON.parse( options.body as string ).JSON;
@@ -217,6 +225,9 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 		client.clear();
 		legacyQueryClient.clear();
 		fetchSpy.mockRestore();
+		if ( ! hadFetch ) {
+			Reflect.deleteProperty( globalThis, 'fetch' );
+		}
 	}
 } );
 

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable testing-library/prefer-user-event */
 import { requestSpeedScores } from '@automattic/jetpack-boost-score-api';
+import { queryClient as legacyQueryClient } from '@automattic/jetpack-react-data-sync-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
 	act,
@@ -11,6 +12,7 @@ import {
 	within,
 } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import { useSingleModuleState } from '../../app/assets/src/js/features/module/lib/stores';
 import { useDismissibleAlertState as useLegacyAlertState } from '../../app/assets/src/js/features/performance-history/lib/hooks';
 import PopOut from '../../app/assets/src/js/features/speed-score/pop-out/pop-out';
 import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
@@ -132,6 +134,81 @@ test( 'loads online scores and regenerates them with refresh tracking and histor
 	await waitFor( () =>
 		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'performance_history' ] } )
 	);
+} );
+
+test( 'regenerates scores after a Settings toggle and return to the mounted Overview', async () => {
+	const initialModules = {
+		performance_history: { available: true, active: true },
+		defer_js: { available: true, active: false },
+	};
+	let savedModules = initialModules;
+	window.jetpack_boost_ds!.modules_state!.value = initialModules;
+	legacyQueryClient.clear();
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = jest.fn().mockImplementation( async ( url, options ) => {
+		if ( options.method === 'POST' ) {
+			savedModules = JSON.parse( options.body ).JSON;
+		}
+		return {
+			ok: true,
+			text: async () => JSON.stringify( { status: 'success', JSON: savedModules } ),
+		};
+	} );
+	const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
+	jest.mocked( apiFetch ).mockImplementation( options =>
+		options.url?.endsWith( '/modules-state' )
+			? Promise.resolve( { status: 'success', JSON: savedModules } )
+			: fetch( options )
+	);
+	function SettingsToggle() {
+		const [ state, setState ] = useSingleModuleState( 'defer_js' );
+		return (
+			<button onClick={ () => setState( ! state?.active ) }>
+				Defer Non-Essential JavaScript
+			</button>
+		);
+	}
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	const dashboard = ( isOverview: boolean ) => (
+		<>
+			<div hidden={ ! isOverview }>
+				<QueryClientProvider client={ client }>
+					<Overview isVisible={ isOverview } />
+				</QueryClientProvider>
+			</div>
+			<div hidden={ isOverview }>
+				<QueryClientProvider client={ legacyQueryClient }>
+					<SettingsToggle />
+				</QueryClientProvider>
+			</div>
+		</>
+	);
+	const view = render( dashboard( true ) );
+	try {
+		await expect( screen.findByText( '91' ) ).resolves.toBeVisible();
+		await waitFor( () => expect( client.isFetching() ).toBe( 0 ) );
+		view.rerender( dashboard( false ) );
+		jest.mocked( requestSpeedScores ).mockResolvedValue( {
+			...scores,
+			current: { desktop: 95, mobile: 85 },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Defer Non-Essential JavaScript' } ) );
+		await waitFor( () => expect( savedModules.defer_js.active ).toBe( true ) );
+		view.rerender( dashboard( true ) );
+		await waitFor( () => expect( screen.getByText( '95' ) ).toBeVisible(), { timeout: 4000 } );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 2 );
+		expect( requestSpeedScores ).toHaveBeenLastCalledWith(
+			true,
+			wpApiSettings.root,
+			Jetpack_Boost.site.url,
+			wpApiSettings.nonce
+		);
+	} finally {
+		view.unmount();
+		client.clear();
+		legacyQueryClient.clear();
+		globalThis.fetch = originalFetch;
+	}
 } );
 
 test( 'keeps offline sites out of score and Data Sync requests', async () => {

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -153,28 +153,27 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 	window.jetpack_boost_ds!.modules_state!.value = initialModules;
 	legacyQueryClient.clear();
 	const stopObserving = observeLegacyModulesState( legacyQueryClient );
-	const originalFetch = globalThis.fetch;
-	globalThis.fetch = jest.fn().mockImplementation( async ( url, options ) => {
+	const fetchSpy = jest.spyOn( globalThis, 'fetch' ).mockImplementation( async ( url, options ) => {
 		if ( options.method === 'POST' ) {
-			savedModules = JSON.parse( options.body ).JSON;
+			savedModules = JSON.parse( options.body as string ).JSON;
 		}
 		return {
 			ok: true,
 			text: async () => JSON.stringify( { status: 'success', JSON: savedModules } ),
-		};
+		} as Response;
 	} );
 	const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
-	jest.mocked( apiFetch ).mockImplementation( options =>
-		options.url?.endsWith( '/modules-state' )
-			? Promise.resolve( { status: 'success', JSON: savedModules } )
-			: fetch( options )
-	);
+	jest
+		.mocked( apiFetch )
+		.mockImplementation( options =>
+			options.url?.endsWith( '/modules-state' )
+				? Promise.resolve( { status: 'success', JSON: savedModules } )
+				: fetch( options )
+		);
 	function SettingsToggle() {
 		const [ state, setState ] = useSingleModuleState( 'defer_js' );
 		return (
-			<button onClick={ () => setState( ! state?.active ) }>
-				Defer Non-Essential JavaScript
-			</button>
+			<button onClick={ () => setState( ! state?.active ) }>Defer Non-Essential JavaScript</button>
 		);
 	}
 	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -217,7 +216,7 @@ test( 'regenerates scores after a Settings toggle and return to the mounted Over
 		view.unmount();
 		client.clear();
 		legacyQueryClient.clear();
-		globalThis.fetch = originalFetch;
+		fetchSpy.mockRestore();
 	}
 } );
 

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -119,7 +119,10 @@ test( 'contains a render failure with the Overview error fallback', () => {
 	}
 } );
 
-test( 'keeps score errors silent while the Overview is hidden', async () => {
+test.each( [
+	[ 'score', 'Failed to load Speed Scores' ],
+	[ 'performance-history', 'Failed to load performance history' ],
+] )( 'keeps %s errors silent while the Overview is hidden', async ( source, message ) => {
 	/* eslint-disable testing-library/no-node-access */
 	const region =
 		document.getElementById( 'a11y-speak-assertive' ) ?? document.createElement( 'div' );
@@ -128,21 +131,31 @@ test( 'keeps score errors silent while the Overview is hidden', async () => {
 	region.textContent = '';
 	document.body.appendChild( region );
 	/* eslint-enable testing-library/no-node-access */
-	jest.mocked( requestSpeedScores ).mockRejectedValue( new Error( 'Score request failed' ) );
+	const error = new Error( `${ source } request failed` );
+	if ( source === 'score' ) {
+		jest.mocked( requestSpeedScores ).mockRejectedValue( error );
+	} else {
+		const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
+		jest
+			.mocked( apiFetch )
+			.mockImplementation( options =>
+				options.url?.endsWith( `/${ source }` ) ? Promise.reject( error ) : fetch( options )
+			);
+	}
 	const { rerender } = render(
 		<div hidden>
 			<Overview isVisible={ false } />
 		</div>,
 		{ wrapper: queryWrapper() }
 	);
-	await expect( screen.findByText( 'Score request failed' ) ).resolves.toBeInTheDocument();
+	await expect( screen.findByText( error.message ) ).resolves.toBeInTheDocument();
 	expect( region ).toBeEmptyDOMElement();
 	rerender(
 		<div>
 			<Overview isVisible />
 		</div>
 	);
-	expect( region ).toHaveTextContent( 'Failed to load Speed Scores' );
+	expect( region ).toHaveTextContent( message );
 } );
 
 test( 'loads online scores and regenerates them with refresh tracking and history invalidation', async () => {

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -459,9 +459,9 @@ test( 'shows a score decrease with guidance and persists permanent dismissal', a
 	await waitFor( () =>
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/set',
+				url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/merge',
 				method: 'POST',
-				data: { JSON: { performance_history_fresh_start: true, score_decrease: true } },
+				data: { JSON: { score_decrease: true } },
 			} )
 		)
 	);

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -519,6 +519,7 @@ test( 'uses the legacy dismissal hook when no alert adapter is supplied', () => 
 } );
 
 test( 'reports module request errors independently and retries only modules', async () => {
+	window.jetpack_boost_ds!.modules_state!.value = undefined;
 	jest.mocked( apiFetch ).mockImplementation( async ( { url } ) => {
 		if ( url?.includes( 'modules-state' ) ) {
 			throw new Error( 'Module settings unavailable' );

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -1,0 +1,482 @@
+/* eslint-disable testing-library/prefer-user-event */
+import { requestSpeedScores } from '@automattic/jetpack-boost-score-api';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+	act,
+	fireEvent,
+	render,
+	renderHook,
+	screen,
+	waitFor,
+	within,
+} from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { useDismissibleAlertState as useLegacyAlertState } from '../../app/assets/src/js/features/performance-history/lib/hooks';
+import PopOut from '../../app/assets/src/js/features/speed-score/pop-out/pop-out';
+import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
+import * as speedScores from './lib/use-speed-scores';
+import Overview from './overview';
+import ScoreCard from './score-card';
+import ScoreCards from './score-cards';
+
+jest.mock( '@automattic/jetpack-boost-score-api', () => ( {
+	...jest.requireActual( '@automattic/jetpack-boost-score-api' ),
+	requestSpeedScores: jest.fn(),
+} ) );
+jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../../app/assets/src/js/features/performance-history/lib/hooks', () => ( {
+	...jest.requireActual( '../../app/assets/src/js/features/performance-history/lib/hooks' ),
+	useDismissibleAlertState: jest.fn(),
+} ) );
+jest.mock( '@react-spring/web', () => ( {
+	animated: { div: 'div' },
+	useSpring: ( { to }: { to: { right: string } } ) => ( {
+		visibility: to.right === '0%' ? 'visible' : 'hidden',
+	} ),
+} ) );
+jest.mock( '../../app/assets/src/js/lib/utils/analytics', () => ( {
+	recordBoostEvent: jest.fn(),
+} ) );
+jest.mock( './upgrade-cta', () => ( {
+	__esModule: true,
+	default: () => <button>Upgrade now</button>,
+} ) );
+
+const scores = {
+	current: { desktop: 91, mobile: 81 },
+	noBoost: { desktop: 81, mobile: 80 },
+	isStale: false,
+};
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	Object.assign( window, {
+		Jetpack_Boost: { site: { url: 'https://example.org', online: true } },
+		wpApiSettings: { root: 'https://example.org/wp-json/', nonce: 'wp-nonce' },
+		jetpack_boost_ds: {
+			rest_api: { value: 'https://example.org/wp-json/jetpack-boost-ds', nonce: 'wp-nonce' },
+			modules_state: {
+				nonce: 'modules-nonce',
+				value: { performance_history: { available: true, active: true } },
+			},
+			performance_history: { nonce: 'history-nonce' },
+			dismissed_alerts: { nonce: 'alerts-nonce', value: { performance_history_fresh_start: true } },
+		},
+	} );
+	jest.mocked( requestSpeedScores ).mockResolvedValue( scores );
+	jest.mocked( apiFetch ).mockImplementation( async ( { url, data } ) => ( {
+		status: 'success',
+		JSON: url?.includes( 'modules-state' )
+			? window.jetpack_boost_ds!.modules_state!.value
+			: url?.includes( 'dismissed-alerts' )
+			? data?.JSON ?? window.jetpack_boost_ds!.dismissed_alerts!.value
+			: null,
+	} ) );
+} );
+
+function queryWrapper() {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+}
+
+function renderOverview() {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	const view = render(
+		<QueryClientProvider client={ client }>
+			<Overview />
+		</QueryClientProvider>
+	);
+	return { ...view, client };
+}
+
+test( 'contains a render failure with the Overview error fallback', () => {
+	const scoreHook = jest.spyOn( speedScores, 'useSpeedScores' ).mockImplementation( () => {
+		throw new Error( 'Score rendering failed' );
+	} );
+	const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	try {
+		renderOverview();
+		expect(
+			screen.getByText( 'Unable to display performance scores', { selector: 'span' } )
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Score rendering failed' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Refresh' } ) ).not.toBeInTheDocument();
+	} finally {
+		scoreHook.mockRestore();
+		consoleError.mockRestore();
+	}
+} );
+
+test( 'loads online scores and regenerates them with refresh tracking and history invalidation', async () => {
+	const { client } = renderOverview();
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	expect( requestSpeedScores ).toHaveBeenCalledWith(
+		false,
+		wpApiSettings.root,
+		Jetpack_Boost.site.url,
+		wpApiSettings.nonce
+	);
+	const invalidate = jest.spyOn( client, 'invalidateQueries' );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await waitFor( () =>
+		expect( requestSpeedScores ).toHaveBeenLastCalledWith(
+			true,
+			wpApiSettings.root,
+			Jetpack_Boost.site.url,
+			wpApiSettings.nonce
+		)
+	);
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'speed_score_refresh_clicked', {} );
+	await waitFor( () =>
+		expect( invalidate ).toHaveBeenCalledWith( { queryKey: [ 'performance_history' ] } )
+	);
+} );
+
+test( 'keeps offline sites out of score and Data Sync requests', async () => {
+	Jetpack_Boost.site.online = false;
+	renderOverview();
+	expect(
+		screen.getByText( 'Website is not publicly available', { selector: 'span' } )
+	).toBeInTheDocument();
+	expect( screen.queryByRole( 'button', { name: 'Refresh' } ) ).not.toBeInTheDocument();
+	expect( requestSpeedScores ).not.toHaveBeenCalled();
+	expect( apiFetch ).not.toHaveBeenCalled();
+	const { result } = renderHook( () => speedScores.useSpeedScores(), { wrapper: queryWrapper() } );
+	await act( async () => result.current[ 1 ]( true ) );
+	expect( requestSpeedScores ).not.toHaveBeenCalled();
+} );
+
+test( 'tracks score errors and offers a successful retry', async () => {
+	jest
+		.mocked( requestSpeedScores )
+		.mockRejectedValueOnce( new Error( 'Score service unavailable' ) );
+	renderOverview();
+	await expect( screen.findByText( 'Score service unavailable' ) ).resolves.toBeTruthy();
+	expect( screen.queryByText( '91' ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( '81' ) ).not.toBeInTheDocument();
+	expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	for ( const name of [ 'Overall grade', 'Desktop', 'Mobile' ] ) {
+		expect( screen.getByRole( 'region', { name } ) ).toHaveAttribute( 'aria-busy', 'false' );
+	}
+	expect( screen.getByRole( 'button', { name: 'Refresh' } ) ).toBeEnabled();
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'speed_score_request_error', {
+		error_message: 'Score service unavailable',
+	} );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	expect( screen.queryByText( 'Score service unavailable' ) ).not.toBeInTheDocument();
+} );
+
+test( 'retains loaded scores and Refresh alongside a subsequent score error', async () => {
+	renderOverview();
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+	jest.mocked( requestSpeedScores ).mockRejectedValueOnce( new Error( 'Refresh failed' ) );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await expect( screen.findByText( 'Refresh failed' ) ).resolves.toBeTruthy();
+	expect( screen.getByText( '91' ) ).toBeInTheDocument();
+	expect( screen.getByText( '81' ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+		'aria-busy',
+		'false'
+	);
+	expect( screen.getByRole( 'button', { name: 'Refresh' } ) ).toBeEnabled();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	await waitFor( () => expect( screen.queryByText( 'Refresh failed' ) ).not.toBeInTheDocument() );
+	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();
+} );
+
+test( 'does not present initial loading scores as measured scores', () => {
+	jest.mocked( requestSpeedScores ).mockReturnValue( new Promise( () => {} ) );
+	renderOverview();
+	expect( screen.queryByText( '91' ) ).not.toBeInTheDocument();
+	expect( screen.queryByText( '81' ) ).not.toBeInTheDocument();
+	expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+		'aria-busy',
+		'true'
+	);
+	expect( screen.queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Refresh' } ) );
+	expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+} );
+
+test.each( [
+	[ 40, 'Poor' ],
+	[ 60, 'Could be improved' ],
+	[ 90, 'Good' ],
+] as const )( 'renders score %i with its tier, bar, and delta', ( score, tier ) => {
+	render(
+		<ScoreCard
+			icon={ null }
+			label="Desktop"
+			value={ score }
+			score={ score }
+			noBoost={ score - 10 }
+		/>
+	);
+	expect( screen.getByText( String( score ) ) ).toBeInTheDocument();
+	expect( screen.getByRole( 'progressbar', { name: 'Desktop' } ) ).toHaveValue( score );
+	expect( screen.getByText( '+10 points compared to without Boost' ) ).toBeInTheDocument();
+	expect( screen.getByText( tier ) ).toBeInTheDocument();
+} );
+
+test( 'opens the overall grade explanation and dismisses it with Escape', async () => {
+	render( <ScoreCards scores={ scores } /> );
+	expect(
+		within( screen.getByRole( 'region', { name: 'Overall grade' } ) ).getByText( 'Good' )
+	).toBeInTheDocument();
+	const trigger = within( screen.getByRole( 'region', { name: 'Overall grade' } ) ).getByRole(
+		'button',
+		{ name: 'How the overall grade is calculated' }
+	);
+	expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	fireEvent.click( trigger );
+	const tooltip = await screen.findByRole( 'dialog' );
+	expect( tooltip ).toHaveTextContent(
+		"Your Overall Score is a summary of your first Cornerstone Page across both mobile and desktop devices. It gives a general idea of your site's overall performance."
+	);
+	expect( trigger ).toHaveAttribute( 'aria-expanded', 'true' );
+	fireEvent.keyDown( tooltip, { key: 'Escape' } );
+	await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument() );
+	expect( trigger ).toHaveFocus();
+} );
+
+test( 'renders a negative baseline delta alongside the current measured bar', () => {
+	render( <ScoreCard icon={ null } label="Mobile" value={ 40 } score={ 40 } noBoost={ 60 } /> );
+	expect( screen.getByRole( 'progressbar', { name: 'Mobile' } ) ).toHaveValue( 40 );
+	expect( screen.getByText( '−20 points compared to without Boost' ) ).toBeInTheDocument();
+	expect( screen.getByText( 'Poor' ) ).toBeInTheDocument();
+} );
+
+test( 'hides stale and absent baselines while preserving measured scores', () => {
+	const { rerender } = render( <ScoreCards scores={ scores } /> );
+	expect( screen.getByText( /\+10 points/ ) ).toBeInTheDocument();
+	rerender( <ScoreCards scores={ { ...scores, isStale: true } } /> );
+	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+	expect( screen.getByText( '91' ) ).toBeInTheDocument();
+	rerender( <ScoreCards scores={ { ...scores, noBoost: null } } /> );
+	expect( screen.queryByText( /compared to without Boost/ ) ).not.toBeInTheDocument();
+} );
+
+test( 'selects the free history upgrade using module availability', async () => {
+	window.jetpack_boost_ds!.modules_state!.value = {
+		performance_history: { available: false, active: false },
+	};
+	renderOverview();
+	await expect( screen.findByRole( 'button', { name: 'Upgrade now' } ) ).resolves.toBeTruthy();
+	expect( screen.queryByText( /Performance history will appear/ ) ).not.toBeInTheDocument();
+} );
+
+test( 'retains the free history state when a modules refetch fails with a fresh-start alert', async () => {
+	window.jetpack_boost_ds!.modules_state!.value = {
+		performance_history: { available: false, active: false },
+	};
+	window.jetpack_boost_ds!.dismissed_alerts!.value = {
+		performance_history_fresh_start: false,
+	};
+	const { client } = renderOverview();
+	await expect( screen.findByRole( 'button', { name: 'Upgrade now' } ) ).resolves.toBeTruthy();
+	await waitFor( () => expect( client.isFetching() ).toBe( 0 ) );
+	jest.mocked( apiFetch ).mockRejectedValueOnce( new Error( 'Module settings unavailable' ) );
+	await act( async () => {
+		await client.refetchQueries( { queryKey: [ 'modules_state' ] } );
+	} );
+	await expect( screen.findByText( 'Module settings unavailable' ) ).resolves.toBeTruthy();
+	expect( screen.getByRole( 'button', { name: 'Upgrade now' } ) ).toBeInTheDocument();
+	expect(
+		screen.queryByText( /Jetpack Boost premium has been activated/ )
+	).not.toBeInTheDocument();
+} );
+
+test( 'selects the paid empty history state using module availability', async () => {
+	renderOverview();
+	await expect( screen.findByText( /Performance history will appear/ ) ).resolves.toBeTruthy();
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).not.toBeInTheDocument();
+} );
+
+test( 'debounces optimization changes and waits for generation to finish', async () => {
+	jest.useFakeTimers();
+	try {
+		const { result, rerender, unmount } = renderHook(
+			state => speedScores.useSpeedScores( state ),
+			{
+				initialProps: { config: 'modules-active:1,updated:10', isPending: false },
+				wrapper: queryWrapper(),
+			}
+		);
+		await waitFor( () => expect( result.current[ 0 ].status ).toBe( 'loaded' ) );
+		rerender( { config: 'modules-active:1,updated:20', isPending: true } );
+		act( () => jest.advanceTimersByTime( 2000 ) );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+		rerender( { config: 'modules-active:1,updated:20', isPending: false } );
+		act( () => jest.advanceTimersByTime( 1999 ) );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 1 );
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+		expect( requestSpeedScores ).toHaveBeenCalledTimes( 2 );
+		expect( requestSpeedScores ).toHaveBeenLastCalledWith(
+			true,
+			wpApiSettings.root,
+			Jetpack_Boost.site.url,
+			wpApiSettings.nonce
+		);
+		unmount();
+	} finally {
+		jest.useRealTimers();
+	}
+} );
+
+test( 'passes the history server error message to the notice', async () => {
+	const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
+	jest
+		.mocked( apiFetch )
+		.mockImplementation( options =>
+			options.url?.endsWith( '/performance-history' )
+				? Promise.resolve( { status: 'error', message: 'History service unavailable' } )
+				: fetch( options )
+		);
+	renderOverview();
+	await expect( screen.findByText( 'History service unavailable' ) ).resolves.toBeTruthy();
+	await expect( screen.findByRole( 'button', { name: 'Try again' } ) ).resolves.toBeEnabled();
+} );
+
+const decreasedScores = {
+	current: { desktop: 60, mobile: 60 },
+	noBoost: { desktop: 80, mobile: 80 },
+	isStale: false,
+};
+
+test( 'shows a score decrease with guidance and persists permanent dismissal', async () => {
+	jest.mocked( requestSpeedScores ).mockResolvedValue( decreasedScores );
+	renderOverview();
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).toBeVisible() );
+	expect( screen.getByRole( 'link', { name: /Read the guide/ } ) ).toHaveAttribute(
+		'href',
+		expect.stringContaining( 'boost-improve-site-speed-score' )
+	);
+	fireEvent.click( screen.getByRole( 'button', { name: 'Do not show me again' } ) );
+	await waitFor( () =>
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				url: 'https://example.org/wp-json/jetpack-boost-ds/dismissed-alerts/set',
+				method: 'POST',
+				data: { JSON: { performance_history_fresh_start: true, score_decrease: true } },
+			} )
+		)
+	);
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).not.toBeVisible() );
+} );
+
+test( 'temporarily closes the score decrease without persisting dismissal', async () => {
+	jest.mocked( requestSpeedScores ).mockResolvedValue( decreasedScores );
+	renderOverview();
+	await waitFor( () => expect( screen.getByText( 'Speed score has fallen' ) ).toBeVisible() );
+	fireEvent.click( screen.getByRole( 'link', { name: 'Dismiss' } ) );
+	expect( screen.getByText( 'Speed score has fallen' ) ).not.toBeVisible();
+	expect( apiFetch ).not.toHaveBeenCalledWith( expect.objectContaining( { method: 'POST' } ) );
+} );
+
+test.each( [
+	{ name: 'dismissed', scoreFixture: decreasedScores, dismissed: true },
+	{
+		name: 'unchanged',
+		scoreFixture: { ...decreasedScores, current: { desktop: 80, mobile: 80 } },
+		dismissed: false,
+	},
+	{ name: 'stale', scoreFixture: { ...decreasedScores, isStale: true }, dismissed: false },
+] )( 'does not show a $name score decrease alert', async ( { scoreFixture, dismissed } ) => {
+	window.jetpack_boost_ds!.dismissed_alerts!.value = {
+		performance_history_fresh_start: true,
+		score_decrease: dismissed,
+	};
+	jest.mocked( requestSpeedScores ).mockResolvedValue( scoreFixture );
+	renderOverview();
+	await waitFor( () =>
+		expect( screen.getByRole( 'region', { name: 'Desktop' } ) ).toHaveAttribute(
+			'aria-busy',
+			'false'
+		)
+	);
+	expect(
+		screen.queryByRole( 'heading', { name: 'Speed score has fallen' } )
+	).not.toBeInTheDocument();
+	expect( recordBoostEvent ).not.toHaveBeenCalledWith(
+		'speed_score_alert_shown',
+		expect.anything()
+	);
+} );
+
+test( 'uses the legacy dismissal hook when no alert adapter is supplied', () => {
+	const dismiss = jest.fn();
+	jest.mocked( useLegacyAlertState ).mockReturnValue( [ false, dismiss ] );
+	const { rerender } = render( <PopOut scoreChange={ -20 } /> );
+	expect( useLegacyAlertState ).toHaveBeenCalledWith( 'score_decrease' );
+	expect( screen.getByText( 'Speed score has fallen' ) ).toBeVisible();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Do not show me again' } ) );
+	expect( dismiss ).toHaveBeenCalledTimes( 1 );
+	jest.mocked( useLegacyAlertState ).mockReturnValue( [ true, dismiss ] );
+	rerender( <PopOut scoreChange={ -20 } /> );
+	expect( screen.getByText( 'Speed score has fallen' ) ).not.toBeVisible();
+} );
+
+test( 'reports module request errors independently and retries only modules', async () => {
+	jest.mocked( apiFetch ).mockImplementation( async ( { url } ) => {
+		if ( url?.includes( 'modules-state' ) ) {
+			throw new Error( 'Module settings unavailable' );
+		}
+		return { status: 'success', JSON: null };
+	} );
+	renderOverview();
+	await expect( screen.findByText( 'Module settings unavailable' ) ).resolves.toBeTruthy();
+	expect(
+		screen.getByText( 'Failed to load module settings', { selector: 'span' } )
+	).toBeInTheDocument();
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).not.toBeInTheDocument();
+	jest.mocked( apiFetch ).mockClear();
+	fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+	await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 1 ) );
+	expect( apiFetch ).toHaveBeenCalledWith(
+		expect.objectContaining( { url: expect.stringContaining( 'modules-state' ) } )
+	);
+} );
+
+test.each( [
+	[ 100, 'A', 'Good', 'good' ],
+	[ 90, 'B', 'Good', 'good' ],
+	[ 76, 'B', 'Good', 'good' ],
+	[ 75, 'C', 'Could be improved', 'medium' ],
+	[ 71, 'C', 'Could be improved', 'medium' ],
+	[ 50, 'D', 'Poor', 'poor' ],
+	[ 30, 'E', 'Poor', 'poor' ],
+	[ 0, 'F', 'Poor', 'poor' ],
+] )( 'keeps the Overall letter and tier aligned at score %s', ( score, grade, word, tier ) => {
+	render(
+		<ScoreCards
+			scores={ {
+				current: { desktop: Number( score ), mobile: Number( score ) },
+				noBoost: null,
+				isStale: false,
+			} }
+		/>
+	);
+	const overall = within( screen.getByRole( 'region', { name: 'Overall grade' } ) );
+	expect( overall.getByText( String( grade ) ) ).toBeInTheDocument();
+	expect( overall.getByText( String( word ) ) ).toHaveClass(
+		`jetpack-boost-overview__tier--${ tier }`
+	);
+} );
+
+test( 'keeps numeric device tiers when the Overall letter uses a different tier', () => {
+	render(
+		<ScoreCards
+			scores={ { current: { desktop: 71, mobile: 71 }, noBoost: null, isStale: false } }
+		/>
+	);
+	for ( const name of [ 'Desktop', 'Mobile' ] ) {
+		expect( within( screen.getByRole( 'region', { name } ) ).getByText( 'Good' ) ).toHaveClass(
+			'jetpack-boost-overview__tier--good'
+		);
+	}
+} );

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -123,19 +123,33 @@ test.each( [
 	[ 'score', 'Failed to load Speed Scores' ],
 	[ 'performance-history', 'Failed to load performance history' ],
 	[ 'modules-state', 'Failed to load module settings' ],
+	[ 'offline', 'Website is not publicly available' ],
+	[ 'fallback', 'Unable to display performance scores' ],
 ] )( 'keeps %s errors silent while the Overview is hidden', async ( source, message ) => {
 	/* eslint-disable testing-library/no-node-access */
-	const region =
-		document.getElementById( 'a11y-speak-assertive' ) ?? document.createElement( 'div' );
-	region.id = 'a11y-speak-assertive';
+	const regionId = `a11y-speak-${ source === 'offline' ? 'polite' : 'assertive' }`;
+	const region = document.getElementById( regionId ) ?? document.createElement( 'div' );
+	region.id = regionId;
 	region.className = 'a11y-speak-region';
 	region.textContent = '';
 	document.body.appendChild( region );
 	/* eslint-enable testing-library/no-node-access */
 	const error = new Error( `${ source } request failed` );
-	if ( source === 'score' ) {
+	const scoreHook =
+		source === 'fallback'
+			? jest.spyOn( speedScores, 'useSpeedScores' ).mockImplementation( () => {
+					throw error;
+			  } )
+			: undefined;
+	const consoleError =
+		source === 'fallback'
+			? jest.spyOn( console, 'error' ).mockImplementation( () => {} )
+			: undefined;
+	if ( source === 'offline' ) {
+		Jetpack_Boost.site.online = false;
+	} else if ( source === 'score' ) {
 		jest.mocked( requestSpeedScores ).mockRejectedValue( error );
-	} else {
+	} else if ( source !== 'fallback' ) {
 		const fetch = jest.mocked( apiFetch ).getMockImplementation()!;
 		jest
 			.mocked( apiFetch )
@@ -143,20 +157,36 @@ test.each( [
 				options.url?.endsWith( `/${ source }` ) ? Promise.reject( error ) : fetch( options )
 			);
 	}
-	const { rerender } = render(
-		<div hidden>
-			<Overview isVisible={ false } />
-		</div>,
-		{ wrapper: queryWrapper() }
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	const wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
 	);
-	await expect( screen.findByText( error.message ) ).resolves.toBeInTheDocument();
-	expect( region ).toBeEmptyDOMElement();
-	rerender(
-		<div>
-			<Overview isVisible />
-		</div>
-	);
-	expect( region ).toHaveTextContent( message );
+	try {
+		const { rerender } = render(
+			<div hidden>
+				<Overview isVisible={ false } />
+			</div>,
+			{ wrapper }
+		);
+		await waitFor( () => {
+			expect( client.isFetching() ).toBe( 0 );
+			expect(
+				screen.getByText( source === 'offline' ? message : error.message )
+			).toBeInTheDocument();
+		} );
+		expect( region ).toBeEmptyDOMElement();
+		await waitFor( () => expect( client.isFetching() ).toBe( 0 ) );
+		rerender(
+			<div>
+				<Overview isVisible />
+			</div>
+		);
+		await waitFor( () => expect( region ).toHaveTextContent( message ) );
+	} finally {
+		scoreHook?.mockRestore();
+		consoleError?.mockRestore();
+		client.clear();
+	}
 } );
 
 test( 'loads online scores and regenerates them with refresh tracking and history invalidation', async () => {

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -119,6 +119,32 @@ test( 'contains a render failure with the Overview error fallback', () => {
 	}
 } );
 
+test( 'keeps score errors silent while the Overview is hidden', async () => {
+	/* eslint-disable testing-library/no-node-access */
+	const region =
+		document.getElementById( 'a11y-speak-assertive' ) ?? document.createElement( 'div' );
+	region.id = 'a11y-speak-assertive';
+	region.className = 'a11y-speak-region';
+	region.textContent = '';
+	document.body.appendChild( region );
+	/* eslint-enable testing-library/no-node-access */
+	jest.mocked( requestSpeedScores ).mockRejectedValue( new Error( 'Score request failed' ) );
+	const { rerender } = render(
+		<div hidden>
+			<Overview isVisible={ false } />
+		</div>,
+		{ wrapper: queryWrapper() }
+	);
+	await expect( screen.findByText( 'Score request failed' ) ).resolves.toBeInTheDocument();
+	expect( region ).toBeEmptyDOMElement();
+	rerender(
+		<div>
+			<Overview isVisible />
+		</div>
+	);
+	expect( region ).toHaveTextContent( 'Failed to load Speed Scores' );
+} );
+
 test( 'loads online scores and regenerates them with refresh tracking and history invalidation', async () => {
 	const { client } = renderOverview();
 	await expect( screen.findByText( '91' ) ).resolves.toBeTruthy();

--- a/projects/plugins/boost/_inc/overview/overview.test.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.test.tsx
@@ -358,12 +358,17 @@ test( 'hides stale and absent baselines while preserving measured scores', () =>
 	expect( screen.queryByText( /compared with Boost disabled/ ) ).not.toBeInTheDocument();
 } );
 
-test( 'selects the free history upgrade using module availability', async () => {
+test( 'shows the free history upgrade without requesting history', async () => {
 	window.jetpack_boost_ds!.modules_state!.value = {
 		performance_history: { available: false, active: false },
 	};
 	renderOverview();
 	await expect( screen.findByRole( 'button', { name: 'Upgrade now' } ) ).resolves.toBeTruthy();
+	expect( apiFetch ).not.toHaveBeenCalledWith(
+		expect.objectContaining( {
+			url: 'https://example.org/wp-json/jetpack-boost-ds/performance-history',
+		} )
+	);
 	expect( screen.queryByText( /Performance history will appear/ ) ).not.toBeInTheDocument();
 } );
 

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -24,7 +24,11 @@ export default function Overview( props: { isVisible?: boolean } ) {
 			fallback={ error => (
 				<Notice.Root
 					intent="error"
-					spokenMessage={ __( 'Unable to display performance scores', 'jetpack-boost' ) }
+					spokenMessage={
+						props.isVisible !== false
+							? __( 'Unable to display performance scores', 'jetpack-boost' )
+							: ''
+					}
 				>
 					<Notice.Title>
 						{ __( 'Unable to display performance scores', 'jetpack-boost' ) }
@@ -78,7 +82,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 			<div className="jetpack-boost-overview">
 				<Notice.Root
 					intent="info"
-					spokenMessage={ __( 'Website is not publicly available', 'jetpack-boost' ) }
+					spokenMessage={
+						isVisible ? __( 'Website is not publicly available', 'jetpack-boost' ) : ''
+					}
 				>
 					<Notice.Title>
 						{ __( 'Website is not publicly available', 'jetpack-boost' ) }

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -145,7 +145,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 				isError={ history.isError && ! history.isFetching }
 				error={ history.error }
 				onRetry={ () => history.refetch() }
-				needsUpgrade={ modules.data?.performance_history?.available !== true }
+				needsUpgrade={
+					modules.data !== undefined && modules.data.performance_history?.available !== true
+				}
 				isFreshStart={ ! freshStartCompleted }
 				onDismissFreshStart={ dismissFreshStart }
 			/>

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -99,7 +99,7 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 			{ scoreState.status === 'error' && (
 				<Notice.Root
 					intent="error"
-					spokenMessage={ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }
+					spokenMessage={ isVisible ? __( 'Failed to load Speed Scores', 'jetpack-boost' ) : '' }
 				>
 					<Notice.Title>{ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }</Notice.Title>
 					<Notice.Description>{ scoreState.error?.message }</Notice.Description>
@@ -131,7 +131,7 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 			{ modules.isError && (
 				<Notice.Root
 					intent="error"
-					spokenMessage={ __( 'Failed to load module settings', 'jetpack-boost' ) }
+					spokenMessage={ isVisible ? __( 'Failed to load module settings', 'jetpack-boost' ) : '' }
 				>
 					<Notice.Title>{ __( 'Failed to load module settings', 'jetpack-boost' ) }</Notice.Title>
 					<Notice.Description>{ modules.error.message }</Notice.Description>

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -52,8 +52,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 	const isLoading = scoreState.status === 'loading';
 
 	useEffect( () => {
-		const onModulesChange = () => {
-			for ( const key of relayedQueryKeys ) {
+		const onModulesChange = ( event: Event ) => {
+			const key = ( event as CustomEvent< string > ).detail;
+			if ( relayedQueryKeys.includes( key ) ) {
 				queryClient.invalidateQueries( { queryKey: [ key ] } );
 			}
 		};

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -1,5 +1,4 @@
 import { getScoreMovementPercentage } from '@automattic/jetpack-boost-score-api';
-import { queryClient as legacyQueryClient } from '@automattic/jetpack-react-data-sync-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/ui';
@@ -8,6 +7,7 @@ import ScoreAlert from './score-alert';
 import ErrorBoundary from '../../app/assets/src/js/features/error-boundary/error-boundary';
 import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
 import HistoryChartCard from './history-chart-card';
+import { OVERVIEW_MODULES_CHANGE_EVENT } from './lib/modules-state-bridge';
 import { isSiteOnline, useModulesState, useScoreRefreshState } from './lib/use-modules-state';
 import {
 	performanceHistoryQueryKey,
@@ -51,15 +51,11 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 	const isLoading = scoreState.status === 'loading';
 
 	useEffect( () => {
-		return legacyQueryClient.getQueryCache().subscribe( event => {
-			if (
-				event.type === 'updated' &&
-				event.action.type === 'success' &&
-				event.query.queryKey[ 0 ] === 'modules_state'
-			) {
-				queryClient.invalidateQueries( { queryKey: [ 'modules_state' ] } );
-			}
-		} );
+		const onModulesChange = () => {
+			queryClient.invalidateQueries( { queryKey: [ 'modules_state' ] } );
+		};
+		window.addEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );
+		return () => window.removeEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );
 	}, [ queryClient ] );
 
 	useEffect( () => {

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -8,7 +8,12 @@ import ErrorBoundary from '../../app/assets/src/js/features/error-boundary/error
 import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
 import HistoryChartCard from './history-chart-card';
 import { OVERVIEW_MODULES_CHANGE_EVENT } from './lib/modules-state-bridge';
-import { isSiteOnline, useModulesState, useScoreRefreshState } from './lib/use-modules-state';
+import {
+	isSiteOnline,
+	modulesStateQueryKey,
+	useModulesState,
+	useScoreRefreshState,
+} from './lib/use-modules-state';
 import {
 	performanceHistoryQueryKey,
 	useDismissibleAlertState,
@@ -52,7 +57,7 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 
 	useEffect( () => {
 		const onModulesChange = () => {
-			queryClient.invalidateQueries( { queryKey: [ 'modules_state' ] } );
+			queryClient.invalidateQueries( { queryKey: modulesStateQueryKey } );
 		};
 		window.addEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );
 		return () => window.removeEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -100,9 +100,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 					<Notice.Title>{ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }</Notice.Title>
 					<Notice.Description>{ scoreState.error?.message }</Notice.Description>
 					<Notice.Actions>
-						<Button onClick={ () => refreshScores( true ) }>
+						<Notice.ActionButton onClick={ () => refreshScores( true ) }>
 							{ __( 'Try again', 'jetpack-boost' ) }
-						</Button>
+						</Notice.ActionButton>
 					</Notice.Actions>
 				</Notice.Root>
 			) }
@@ -132,9 +132,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 					<Notice.Title>{ __( 'Failed to load module settings', 'jetpack-boost' ) }</Notice.Title>
 					<Notice.Description>{ modules.error.message }</Notice.Description>
 					<Notice.Actions>
-						<Button onClick={ () => modules.refetch() }>
+						<Notice.ActionButton onClick={ () => modules.refetch() }>
 							{ __( 'Try again', 'jetpack-boost' ) }
-						</Button>
+						</Notice.ActionButton>
 					</Notice.Actions>
 				</Notice.Root>
 			) }

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -42,7 +42,8 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 	const modules = useModulesState();
 	const refreshState = useScoreRefreshState( modules.data );
 	const [ scoreState, refreshScores ] = useSpeedScores( refreshState );
-	const history = usePerformanceHistory( modules.data?.performance_history?.available === true );
+	const historyAvailable = modules.data?.performance_history?.available === true;
+	const history = usePerformanceHistory( historyAvailable );
 	const [ freshStartCompleted, dismissFreshStart ] = useDismissibleAlertState(
 		'performance_history_fresh_start'
 	);
@@ -143,13 +144,11 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 			<HistoryChartCard
 				isVisible={ isVisible }
 				data={ modules.isPending ? undefined : history.data }
-				isLoading={ modules.isPending || history.isPending }
+				isLoading={ modules.isPending || ( historyAvailable && history.isPending ) }
 				isError={ history.isError && ! history.isFetching }
 				error={ history.error }
 				onRetry={ () => history.refetch() }
-				needsUpgrade={
-					modules.data !== undefined && modules.data.performance_history?.available !== true
-				}
+				needsUpgrade={ modules.data !== undefined && ! historyAvailable }
 				isFreshStart={ ! freshStartCompleted }
 				onDismissFreshStart={ dismissFreshStart }
 			/>

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -7,13 +7,8 @@ import ScoreAlert from './score-alert';
 import ErrorBoundary from '../../app/assets/src/js/features/error-boundary/error-boundary';
 import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
 import HistoryChartCard from './history-chart-card';
-import { OVERVIEW_MODULES_CHANGE_EVENT } from './lib/modules-state-bridge';
-import {
-	isSiteOnline,
-	modulesStateQueryKey,
-	useModulesState,
-	useScoreRefreshState,
-} from './lib/use-modules-state';
+import { OVERVIEW_MODULES_CHANGE_EVENT, relayedQueryKeys } from './lib/modules-state-bridge';
+import { isSiteOnline, useModulesState, useScoreRefreshState } from './lib/use-modules-state';
 import {
 	performanceHistoryQueryKey,
 	useDismissibleAlertState,
@@ -57,7 +52,9 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 
 	useEffect( () => {
 		const onModulesChange = () => {
-			queryClient.invalidateQueries( { queryKey: modulesStateQueryKey } );
+			for ( const key of relayedQueryKeys ) {
+				queryClient.invalidateQueries( { queryKey: [ key ] } );
+			}
 		};
 		window.addEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );
 		return () => window.removeEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onModulesChange );

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -42,7 +42,7 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 	const modules = useModulesState();
 	const refreshState = useScoreRefreshState( modules.data );
 	const [ scoreState, refreshScores ] = useSpeedScores( refreshState );
-	const history = usePerformanceHistory();
+	const history = usePerformanceHistory( modules.data?.performance_history?.available === true );
 	const [ freshStartCompleted, dismissFreshStart ] = useDismissibleAlertState(
 		'performance_history_fresh_start'
 	);
@@ -141,7 +141,7 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 			<HistoryChartCard
 				isVisible={ isVisible }
 				data={ modules.isPending ? undefined : history.data }
-				isLoading={ modules.isPending || ( history.isFetching && ! history.data?.periods.length ) }
+				isLoading={ modules.isPending || history.isPending }
 				isError={ history.isError && ! history.isFetching }
 				error={ history.error }
 				onRetry={ () => history.refetch() }

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -1,4 +1,5 @@
 import { getScoreMovementPercentage } from '@automattic/jetpack-boost-score-api';
+import { queryClient as legacyQueryClient } from '@automattic/jetpack-react-data-sync-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { Button, Notice } from '@wordpress/ui';
@@ -48,6 +49,18 @@ function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
 	const queryClient = useQueryClient();
 	const online = isSiteOnline();
 	const isLoading = scoreState.status === 'loading';
+
+	useEffect( () => {
+		return legacyQueryClient.getQueryCache().subscribe( event => {
+			if (
+				event.type === 'updated' &&
+				event.action.type === 'success' &&
+				event.query.queryKey[ 0 ] === 'modules_state'
+			) {
+				queryClient.invalidateQueries( { queryKey: [ 'modules_state' ] } );
+			}
+		} );
+	}, [ queryClient ] );
 
 	useEffect( () => {
 		if ( online && scoreState.status === 'loaded' ) {

--- a/projects/plugins/boost/_inc/overview/overview.tsx
+++ b/projects/plugins/boost/_inc/overview/overview.tsx
@@ -1,0 +1,145 @@
+import { getScoreMovementPercentage } from '@automattic/jetpack-boost-score-api';
+import { useQueryClient } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { Button, Notice } from '@wordpress/ui';
+import { useEffect } from 'react';
+import ScoreAlert from './score-alert';
+import ErrorBoundary from '../../app/assets/src/js/features/error-boundary/error-boundary';
+import { recordBoostEvent } from '../../app/assets/src/js/lib/utils/analytics';
+import HistoryChartCard from './history-chart-card';
+import { isSiteOnline, useModulesState, useScoreRefreshState } from './lib/use-modules-state';
+import {
+	performanceHistoryQueryKey,
+	useDismissibleAlertState,
+	usePerformanceHistory,
+} from './lib/use-performance-history';
+import { useSpeedScores } from './lib/use-speed-scores';
+import ScoreCards from './score-cards';
+import './overview.scss';
+
+export default function Overview( props: { isVisible?: boolean } ) {
+	return (
+		<ErrorBoundary
+			fallback={ error => (
+				<Notice.Root
+					intent="error"
+					spokenMessage={ __( 'Unable to display performance scores', 'jetpack-boost' ) }
+				>
+					<Notice.Title>
+						{ __( 'Unable to display performance scores', 'jetpack-boost' ) }
+					</Notice.Title>
+					<Notice.Description>{ error.message }</Notice.Description>
+				</Notice.Root>
+			) }
+		>
+			<OverviewContent { ...props } />
+		</ErrorBoundary>
+	);
+}
+
+function OverviewContent( { isVisible = true }: { isVisible?: boolean } ) {
+	const modules = useModulesState();
+	const refreshState = useScoreRefreshState( modules.data );
+	const [ scoreState, refreshScores ] = useSpeedScores( refreshState );
+	const history = usePerformanceHistory();
+	const [ freshStartCompleted, dismissFreshStart ] = useDismissibleAlertState(
+		'performance_history_fresh_start'
+	);
+	const queryClient = useQueryClient();
+	const online = isSiteOnline();
+	const isLoading = scoreState.status === 'loading';
+
+	useEffect( () => {
+		if ( online && scoreState.status === 'loaded' ) {
+			queryClient.invalidateQueries( { queryKey: performanceHistoryQueryKey } );
+		}
+	}, [ online, scoreState.status, queryClient ] );
+
+	const onRefresh = () => {
+		recordBoostEvent( 'speed_score_refresh_clicked', {} );
+		refreshScores( true );
+	};
+
+	if ( ! online ) {
+		return (
+			<div className="jetpack-boost-overview">
+				<Notice.Root
+					intent="info"
+					spokenMessage={ __( 'Website is not publicly available', 'jetpack-boost' ) }
+				>
+					<Notice.Title>
+						{ __( 'Website is not publicly available', 'jetpack-boost' ) }
+					</Notice.Title>
+					<Notice.Description>
+						{ __(
+							'Performance score and some other Boost features cannot work because the Boost Cloud cannot reach your website. To fix this, you need to make your website publicly available.',
+							'jetpack-boost'
+						) }
+					</Notice.Description>
+				</Notice.Root>
+			</div>
+		);
+	}
+
+	return (
+		<div className="jetpack-boost-overview">
+			{ scoreState.status === 'error' && (
+				<Notice.Root
+					intent="error"
+					spokenMessage={ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }
+				>
+					<Notice.Title>{ __( 'Failed to load Speed Scores', 'jetpack-boost' ) }</Notice.Title>
+					<Notice.Description>{ scoreState.error?.message }</Notice.Description>
+					<Notice.Actions>
+						<Button onClick={ () => refreshScores( true ) }>
+							{ __( 'Try again', 'jetpack-boost' ) }
+						</Button>
+					</Notice.Actions>
+				</Notice.Root>
+			) }
+			<ScoreCards
+				scores={ scoreState.scores }
+				isLoading={ isLoading }
+				showPlaceholder={ isLoading || ! scoreState.hasScores }
+				headerAction={
+					<Button variant="minimal" size="compact" disabled={ isLoading } onClick={ onRefresh }>
+						{ __( 'Refresh', 'jetpack-boost' ) }
+					</Button>
+				}
+			/>
+			<ScoreAlert
+				scoreChange={
+					scoreState.status === 'loaded' &&
+					! scoreState.scores.isStale &&
+					getScoreMovementPercentage( scoreState.scores )
+				}
+				isVisible={ isVisible }
+			/>
+			{ modules.isError && (
+				<Notice.Root
+					intent="error"
+					spokenMessage={ __( 'Failed to load module settings', 'jetpack-boost' ) }
+				>
+					<Notice.Title>{ __( 'Failed to load module settings', 'jetpack-boost' ) }</Notice.Title>
+					<Notice.Description>{ modules.error.message }</Notice.Description>
+					<Notice.Actions>
+						<Button onClick={ () => modules.refetch() }>
+							{ __( 'Try again', 'jetpack-boost' ) }
+						</Button>
+					</Notice.Actions>
+				</Notice.Root>
+			) }
+			<HistoryChartCard
+				isVisible={ isVisible }
+				data={ modules.isPending ? undefined : history.data }
+				isLoading={ modules.isPending || ( history.isFetching && ! history.data?.periods.length ) }
+				isError={ history.isError && ! history.isFetching }
+				error={ history.error }
+				onRetry={ () => history.refetch() }
+				needsUpgrade={ modules.data?.performance_history?.available !== true }
+				isFreshStart={ ! freshStartCompleted }
+				onDismissFreshStart={ dismissFreshStart }
+			/>
+		</div>
+	);
+}

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
@@ -1,6 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { z } from 'zod';
-import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
+import { queryClient, useDataSync } from '@automattic/jetpack-react-data-sync-client';
 
 const periodsSchema = z.object( {
 	timestamp: z.number(),
@@ -79,7 +79,25 @@ export const useDismissibleAlertState = ( alertId: AlertIds ) => {
 		dismissedAlertsSchema,
 		{
 			mutation: {
+				// Serialize dismissals so a late response cannot overwrite a newer dismissal.
 				scope: { id: 'jetpack_boost_dismissed_alerts' },
+				onError: ( _error, _variables, context ) => {
+					const previous = (
+						context as { previousValue?: z.infer< typeof dismissedAlertsSchema > }
+					 )?.previousValue?.[ alertId ];
+					queryClient.setQueryData< z.infer< typeof dismissedAlertsSchema > >(
+						[ 'dismissed_alerts' ],
+						current => {
+							const restored = { ...current };
+							if ( previous === undefined ) {
+								delete restored[ alertId ];
+							} else {
+								restored[ alertId ] = previous;
+							}
+							return restored;
+						}
+					);
+				},
 				mutationFn: async () => {
 					const { rest_api, dismissed_alerts } = window.jetpack_boost_ds;
 					const response = await apiFetch< { JSON: unknown } >( {

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
@@ -79,6 +79,7 @@ export const useDismissibleAlertState = ( alertId: AlertIds ) => {
 		dismissedAlertsSchema,
 		{
 			mutation: {
+				scope: { id: 'jetpack_boost_dismissed_alerts' },
 				mutationFn: async () => {
 					const { rest_api, dismissed_alerts } = window.jetpack_boost_ds;
 					const response = await apiFetch< { JSON: unknown } >( {

--- a/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/performance-history/lib/hooks.ts
@@ -1,3 +1,4 @@
+import apiFetch from '@wordpress/api-fetch';
 import { z } from 'zod';
 import { useDataSync } from '@automattic/jetpack-react-data-sync-client';
 
@@ -63,6 +64,8 @@ type AlertIds =
 	| 'score_decrease'
 	| 'legacy_minify_notice';
 
+const dismissedAlertsSchema = z.record( z.string().min( 1 ), z.boolean() );
+
 /**
  * A hook that handles permanent dismissals of alerts.
  *
@@ -73,7 +76,25 @@ export const useDismissibleAlertState = ( alertId: AlertIds ) => {
 	const [ { data: dismissedAlerts }, { mutate } ] = useDataSync(
 		'jetpack_boost_ds',
 		'dismissed_alerts',
-		z.record( z.string().min( 1 ), z.boolean() )
+		dismissedAlertsSchema,
+		{
+			mutation: {
+				mutationFn: async () => {
+					const { rest_api, dismissed_alerts } = window.jetpack_boost_ds;
+					const response = await apiFetch< { JSON: unknown } >( {
+						url: `${ rest_api.value.replace( /\/$/, '' ) }/dismissed-alerts/merge`,
+						method: 'POST',
+						credentials: 'same-origin',
+						headers: {
+							'X-WP-Nonce': rest_api.nonce,
+							'X-Jetpack-WP-JS-Sync-Nonce': dismissed_alerts.nonce,
+						},
+						data: { JSON: { [ alertId ]: true } },
+					} );
+					return dismissedAlertsSchema.parse( response.JSON );
+				},
+			},
+		}
 	);
 	const dismiss = () => {
 		mutate( { ...dismissedAlerts, [ alertId ]: true } );

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable testing-library/prefer-user-event */
 /* eslint-disable jest-dom/prefer-in-document -- The legacy Boost Jest project does not load jest-dom. */
+import { queryClient } from '@automattic/jetpack-react-data-sync-client';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { createRoot } from '@wordpress/element';
+import { OVERVIEW_MODULES_CHANGE_EVENT } from '../../../../_inc/overview/lib/modules-state-bridge';
 import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
 import { recordBoostEvent } from './lib/utils/analytics';
 import './modern-overview-upgrade';
@@ -48,4 +50,18 @@ test( 'cancels a pending root before a strict-mode remount', async () => {
 	expect( screen.getAllByRole( 'button', { name: 'Upgrade now' } ) ).toHaveLength( 1 );
 	await act( async () => second.unmount?.() );
 	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+} );
+
+test( 'relays module updates from the Data Sync client', () => {
+	const onChange = jest.fn();
+	window.addEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onChange );
+	try {
+		queryClient.setQueryData( [ 'modules_state' ], {
+			defer_js: { active: true, available: true },
+		} );
+		expect( onChange ).toHaveBeenCalledTimes( 1 );
+	} finally {
+		window.removeEventListener( OVERVIEW_MODULES_CHANGE_EVENT, onChange );
+		queryClient.clear();
+	}
 } );

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.test.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable testing-library/prefer-user-event */
+/* eslint-disable jest-dom/prefer-in-document -- The legacy Boost Jest project does not load jest-dom. */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createRoot } from '@wordpress/element';
+import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
+import { recordBoostEvent } from './lib/utils/analytics';
+import './modern-overview-upgrade';
+import type { UpgradeSlotRequest } from '../../../../_inc/overview/lib/upgrade-bridge';
+import type { ReactNode } from 'react';
+
+jest.mock( './features/upgrade-cta/interstitial-modal-cta', () => ( {
+	__esModule: true,
+	default: ( { customModalTrigger }: { customModalTrigger: ReactNode } ) => customModalTrigger,
+} ) );
+jest.mock( './lib/utils/analytics', () => ( { recordBoostEvent: jest.fn() } ) );
+jest.mock( '@wordpress/element', () => ( {
+	...jest.requireActual( '@wordpress/element' ),
+	createRoot: jest.fn( jest.requireActual( '@wordpress/element' ).createRoot ),
+} ) );
+jest.mock( 'jetpackConfig', () => ( { consumer_slug: 'jetpack-boost' } ), { virtual: true } );
+
+test( 'mounts the upgrade action on request and cleans up its root', async () => {
+	render( <div data-testid="upgrade-slot" /> );
+	const request: UpgradeSlotRequest = { container: screen.getByTestId( 'upgrade-slot' ) };
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+	await act( async () => {
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: request } ) );
+	} );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Upgrade now' } ) );
+	expect( recordBoostEvent ).toHaveBeenCalledWith( 'performance_history_upgrade_cta_click', {} );
+	await act( async () => request.unmount?.() );
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+} );
+
+test( 'cancels a pending root before a strict-mode remount', async () => {
+	render( <div data-testid="upgrade-slot" /> );
+	jest.mocked( createRoot ).mockClear();
+	const container = screen.getByTestId( 'upgrade-slot' );
+	const first: UpgradeSlotRequest = { container };
+	const second: UpgradeSlotRequest = { container };
+	await act( async () => {
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: first } ) );
+		first.unmount?.();
+		window.dispatchEvent( new CustomEvent( OVERVIEW_UPGRADE_EVENT, { detail: second } ) );
+	} );
+	expect( createRoot ).toHaveBeenCalledTimes( 1 );
+	expect( createRoot ).toHaveBeenCalledWith( container );
+	expect( screen.getAllByRole( 'button', { name: 'Upgrade now' } ) ).toHaveLength( 1 );
+	await act( async () => second.unmount?.() );
+	expect( screen.queryByRole( 'button', { name: 'Upgrade now' } ) ).toBeNull();
+} );

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
@@ -1,10 +1,14 @@
 import { Button } from '@automattic/jetpack-components';
+import { queryClient } from '@automattic/jetpack-react-data-sync-client';
 import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { observeLegacyModulesState } from '../../../../_inc/overview/lib/modules-state-bridge';
 import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
 import InterstitialModalCTA from './features/upgrade-cta/interstitial-modal-cta';
 import { recordBoostEvent } from './lib/utils/analytics';
 import type { UpgradeSlotRequest } from '../../../../_inc/overview/lib/upgrade-bridge';
+
+observeLegacyModulesState( queryClient );
 
 function handleUpgrade() {
 	recordBoostEvent( 'performance_history_upgrade_cta_click', {} );

--- a/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
+++ b/projects/plugins/boost/app/assets/src/js/modern-overview-upgrade.tsx
@@ -1,0 +1,37 @@
+import { Button } from '@automattic/jetpack-components';
+import { createRoot } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { OVERVIEW_UPGRADE_EVENT } from '../../../../_inc/overview/lib/upgrade-bridge';
+import InterstitialModalCTA from './features/upgrade-cta/interstitial-modal-cta';
+import { recordBoostEvent } from './lib/utils/analytics';
+import type { UpgradeSlotRequest } from '../../../../_inc/overview/lib/upgrade-bridge';
+
+function handleUpgrade() {
+	recordBoostEvent( 'performance_history_upgrade_cta_click', {} );
+}
+
+window.addEventListener( OVERVIEW_UPGRADE_EVENT, ( event: Event ) => {
+	const request = ( event as CustomEvent< UpgradeSlotRequest > ).detail;
+	let disposed = false;
+	let root: ReturnType< typeof createRoot > | undefined;
+
+	// The slot mounts inside another React root; defer nested root updates until its commit completes.
+	request.unmount = () => {
+		disposed = true;
+		queueMicrotask( () => root?.unmount() );
+	};
+	queueMicrotask( () => {
+		if ( disposed ) {
+			return;
+		}
+		root = createRoot( request.container );
+		root.render(
+			<InterstitialModalCTA
+				identifier="historical-performance"
+				customModalTrigger={
+					<Button onClick={ handleUpgrade }>{ __( 'Upgrade now', 'jetpack-boost' ) }</Button>
+				}
+			/>
+		);
+	} );
+} );

--- a/projects/plugins/boost/changelog/cycle-one-overview
+++ b/projects/plugins/boost/changelog/cycle-one-overview
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add Overview presentation behind the disabled modern dashboard filter.
+
+

--- a/projects/plugins/boost/changelog/cycle-one-overview
+++ b/projects/plugins/boost/changelog/cycle-one-overview
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Add Overview presentation behind the disabled modern dashboard filter.
+Comment: Add disabled modern Overview presentation and shared dashboard event registration.

--- a/projects/plugins/boost/changelog/cycle-one-overview
+++ b/projects/plugins/boost/changelog/cycle-one-overview
@@ -1,5 +1,3 @@
 Significance: patch
 Type: changed
 Comment: Add Overview presentation behind the disabled modern dashboard filter.
-
-

--- a/projects/plugins/boost/changelog/overview-interaction-errors
+++ b/projects/plugins/boost/changelog/overview-interaction-errors
@@ -1,4 +1,3 @@
 Significance: patch
-Type: fixed
-
-Improve error handling and chart interaction in the experimental dashboard.
+Type: changed
+Comment: Improve Overview error handling and chart interaction behind the disabled filter.

--- a/projects/plugins/boost/changelog/overview-interaction-errors
+++ b/projects/plugins/boost/changelog/overview-interaction-errors
@@ -1,3 +1,3 @@
 Significance: patch
 Type: changed
-Comment: Improve Overview error handling and chart interaction behind the disabled filter.
+Comment: Improve Overview error handling and chart interaction, and preserve alert dismissals across dashboard bundles.

--- a/projects/plugins/boost/changelog/overview-interaction-errors
+++ b/projects/plugins/boost/changelog/overview-interaction-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Improve error handling and chart interaction in the experimental dashboard.

--- a/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
+++ b/projects/plugins/boost/docs/DEVELOPEMENT_GUIDE.md
@@ -39,6 +39,7 @@ Add `--production` for a production build. The build produces both the legacy
 webpack assets and the modern dashboard assets. For an opt-in local demo, see
 [Dashboard modernization](../tests/e2e/README.md#dashboard-modernization).
 
+For development access to the modern dashboard, use the `rsm_jetpack_ui_modernization_boost` filter documented in [the admin loader](../app/admin/class-admin.php). Its default and asset fallback are defined there.
 
 ## PHP unit tests
 
@@ -93,8 +94,15 @@ check the full legacy application.
 
 ## Linting Jetpack Boost JavaScript code
 
-Run JavaScript linting from the monorepo root as described in the
-[development environment guide](../../../../docs/development-environment.md#linting-jetpacks-javascript).
+Run the monorepo's ESLint command from the monorepo root, scoped to Boost:
+
+```sh
+pnpm run lint-file projects/plugins/boost
+```
+
+Append `--fix` to apply automatic fixes. See the
+[development environment guide](../../../../docs/development-environment.md#linting-jetpacks-javascript)
+for configuration guidance.
 
 # Debugging Concatenate JS/CSS exclusions
 

--- a/projects/plugins/boost/routes/dashboard/stage.test.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable testing-library/no-node-access */
+import 'jetpack-js-tools/jest/setup-jest-dom';
 // Test dependencies come from the plugin, not the wp-build route package.
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { act, fireEvent, render, screen } from '@testing-library/react';
@@ -6,6 +7,13 @@ import { stage as Stage } from './stage';
 import type { ReactNode } from 'react';
 
 const mockNavigate = jest.fn();
+
+jest.mock( '../../_inc/overview/overview', () => ( {
+	__esModule: true,
+	default: ( { isVisible }: { isVisible: boolean } ) => (
+		<div data-visible={ isVisible }>Performance Overview</div>
+	),
+} ) );
 
 jest.mock( '@wordpress/route', () => ( {
 	useSearch: () => ( { tab: new URLSearchParams( globalThis.location.search ).get( 'tab' ) } ),
@@ -45,6 +53,10 @@ describe( 'Boost dashboard stage', () => {
 			screen.getByRole( 'tab', { name: tab } )
 		);
 		expect( getSubpageMount()?.hidden ).toBe( true );
+		expect( screen.getByText( 'Performance Overview' ) ).toHaveAttribute(
+			'data-visible',
+			String( tab === 'Overview' )
+		);
 		expect( getSettingsMount() ).not.toBeNull();
 		expect( screen.getByRole( 'tabpanel' ).tabIndex ).toBe( 0 );
 		expect( screen.getByRole( 'tabpanel' ).contains( getSettingsMount() ) ).toBe(
@@ -62,6 +74,7 @@ describe( 'Boost dashboard stage', () => {
 		render( <Stage /> );
 
 		expect( getSubpageMount()?.hidden ).toBe( false );
+		expect( screen.getByText( 'Performance Overview' ) ).toHaveAttribute( 'data-visible', 'false' );
 		expect( getSubpageMount()?.closest( '[role="tabpanel"]' ) ).toBeNull();
 		expect( screen.queryAllByRole( 'tablist' ) ).toHaveLength( 0 );
 		expect( getSettingsMount() ).not.toBeNull();
@@ -109,8 +122,9 @@ describe( 'Boost dashboard stage', () => {
 		expect( mockNavigate ).toHaveBeenCalledWith( { search: { tab: 'settings' }, replace: true } );
 	} );
 
-	it( 'keeps both mount nodes across tab changes and subpage visits', () => {
+	it( 'keeps Overview and both mount nodes across tab changes and subpage visits', () => {
 		const { rerender } = render( <Stage /> );
+		const overview = screen.getByText( 'Performance Overview' );
 		const settingsMount = getSettingsMount();
 		const subpageMount = getSubpageMount();
 
@@ -126,6 +140,7 @@ describe( 'Boost dashboard stage', () => {
 			} );
 			rerender( <Stage /> );
 
+			expect( screen.getByText( 'Performance Overview' ) ).toBe( overview );
 			expect( getSettingsMount() ).toBe( settingsMount );
 			expect( getSubpageMount() ).toBe( subpageMount );
 		}

--- a/projects/plugins/boost/routes/dashboard/stage.tsx
+++ b/projects/plugins/boost/routes/dashboard/stage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { Tabs } from '@wordpress/ui';
 import BoostPage from '../../_inc/components/boost-page';
+import Overview from '../../_inc/overview/overview';
 import {
 	getSubpage,
 	LOCATION_CHANGE_EVENT,
@@ -88,8 +89,10 @@ function Stage() {
 			onTabChange={ onTabChange }
 			subpage={ <div id={ SUBPAGE_SLOT_ID } hidden={ subpage === null } /> }
 		>
-			<Tabs.Panel value="overview">
-				<QueryClientProvider client={ queryClient }>{ null }</QueryClientProvider>
+			<Tabs.Panel value="overview" keepMounted>
+				<QueryClientProvider client={ queryClient }>
+					<Overview isVisible={ activeTab === 'overview' && subpage === null } />
+				</QueryClientProvider>
 			</Tabs.Panel>
 			<Tabs.Panel value="settings" keepMounted>
 				<div id={ SETTINGS_SLOT_ID } />

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = [
 	 */
 	{
 		entry: {
-			index: './app/assets/src/js/index.tsx',
+			index: [ './app/assets/src/js/modern-overview-upgrade.tsx', './app/assets/src/js/index.tsx' ],
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,

--- a/projects/plugins/boost/webpack.config.js
+++ b/projects/plugins/boost/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = [
 	 */
 	{
 		entry: {
-			index: [ './app/assets/src/js/modern-overview-upgrade.tsx', './app/assets/src/js/index.tsx' ],
+			index: [ './app/assets/src/js/index.tsx', './app/assets/src/js/modern-overview-upgrade.tsx' ],
 		},
 		mode: jetpackWebpackConfig.mode,
 		devtool: jetpackWebpackConfig.devtool,


### PR DESCRIPTION
Fixes [BOOST-669](https://linear.app/a8c/issue/BOOST-669)

## Proposed changes

Mount Overview beside Settings behind the default-off `rsm_jetpack_ui_modernization_boost` filter. Connect scores, history, Refresh, notices, alerts, and the upgrade modal. Retain Overview across tabs; relay manual module and generation-state updates to the corresponding query. Preserve dismissals across both bundles and suppress hidden error announcements.

This PR owns the `stage.tsx` mounting and `webpack.config.js` entry changes. BOOST-673 remains the integration follow-up. With the filter off, the modern dashboard stays disabled; the legacy bundle registers bridge listeners and alert dismissals use partial merges.

## Related product discussion/links

Base: trunk. Merged prerequisites:

- https://github.com/Automattic/jetpack/pull/52165 (cards)
- https://github.com/Automattic/jetpack/pull/52168 (history)
- https://github.com/Automattic/jetpack/pull/52134 (Settings)

Next: https://github.com/Automattic/jetpack/pull/52184 (browser coverage).

## Does this pull request change what data or activity we track or use?

No. Existing event names remain unchanged.

## Testing instructions

1. Run the full Boost Jest suite and dashboard typecheck; build with `jp build plugins/boost`.
2. Enable `rsm_jetpack_ui_modernization_boost` via an mu-plugin. Open Boost; check scores, Refresh, history annotations and tooltip. On a free plan, open the upgrade modal.
3. Toggle a module in Settings, return to Overview, and verify scores regenerate. Confirm dismissed alerts remain dismissed across tabs.
4. Remove the filter and verify the legacy dashboard.

| Desktop | Mobile |
| --- | --- |
| ![Desktop](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-overview-composition/overview-desktop.png) | ![Mobile](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-overview-composition/overview-mobile.png) |

![History tooltip](https://github.com/Automattic/jetpack/raw/screenshots/fm/cycle1-overview-composition/history-tooltip.png)