### PR TITLE
Activity log: use core range calendar component

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1828,9 +1828,9 @@ importers:
       '@automattic/jetpack-connection':
         specifier: workspace:*
         version: link:../../js-packages/connection
-      '@automattic/ui':
-        specifier: 1.0.2
-        version: 1.0.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@date-fns/tz':
+        specifier: 1.4.1
+        version: 1.4.1
       '@jetpack-activity-log/init':
         specifier: link:packages/init
         version: link:packages/init
@@ -1839,7 +1839,7 @@ importers:
         version: 5.101.2(react@18.3.1)
       '@wordpress/admin-ui':
         specifier: 2.9.0
-        version: 2.9.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.9.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/api-fetch':
         specifier: 7.54.0
         version: 7.54.0
@@ -1848,7 +1848,7 @@ importers:
         version: 13.0.0
       '@wordpress/components':
         specifier: 40.0.0
-        version: 40.0.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 40.0.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose':
         specifier: 8.7.0
         version: 8.7.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1878,7 +1878,7 @@ importers:
         version: 0.20.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: 0.21.0
-        version: 0.21.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.21.0(@date-fns/tz@1.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/url':
         specifier: 4.54.0
         version: 4.54.0
@@ -19484,23 +19484,6 @@ snapshots:
       '@wordpress/i18n': 6.27.0
       '@wordpress/icons': 15.5.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/primitives': 4.54.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      clsx: 2.1.1
-      date-fns: 4.1.0
-      react: 18.3.1
-      react-day-picker: 9.14.0(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-
-  '@automattic/ui@1.0.2(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@wordpress/base-styles': 13.0.0
-      '@wordpress/compose': 8.7.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/element': 8.6.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/i18n': 6.27.0
-      '@wordpress/icons': 15.5.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/primitives': 4.54.0(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       clsx: 2.1.1
       date-fns: 4.1.0
       react: 18.3.1

--- a/projects/packages/activity-log/changelog/update-activity-log-range-calendar
+++ b/projects/packages/activity-log/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/packages/activity-log/changelog/update-activity-log-range-calendar
+++ b/projects/packages/activity-log/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Switch the date-range picker to the WordPress Design System calendar.
+Comment: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/packages/activity-log/package.json
+++ b/projects/packages/activity-log/package.json
@@ -45,7 +45,7 @@
 		"@automattic/jetpack-analytics": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
-		"@automattic/ui": "1.0.2",
+		"@date-fns/tz": "1.4.1",
 		"@jetpack-activity-log/init": "link:packages/init",
 		"@tanstack/react-query": "^5.90.8",
 		"@wordpress/admin-ui": "2.9.0",

--- a/projects/packages/activity-log/routes/dashboard/package.json
+++ b/projects/packages/activity-log/routes/dashboard/package.json
@@ -6,7 +6,6 @@
 		"@automattic/jetpack-base-styles": "workspace:*",
 		"@automattic/jetpack-components": "workspace:*",
 		"@automattic/jetpack-connection": "workspace:*",
-		"@automattic/ui": "1.0.2",
 		"@tanstack/react-query": "^5.90.8",
 		"@types/react": "18.3.31",
 		"@wordpress/api-fetch": "7.54.0",

--- a/projects/packages/activity-log/src/js/components/DateRangePicker/date-range-content.tsx
+++ b/projects/packages/activity-log/src/js/components/DateRangePicker/date-range-content.tsx
@@ -4,7 +4,7 @@
  * with local imports and Calypso's tiny `ButtonStack` wrapper inlined
  * (it was just an HStack with a fixed spacing).
  */
-import { DateRangeCalendar, TZDate } from '@automattic/ui';
+import { TZDate } from '@date-fns/tz';
 import {
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Button,
@@ -12,6 +12,7 @@ import {
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { RangeCalendar } from '@wordpress/ui';
 import { startOfMonth, subMonths } from 'date-fns';
 import { useState } from 'react';
 import { DateInputs } from './date-inputs';
@@ -171,13 +172,18 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 
 	const endMonth = makeTZMonthFromDate( siteMonthStart );
 
-	const selected =
-		timeZoneForCalendar && ( fromDraft || toDraft )
-			? {
-					from: fromDraft ? new TZDate( +fromDraft, timeZoneForCalendar ) : undefined,
-					to: toDraft ? new TZDate( +toDraft, timeZoneForCalendar ) : undefined,
-			  }
-			: { from: fromDraft ?? undefined, to: toDraft ?? undefined };
+	const selected = ( () => {
+		if ( ! fromDraft && ! toDraft ) {
+			return null;
+		}
+		if ( timeZoneForCalendar ) {
+			return {
+				from: fromDraft ? new TZDate( +fromDraft, timeZoneForCalendar ) : undefined,
+				to: toDraft ? new TZDate( +toDraft, timeZoneForCalendar ) : undefined,
+			};
+		}
+		return { from: fromDraft ?? undefined, to: toDraft ?? undefined };
+	} )();
 
 	return (
 		<VStack as="div" spacing={ 3 } style={ { padding: 12 } }>
@@ -303,30 +309,22 @@ export function DateRangeContent( props: DateRangeContentProps ) {
 				) }
 
 				<div className="daterange-calendar">
-					<DateRangeCalendar
+					<RangeCalendar
 						timeZone={ timeZoneForCalendar }
 						numberOfMonths={ isSmall ? 1 : 2 }
 						defaultMonth={ defaultMonth }
 						endMonth={ endMonth }
 						disabled={ disableFuture ? { after: today } : undefined }
 						excludeDisabled
-						selected={ selected }
-						onSelect={ range => {
+						value={ selected }
+						onValueChange={ range => {
 							const toNative = ( d?: Date ) => ( d ? new Date( d.getTime() ) : undefined );
-							if ( range?.from ) {
-								const from = toNative( range.from );
-								setFromDraft( from );
-								if ( from ) {
-									setFromStr( formatYmd( from, timezoneString, gmtOffset ) );
-								}
-							}
-							if ( range?.to ) {
-								const to = toNative( range.to );
-								setToDraft( to );
-								if ( to ) {
-									setToStr( formatYmd( to, timezoneString, gmtOffset ) );
-								}
-							}
+							const from = toNative( range?.from );
+							const to = toNative( range?.to );
+							setFromDraft( from );
+							setToDraft( to );
+							setFromStr( from ? formatYmd( from, timezoneString, gmtOffset ) : '' );
+							setToStr( to ? formatYmd( to, timezoneString, gmtOffset ) : '' );
 							setIsTyping( false );
 						} }
 					/>

--- a/projects/packages/activity-log/src/js/components/DateRangePicker/index.tsx
+++ b/projects/packages/activity-log/src/js/components/DateRangePicker/index.tsx
@@ -20,12 +20,6 @@ import { formatLabel } from './utils';
 import type { PresetId } from './utils';
 import './style.scss';
 
-// `@automattic/ui`'s `DateRangeCalendar` styling lives in its own
-// stylesheet — the JS bundle doesn't carry it. Import it here so the
-// calendar renders with the Calypso-style clean day numbers instead
-// of wp-admin's default button boxes.
-import '@automattic/ui/style.css';
-
 type DateRangePickerProps = {
 	start: Date;
 	end: Date;

--- a/projects/plugins/backup/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/backup/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/backup/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/backup/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/boost/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/boost/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/boost/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/boost/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/jetpack/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/jetpack/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/jetpack/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/jetpack/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
-Type: enhancement
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Type: other
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/protect/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/protect/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/protect/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/protect/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/search/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/search/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/search/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/search/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/videopress/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/videopress/changelog/update-activity-log-range-calendar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Activity Log: Switch the date-range picker to the WordPress Design System calendar.

--- a/projects/plugins/videopress/changelog/update-activity-log-range-calendar
+++ b/projects/plugins/videopress/changelog/update-activity-log-range-calendar
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Activity Log: Switch the date-range picker to the WordPress Design System calendar.
+Comment: Activity Log: Switch the date-range picker to the WordPress Design System calendar.


### PR DESCRIPTION
Sibling to https://github.com/Automattic/jetpack/pull/48742 and https://github.com/Automattic/jetpack/pull/52090 where we removed our own range calendar component with `@wordpress/ui`; Activity Log is now the last one using the `@automattic/ui` package so the whole package can be now removed.


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Switch `@automattic/ui` component to latest design system `@wordpress/ui` one.

There's a slight UX improvement for changing [ranges coming up](https://github.com/WordPress/gutenberg/pull/82612) in the next ui package release. The UX improvement will apply here when `@wordpress/ui` gets updated next time.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
*  https://github.com/Automattic/jetpack/pull/49934#issuecomment-5425076648

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to Activity Log
* Test calendar component across desktop and mobile; it should continue to behave as previously

<img width="1677" height="651" alt="Screenshot 2026-09-10 at 12 29 59" src="https://github.com/user-attachments/assets/3329b7c8-3766-4f2f-84d0-3d0c5febc9b4" />

