### PR TITLE
Premium Analytics: ask the readiness question when switching the new Traffic tab off

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2113-switch-off-readiness-question
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2113-switch-off-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Ask the same readiness question when switching the new Traffic tab off, and point to the Modules Visibility setting to switch it back on.

--- a/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/feedback/feedback-fields.tsx
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { type StatsFeedbackRating } from '@jetpack-premium-analytics/data';
 import { Stack, Text, TextareaControl } from '@jetpack-premium-analytics/externals';
 import { RadioControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
@@ -13,21 +12,6 @@ export type StatsFeedbackReadiness = 'ready' | 'almost' | 'not_yet';
 // Tracks drops an event whose properties are oversized, so a pasted essay would
 // cost us the answer too.
 const COMMENT_MAX_LENGTH = 1000;
-
-/**
- * The comparison scale, worst to best. `value` is the score that reaches Tracks.
- *
- * @return The options, in scale order.
- */
-function ratingOptions() {
-	return [
-		{ value: '1', label: __( 'Much worse', 'jetpack-premium-analytics-pkg' ) },
-		{ value: '2', label: __( 'A bit worse', 'jetpack-premium-analytics-pkg' ) },
-		{ value: '3', label: __( 'About the same', 'jetpack-premium-analytics-pkg' ) },
-		{ value: '4', label: __( 'A bit better', 'jetpack-premium-analytics-pkg' ) },
-		{ value: '5', label: __( 'Much better', 'jetpack-premium-analytics-pkg' ) },
-	];
-}
 
 /**
  * The readiness answers, readiest first. `value` is what reaches Tracks.
@@ -113,69 +97,12 @@ function CommentField( { question, comment, onCommentChange }: CommentFieldProps
 	);
 }
 
-type ComparisonFieldsProps = {
-	rating: StatsFeedbackRating | undefined;
-	onRatingChange: ( rating: StatsFeedbackRating ) => void;
-	comment: string;
-	onCommentChange: ( comment: string ) => void;
-	commentQuestion: string;
-};
-
-/**
- * The comparison scale, above an open question the surface chooses.
- *
- * @param {ComparisonFieldsProps} props                 - Component props.
- * @param {number|undefined}      props.rating          - The score picked, if any.
- * @param {Function}              props.onRatingChange  - Called with the score picked.
- * @param {string}                props.comment         - The comment as typed.
- * @param {Function}              props.onCommentChange - Called with the comment as typed.
- * @param {string}                props.commentQuestion - The question above the comment box.
- * @return The two fields.
- */
-export function ComparisonFields( {
-	rating,
-	onRatingChange,
-	comment,
-	onCommentChange,
-	commentQuestion,
-}: ComparisonFieldsProps ) {
-	const comparisonQuestion = __(
-		'Compared with the existing Traffic tab in Stats, the new Traffic tab is:',
-		'jetpack-premium-analytics-pkg'
-	);
-
-	const selectRating = useCallback(
-		( value: string ) => onRatingChange( Number( value ) as StatsFeedbackRating ),
-		[ onRatingChange ]
-	);
-
-	return (
-		<>
-			<Stack direction="column" gap="sm">
-				<Question>{ comparisonQuestion }</Question>
-				<RadioControl
-					hideLabelFromVision
-					label={ comparisonQuestion }
-					options={ ratingOptions() }
-					selected={ rating?.toString() }
-					onChange={ selectRating }
-				/>
-			</Stack>
-
-			<CommentField
-				question={ commentQuestion }
-				comment={ comment }
-				onCommentChange={ onCommentChange }
-			/>
-		</>
-	);
-}
-
 type ReadinessFieldsProps = {
 	readiness: StatsFeedbackReadiness | undefined;
 	onReadinessChange: ( readiness: StatsFeedbackReadiness ) => void;
 	comment: string;
 	onCommentChange: ( comment: string ) => void;
+	question?: string;
 };
 
 /**
@@ -186,6 +113,7 @@ type ReadinessFieldsProps = {
  * @param {Function}             props.onReadinessChange - Called with the answer picked.
  * @param {string}               props.comment           - The comment as typed.
  * @param {Function}             props.onCommentChange   - Called with the comment as typed.
+ * @param {string}               props.question          - The readiness question, if the surface words it its own way.
  * @return The two fields.
  */
 export function ReadinessFields( {
@@ -193,11 +121,11 @@ export function ReadinessFields( {
 	onReadinessChange,
 	comment,
 	onCommentChange,
+	question,
 }: ReadinessFieldsProps ) {
-	const readinessQuestion = __(
-		'Is the new Traffic tab ready to replace the old one?',
-		'jetpack-premium-analytics-pkg'
-	);
+	const readinessQuestion =
+		question ??
+		__( 'Is the new Traffic tab ready to replace the old one?', 'jetpack-premium-analytics-pkg' );
 
 	// "What's missing?" reads oddly after "Yes", where nothing is missing by definition.
 	const commentQuestion =

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/dashboard-options-menu.test.tsx
@@ -368,12 +368,14 @@ describe( 'switching the new Traffic tab off', () => {
 
 		const dialog = screen.getByRole( 'dialog', { name: 'Switch off the new Traffic tab?' } );
 		expect( dialog ).toHaveTextContent(
-			"You'll go back to your current Stats. You can switch the new Traffic tab on again from the banner there."
+			"You'll go back to your current Stats. You can switch the new Traffic tab on again from the Modules Visibility setting."
 		);
 		// The reason is asked for, never required: the button is live with nothing filled in.
-		expect( within( dialog ).getByRole( 'radiogroup' ) ).toBeInTheDocument();
+		expect( within( dialog ).getByRole( 'radiogroup' ) ).toHaveAccessibleName(
+			'Before you go — is the new Traffic tab ready to replace the old one?'
+		);
 		expect(
-			within( dialog ).getByRole( 'textbox', { name: 'What made you switch it off?' } )
+			within( dialog ).getByRole( 'textbox', { name: "What's missing?" } )
 		).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Switch it off' } ) ).toBeEnabled();
 		expect( mockApiFetch ).not.toHaveBeenCalled();
@@ -386,19 +388,23 @@ describe( 'switching the new Traffic tab off', () => {
 		expect( mockReturnToClassicStats ).not.toHaveBeenCalled();
 	} );
 
-	it( 'still asks how it compares, on the five points worst to best', async () => {
-		await openConfirmation();
+	it( 'asks the same readiness question as the feedback modal', async () => {
+		const user = await openConfirmation();
 
-		const scale = screen.getAllByRole< HTMLInputElement >( 'radio' );
+		const answers = screen.getAllByRole< HTMLInputElement >( 'radio' );
 
-		expect( scale.map( point => point.labels?.[ 0 ]?.textContent ) ).toEqual( [
-			'Much worse',
-			'A bit worse',
-			'About the same',
-			'A bit better',
-			'Much better',
+		expect( answers.map( answer => answer.labels?.[ 0 ]?.textContent ) ).toEqual( [
+			READY,
+			ALMOST,
+			'Not yet',
 		] );
-		expect( scale.map( point => point.value ) ).toEqual( [ '1', '2', '3', '4', '5' ] );
+		expect( answers.map( answer => answer.value ) ).toEqual( [ 'ready', 'almost', 'not_yet' ] );
+
+		await user.click( screen.getByRole( 'radio', { name: READY } ) );
+
+		expect(
+			screen.getByRole( 'textbox', { name: "Any other feedback you'd like to share?" } )
+		).toBeInTheDocument();
 	} );
 
 	it( 'writes the opt-in off, reports it, and returns the reader to classic Stats', async () => {
@@ -427,24 +433,25 @@ describe( 'switching the new Traffic tab off', () => {
 	it( 'carries the reason on the event and hands the comment to Happiness', async () => {
 		const user = await openConfirmation();
 
-		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
+		await user.click( screen.getByRole( 'radio', { name: ALMOST } ) );
 		await user.type( screen.getByRole( 'textbox' ), '  Too slow on my phone  ' );
 		await user.click( screen.getByRole( 'button', { name: 'Switch it off' } ) );
 
 		await waitFor( () => expect( mockReturnToClassicStats ).toHaveBeenCalledTimes( 1 ) );
 		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_premium_analytics_preview_disable', {
-			rating: 2,
+			readiness: 'almost',
 			comment: 'Too slow on my phone',
 		} );
 		expect( mockApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
 				path: '/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats/user-feedback',
 				method: 'POST',
-				data: expect.objectContaining( {
+				data: {
+					source_url: window.location.href,
 					product_name: 'Jetpack Stats v2 (switched off)',
-					feedback: 'Too slow on my phone',
-					rating: 2,
-				} ),
+					feedback:
+						'[Ready to replace the old Traffic tab? Almost, a few things missing] Too slow on my phone',
+				},
 			} )
 		);
 		expect( mockApiFetch ).toHaveBeenCalledWith(
@@ -468,6 +475,12 @@ describe( 'switching the new Traffic tab off', () => {
 		expect( mockRecordEvent ).toHaveBeenCalledWith( 'jetpack_premium_analytics_preview_disable', {
 			comment: 'No comparison on the map',
 		} );
+		// No answer picked, so the comment goes to Happiness without a readiness prefix.
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				data: expect.objectContaining( { feedback: 'No comparison on the map' } ),
+			} )
+		);
 		expect( warn ).toHaveBeenCalledTimes( 1 );
 		warn.mockRestore();
 	} );
@@ -524,7 +537,7 @@ describe( 'switching the new Traffic tab off', () => {
 	it( 'starts over after Cancel', async () => {
 		const user = await openConfirmation();
 
-		await user.click( screen.getByRole( 'radio', { name: 'A bit worse' } ) );
+		await user.click( screen.getByRole( 'radio', { name: 'Not yet' } ) );
 		await user.type( screen.getByRole( 'textbox' ), 'Too slow' );
 		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
 		await waitFor( () => expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument() );
@@ -532,7 +545,7 @@ describe( 'switching the new Traffic tab off', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Page options' } ) );
 		await user.click( await screen.findByRole( 'menuitem', { name: 'Switch off the preview' } ) );
 
-		expect( screen.getByRole( 'radio', { name: 'A bit worse' } ) ).not.toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'Not yet' } ) ).not.toBeChecked();
 		expect( screen.getByRole( 'textbox' ) ).toHaveValue( '' );
 	} );
 

--- a/projects/packages/premium-analytics/routes/dashboard/components/options-menu/switch-off-dialog.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/options-menu/switch-off-dialog.tsx
@@ -5,7 +5,6 @@ import {
 	disableDashboard,
 	getApiErrorCode,
 	submitStatsUserFeedback,
-	type StatsFeedbackRating,
 } from '@jetpack-premium-analytics/data';
 import { Button, Dialog, Notice, Stack } from '@jetpack-premium-analytics/externals';
 import { useCallback, useRef, useState } from '@wordpress/element';
@@ -14,7 +13,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useTrackEvent } from '../../hooks/use-track-event';
-import { ComparisonFields } from '../feedback/feedback-fields';
+import {
+	ReadinessFields,
+	readinessSummary,
+	type StatsFeedbackReadiness,
+} from '../feedback/feedback-fields';
 import { returnToClassicStats } from './return-to-classic-stats';
 
 // Reaches Happiness as the subject line, so it tells exit feedback from the in-product kind.
@@ -34,11 +37,11 @@ type SwitchOffDialogProps = {
  */
 export function SwitchOffDialog( { onClose }: SwitchOffDialogProps ) {
 	const trackEvent = useTrackEvent();
-	const [ rating, setRating ] = useState< StatsFeedbackRating >();
+	const [ readiness, setReadiness ] = useState< StatsFeedbackReadiness >();
 	const [ comment, setComment ] = useState( '' );
 	const [ isSwitchingOff, setIsSwitchingOff ] = useState( false );
 	const [ hasFailed, setHasFailed ] = useState( false );
-	// A confirmation opens on its way out, not on the first point of a scale nobody has to fill in.
+	// A confirmation opens on its way out, not on the first of answers nobody has to pick.
 	const cancelRef = useRef< HTMLButtonElement >( null );
 
 	// Escape and the backdrop wait for the write too: a success would otherwise navigate away
@@ -73,15 +76,14 @@ export function SwitchOffDialog( { onClose }: SwitchOffDialogProps ) {
 
 		// After the write so a retry counts once, before the navigation so the beacon is not cut short.
 		trackEvent( 'jetpack_premium_analytics_preview_disable', {
-			...( rating === undefined ? {} : { rating } ),
+			...( readiness === undefined ? {} : { readiness } ),
 			...( message ? { comment: message } : {} ),
 		} );
 
 		// Happiness gets the comment too; a failure there must not keep the reader here.
 		if ( message ) {
 			await submitStatsUserFeedback( {
-				rating,
-				comment: message,
+				comment: readiness ? `${ readinessSummary( readiness ) } ${ message }` : message,
 				productName: PRODUCT_NAME,
 			} ).catch( ( error: unknown ) => {
 				// eslint-disable-next-line no-console -- swallowed on purpose, so this is the only trace
@@ -90,7 +92,7 @@ export function SwitchOffDialog( { onClose }: SwitchOffDialogProps ) {
 		}
 
 		returnToClassicStats();
-	}, [ comment, rating, trackEvent ] );
+	}, [ comment, readiness, trackEvent ] );
 
 	return (
 		<Dialog.Root open onOpenChange={ handleOpenChange }>
@@ -103,19 +105,19 @@ export function SwitchOffDialog( { onClose }: SwitchOffDialogProps ) {
 							</Dialog.Title>
 							<Dialog.Description>
 								{ __(
-									"You'll go back to your current Stats. You can switch the new Traffic tab on again from the banner there.",
+									"You'll go back to your current Stats. You can switch the new Traffic tab on again from the Modules Visibility setting.",
 									'jetpack-premium-analytics-pkg'
 								) }
 							</Dialog.Description>
 						</Stack>
 
-						<ComparisonFields
-							rating={ rating }
-							onRatingChange={ setRating }
+						<ReadinessFields
+							readiness={ readiness }
+							onReadinessChange={ setReadiness }
 							comment={ comment }
 							onCommentChange={ setComment }
-							commentQuestion={ __(
-								'What made you switch it off?',
+							question={ __(
+								'Before you go — is the new Traffic tab ready to replace the old one?',
 								'jetpack-premium-analytics-pkg'
 							) }
 						/>

--- a/projects/plugins/jetpack/changelog/wooa7s-2113-switch-off-readiness-question
+++ b/projects/plugins/jetpack/changelog/wooa7s-2113-switch-off-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Ask the same readiness question when switching the new Traffic tab off, and point to the Modules Visibility setting to switch it back on.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2113-switch-off-readiness-question
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2113-switch-off-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Ask the same readiness question when switching the new Traffic tab off, and point to the Modules Visibility setting to switch it back on.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2113-switch-off-readiness-question
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2113-switch-off-readiness-question
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Ask the same readiness question when switching the new Traffic tab off, and point to the Modules Visibility setting to switch it back on.


### PR DESCRIPTION
Fixes WOOA7S-2113

## Proposed changes
* The "Switch off the new Traffic tab?" dialog now asks the same readiness question as the **Any feedback?** modal, instead of the old five-point comparison scale: "Before you go — is the new Traffic tab ready to replace the old one?", with "Yes, I'd be happy to switch now", "Almost — there are a few things missing" and "Not yet".
* The open question under it is "What's missing?", and becomes "Any other feedback you'd like to share?" once the answer is "Yes", the same as in the feedback modal.
* The sub-copy now points to the Modules Visibility setting in Stats, which is where the new Traffic tab can be switched back on, rather than to a banner.
* `jetpack_premium_analytics_preview_disable` now carries `readiness` (`ready` | `almost` | `not_yet`) instead of `rating`. A comment sent to Happiness gets the answer as a `[Ready to replace the old Traffic tab? …]` prefix, as the feedback modal already does, and no `rating` field.
* `ReadinessFields` takes an optional `question` so the dialog can add its "Before you go —" lead-in. `ComparisonFields` and the five-point scale had no other callers and are removed.
* Answering stays optional: "Switch it off" works with nothing filled in.

#52109 left this dialog on the comparison scale on purpose. Design has since asked for the two surfaces to match (see WOOA7S-2113), so this PR brings the dialog in line.

## Related product discussion/links
* WOOA7S-2113
* #52109, which introduced the readiness question in the feedback modal

## Does this pull request change what data or activity we track or use?
Yes, for one existing event, in the same way #52109 did for the feedback modal. `jetpack_premium_analytics_preview_disable` keeps its name, but its optional `rating` property (an integer 1 to 5) is replaced by `readiness` (one of three fixed strings). No new category of data is collected, and the free-text `comment` property is unchanged. The event still fires when nothing is filled in, with neither property.

## Testing instructions

* Build Premium Analytics and Jetpack, then open the new Traffic tab as an administrator: `wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`.
* Open **Page options** (top right) and choose **Switch off the preview**.
* Confirm the dialog reads:
  * Title: "Switch off the new Traffic tab?"
  * Sub-copy: "You'll go back to your current Stats. You can switch the new Traffic tab on again from the Modules Visibility setting."
  * Question: "Before you go — is the new Traffic tab ready to replace the old one?", with the three answers above.
  * Box label: "What's missing?"
* Pick "Yes, I'd be happy to switch now" and confirm the box relabels to "Any other feedback you'd like to share?". Pick another answer and confirm it goes back to "What's missing?".
* Press **Cancel** and confirm nothing changes. Reopen the dialog and confirm it starts empty.
* Optional, on a test site you can switch back on afterwards: pick an answer, type a comment, and press **Switch it off** with the network panel open. The `pixel.wp.com/t.gif` request for `jetpack_premium_analytics_preview_disable` should carry `readiness=<answer>` and no `rating`, the `POST` to `.../jetpack-stats/user-feedback` should have the `[Ready to replace the old Traffic tab? …]` prefix in `feedback`, and you should land on classic Stats.

What I tested: the Jest suite for the options menu (32 tests), ESLint, the package typecheck, and the dialog on a local Docker site (the screenshots below, opened and cancelled). I did not press **Switch it off** on a live site. The Tracks and Happiness payloads are covered by the Jest tests only.

## Before / after

Captured on a local Docker site, same session, dialog only.

| Before (trunk) | After (this PR) |
| --- | --- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-2113-update-traffic-tab-switch-off-modal-content/before-switch-off.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-2113-update-traffic-tab-switch-off-modal-content/after-switch-off.png) |

With "Yes, I'd be happy to switch now" picked, the open question changes:

<img src="https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-2113-update-traffic-tab-switch-off-modal-content/after-switch-off-yes.png" width="450px" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBFRkG94GLghBnk4Wo7ru1
