### PR TITLE
Sharing: open the post template from the Site Editor links

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-sharing-site-editor-template-links
+++ b/projects/plugins/jetpack/changelog/fix-sharing-site-editor-template-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Sharing: Open the post template instead of the template list when linking to the Site Editor.

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -330,12 +330,8 @@ class Jetpack_Plugin_Search {
 	 * @return string
 	 */
 	private function get_sharing_block_editor_url() {
-		return add_query_arg(
-			array(
-				'p'      => '/wp_template/' . get_stylesheet() . '//single',
-				'canvas' => 'edit',
-			),
-			admin_url( 'site-editor.php' )
+		return admin_url(
+			'site-editor.php?p=' . rawurlencode( '/wp_template/' . get_stylesheet() . '//single' ) . '&canvas=edit'
 		);
 	}
 

--- a/projects/plugins/jetpack/modules/plugin-search.php
+++ b/projects/plugins/jetpack/modules/plugin-search.php
@@ -319,8 +319,23 @@ class Jetpack_Plugin_Search {
 				'module'              => 'sharing-block',
 				'sort'                => '13',
 				'learn_more_button'   => Redirect::get_url( 'jetpack-support-sharing-block' ),
-				'configure_url'       => admin_url( 'site-editor.php?path=%2Fwp_template' ),
+				'configure_url'       => $this->get_sharing_block_editor_url(),
 			),
+		);
+	}
+
+	/**
+	 * Site Editor URL for the template the Sharing Buttons block goes in.
+	 *
+	 * @return string
+	 */
+	private function get_sharing_block_editor_url() {
+		return add_query_arg(
+			array(
+				'p'      => '/wp_template/' . get_stylesheet() . '//single',
+				'canvas' => 'edit',
+			),
+			admin_url( 'site-editor.php' )
 		);
 	}
 
@@ -567,7 +582,7 @@ class Jetpack_Plugin_Search {
 			$links['jp_get_started'] = '<a
 				id="plugin-select-settings"
 				class="jetpack-plugin-search__primary jetpack-plugin-search__get-started button"
-				href="' . esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ) . '"
+				href="' . esc_url( $this->get_sharing_block_editor_url() ) . '"
 				data-module="' . esc_attr( $plugin['module'] ) . '"
 				data-track="get_started"
 				>' . esc_html__( 'Add block', 'jetpack' ) . '</a>';

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -819,12 +819,8 @@ class Sharing_Admin {
 
 		$link = $host->is_wpcom_platform() ? $wpcom_link : Redirect::get_url( 'jetpack-support-sharing-block' );
 
-		$site_editor_url = add_query_arg(
-			array(
-				'p'      => '/wp_template/' . get_stylesheet() . '//single',
-				'canvas' => 'edit',
-			),
-			admin_url( 'site-editor.php' )
+		$site_editor_url = admin_url(
+			'site-editor.php?p=' . rawurlencode( '/wp_template/' . get_stylesheet() . '//single' ) . '&canvas=edit'
 		);
 
 		?>

--- a/projects/plugins/jetpack/modules/sharedaddy/sharing.php
+++ b/projects/plugins/jetpack/modules/sharedaddy/sharing.php
@@ -819,9 +819,17 @@ class Sharing_Admin {
 
 		$link = $host->is_wpcom_platform() ? $wpcom_link : Redirect::get_url( 'jetpack-support-sharing-block' );
 
+		$site_editor_url = add_query_arg(
+			array(
+				'p'      => '/wp_template/' . get_stylesheet() . '//single',
+				'canvas' => 'edit',
+			),
+			admin_url( 'site-editor.php' )
+		);
+
 		?>
 			<div class="sharing-block-message__buttons-wrapper">
-				<a href="<?php echo esc_url( admin_url( 'site-editor.php?path=%2Fwp_template' ) ); ?>" class="button button-primary">
+				<a href="<?php echo esc_url( $site_editor_url ); ?>" class="button button-primary">
 					<?php esc_html_e( 'Go to the site editor', 'jetpack' ); ?>
 				</a>
 				<a data-target="wpcom-help-center" href="<?php echo esc_url( $link ); ?>" class="button" target="_blank" rel="noopener noreferrer">

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Plugin_Search_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Plugin_Search_Test.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Tests for the Jetpack feature hints shown among plugin search results.
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'modules/plugin-search.php';
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * Tests where the Sharing Buttons block card sends people.
+ *
+ * The URL is a contract with the Site Editor router, so these assert the encoded
+ * form rather than the parsed parameters.
+ *
+ * @covers \Jetpack_Plugin_Search::get_extra_features
+ * @covers \Jetpack_Plugin_Search::insert_module_related_links
+ */
+#[CoversMethod( Jetpack_Plugin_Search::class, 'get_extra_features' )]
+#[CoversMethod( Jetpack_Plugin_Search::class, 'insert_module_related_links' )]
+class Jetpack_Plugin_Search_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Pin the stylesheet, so the expected template URL does not depend on the test theme.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'stylesheet', array( $this, 'pin_stylesheet' ) );
+	}
+
+	/**
+	 * Release the stylesheet filter.
+	 */
+	public function tear_down() {
+		remove_filter( 'stylesheet', array( $this, 'pin_stylesheet' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stylesheet used in place of whichever theme the test suite activated.
+	 *
+	 * @return string
+	 */
+	public function pin_stylesheet() {
+		return 'twentytwentyfour';
+	}
+
+	/**
+	 * The active theme's Single template, opened for editing.
+	 *
+	 * @return string
+	 */
+	private function expected_url() {
+		return admin_url( 'site-editor.php' ) . '?p=%2Fwp_template%2Ftwentytwentyfour%2F%2Fsingle&canvas=edit';
+	}
+
+	/**
+	 * The card's Configure destination is the template, not the template list.
+	 */
+	public function test_sharing_block_configure_url_opens_the_single_template() {
+		$features = ( new Jetpack_Plugin_Search() )->get_extra_features();
+
+		$this->assertSame( $this->expected_url(), $features['sharing-block']['configure_url'] );
+	}
+
+	/**
+	 * The card's "Add block" button uses the same destination.
+	 */
+	public function test_sharing_block_add_block_link_opens_the_single_template() {
+		$links = ( new Jetpack_Plugin_Search() )->insert_module_related_links(
+			array(),
+			array(
+				'slug'   => Jetpack_Plugin_Search::$slug,
+				'module' => 'sharing-block',
+			)
+		);
+
+		$this->assertStringContainsString(
+			'href="' . esc_url( $this->expected_url() ) . '"',
+			$links['jp_get_started']
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Plugin_Search_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Plugin_Search_Test.php
@@ -80,9 +80,8 @@ class Jetpack_Plugin_Search_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertStringContainsString(
-			'href="' . esc_url( $this->expected_url() ) . '"',
-			$links['jp_get_started']
-		);
+		$link = $links['jp_get_started'] ?? '';
+
+		$this->assertStringContainsString( 'href="' . esc_url( $this->expected_url() ) . '"', $link );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/sharedaddy/Sharing_Admin_Site_Editor_Prompt_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/sharedaddy/Sharing_Admin_Site_Editor_Prompt_Test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Tests for the Site Editor prompt on the legacy Sharing settings page.
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing.php';
+
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * Tests Sharing_Admin::site_editor_prompt_display().
+ *
+ * The URL is a contract with the Site Editor router, so this asserts the encoded
+ * form rather than the parsed parameters.
+ *
+ * @covers \Sharing_Admin::site_editor_prompt_display
+ */
+#[CoversMethod( Sharing_Admin::class, 'site_editor_prompt_display' )]
+class Sharing_Admin_Site_Editor_Prompt_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Pin the stylesheet, so the expected template URL does not depend on the test theme.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'stylesheet', array( $this, 'pin_stylesheet' ) );
+	}
+
+	/**
+	 * Release the stylesheet filter.
+	 */
+	public function tear_down() {
+		remove_filter( 'stylesheet', array( $this, 'pin_stylesheet' ) );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Stylesheet used in place of whichever theme the test suite activated.
+	 *
+	 * @return string
+	 */
+	public function pin_stylesheet() {
+		return 'twentytwentyfour';
+	}
+
+	/**
+	 * The prompt's primary button opens the template, not the template list.
+	 */
+	public function test_prompt_opens_the_active_theme_single_template() {
+		$admin = new Sharing_Admin();
+
+		ob_start();
+		$admin->site_editor_prompt_display();
+		$html = ob_get_clean();
+
+		$expected = esc_url(
+			admin_url( 'site-editor.php' ) . '?p=%2Fwp_template%2Ftwentytwentyfour%2F%2Fsingle&canvas=edit'
+		);
+
+		$this->assertStringContainsString( 'href="' . $expected . '"', $html );
+		$this->assertStringNotContainsString( 'path=%2Fwp_template', $html );
+	}
+}


### PR DESCRIPTION
Fixes CM-910

## Proposed changes

The legacy wp-admin Sharing page and the plugin-search feature card both sent people to `site-editor.php?path=%2Fwp_template`. That opens the template list rather than a template, so an owner who followed either one still had to work out which template holds the Sharing Buttons block. `?path=` is the pre-6.6 Site Editor param, too.

All three links now open the active theme's Single template with the canvas in edit mode, which is what the Settings → Sharing cards have done since #52198:

* `modules/sharedaddy/sharing.php`: the **Go to the site editor** primary button in `site_editor_prompt_display()`.
* `modules/plugin-search.php`: the `configure_url` for the "Sharing buttons block" card, and the **Add block** button on it. Both read one new private helper, so the URL is stated once per file.

The path is percent-encoded with `rawurlencode()`, which produces the same string `encodeURIComponent()` does on the dashboard side, so the two surfaces build a byte-identical URL.

### Rationale

Both platforms reach that prompt, by different routes. `should_use_site_editor()` swaps the whole services UI for `sharing_block_display()` off WordPress.com, and renders the prompt above the legacy UI on Simple. So unlike the dead React fallbacks in #52202, these are links real site owners click.

Nobody is newly sent somewhere they can't use. The plugin-search card is already block-theme-only: `sharing-block` joins `$searchable_modules` under `wp_is_block_theme()`, with `sharedaddy` offered on classic themes instead. `get_configure_url()` has no `sharing-block` case, so it passes the new URL through untouched.

I left the button copy alone. "Go to the site editor" still describes where it goes, and rewording it would mean re-translating a string for no gain.

Non-goal: this names the `single` slug without checking the active theme ships that template. Every other caller in the monorepo does the same (the dashboard cards, My Jetpack, the Newsletter settings), so fixing it properly means fixing it everywhere, and that has its own issue under CM-884.

## Related product discussion/links

* CM-910, a sub-issue of CM-884
* Follows #52198 and #52202

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need a block theme with the Sharing Buttons block available.

* Go to **Settings → Sharing** in wp-admin. Off WordPress.com the page is replaced by the block prompt; on Simple the prompt sits above the legacy buttons UI.
* Click **Go to the site editor**. It should open your theme's Single template in the editor, ready for you to insert the block, rather than dropping you on the template list.
* Go to **Plugins → Add New** and search for "sharing buttons". The Jetpack card's **Add block** button should land in the same place.
* Switch to a classic theme and search again. You should get the old Sharing module card, not the block one.
* `jp docker phpunit jetpack -- --filter='Jetpack_Plugin_Search_Test|Sharing_Admin_Site_Editor_Prompt_Test'` covers both destinations.

I couldn't run those two suites locally: this branch is in a Conductor worktree, where `jp` can't see the worktree's Compose project and the container has neither the plugin's `vendor/` nor the WordPress test library. That mattered. The first push used `add_query_arg()`, which turns out not to urlencode its values, and CI failed all three tests on `p=/wp_template/...` versus the encoded form. Phan also flagged a possibly-missing array key in one assertion. Both are fixed in cf35c32ed44.

