### PR TITLE
ci: Fix `git diff` in pr-is-up-to-date.yml

### DIFF
--- a/.github/workflows/pr-is-up-to-date.yml
+++ b/.github/workflows/pr-is-up-to-date.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Determine tags for PR or tag and paths for tag push
         id: determine
         env:
+          BASE: ${{ github.event.pull_request.base.sha }}
           REF: ${{ github.event.pull_request.head.sha }}
         run: |
           TAGS=()
@@ -44,8 +45,14 @@ jobs:
               PATHS="${TAG#pr-update-to-}"
             fi
           else
-            TMP="$(git -c core.quotepath=off diff --name-only "origin/trunk...${REF}" projects/*/*/ | sed -nE 's!^(projects/[^/]+/[^/]+)/.*!pr-update-to-\1!p' | sort -u)"
-            mapfile -t TAGS <<<"$TMP"
+            while IFS= read -r T; do
+              if [[ -n "$( git ls-remote --tags origin "$T" 2>/dev/null )" ]]; then
+                echo "Touched $T"
+                TAGS+=( "$T" )
+              else
+                echo "Touched $T, but that hasn't been created yet so ignore it"
+              fi
+            done < <( git -c core.quotepath=off diff --name-only "${BASE}...${REF}" projects/ | sed -nE 's!^(projects/[^/]+/[^/]+)/.*!pr-update-to-\1!p' | sort -u )
             TAGS+=( pr-update-to )
           fi
           echo "pr-tags=${TAGS[*]}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The `deepen-to-merge-base` action doesn't necessarily update `origin/trunk`. Use the actual base sha of the PR instead of assuming.

Then also fix it to properly ignore tags that haven't been created yet (e.g. on the PR for a new project), where before it was only accidentally doing so through having checked out trunk and filtering the diff based on what directories existed in that checkout at `projects/*/*/`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Fork it, and make a PR on the fork.
  * [x] https://github.com/anomiex/jetpack/actions/runs/34498677277/job/102943594501
