### PR TITLE
Likes: guide block-theme users to the Like block

### DIFF
--- a/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/likes.jsx
@@ -3,6 +3,7 @@ import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { __, _x } from '@wordpress/i18n';
 import { Component } from 'react';
 import BlockThemeNotice from 'components/block-theme-notice';
+import Button from 'components/button';
 import Card from 'components/card';
 import { withModuleSettingsFormHelpers } from 'components/module-settings/with-module-settings-form-helpers';
 import { ModuleToggle } from 'components/module-toggle';
@@ -20,13 +21,50 @@ export const Likes = withModuleSettingsFormHelpers(
 			} );
 		}
 
+		switchToLikeBlock = () => {
+			analytics.tracks.recordEvent( 'jetpack_wpa_module_toggle', {
+				module: 'likes',
+				toggled: 'off',
+			} );
+
+			this.props.updateOptions(
+				{ likes: false },
+				{
+					progress: __( 'Deactivating legacy Like buttons…', 'jetpack' ),
+					success: __( 'Like buttons have been deactivated.', 'jetpack' ),
+				}
+			);
+		};
+
 		render() {
-			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'likes' );
-			const siteAdminUrl = this.props.siteAdminUrl;
-			const isActive = this.props.getOptionValue( 'likes' );
-			const isBlockTheme = this.props.isBlockTheme;
-			const hasLikeBlock = this.props.hasLikeBlock;
+			const unavailableInOfflineMode = this.props.isUnavailableInOfflineMode( 'likes' ),
+				siteAdminUrl = this.props.siteAdminUrl,
+				hasLikeBlock = this.props.hasLikeBlock,
+				isBlockTheme = this.props.isBlockTheme,
+				isActive = this.props.getOptionValue( 'likes' );
+
 			const shouldShowLikeBlock = isBlockTheme && hasLikeBlock;
+			const likeTemplateUrl =
+				siteAdminUrl && this.props.themeStylesheet
+					? `${ siteAdminUrl }site-editor.php?p=%2Fwp_template%2F${ encodeURIComponent(
+							this.props.themeStylesheet
+					  ) }%2F%2Fsingle&canvas=edit`
+					: '';
+			const shouldUseLikeBlockAction = shouldShowLikeBlock && likeTemplateUrl;
+			const isForcedActive = isActive && this.props.getModule?.( 'likes' )?.override === 'active';
+			let description = __(
+				'The Like button is a way for people on WordPress.com to show their appreciation for your content.',
+				'jetpack'
+			);
+			if ( shouldUseLikeBlockAction ) {
+				description = isActive
+					? __( 'Legacy Like buttons cannot be customized on block themes.', 'jetpack' )
+					: _x(
+							'Add the Like block to your theme’s template.',
+							'Like block migration instruction',
+							'jetpack'
+					  );
+			}
 
 			/**
 			 * Like block configuration link.
@@ -49,6 +87,55 @@ export const Likes = withModuleSettingsFormHelpers(
 				);
 			};
 
+			/**
+			 * Use the legacy toggle where needed; otherwise guide block themes through
+			 * deactivating legacy likes before configuring the Like block.
+			 *
+			 * @return {import('react').ReactNode} The likes module action.
+			 */
+			const moduleAction = () => {
+				const toggle = (
+					<ModuleToggle
+						slug="likes"
+						disabled={
+							isForcedActive || unavailableInOfflineMode || this.props.isSavingAnyOption( 'likes' )
+						}
+						activated={ isActive }
+						toggleModule={ this.props.toggleModuleNow }
+					>
+						<span className="jp-form-toggle-explanation">
+							{ __( 'Add Like buttons to your posts and pages', 'jetpack' ) }
+						</span>
+					</ModuleToggle>
+				);
+
+				if ( ! shouldUseLikeBlockAction ) {
+					return toggle;
+				}
+
+				if ( isForcedActive ) {
+					return toggle;
+				}
+
+				if ( isActive ) {
+					const isSwitching = this.props.isSavingAnyOption( 'likes' );
+
+					return (
+						<Button rna compact disabled={ isSwitching } onClick={ this.switchToLikeBlock }>
+							{ isSwitching
+								? _x( 'Switching…', 'Button caption', 'jetpack' )
+								: __( 'Switch to the Like block', 'jetpack' ) }
+						</Button>
+					);
+				}
+
+				return (
+					<Button rna compact href={ likeTemplateUrl } onClick={ this.trackClickConfigure }>
+						{ __( 'Open Site Editor', 'jetpack' ) }
+					</Button>
+				);
+			};
+
 			return (
 				<SettingsCard
 					{ ...this.props }
@@ -64,28 +151,16 @@ export const Likes = withModuleSettingsFormHelpers(
 								'Adds like buttons to your content so that visitors can show their appreciation or enjoyment.',
 								'jetpack'
 							),
-							link: getRedirectUrl( 'jetpack-support-likes' ),
+							link: shouldShowLikeBlock
+								? getRedirectUrl( 'jetpack-support-like-block' )
+								: getRedirectUrl( 'jetpack-support-likes' ),
 						} }
 					>
-						<p>
-							{ __(
-								'The Like button is a way for people on WordPress.com to show their appreciation for your content.',
-								'jetpack'
-							) }
-						</p>
-						<ModuleToggle
-							slug="likes"
-							disabled={ unavailableInOfflineMode || this.props.isSavingAnyOption( 'likes' ) }
-							activated={ isActive }
-							toggleModule={ this.props.toggleModuleNow }
-						>
-							<span className="jp-form-toggle-explanation">
-								{ __( 'Add Like buttons to your posts and pages', 'jetpack' ) }
-							</span>
-						</ModuleToggle>
+						<p>{ description }</p>
+						{ moduleAction() }
 					</SettingsGroup>
 
-					{ shouldShowLikeBlock && (
+					{ ! shouldUseLikeBlockAction && shouldShowLikeBlock && (
 						<div className="jp-settings-card__notice">
 							<BlockThemeNotice
 								isModuleActive={ isActive }
@@ -94,7 +169,7 @@ export const Likes = withModuleSettingsFormHelpers(
 						</div>
 					) }
 
-					{ shouldShowLikeBlock && configCard() }
+					{ shouldShowLikeBlock && ! shouldUseLikeBlockAction && configCard() }
 				</SettingsCard>
 			);
 		}

--- a/projects/plugins/jetpack/_inc/client/sharing/test/likes.test.jsx
+++ b/projects/plugins/jetpack/_inc/client/sharing/test/likes.test.jsx
@@ -1,0 +1,201 @@
+import userEvent from '@testing-library/user-event';
+import analytics from 'lib/analytics';
+import { render, screen } from 'test/test-utils';
+import { Likes } from '../likes';
+
+jest.mock( '@automattic/jetpack-components', () => ( {
+	getRedirectUrl: jest.fn( key => `https://jetpack.com/redirect/?source=${ key }` ),
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isWpcomPlatformSite: jest.fn().mockReturnValue( false ),
+} ) );
+
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+		recordJetpackClick: jest.fn(),
+	},
+} ) );
+
+jest.mock( 'components/settings-card', () => ( { children } ) => <section>{ children }</section> );
+jest.mock( 'components/settings-group', () => ( { children } ) => <div>{ children }</div> );
+jest.mock( 'components/block-theme-notice', () => () => <div>Block theme notice</div> );
+jest.mock( 'components/module-settings/with-module-settings-form-helpers', () => ( {
+	withModuleSettingsFormHelpers: Component => Component,
+} ) );
+jest.mock( 'components/module-toggle', () => ( {
+	ModuleToggle: ( { activated, children, disabled } ) => (
+		<label htmlFor="likes-module-toggle">
+			<input
+				id="likes-module-toggle"
+				type="checkbox"
+				checked={ activated }
+				disabled={ disabled }
+				readOnly
+			/>
+			{ children }
+		</label>
+	),
+} ) );
+jest.mock( 'components/button', () => ( { children, href, ...props } ) => {
+	delete props.compact;
+	delete props.rna;
+
+	return href ? (
+		<a href={ href } { ...props }>
+			{ children }
+		</a>
+	) : (
+		<button { ...props }>{ children }</button>
+	);
+} );
+jest.mock( 'components/card', () => ( { children, href, ...props } ) => {
+	delete props.compact;
+
+	return (
+		<a href={ href } { ...props }>
+			{ children }
+		</a>
+	);
+} );
+
+const getActiveOptionValue = () => true;
+const getInactiveOptionValue = () => false;
+const getModule = () => ( { override: false } );
+const getForcedActiveModule = () => ( { override: 'active' } );
+const isNotSaving = () => false;
+const isSaving = () => true;
+const isAvailableInOfflineMode = () => false;
+const isUnavailableInOfflineMode = () => true;
+
+describe( 'Like buttons settings', () => {
+	const updateOptions = jest.fn();
+	const defaultProps = {
+		getModule,
+		getOptionValue: getInactiveOptionValue,
+		hasLikeBlock: true,
+		isBlockTheme: true,
+		isSavingAnyOption: isNotSaving,
+		isUnavailableInOfflineMode: isAvailableInOfflineMode,
+		siteAdminUrl: 'https://example.com/wp-admin/',
+		themeStylesheet: 'twentytwentyfour',
+		updateOptions,
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'requires active legacy likes to be deactivated before configuring the block', async () => {
+		const user = userEvent.setup();
+		render( <Likes { ...defaultProps } getOptionValue={ getActiveOptionValue } /> );
+
+		expect(
+			screen.getByText( 'Legacy Like buttons cannot be customized on block themes.' )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Open Site Editor' } ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Switch to the Like block' } ) );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith( 'jetpack_wpa_module_toggle', {
+			module: 'likes',
+			toggled: 'off',
+		} );
+		expect( updateOptions ).toHaveBeenCalledWith(
+			{ likes: false },
+			expect.objectContaining( {
+				progress: 'Deactivating legacy Like buttons…',
+				success: 'Like buttons have been deactivated.',
+			} )
+		);
+	} );
+
+	it( 'links inactive legacy likes to the active theme Single template', async () => {
+		const user = userEvent.setup();
+		render( <Likes { ...defaultProps } /> );
+
+		expect(
+			screen.getByText( 'Add the Like block to your theme’s template.' )
+		).toBeInTheDocument();
+		const configureLink = screen.getByRole( 'link', { name: 'Open Site Editor' } );
+		expect( configureLink ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-admin/site-editor.php?p=%2Fwp_template%2Ftwentytwentyfour%2F%2Fsingle&canvas=edit'
+		);
+		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+		configureLink.addEventListener( 'click', event => event.preventDefault() );
+
+		await user.click( configureLink );
+
+		expect( analytics.tracks.recordJetpackClick ).toHaveBeenCalledWith( {
+			target: 'configure-like-block',
+			page: 'sharing',
+			platform: 'jetpack',
+		} );
+	} );
+
+	it( 'disables the migration action while legacy likes are being deactivated', () => {
+		render(
+			<Likes
+				{ ...defaultProps }
+				getOptionValue={ getActiveOptionValue }
+				isSavingAnyOption={ isSaving }
+			/>
+		);
+
+		expect( screen.getByRole( 'button', { name: 'Switching…' } ) ).toBeDisabled();
+	} );
+
+	it( 'keeps the legacy toggle on classic themes', () => {
+		render(
+			<Likes { ...defaultProps } getOptionValue={ getActiveOptionValue } isBlockTheme={ false } />
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+		expect( screen.queryByText( 'Block theme notice' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Configure your Like buttons' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps a forced-active module non-actionable', () => {
+		render(
+			<Likes
+				{ ...defaultProps }
+				getModule={ getForcedActiveModule }
+				getOptionValue={ getActiveOptionValue }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeDisabled();
+		expect(
+			screen.queryByRole( 'button', { name: 'Switch to the Like block' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'Open Site Editor' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the existing block-theme fallback when the exact template URL is unavailable', () => {
+		render( <Likes { ...defaultProps } themeStylesheet="" /> );
+
+		expect( screen.getByRole( 'checkbox' ) ).not.toBeChecked();
+		expect( screen.getByText( 'Block theme notice' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Configure your Like buttons' } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/wp-admin/site-editor.php?path=%2Fwp_template'
+		);
+	} );
+
+	it( 'disables the toggle in offline mode', () => {
+		render(
+			<Likes
+				{ ...defaultProps }
+				isBlockTheme={ false }
+				isUnavailableInOfflineMode={ isUnavailableInOfflineMode }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeDisabled();
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/update-likes-block-theme-action
+++ b/projects/plugins/jetpack/changelog/update-likes-block-theme-action
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Likes: Guide block-theme users from legacy Like buttons to the Like block.


### PR DESCRIPTION
Fixes CM-908

## Proposed changes

On a block theme, the Sharing and Likes cards in Jetpack → Settings → Sharing gave opposite advice. Sharing replaces the legacy toggle outright since #50355. Likes still showed the toggle, with a notice underneath telling you not to use it, so the screen offered a switch and then argued against it.

The Likes card now follows the Sharing one:

* Module active: "Legacy Like buttons cannot be customized on block themes." plus a **Switch to the Like block** button that turns the module off.
* Module inactive: "Add the Like block to your theme's template." plus **Open Site Editor**, linking to the active theme's Single template.
* Classic themes keep the toggle and the existing copy.

This works because the Like block doesn't need the `likes` module. `extensions/blocks/like/like.php` registers it on connection alone, and `render.php` pulls in `jetpack-likes-master-iframe.php` itself, so turning the module off doesn't take the block with it.

Two bits aren't a straight copy of the Sharing card:

* The toggle is now disabled when the module is force-activated (`override === 'active'`). Sharing already did this; Likes was showing a control that looked actionable and wasn't.
* Offline mode still disables the toggle. Sharing has no equivalent, so I kept the Likes behavior rather than matching for the sake of it.

Of note, this doesn't give us the single site-wide switch CM-884 asks for. It just gets rid of the contradictory advice and makes the two cards read the same.

## Related product discussion/links

* CM-908, sub-issue of CM-884
* Same change for sharing buttons: #50355

## Does this pull request change what data or activity we track or use?

No. Same `jetpack_wpa_module_toggle` and `configure-like-block` events with the same properties; they're just fired from the button now instead of the toggle.

## Testing instructions

On a connected site running a block theme (Twenty Twenty-Four or similar):

* Go to Jetpack → Settings → Sharing with Likes **on**. The Like buttons card should show "Legacy Like buttons cannot be customized on block themes." and a **Switch to the Like block** button. No toggle, no notice.
* Click it. The module deactivates, and the card switches to "Add the Like block to your theme's template." with **Open Site Editor**.
* Click **Open Site Editor**. You should land in the Single template with the canvas in edit mode, ready to drop the Like block in.
* Add the Like block, save, and view a post. Likes should render with the module off.

Then switch to a classic theme (Twenty Twenty-One):

* The card should look exactly as it did before: toggle, original description, no site editor link.
* Toggle Likes off and on. It should behave as it always did.
