### PR TITLE
changelogger: Set `maintenance.auto` false in git fixtures in tests

### DIFF
--- a/projects/packages/changelogger/changelog/fix-changelogger-git-tests
+++ b/projects/packages/changelogger/changelog/fix-changelogger-git-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Tests: Set `maintenance.auto` false in git fixtures created during tests.
+
+

--- a/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/AddCommandTest.php
@@ -62,6 +62,8 @@ class AddCommandTest extends CommandTestCase {
 			),
 		);
 		Utils::runCommand( array( 'git', 'init', '.' ), ...$args );
+		Utils::runCommand( array( 'git', 'config', '--local', 'gc.auto', '0' ), ...$args );
+		Utils::runCommand( array( 'git', 'config', '--local', 'maintenance.auto', 'false' ), ...$args );
 		Utils::runCommand( array( 'git', 'checkout', '-b', 'trunk' ), ...$args );
 		Utils::runCommand( array( 'git', 'commit', '--allow-empty', '-m', 'Empty' ), ...$args );
 		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{6}$/', $w->getDefaultFilename( $output ) );

--- a/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
+++ b/projects/packages/changelogger/tests/php/tests/src/UtilsTest.php
@@ -380,6 +380,8 @@ class UtilsTest extends TestCase {
 			),
 		);
 		Utils::runCommand( array( 'git', 'init', '-b', 'main', '.' ), ...$args );
+		Utils::runCommand( array( 'git', 'config', '--local', 'gc.auto', '0' ), ...$args );
+		Utils::runCommand( array( 'git', 'config', '--local', 'maintenance.auto', 'false' ), ...$args );
 		Utils::runCommand( array( 'git', 'add', 'in-git.txt' ), ...$args );
 		Utils::runCommand( array( 'git', 'commit', '-m', 'Commit (#123)' ), ...$args );
 


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
`git` can trigger background maintenance for some operations. There's no point to it doing this for the fixtures we create during testing, as they'll be quickly deleted, and in very rare cases the background deletion of a file might race with the test cleanup and cause a failure.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1789058261647669-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy? Triggering the failure case intentionally is pretty much impossible, but we can at least make sure the happy path is still happy.