### PR TITLE
Newsletter: drop redundant link rel attributes, and let Stack lay out the Freshly Pressed list

### DIFF
--- a/projects/packages/newsletter/changelog/update-newsletter-writing-prompt-link-rel
+++ b/projects/packages/newsletter/changelog/update-newsletter-writing-prompt-link-rel
@@ -1,5 +1,5 @@
 Significance: patch
 Type: changed
-Comment: Drop redundant rel attributes from the writing prompt links; the Link component and modern browsers handle it.
+Comment: Drop redundant rel attributes from the writing prompt links, and let Stack lay out the Freshly Pressed list. No user-facing change.
 
 

--- a/projects/packages/newsletter/changelog/update-newsletter-writing-prompt-link-rel
+++ b/projects/packages/newsletter/changelog/update-newsletter-writing-prompt-link-rel
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Drop redundant rel attributes from the writing prompt links; the Link component and modern browsers handle it.
+
+

--- a/projects/packages/newsletter/src/writing-prompt/freshly-pressed-panel.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/freshly-pressed-panel.jsx
@@ -47,8 +47,11 @@ const FreshlyPressedPanel = ( { posts, siteType } ) => (
 		>
 			{ __( "Freshly Pressed highlights our team's favorite blog posts.", 'jetpack-newsletter' ) }
 		</Text>
-		<ul
+		<Stack
 			className="wpcom-daily-writing-prompt--freshly-pressed-list"
+			direction="column"
+			gap="sm"
+			render={ <ul /> }
 			aria-label={ __( 'Freshly Pressed posts', 'jetpack-newsletter' ) }
 		>
 			{ posts.map( ( post, position ) => (
@@ -56,7 +59,7 @@ const FreshlyPressedPanel = ( { posts, siteType } ) => (
 					<FreshlyPressedPost post={ post } position={ position } siteType={ siteType } />
 				</li>
 			) ) }
-		</ul>
+		</Stack>
 	</Stack>
 );
 

--- a/projects/packages/newsletter/src/writing-prompt/freshly-pressed-panel.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/freshly-pressed-panel.jsx
@@ -24,13 +24,7 @@ const FreshlyPressedPost = ( { post, position, siteType } ) => {
 	}, [ post, position, siteType ] );
 
 	return (
-		<Link
-			tone="neutral"
-			href={ post.permalink }
-			openInNewTab
-			rel="noreferrer noopener"
-			onClick={ recordClick }
-		>
+		<Link tone="neutral" href={ post.permalink } openInNewTab onClick={ recordClick }>
 			{ decodeEntities( post.title ) }
 		</Link>
 	);

--- a/projects/packages/newsletter/src/writing-prompt/prompt-panel.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/prompt-panel.jsx
@@ -52,7 +52,6 @@ const PromptPanel = ( { prompts, siteType, readerUrl, openReaderInNewTab, onRead
 								tone="neutral"
 								href={ readerUrl }
 								openInNewTab={ openReaderInNewTab }
-								rel={ openReaderInNewTab ? 'noreferrer noopener' : undefined }
 								onClick={ onReaderClick }
 							/>
 						),
@@ -153,7 +152,6 @@ const PromptPanel = ( { prompts, siteType, readerUrl, openReaderInNewTab, onRead
 							<Link
 								href={ new URL( prompt.answered_link ).toString() }
 								openInNewTab
-								rel="noreferrer noopener"
 								onClick={ recordViewResponsesClick }
 							>
 								{ __( 'View responses', 'jetpack-newsletter' ) }

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -51,9 +51,6 @@
 }
 
 .wpcom-daily-writing-prompt--freshly-pressed-list {
-	display: flex;
-	flex-direction: column;
-	gap: var(--wpds-dimension-gap-sm);
 	margin: 0;
 
 	li {

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
@@ -142,7 +142,6 @@ const WritingPrompt = () => {
 					tone="neutral"
 					href={ readerUrl }
 					openInNewTab={ openReaderInNewTab }
-					rel={ openReaderInNewTab ? 'noreferrer noopener' : undefined }
 					onClick={ recordReaderClick }
 				>
 					{ __( 'Read the blogs and topics you follow', 'jetpack-newsletter' ) }

--- a/projects/packages/newsletter/tests/freshly-pressed.test.tsx
+++ b/projects/packages/newsletter/tests/freshly-pressed.test.tsx
@@ -164,7 +164,6 @@ describe( 'Freshly Pressed tab', () => {
 			'https://wordpress.com/reader/blogs/34/posts/12?algo=freshly-pressed&ref=dashboard_widget'
 		);
 		expect( link ).toHaveAttribute( 'target', '_blank' );
-		expect( link ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
 	} );
 
 	it( 'decodes HTML entities in post titles', async () => {

--- a/projects/packages/newsletter/tests/freshly-pressed.test.tsx
+++ b/projects/packages/newsletter/tests/freshly-pressed.test.tsx
@@ -152,6 +152,14 @@ describe( 'Freshly Pressed tab', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'keeps the list semantics when Stack renders the ul', async () => {
+		await renderSettled();
+		await openFreshlyPressedTab();
+
+		const list = screen.getByRole( 'list', { name: 'Freshly Pressed posts' } );
+		expect( within( list ).getAllByRole( 'listitem' ) ).toHaveLength( 2 );
+	} );
+
 	it( 'lists the posts as Reader links once the tab is opened', async () => {
 		await renderSettled();
 		await openFreshlyPressedTab();

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -231,7 +231,6 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 			name: /Read the blogs and topics you follow/,
 		} );
 		expect( readerLink ).toHaveAttribute( 'target', '_blank' );
-		expect( readerLink ).toHaveAttribute( 'rel', expect.stringContaining( 'noopener' ) );
 	} );
 
 	it( 'opens the Reader link in the same tab on wpcom platforms', async () => {
@@ -244,7 +243,6 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 			name: /Read the blogs and topics you follow/,
 		} );
 		expect( readerLink ).not.toHaveAttribute( 'target' );
-		expect( readerLink ).not.toHaveAttribute( 'rel' );
 	} );
 
 	it( 'falls back to the bare Reader URL when site data is unavailable', async () => {


### PR DESCRIPTION
Follow-up to #52077, addressing post-merge review feedback from @simison.

## Proposed changes

Two review comments on #52077, both on the Daily Writing Prompt widget. Neither change is user-facing.

* **Drop the `rel` attributes.** Every link in the widget passed `rel="noreferrer noopener"` alongside `openInNewTab`. Neither half is needed: browsers have implied `noopener` for `target="_blank"` for years, and `@wordpress/ui`'s `Link` deliberately doesn't set `rel` at all. `noreferrer` also strips the `Referer` header from links we control and want attribution for. Every browser in `@wordpress/browserslist-config` is well past the implicit-`noopener` cutoff, so there's no security tradeoff here.
* **Let `Stack` lay out the Freshly Pressed list.** The list hand-rolled `display: flex`, `flex-direction: column` and a `--wpds-dimension-gap-sm` gap in SCSS, which is what `Stack` already does, and what the surrounding panel uses. `Stack` takes a `render` prop, so the `<ul>` keeps its own element and its list semantics; only the three layout declarations go. Computed styles come out identical, and the inline gap `Stack` emits carries an `8px` fallback the raw SCSS var didn't have.

Of note, the suite had nothing asserting the list was a list, so a `render` prop that silently fell back to a `div` would have sailed through all 31 tests. I added one for the role and its items, and checked it goes red without the prop :)

## Related product discussion/links

* Review comments: [`rel` attributes](https://github.com/Automattic/jetpack/pull/52077#discussion_r3978230904), [`Stack` for the list styles](https://github.com/Automattic/jetpack/pull/52077#discussion_r3978249308)
* [WordPress/gutenberg#79743](https://github.com/WordPress/gutenberg/pull/79743) and [WordPress/gutenberg#26914](https://github.com/WordPress/gutenberg/issues/26914), on why `Link` doesn't set `rel`

## Does this pull request change what data or activity we track or use?

No. The Tracks events on these links are untouched.

## Testing instructions

On a connected Jetpack site (a Jurassic Ninja site works well), go to **wp-admin → Dashboard** and find the **Daily Writing Prompt** widget.

* Both tabs should look exactly as they did before: same spacing between the Freshly Pressed entries, same layout everywhere else.
* Inspect any link that opens WordPress.com ("View responses", "Read the blogs and topics you follow", or any Freshly Pressed post). It should still carry `target="_blank"`, and no longer carry a `rel` attribute. Clicking it still opens the Reader in a new tab.
* Inspect the Freshly Pressed list itself. It should still be a `<ul>` with `aria-label="Freshly Pressed posts"` and one `<li>` per post, with a computed `display: flex`, `flex-direction: column` and `row-gap: 8px`.

`jetpack test js packages/newsletter` covers the same ground.
