### PR TITLE
WPDS tokens: enqueue tokens shipping in WP via wp-theme handle

### DIFF
--- a/projects/packages/admin-ui/changelog/update-support-wp-theme
+++ b/projects/packages/admin-ui/changelog/update-support-wp-theme
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Prefer Core's wp-theme stylesheet for WPDS design tokens when it is registered.

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -544,7 +544,7 @@ class Admin_Menu {
 			return;
 		}
 
-		// @todo Remove when WP 7.1 is the minimum version.
+		// @todo Remove this, the called function, and the webpack entrypoint it registers when WP 7.1 is the minimum version.
 		self::register_design_tokens_style();
 		wp_enqueue_style( self::DESIGN_TOKENS_HANDLE );
 	}

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -544,6 +544,7 @@ class Admin_Menu {
 			return;
 		}
 
+		// @todo Remove when WP 7.1 is the minimum version.
 		self::register_design_tokens_style();
 		wp_enqueue_style( self::DESIGN_TOKENS_HANDLE );
 	}

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -36,11 +36,9 @@ class Admin_Menu {
 	const UPGRADE_MENU_FALLBACK_URL = 'https://jetpack.com/upgrade/';
 
 	/**
-	 * Handle for the shared, token-only WPDS design-tokens stylesheet.
+	 * Handle for the bundled WPDS design-tokens stylesheet.
 	 *
-	 * Registered once and enqueued on every Jetpack admin page so that
-	 * `var(--wpds-*)` values resolve at runtime instead of falling back to
-	 * their hand-written hex defaults.
+	 * Fallback when Core/Gutenberg has not registered the `wp-theme` style.
 	 *
 	 * @var string
 	 */
@@ -531,29 +529,29 @@ class Admin_Menu {
 	}
 
 	/**
-	 * Enqueues the shared, token-only WPDS design-tokens stylesheet.
+	 * Enqueues WPDS design tokens so `var(--wpds-*)` values resolve at runtime.
 	 *
-	 * Single entry point for any consumer that needs WPDS `var(--wpds-*)` values
-	 * to resolve at runtime on a Jetpack admin page. Registers the handle on
-	 * first use (idempotent) and enqueues it; the caller is responsible for
-	 * scoping the call to the right page(s). Since admin-ui is a dependency of
-	 * the Jetpack plugin and the modernized packages, both the plugin's
-	 * legacy/wrap_ui gate and this package's own dashboards call through here,
-	 * so the handle has a single owner and there is no duplicated enqueue logic.
+	 * Prefer Core/Gutenberg's `wp-theme` style when registered; otherwise ship
+	 * the bundled copy. The caller scopes the call to the right page(s).
 	 *
 	 * @return void
 	 */
 	public static function enqueue_design_tokens() {
+		// Style handle, not the JS polyfill. Registered since WP 7.1 (and by Gutenberg):
+		// https://make.wordpress.org/core/2026/07/31/design-system-theming-in-wordpress-7-1/
+		if ( wp_style_is( 'wp-theme', 'registered' ) ) {
+			wp_enqueue_style( 'wp-theme' );
+			return;
+		}
+
 		self::register_design_tokens_style();
 		wp_enqueue_style( self::DESIGN_TOKENS_HANDLE );
 	}
 
 	/**
-	 * Registers the shared, token-only WPDS design-tokens stylesheet.
+	 * Registers the bundled, token-only WPDS design-tokens stylesheet.
 	 *
-	 * The stylesheet only defines `:root{--wpds-*}` custom properties (no
-	 * component or class styles), giving every Jetpack admin page a single
-	 * runtime source for design tokens. It is safe to call repeatedly:
+	 * Used only when `wp-theme` is not registered. Safe to call repeatedly:
 	 * wp_register_style() is a no-op once the handle is registered.
 	 *
 	 * @return void

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -537,7 +537,7 @@ class Admin_Menu {
 	 * @return void
 	 */
 	public static function enqueue_design_tokens() {
-		// Style handle, not the JS polyfill. Registered since WP 7.1 (and by Gutenberg):
+		// Registered since WP 7.1 (and by Gutenberg):
 		// https://make.wordpress.org/core/2026/07/31/design-system-theming-in-wordpress-7-1/
 		if ( wp_style_is( 'wp-theme', 'registered' ) ) {
 			wp_enqueue_style( 'wp-theme' );

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -108,6 +108,15 @@ class Admin_Menu_Test extends TestCase {
 		wp_deregister_script( 'jetpack-admin-ui-upgrade-menu' );
 		wp_dequeue_style( Admin_Menu::HIDE_CORE_NOTICES_HANDLE );
 		wp_deregister_style( Admin_Menu::HIDE_CORE_NOTICES_HANDLE );
+		wp_dequeue_style( Admin_Menu::DESIGN_TOKENS_HANDLE );
+		wp_deregister_style( Admin_Menu::DESIGN_TOKENS_HANDLE );
+		wp_dequeue_script( 'wp-theme' );
+		wp_deregister_script( 'wp-theme' );
+
+		$styles        = wp_styles();
+		$styles->queue = array();
+		$styles->to_do = array();
+		$styles->done  = array();
 
 		$reflection = new \ReflectionClass( Admin_Menu::class );
 
@@ -127,6 +136,15 @@ class Admin_Menu_Test extends TestCase {
 				$initialized->setAccessible( true );
 			}
 			$initialized->setValue( null, false );
+		}
+
+		if ( $reflection->hasProperty( 'page_hooks' ) ) {
+			$page_hooks = $reflection->getProperty( 'page_hooks' );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$page_hooks->setAccessible( true );
+			}
+			$page_hooks->setValue( null, array() );
 		}
 	}
 
@@ -556,6 +574,73 @@ class Admin_Menu_Test extends TestCase {
 		do_action( 'admin_menu' );
 
 		$this->assertUpgradeMenuItemAbsent();
+	}
+
+	/**
+	 * Bundled tokens enqueue when Core has not registered the wp-theme style.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_design_tokens_falls_back_when_wp_theme_style_is_unregistered() {
+		wp_dequeue_style( 'wp-theme' );
+		wp_deregister_style( 'wp-theme' );
+
+		Admin_Menu::enqueue_design_tokens();
+
+		$this->assertTrue( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'wp-theme', 'registered' ) );
+	}
+
+	/**
+	 * Core/Gutenberg's wp-theme style is used when that handle is registered.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_design_tokens_uses_wp_theme_when_registered() {
+		if ( ! wp_style_is( 'wp-theme', 'registered' ) ) {
+			wp_register_style( 'wp-theme', 'https://example.com/wp-theme.css', array(), '7.1' );
+		}
+
+		Admin_Menu::enqueue_design_tokens();
+
+		$this->assertTrue( wp_style_is( 'wp-theme', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
+	}
+
+	/**
+	 * The wp-theme script polyfill must not be treated as the tokens stylesheet.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_design_tokens_ignores_wp_theme_script_handle() {
+		wp_dequeue_style( 'wp-theme' );
+		wp_deregister_style( 'wp-theme' );
+		wp_register_script( 'wp-theme', 'https://example.com/theme.js', array(), '1.0.0', true );
+
+		Admin_Menu::enqueue_design_tokens();
+
+		$this->assertTrue( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'wp-theme', 'registered' ) );
+	}
+
+	/**
+	 * Design tokens load only on pages registered through Admin_Menu.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_design_tokens_is_scoped_to_registered_pages() {
+		wp_dequeue_style( 'wp-theme' );
+		wp_deregister_style( 'wp-theme' );
+
+		$hook = Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'tokens_scope_menu', '__return_null' );
+
+		Admin_Menu::maybe_enqueue_design_tokens( 'plugins.php' );
+
+		$this->assertFalse( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
+
+		Admin_Menu::maybe_enqueue_design_tokens( $hook );
+
+		$this->assertTrue( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
 	}
 
 	/**

--- a/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
+++ b/projects/packages/admin-ui/tests/php/Admin_Menu_Test.php
@@ -608,42 +608,6 @@ class Admin_Menu_Test extends TestCase {
 	}
 
 	/**
-	 * The wp-theme script polyfill must not be treated as the tokens stylesheet.
-	 *
-	 * @return void
-	 */
-	public function test_enqueue_design_tokens_ignores_wp_theme_script_handle() {
-		wp_dequeue_style( 'wp-theme' );
-		wp_deregister_style( 'wp-theme' );
-		wp_register_script( 'wp-theme', 'https://example.com/theme.js', array(), '1.0.0', true );
-
-		Admin_Menu::enqueue_design_tokens();
-
-		$this->assertTrue( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
-		$this->assertFalse( wp_style_is( 'wp-theme', 'registered' ) );
-	}
-
-	/**
-	 * Design tokens load only on pages registered through Admin_Menu.
-	 *
-	 * @return void
-	 */
-	public function test_maybe_enqueue_design_tokens_is_scoped_to_registered_pages() {
-		wp_dequeue_style( 'wp-theme' );
-		wp_deregister_style( 'wp-theme' );
-
-		$hook = Admin_Menu::add_menu( 'Test', 'Test', 'edit_posts', 'tokens_scope_menu', '__return_null' );
-
-		Admin_Menu::maybe_enqueue_design_tokens( 'plugins.php' );
-
-		$this->assertFalse( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
-
-		Admin_Menu::maybe_enqueue_design_tokens( $hook );
-
-		$this->assertTrue( wp_style_is( Admin_Menu::DESIGN_TOKENS_HANDLE, 'enqueued' ) );
-	}
-
-	/**
 	 * Upgrade menu stylesheet is enqueued for a free-plan site.
 	 *
 	 * The sidebar is visible everywhere in wp-admin, so styles must load globally.


### PR DESCRIPTION
See: https://make.wordpress.org/core/2026/07/31/design-system-theming-in-wordpress-7-1/

WP 7.1+ now includes WPDS tokens in a stylesheet available via the `wp-theme` style handle. They're not (yet) automatically loaded on every WP Admin page load, but eventually will be.

Meanwhile, admin pages that do load it, will use the `wp-theme` style slug so this avoids loading the tokens twice (Jetpack's own method and core's).

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Rely on `wp-theme` tokens shipped with WP 7.1+ or Gutenberg plugin. When not present, load the version compiled and bundled by the plugin. As the minimum supported version of Jetpack moves to 7.1, then we can simply enqueue the core file.

This will slightly improve speed as well since there will be less CSS to load.

Summary of how the WPDS theming system works:

- Jetpack uses lint-validated real tokens in its styles; lint rule checks tokens against the defined version of `@wordpress/theme` so updating the dependency will bring future new tokens available Jetpack.
- Plugin injects fallbacks (i.e. `var( --wpds-example, fallback-here )`) at build time (with just a few [exceptions](https://github.com/Automattic/jetpack/blob/b1c6171e0f7b789e1f66caadd2ed85373f2ae2f8/tools/js-tools/stylelint.config.base.mjs#L87-L98) left) based on the defined version of `@wordpress/theme`. Fallbacks are helpful when wpds tokens end up not defined in core yet (Jetpack's tokens are ahead of minimum WP version. That's normal.
- The actual runtime tokens get applied from the active WordPress or Gutenberg.
- As actual token values keep shifting across WP versions (see [recent PRs](https://github.com/WordPress/gutenberg/pulls?q=is%3Apr+state%3Aclosed++label%3A%22%5BPackage%5D+Theme%22)), the actual values will vary and sometimes conflict with the values in fallbacks. That's by design; Jetpack UIs will always look consistent with the rest of the installed WP/Gutenberg version.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test all Jetpack admin pages continue to have runtime tokens, both classic admin, editor and WP Build dashboards.
