### PR TITLE
Editor: Stop nudging to activate Likes and Sharing on block themes

### DIFF
--- a/projects/plugins/jetpack/changelog/block-theme-module-nudge
+++ b/projects/plugins/jetpack/changelog/block-theme-module-nudge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Editor: Stop offering to activate the legacy Likes and Sharing buttons modules on block themes, where the corresponding blocks should be added to a template instead.

--- a/projects/plugins/jetpack/extensions/plugins/likes/likes.php
+++ b/projects/plugins/jetpack/extensions/plugins/likes/likes.php
@@ -47,8 +47,7 @@ add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_
 /**
  * Register post types.
  *
- * The support flag only exists to render the module activation nudge, so it is not needed
- * on block themes, where we do not offer that nudge.
+ * The support flag only exists to render the module activation nudge.
  */
 add_action(
 	'rest_api_init',

--- a/projects/plugins/jetpack/extensions/plugins/likes/likes.php
+++ b/projects/plugins/jetpack/extensions/plugins/likes/likes.php
@@ -26,9 +26,10 @@ function register_plugins() {
 	/*
 	 * The extension is available even when the module is not active,
 	 * so we can display a nudge to activate the module instead of the block.
-	 * However, since non-admins cannot activate modules, we do not display the empty block for them.
+	 * We skip that nudge for non-admins, who cannot activate modules, and on block themes,
+	 * where the answer is the Like block in a template rather than the legacy module.
 	 */
-	if ( ! ( new Modules() )->is_active( 'likes' ) && ! current_user_can( 'jetpack_activate_modules' ) ) {
+	if ( ! ( new Modules() )->is_active( 'likes' ) && ( ! current_user_can( 'jetpack_activate_modules' ) || wp_is_block_theme() ) ) {
 		return;
 	}
 
@@ -44,12 +45,15 @@ function register_plugins() {
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugins' );
 
 /**
- * Register post types
+ * Register post types.
+ *
+ * The support flag only exists to render the module activation nudge, so it is not needed
+ * on block themes, where we do not offer that nudge.
  */
 add_action(
 	'rest_api_init',
 	function () {
-		if ( ! ( new Modules() )->is_active( 'likes' ) ) {
+		if ( ! ( new Modules() )->is_active( 'likes' ) && ! wp_is_block_theme() ) {
 			$post_types = get_post_types( array( 'public' => true ) );
 			foreach ( $post_types as $post_type ) {
 				add_post_type_support( $post_type, 'jetpack-post-likes' );

--- a/projects/plugins/jetpack/extensions/plugins/likes/likes.php
+++ b/projects/plugins/jetpack/extensions/plugins/likes/likes.php
@@ -45,14 +45,12 @@ function register_plugins() {
 add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_plugins' );
 
 /**
- * Register post types.
- *
- * The support flag only exists to render the module activation nudge.
+ * Register post types
  */
 add_action(
 	'rest_api_init',
 	function () {
-		if ( ! ( new Modules() )->is_active( 'likes' ) && ! wp_is_block_theme() ) {
+		if ( ! ( new Modules() )->is_active( 'likes' ) ) {
 			$post_types = get_post_types( array( 'public' => true ) );
 			foreach ( $post_types as $post_type ) {
 				add_post_type_support( $post_type, 'jetpack-post-likes' );

--- a/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
@@ -40,9 +40,7 @@ add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_
  * The sharing module declares support for sharing for all the public post types.
  * Let's do the same thing when the module isn't active yet.
  *
- * The support flag only exists to render the module activation nudge, so we skip it on
- * block themes, where we no longer offer that nudge. The REST field is registered either
- * way, so the response shape does not change with the theme.
+ * The support flag only exists to render the module activation nudge.
  */
 add_action(
 	'rest_api_init',

--- a/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
@@ -23,9 +23,10 @@ function register_plugins() {
 	/*
 	 * The extension is available even when the module is not active,
 	 * so we can display a nudge to activate the module instead of the block.
-	 * However, since non-admins cannot activate modules, we do not display the empty block for them.
+	 * We skip that nudge for non-admins, who cannot activate modules, and on block themes,
+	 * where the answer is the sharing block in a template rather than the legacy module.
 	 */
-	if ( ! ( new Modules() )->is_active( 'sharedaddy' ) && ! current_user_can( 'jetpack_activate_modules' ) ) {
+	if ( ! ( new Modules() )->is_active( 'sharedaddy' ) && ( ! current_user_can( 'jetpack_activate_modules' ) || wp_is_block_theme() ) ) {
 		return;
 	}
 
@@ -38,12 +39,17 @@ add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_
  * The Sharing panel is only displayed for post types that support sharing.
  * The sharing module declares support for sharing for all the public post types.
  * Let's do the same thing when the module isn't active yet.
+ *
+ * The support flag only exists to render the module activation nudge, so we skip it on
+ * block themes, where we no longer offer that nudge. The REST field is registered either
+ * way, so the response shape does not change with the theme.
  */
 add_action(
 	'rest_api_init',
 	function () {
 		if ( ! ( new Modules() )->is_active( 'sharedaddy' ) ) {
-			$post_types = get_post_types( array( 'public' => true ) );
+			$post_types     = get_post_types( array( 'public' => true ) );
+			$is_block_theme = wp_is_block_theme();
 
 			foreach ( $post_types as $post_type ) {
 				register_rest_field(
@@ -63,7 +69,10 @@ add_action(
 						),
 					)
 				);
-				add_post_type_support( $post_type, 'jetpack-sharing-buttons' );
+
+				if ( ! $is_block_theme ) {
+					add_post_type_support( $post_type, 'jetpack-sharing-buttons' );
+				}
 			}
 		}
 	}

--- a/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
@@ -24,7 +24,7 @@ function register_plugins() {
 	 * The extension is available even when the module is not active,
 	 * so we can display a nudge to activate the module instead of the block.
 	 * We skip that nudge for non-admins, who cannot activate modules, and on block themes,
-	 * where the answer is the sharing block in a template rather than the legacy module.
+	 * where the answer is the Sharing Buttons block in a template rather than the legacy module.
 	 */
 	if ( ! ( new Modules() )->is_active( 'sharedaddy' ) && ( ! current_user_can( 'jetpack_activate_modules' ) || wp_is_block_theme() ) ) {
 		return;

--- a/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
+++ b/projects/plugins/jetpack/extensions/plugins/sharing/sharing.php
@@ -39,15 +39,12 @@ add_action( 'jetpack_register_gutenberg_extensions', __NAMESPACE__ . '\register_
  * The Sharing panel is only displayed for post types that support sharing.
  * The sharing module declares support for sharing for all the public post types.
  * Let's do the same thing when the module isn't active yet.
- *
- * The support flag only exists to render the module activation nudge.
  */
 add_action(
 	'rest_api_init',
 	function () {
 		if ( ! ( new Modules() )->is_active( 'sharedaddy' ) ) {
-			$post_types     = get_post_types( array( 'public' => true ) );
-			$is_block_theme = wp_is_block_theme();
+			$post_types = get_post_types( array( 'public' => true ) );
 
 			foreach ( $post_types as $post_type ) {
 				register_rest_field(
@@ -67,10 +64,7 @@ add_action(
 						),
 					)
 				);
-
-				if ( ! $is_block_theme ) {
-					add_post_type_support( $post_type, 'jetpack-sharing-buttons' );
-				}
+				add_post_type_support( $post_type, 'jetpack-sharing-buttons' );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes CM-907

## Proposed changes

* When the Likes or Sharing buttons module is inactive, the block editor shows an "Insert likes and sharing" panel with an "Activate the Likes feature" button inside it. That happens on every theme today. With this change it no longer happens on block themes.
* On a block theme, activating those modules isn't the advice we want to give. They inject markup below post content via `the_content`, so there's nothing in the Single Post template to select or delete, and that's what people get stuck on in the reports behind CM-884. A Like block or sharing block placed in a template is the thing they can remove themselves.
* Our own Jetpack dashboard already says this. The Likes and Sharing cards render a `BlockThemeNotice` telling people to add the block instead of enabling the legacy feature, so the dashboard and the editor were giving opposite advice.
* Nothing changes while a module is active. `modules/likes.php` and `modules/sharedaddy/sharing.php` register their own post type support and REST fields, so the per-post "Show likes" and "Show sharing buttons" toggles keep working on every theme.
* Classic themes keep the activation nudge, since that really is the answer there.

Two things this deliberately doesn't do:

* It leaves the Jetpack dashboard alone. Those cards still show an enabled module toggle on block themes, right next to the notice advising against it. That seems fine to me, since the dashboard is where you'd go on purpose to turn a module on, but it's a difference.
* The `jetpack_sharing_enabled` REST field is still registered whatever the theme, so no REST response changes shape. Only the `jetpack-sharing-buttons` post type support flag is skipped, and the one thing reading that flag is the `PostTypeSupportCheck` in the panel we're hiding.

## Related product discussion/links

* https://linear.app/a8c/issue/CM-907
* Parent issue: https://linear.app/a8c/issue/CM-884

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You'll need a Jetpack-connected site, and you'll be switching themes and module states around a few times.

**Block theme, modules off.** This is the actual change.

1. Activate a block theme, e.g. Twenty Twenty-Five.
2. Go to Jetpack > Settings > Sharing and make sure both "Like buttons" and "Sharing buttons" are off.
3. Edit any post and open the Jetpack panel in the sidebar.
4. On trunk you get an "Insert likes and sharing" panel offering to activate Likes and Sharing buttons. With this branch the panel shouldn't be there at all.

**Block theme, modules on.** Nothing should change here.

5. Turn "Like buttons" back on and reload the editor.
6. The "Insert likes and sharing" panel is back, this time with the real "Show likes" toggle. Switch it off, save, reload, and confirm it stuck.
7. Same again with "Sharing buttons" and its "Show sharing buttons" toggle.

**Classic theme, modules off.** Nothing should change here either.

8. Switch to a classic theme, e.g. Twenty Twenty-One, and turn both modules off again.
9. Reload the editor. The activation nudges should still be there, exactly as before.

**REST check, if you want to be thorough.**

10. Block theme, "Sharing buttons" off. `GET /wp-json/wp/v2/posts/<id>?context=edit` should still include `jetpack_sharing_enabled`.

No automated test here, I'm afraid. Nothing in `tests/php/extensions` covers these two files, that suite runs on `WP_UnitTestCase`, and faking `wp_is_block_theme()` means registering a real block theme and switching to it, which no test in the repo does today. Happy to add one if someone has a nicer way in :)
