### PR TITLE
WAF: Fix PHP 8 fatal in deprecated static wrappers

### DIFF
--- a/projects/packages/waf/changelog/protect-193-static-wrappers-php8
+++ b/projects/packages/waf/changelog/protect-193-static-wrappers-php8
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Brute_Force_Protection: fix fatal Error on PHP 8 in deprecated static wrappers ip_is_whitelisted() and is_current_ip_whitelisted() by routing calls through the singleton instance.

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -675,7 +675,7 @@ class Brute_Force_Protection {
 	 */
 	public static function ip_is_whitelisted( $ip ) {
 		_deprecated_function( __METHOD__, 'waf-0.11.0', __CLASS__ . '::ip_is_allowed' );
-		return self::ip_is_allowed( $ip );
+		return self::instance()->ip_is_allowed( $ip );
 	}
 
 	/**
@@ -774,7 +774,7 @@ class Brute_Force_Protection {
 	 */
 	public static function is_current_ip_whitelisted() {
 		_deprecated_function( __METHOD__, 'waf-0.11.0', __CLASS__ . '::is_current_ip_allowed' );
-		return self::is_current_ip_allowed();
+		return self::instance()->is_current_ip_allowed();
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php
@@ -238,6 +238,58 @@ class BruteForceProtectionTest extends WorDBless\BaseTestCase {
 		$this->instance->log_failed_attempt( 'username', $error );
 	}
 
+	/**
+	 * Test that the deprecated ip_is_whitelisted() wrapper delegates to ip_is_allowed().
+ *
+ * @return void
+	 */
+	public function test_ip_is_whitelisted_delegates_to_ip_is_allowed() {
+		$deprecated = array();
+		$capture    = static function ( $function ) use ( &$deprecated ) {
+			$deprecated[] = $function;
+		};
+
+		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		add_action( 'deprecated_function_run', $capture );
+
+		// @phan-suppress-next-line PhanDeprecatedFunction -- This test is the contract for the deprecated shim.
+		$result = Brute_Force_Protection::ip_is_whitelisted( '192.0.2.1' );
+
+		remove_action( 'deprecated_function_run', $capture );
+		remove_filter( 'deprecated_function_trigger_error', '__return_false' );
+
+		$this->assertContains( Brute_Force_Protection::class . '::ip_is_whitelisted', $deprecated );
+		$this->assertSame( Brute_Force_Protection::instance()->ip_is_allowed( '192.0.2.1' ), $result );
+	}
+
+	/**
+	 * Test that the deprecated is_current_ip_whitelisted() wrapper delegates to is_current_ip_allowed().
+	 *
+	 * @backupGlobals enabled
+ *
+ * @return void
+	 */
+	#[BackupGlobals( true )]
+	public function test_is_current_ip_whitelisted_delegates_to_is_current_ip_allowed() {
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.1';
+		$deprecated             = array();
+		$capture                = static function ( $function ) use ( &$deprecated ) {
+			$deprecated[] = $function;
+		};
+
+		add_filter( 'deprecated_function_trigger_error', '__return_false' );
+		add_action( 'deprecated_function_run', $capture );
+
+		// @phan-suppress-next-line PhanDeprecatedFunction -- This test is the contract for the deprecated shim.
+		$result = Brute_Force_Protection::is_current_ip_whitelisted();
+
+		remove_action( 'deprecated_function_run', $capture );
+		remove_filter( 'deprecated_function_trigger_error', '__return_false' );
+
+		$this->assertContains( Brute_Force_Protection::class . '::is_current_ip_whitelisted', $deprecated );
+		$this->assertSame( Brute_Force_Protection::instance()->is_current_ip_allowed(), $result );
+	}
+
 	public static function non_integer_data_provider(): array {
 		return array(
 			array( true ),


### PR DESCRIPTION
Fixes #51728

## Proposed changes

* Fix the PHP 8 fatal Error in the deprecated `ip_is_whitelisted()` wrapper by routing the call through the `Brute_Force_Protection` singleton instance.
* Fix the same issue in the deprecated `is_current_ip_whitelisted()` wrapper.
* Add regression tests covering both deprecated wrappers, including their deprecation behavior and delegated results.
* Add a WAF patch changelog entry.

## Related product discussion/links

* None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The regression tests can be run with:

* `composer --working-dir=projects/packages/waf test-php-integration -- --filter BruteForceProtectionTest`

The full WAF test suites were also run:

* `composer --working-dir=projects/packages/waf test-php-integration`
* `composer --working-dir=projects/packages/waf test-php-unit`

The changed PHP files were checked with:

* `composer phpcs:changed -- projects/packages/waf/src/class-brute-force-protection.php projects/packages/waf/tests/php/integration/BruteForceProtectionTest.php`

The changelog was validated with:

* `bash tools/changelogger-validate-all.sh`

And:

* `git diff --check`