### PR TITLE
Boost: derive dashboard page-view event names from one function

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.test.ts
@@ -1,0 +1,16 @@
+import { getPageViewEventName } from './analytics';
+
+describe( 'getPageViewEventName', () => {
+	it( 'names the settings root, which has no path of its own', () => {
+		expect( getPageViewEventName( '/' ) ).toBe( 'page_view_settings' );
+	} );
+
+	it.each( [
+		[ '/cache-debug-log', 'page_view_cache_debug_log' ],
+		[ '/critical-css-advanced', 'page_view_critical_css_advanced' ],
+		[ '/getting-started', 'page_view_getting_started' ],
+		[ '/purchase-successful', 'page_view_purchase_successful' ],
+	] )( 'names %s', ( pathname, expected ) => {
+		expect( getPageViewEventName( pathname ) ).toBe( expected );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.ts
+++ b/projects/plugins/boost/app/assets/src/js/lib/utils/analytics.ts
@@ -3,6 +3,20 @@ import analytics from '@automattic/jetpack-analytics';
 export type TracksEventProperties = { [ key: string ]: string | number };
 
 /**
+ * Derive a page-view event name from a route pathname.
+ *
+ * A bare `/` becomes `settings`, since that route has no path of its own.
+ *
+ * @param {string} pathname - Route pathname, e.g. `/cache-debug-log`.
+ * @return {string} Event name, minus the `boost_` prefix.
+ */
+export function getPageViewEventName( pathname: string ): string {
+	const path = pathname.replace( /[-/]/g, '_' );
+
+	return `page_view${ path === '_' ? '_settings' : path }`;
+}
+
+/**
  * Send an event to Tracks.
  *
  * @param {string}                eventName Event name, minus the jetpack_boost_ prefix.

--- a/projects/plugins/boost/app/assets/src/js/main.tsx
+++ b/projects/plugins/boost/app/assets/src/js/main.tsx
@@ -7,7 +7,7 @@ import PurchaseSuccess from './pages/purchase-success/purchase-success';
 import SettingsPage from '$layout/settings-page/settings-page';
 import { useEffect, StrictMode } from 'react';
 import type { JSX } from 'react';
-import { recordBoostEvent } from '$lib/utils/analytics';
+import { getPageViewEventName, recordBoostEvent } from '$lib/utils/analytics';
 import { LegacyNavigationProvider } from '$lib/navigation/navigation-context';
 import { DataSyncProvider } from '@automattic/jetpack-react-data-sync-client';
 import { useGettingStarted } from '$lib/stores/getting-started';
@@ -90,12 +90,7 @@ const LegacyRouteFrame = ( { children }: { children: JSX.Element } ) => {
 	const location = useLocation();
 
 	useEffect( () => {
-		let path = location.pathname.replace( /[-/]/g, '_' );
-		if ( path === '_' ) {
-			path = '_settings';
-		}
-
-		recordBoostEvent( `page_view${ path }`, {
+		recordBoostEvent( getPageViewEventName( location.pathname ), {
 			path: location.pathname,
 		} );
 	}, [ location ] );

--- a/projects/plugins/boost/changelog/cycle-one-page-view-name
+++ b/projects/plugins/boost/changelog/cycle-one-page-view-name
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Derive dashboard page-view event names from one function. The names are unchanged.
+
+


### PR DESCRIPTION
Part of BOOST-670.

## Proposed changes

Extract the page-view event name into `getPageViewEventName()`. The rule will be reused by the modernized dashboard, so it lands on its own rather than adding files to review in the PRs that consume it.

Pure extraction: same logic, same event names, one caller as before. A test pins each name.

## Related product discussion/links

* Parent: BOOST-633
* Consumer: #52134

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `pnpm --dir projects/plugins/boost test` — 157 tests, 5 new here.
2. Visit Settings and each Boost sub-page; the Tracks events are unchanged from trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NzGT9kxxs229BAH6yUMoJ3
