### PR TITLE
Backup: stop the JS suite flaking on the coverage job

### DIFF
--- a/projects/packages/backup/changelog/fix-backup-js-test-flakiness
+++ b/projects/packages/backup/changelog/fix-backup-js-test-flakiness
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Test-only: raise the Testing Library async budget and await the row roles.
+
+

--- a/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
+++ b/projects/packages/backup/src/dashboard/hooks/test/use-restore.test.ts
@@ -761,11 +761,9 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 
 		status = { ...status, status: 'finished', progress: 100 };
 
-		await waitFor( () => expect( result.current.state.phase ).toBe( 'success' ), {
-			timeout: 8000,
-		} );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'success' ) );
 		expect( result.current.state ).toEqual( { phase: 'success' } );
-	}, 15000 );
+	} );
 
 	it( 'reports an adopted restore failing, rather than silently re-arming', async () => {
 		let status: Record< string, unknown > = {
@@ -796,9 +794,9 @@ describe( 'useRestore — a restore already running when the screen opens', () =
 
 		status = { ...status, status: 'failed', message: 'Restore aborted.' };
 
-		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ), { timeout: 8000 } );
+		await waitFor( () => expect( result.current.state.phase ).toBe( 'error' ) );
 		expect( result.current.state ).toMatchObject( { message: 'Restore aborted.' } );
-	}, 15000 );
+	} );
 
 	it( 'drops the adoption when the candidate turns out to have finished', async () => {
 		// The collection's status vocabulary is not the status route's, so
@@ -1214,7 +1212,7 @@ describe( 'useRestore — a restore that starts after the screen loaded', () => 
 		expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } );
 		// The whole point: no restore was started.
 		expect( initiateCall() ).toBeUndefined();
-	}, 15000 );
+	} );
 
 	// The same guard, on the status the queue reports before it starts.
 	// A restore WordPress.com is holding is one the reader must not be
@@ -1250,7 +1248,7 @@ describe( 'useRestore — a restore that starts after the screen loaded', () => 
 
 		await waitFor( () => expect( result.current.adopted ).toEqual( { rewindId: OTHER_ID } ) );
 		expect( initiateCall() ).toBeUndefined();
-	}, 15000 );
+	} );
 
 	it( 'still starts the restore when the check cannot be read', async () => {
 		// Fail open on the read, closed on the evidence. Someone
@@ -1275,5 +1273,5 @@ describe( 'useRestore — a restore that starts after the screen loaded', () => 
 
 		await waitFor( () => expect( result.current.state.phase ).toBe( 'progress' ) );
 		expect( initiateCall() ).toBeDefined();
-	}, 15000 );
+	} );
 } );

--- a/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
+++ b/projects/packages/backup/tests/activity-list-busy-scope.test.tsx
@@ -19,7 +19,6 @@ import { INITIAL_VIEW } from '../src/dashboard/screens/overview';
 import type { View } from '@wordpress/dataviews';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
-const SETTLE = { timeout: 10000 };
 
 const row = ( id: string ) => ( {
 	activity_id: id,
@@ -92,7 +91,7 @@ it( 'keeps the rows reachable through a background refetch', async () => {
 		</QueryClientProvider>
 	);
 	await expect(
-		screen.findByRole( 'button', { name: /^Backup 1786600000/ }, SETTLE )
+		screen.findByRole( 'button', { name: /^Backup 1786600000/ } )
 	).resolves.toBeInTheDocument();
 
 	// Mount fires two queries of its own, so only a rise from here proves
@@ -120,7 +119,7 @@ it( 'still reports the page change the reader asked for', async () => {
 		</QueryClientProvider>
 	);
 	await expect(
-		screen.findByRole( 'button', { name: /^Backup 1786600000/ }, SETTLE )
+		screen.findByRole( 'button', { name: /^Backup 1786600000/ } )
 	).resolves.toBeInTheDocument();
 
 	const release = freezeNextFetch();

--- a/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
+++ b/projects/packages/backup/tests/activity-refresh-on-backup-complete.test.tsx
@@ -34,8 +34,6 @@ import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-const SETTLE = { timeout: 10000 };
-
 const OLD_REWIND = '1786644531.100';
 const NEW_REWIND = '1786644532.200';
 
@@ -163,7 +161,7 @@ describe( 'A backup finishing while the Overview is open', () => {
 		// The running backup is reported alongside the list, not in place
 		// of it, because the site already has a restore point.
 		await expect(
-			screen.findByRole( 'heading', { name: 'Older backup complete' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Older backup complete' } )
 		).resolves.toBeInTheDocument();
 		// Settle the opening burst of requests before counting, so the
 		// baseline is a resting value rather than one mid-flight.
@@ -181,12 +179,8 @@ describe( 'A backup finishing while the Overview is open', () => {
 		];
 		await pollAndSettle();
 
-		await waitFor(
-			() =>
-				expect(
-					within( activityList() ).getByText( 'Newest backup complete' )
-				).toBeInTheDocument(),
-			SETTLE
+		await waitFor( () =>
+			expect( within( activityList() ).getByText( 'Newest backup complete' ) ).toBeInTheDocument()
 		);
 
 		// Let a second refetch happen if one was going to, so the count

--- a/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
+++ b/projects/packages/backup/tests/cleared-selection-back-stack.test.tsx
@@ -27,7 +27,6 @@ import { queryClient } from '../src/dashboard/data/query-client';
 import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
-const SETTLE = { timeout: 10000 };
 const PER_PAGE = 10;
 const CLEAR = 'Clear selection';
 
@@ -152,11 +151,11 @@ function renderApp() {
  */
 async function roundTripViaDownload( view: ReturnType< typeof renderApp > ): Promise< string > {
 	const chosen = rewindId( PER_PAGE - 1 );
-	await userEvent.click( await screen.findByRole( 'button', { name: named( chosen ) }, SETTLE ) );
+	await userEvent.click( await screen.findByRole( 'button', { name: named( chosen ) } ) );
 	await waitFor( () => expect( view.state.location.search ).toEqual( { selected: chosen } ) );
 
-	await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ }, SETTLE ) );
-	const back = await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE );
+	await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ } ) );
+	const back = await screen.findByRole( 'link', { name: /Back to overview/ } );
 
 	// One new row lands while they are away — a completed restore writes one, and so does a
 	// finished backup via `useRefreshActivityOnBackupComplete` — pushing their row onto page 2.
@@ -197,7 +196,7 @@ describe( 'Coming back from Download with a row chosen', () => {
 		// One Back from the restored address lands on Download — where the trip out
 		// to Download itself came from — not on an extra step this write invented.
 		await expect(
-			screen.findByRole( 'heading', { name: 'Download backup' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Download backup' } )
 		).resolves.toBeInTheDocument();
 	} );
 
@@ -207,7 +206,7 @@ describe( 'Coming back from Download with a row chosen', () => {
 
 		// The row is on page 2 now and the list is still on page 1, so the pane
 		// cannot resolve it and hedges instead of claiming it is gone.
-		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR } ) );
 		await waitFor( () =>
 			expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument()
 		);
@@ -219,9 +218,7 @@ describe( 'Coming back from Download with a row chosen', () => {
 		// The copy admits the row may still be fine, so the discard has to be
 		// undoable — landing back on the Overview with the selection restored,
 		// not on the Download screen the return trip came from.
-		await expect(
-			screen.findByRole( 'button', { name: CLEAR }, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByRole( 'button', { name: CLEAR } ) ).resolves.toBeInTheDocument();
 		expect( view.state.location.search ).toEqual( { selected: chosen } );
 	} );
 } );
@@ -235,17 +232,15 @@ describe( 'A selection nobody chose', () => {
 		// The default renders, so a bare address below is not a pane that never resolved
 		// anything — it is genuinely nothing having been chosen.
 		await expect(
-			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) }, SETTLE )
+			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) } )
 		).resolves.toBeInTheDocument();
 		expect( view.state.location.search ).toEqual( {} );
 
-		await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ }, SETTLE ) );
-		await userEvent.click(
-			await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE )
-		);
+		await userEvent.click( await screen.findByRole( 'link', { name: /Download backup/ } ) );
+		await userEvent.click( await screen.findByRole( 'link', { name: /Back to overview/ } ) );
 
 		await expect(
-			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) }, SETTLE )
+			screen.findByRole( 'heading', { name: title( rewindId( 0 ) ) } )
 		).resolves.toBeInTheDocument();
 		expect( view.state.location.search ).toEqual( {} );
 	} );

--- a/projects/packages/backup/tests/download-file-selection.test.tsx
+++ b/projects/packages/backup/tests/download-file-selection.test.tsx
@@ -47,8 +47,6 @@ import type { BackupActivityItem } from '../src/dashboard/types/activity';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-const SETTLE = { timeout: 10000 };
-
 const ITEM: BackupActivityItem = {
 	id: 'act-cloud',
 	kind: 'backup',
@@ -186,7 +184,7 @@ describe( 'Download link carrying the file selection', () => {
 			</QueryClientProvider>
 		);
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 
 		expect( screen.getByRole( 'link', { name: /Download backup/ } ) ).toHaveAttribute(
@@ -202,7 +200,7 @@ describe( 'Download link carrying the file selection', () => {
 			</QueryClientProvider>
 		);
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select wp-config.php' } ) );
@@ -237,7 +235,7 @@ describe( 'Download link carrying the file selection', () => {
 			</QueryClientProvider>
 		);
 		await expect(
-			screen.findByRole( 'button', { name: 'Folder: themes' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Folder: themes' } )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select themes' } ) );
@@ -264,7 +262,7 @@ describe( 'Download link carrying the file selection', () => {
 			</QueryClientProvider>
 		);
 		await expect(
-			screen.findByRole( 'button', { name: 'File: orphan.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: orphan.php' } )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select orphan.php' } ) );
@@ -298,7 +296,7 @@ describe( 'Download screen without a file selection', () => {
 		// on it: the button exists and is armed, which only makes sense
 		// alongside a list of categories to arm it.
 		await expect(
-			screen.findByRole( 'button', { name: /Generate download/ }, SETTLE )
+			screen.findByRole( 'button', { name: /Generate download/ } )
 		).resolves.toBeInTheDocument();
 		for ( const label of ITEM_LABELS ) {
 			expect( screen.getByRole( 'checkbox', { name: label } ) ).toBeChecked();
@@ -324,7 +322,7 @@ describe( 'Download screen without a file selection', () => {
 		render( <DownloadStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: /Generate download/ }, SETTLE )
+			screen.findByRole( 'button', { name: /Generate download/ } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Preparing download…' ) ).not.toBeInTheDocument();
 		expect( postCalls() ).toHaveLength( 0 );
@@ -342,9 +340,7 @@ describe( 'Download screen with a file selection', () => {
 		// Sibling witness rather than bare absence: the screen has moved on
 		// to preparing the archive, which is the state that replaces the
 		// checklist. A screen that rendered nothing at all would fail here.
-		await expect(
-			screen.findByText( 'Preparing download…', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Preparing download…' ) ).resolves.toBeInTheDocument();
 
 		for ( const label of ITEM_LABELS ) {
 			expect( screen.queryByRole( 'checkbox', { name: label } ) ).not.toBeInTheDocument();
@@ -358,7 +354,7 @@ describe( 'Download screen with a file selection', () => {
 		render( <DownloadStage /> );
 
 		// Exact, for the reason given in `restore-progress-message.test.tsx`.
-		await expect( screen.findByRole( 'status', undefined, SETTLE ) ).resolves.toHaveTextContent(
+		await expect( screen.findByRole( 'status' ) ).resolves.toHaveTextContent(
 			/^Preparing download…$/
 		);
 	} );
@@ -366,9 +362,7 @@ describe( 'Download screen with a file selection', () => {
 	it( 'asks WordPress.com for the archive once, without being clicked', async () => {
 		render( <DownloadStage /> );
 
-		await expect(
-			screen.findByText( 'Preparing download…', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Preparing download…' ) ).resolves.toBeInTheDocument();
 
 		const posts = postCalls();
 		expect( posts ).toHaveLength( 1 );
@@ -379,9 +373,7 @@ describe( 'Download screen with a file selection', () => {
 	it( 'names the paths type and the entries, and no other category', async () => {
 		render( <DownloadStage /> );
 
-		await expect(
-			screen.findByText( 'Preparing download…', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Preparing download…' ) ).resolves.toBeInTheDocument();
 
 		expect( initiateCalls()[ 0 ]?.data ).toEqual( {
 			types: { paths: true },
@@ -410,9 +402,9 @@ describe( 'Download screen with a file selection', () => {
 
 		render( <DownloadStage /> );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: /Try again/ }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: /Try again/ } ) );
 
-		await waitFor( () => expect( initiateCalls() ).toHaveLength( 2 ), SETTLE );
+		await waitFor( () => expect( initiateCalls() ).toHaveLength( 2 ) );
 		expect( initiateCalls()[ 1 ]?.data ).toEqual( {
 			types: { paths: true },
 			include_path_list: [ WP_CONFIG_ID, README_ID ],
@@ -433,10 +425,10 @@ describe( 'Download screen with a file selection', () => {
 		// the job queued — so waiting on the element alone would pass on a
 		// bar that never took a number from the poll. The polled value is
 		// the assertion that matters.
-		const bar = await screen.findByRole( 'progressbar', undefined, SETTLE );
+		const bar = await screen.findByRole( 'progressbar' );
 		// A number, not a string: `toHaveValue` on `<progress>` reads
 		// `element.value`, which the DOM has already coerced.
-		await waitFor( () => expect( bar ).toHaveValue( 36 ), SETTLE );
+		await waitFor( () => expect( bar ).toHaveValue( 36 ) );
 		// The spinner is the state the bar replaces, so its departure is
 		// half the behaviour. `Spinner` renders an explicit
 		// `role="presentation"`, which is the handle on it.
@@ -454,9 +446,7 @@ describe( 'Download screen with a file selection', () => {
 
 		// Wait for a live poll first, so the flip below lands on a screen
 		// that is genuinely waiting rather than one still mid-POST.
-		await expect(
-			screen.findByRole( 'progressbar', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByRole( 'progressbar' ) ).resolves.toBeInTheDocument();
 
 		downloadStatus = {
 			id: 4242,
@@ -467,7 +457,7 @@ describe( 'Download screen with a file selection', () => {
 			error: '',
 		};
 
-		const link = await screen.findByRole( 'link', { name: 'Download the file' }, SETTLE );
+		const link = await screen.findByRole( 'link', { name: 'Download the file' } );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/archive.zip' );
 		expect( link ).toHaveAttribute( 'download' );
 		// `Notice` also speaks its text through `wp.a11y.speak`, which
@@ -488,7 +478,7 @@ describe( 'Download screen with a file selection', () => {
 		render( <DownloadStage /> );
 
 		await expect(
-			screen.findByText( "This download link isn't valid.", undefined, SETTLE )
+			screen.findByText( "This download link isn't valid." )
 		).resolves.toBeInTheDocument();
 		expect( postCalls() ).toHaveLength( 0 );
 	} );
@@ -508,7 +498,7 @@ describe( 'From the file browser to the request', () => {
 			</QueryClientProvider>
 		);
 		await expect(
-			screen.findByRole( 'button', { name: 'Folder: themes' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Folder: themes' } )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'checkbox', { name: 'Select themes' } ) );
@@ -522,9 +512,7 @@ describe( 'From the file browser to the request', () => {
 			files: new URLSearchParams( href.slice( href.indexOf( '?' ) ) ).get( 'files' ) ?? '',
 		} );
 		render( <DownloadStage /> );
-		await expect(
-			screen.findByText( 'Preparing download…', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Preparing download…' ) ).resolves.toBeInTheDocument();
 
 		// Three entries for two ticked rows: the folder's id is itself a
 		// comma-joined pair.

--- a/projects/packages/backup/tests/empty-selection.test.tsx
+++ b/projects/packages/backup/tests/empty-selection.test.tsx
@@ -44,8 +44,6 @@ import { queryClient } from '../src/dashboard/data/query-client';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-const SETTLE = { timeout: 10000 };
-
 /** Every box in the shared checklist, by its accessible name. */
 const ITEM_LABELS = [
 	'WordPress themes',
@@ -84,7 +82,7 @@ beforeEach( () => {
  */
 async function untickEverything() {
 	for ( const label of ITEM_LABELS ) {
-		await userEvent.click( await screen.findByRole( 'checkbox', { name: label }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'checkbox', { name: label } ) );
 	}
 }
 
@@ -131,7 +129,7 @@ describe( 'Download screen with nothing selected', () => {
 
 		// Mounted and empty before anything is wrong: a live region that
 		// appears together with its first message is unreliable.
-		const hint = await screen.findByRole( 'status', undefined, SETTLE );
+		const hint = await screen.findByRole( 'status' );
 		expect( hint ).toBeEmptyDOMElement();
 		expect( button( /Generate download/ ) ).toHaveAttribute( 'aria-describedby', hint.id );
 

--- a/projects/packages/backup/tests/error-surfacing.test.tsx
+++ b/projects/packages/backup/tests/error-surfacing.test.tsx
@@ -36,17 +36,6 @@ const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected
 const CAPABILITIES = { hasBackupPlan: true, hasScan: false };
 
 /**
- * These render a whole route stage behind three sequential round-trips —
- * capabilities, then activity, then the file listing — each with its own
- * React Query state transitions. Testing Library's default `findBy`
- * window is 1s, which is comfortable locally and not on a loaded CI
- * runner under coverage instrumentation: this suite has taken 32s there
- * against 8s here. The wait is for a deterministic chain, so a longer
- * ceiling costs nothing when it passes.
- */
-const SETTLE = { timeout: 10000 };
-
-/**
  * Route requests by path so one endpoint can fail while the rest answer.
  * The gates have to pass before the body — and therefore the failure
  * under test — is ever rendered.
@@ -142,7 +131,7 @@ describe( 'activity list', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We couldn't load your site's activity.", undefined, SETTLE )
+			screen.findByText( "We couldn't load your site's activity." )
 		).resolves.toBeInTheDocument();
 		// The upstream reason is the only part a support agent can act on.
 		expect( screen.getByText( 'Service unavailable' ) ).toBeInTheDocument();
@@ -163,9 +152,7 @@ describe( 'activity list', () => {
 
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( 'No results', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'No results' ) ).resolves.toBeInTheDocument();
 		expect(
 			screen.queryByText( "We couldn't load your site's activity." )
 		).not.toBeInTheDocument();
@@ -184,7 +171,7 @@ describe( 'file browser', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We couldn't load this backup's files.", undefined, SETTLE )
+			screen.findByText( "We couldn't load this backup's files." )
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'Backup storage unreachable' ) ).toBeInTheDocument();
 		// The regression: a selection summary over a tree that isn't there.
@@ -217,13 +204,11 @@ describe( 'file browser', () => {
 
 		render( <OverviewStage /> );
 
-		await userEvent.click( await screen.findByRole( 'button', { name: /wp-content/ }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: /wp-content/ } ) );
 
 		// "we couldn't look inside" and "there is nothing inside" used to
 		// be the same output.
-		await expect(
-			screen.findByText( "Couldn't load this folder.", undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( "Couldn't load this folder." ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Empty' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/jest.config.js
+++ b/projects/packages/backup/tests/jest.config.js
@@ -10,14 +10,10 @@ module.exports = {
 	...baseConfig,
 	rootDir: path.join( __dirname, '..' ),
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest.setup.js' ],
-	// Raised above Jest's 5s default so the `SETTLE` windows the route-stage
-	// suites pass to `findBy*` can actually elapse. Those stages render
-	// behind several sequential requests and have taken well over a second
-	// on a loaded runner under coverage, which is why they ask for a longer
-	// deadline than Testing Library's 1s default — but Jest's own timeout
-	// fires first when it is lower, killing the test with a bare "Exceeded
-	// timeout" instead of Testing Library's "Unable to find an element with
-	// the text …" plus the rendered DOM. Losing that dump is losing the one
-	// thing that says what actually went wrong on CI.
+	// Must stay above the `asyncUtilTimeout` set in jest.setup.js: whichever
+	// fires first owns the failure, and Jest's own timeout reports a bare
+	// "Exceeded timeout" where Testing Library reports the missing element
+	// plus the rendered DOM. On CI that dump is the only account of what went
+	// wrong.
 	testTimeout: 20000,
 };

--- a/projects/packages/backup/tests/jest.config.js
+++ b/projects/packages/backup/tests/jest.config.js
@@ -10,10 +10,7 @@ module.exports = {
 	...baseConfig,
 	rootDir: path.join( __dirname, '..' ),
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest.setup.js' ],
-	// Must stay above the `asyncUtilTimeout` set in jest.setup.js: whichever
-	// fires first owns the failure, and Jest's own timeout reports a bare
-	// "Exceeded timeout" where Testing Library reports the missing element
-	// plus the rendered DOM. On CI that dump is the only account of what went
-	// wrong.
+	// Keep above jest.setup.js's `asyncUtilTimeout`, so a stuck wait fails with Testing
+	// Library's missing-element message and DOM dump rather than Jest's bare timeout.
 	testTimeout: 20000,
 };

--- a/projects/packages/backup/tests/jest.setup.js
+++ b/projects/packages/backup/tests/jest.setup.js
@@ -1,3 +1,10 @@
+const { configure } = require( '@testing-library/react' );
+
+// Testing Library's 1s default leaves these route-stage suites no headroom in
+// the coverage job, where every project's jest pool shares one runner and every
+// module is instrumented. Only a failing wait pays the longer budget.
+configure( { asyncUtilTimeout: 10000 } );
+
 window.JP_CONNECTION_INITIAL_STATE = {
 	userConnectionData: {
 		currentUser: {

--- a/projects/packages/backup/tests/list-state-round-trip.test.tsx
+++ b/projects/packages/backup/tests/list-state-round-trip.test.tsx
@@ -45,7 +45,6 @@ import { keys, queryClient } from '../src/dashboard/data/query-client';
 import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
-const SETTLE = { timeout: 10000 };
 
 /** Flipped per test, so the gate verdict can be made to change under a mounted screen. */
 let hasBackupPlan = true;
@@ -138,7 +137,7 @@ function row( page: number, number: number ): HTMLElement {
 async function openOverview( page: number, number: number ) {
 	const view = render( <OverviewStage /> );
 	await expect(
-		screen.findByRole( 'button', { name: rowNamed( page, number ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( page, number ) } )
 	).resolves.toBeInTheDocument();
 	return view;
 }
@@ -218,7 +217,7 @@ function mockEndpoints( {
  */
 async function roundTripVia( Stage: () => React.JSX.Element ): Promise< void > {
 	const view = render( <Stage /> );
-	const back = await screen.findByRole( 'link', { name: /Back to overview/ }, SETTLE );
+	const back = await screen.findByRole( 'link', { name: /Back to overview/ } );
 	const [ , query = '' ] = ( back.getAttribute( 'href' ) ?? '' ).split( '?' );
 	routerSearch = Object.fromEntries( new URLSearchParams( query ) );
 	view.unmount();
@@ -238,11 +237,11 @@ async function roundTripFromPage2Of20( Stage: () => React.JSX.Element ): Promise
 	await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
 	await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
 	await expect(
-		screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( 1, 20 ) } )
 	).resolves.toBeInTheDocument();
 	await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 	await expect(
-		screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
+		screen.findByRole( 'button', { name: rowNamed( 2, 20 ) } )
 	).resolves.toBeInTheDocument();
 
 	overview.unmount();
@@ -291,7 +290,7 @@ describe( 'The trip out to Download and back', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 
 		await userEvent.click( row( 2, 10 ) );
@@ -313,7 +312,7 @@ describe( 'The trip out to Download and back', () => {
 		// The detail pane resolves first — `useActivityById` scans every cached page —
 		// so the list's own rows are the later of the two.
 		await expect(
-			screen.findByRole( 'heading', { name: rowTitle( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'heading', { name: rowTitle( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 		await waitFor( () => expect( row( 2, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' ) );
 		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
@@ -328,7 +327,7 @@ describe( 'The trip out to Restore and back', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: 'View options' } ) );
 		await userEvent.click( screen.getByRole( 'radio', { name: '20' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) } )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -337,7 +336,7 @@ describe( 'The trip out to Restore and back', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 20 ) } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
 	} );
@@ -351,7 +350,7 @@ describe( 'A gate verdict that changes under the reader', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 
 		hasBackupPlan = false;
@@ -359,7 +358,7 @@ describe( 'A gate verdict that changes under the reader', () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
 		await expect(
-			screen.findByText( "This site doesn't have an active Backup plan", {}, SETTLE )
+			screen.findByText( "This site doesn't have an active Backup plan" )
 		).resolves.toBeInTheDocument();
 
 		hasBackupPlan = true;
@@ -368,7 +367,7 @@ describe( 'A gate verdict that changes under the reader', () => {
 		} );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 10 ) } ) ).not.toBeInTheDocument();
 	} );
@@ -381,7 +380,7 @@ describe( 'A fresh page load', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 		overview.unmount();
 		await roundTripVia( DownloadStage );
@@ -393,7 +392,7 @@ describe( 'A fresh page load', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) } )
 		).resolves.toBeInTheDocument();
 		expect( row( 1, 10 ) ).toHaveAttribute( 'aria-pressed', 'true' );
 		expect( screen.queryByRole( 'button', { name: rowNamed( 2, 10 ) } ) ).not.toBeInTheDocument();
@@ -407,7 +406,7 @@ describe( 'A remembered place that no longer exists', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -422,7 +421,7 @@ describe( 'A remembered place that no longer exists', () => {
 		// The row is the positive: without the clamp the list asks for page 2 of a
 		// one-page log and DataViews renders "No results" with no footer.
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
 	} );
@@ -434,7 +433,7 @@ describe( 'A remembered place that no longer exists', () => {
 		const overview = await openOverview( 1, 10 );
 		await userEvent.click( screen.getByRole( 'button', { name: 'Next page' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 10 ) } )
 		).resolves.toBeInTheDocument();
 
 		overview.unmount();
@@ -446,7 +445,7 @@ describe( 'A remembered place that no longer exists', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 1, 10 ) } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'No results' ) ).not.toBeInTheDocument();
 	} );
@@ -469,7 +468,7 @@ describe( 'A remembered place that no longer exists', () => {
 
 		const view = render( <OverviewStage /> );
 
-		await expect( screen.findByText( 'No results', {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'No results' ) ).resolves.toBeInTheDocument();
 		expect( activityRequests() ).not.toContain( '0/20' );
 
 		view.unmount();
@@ -499,7 +498,7 @@ describe( 'A remembered place the log cannot answer for', () => {
 
 		// The reason, where DataViews would otherwise say "No results".
 		await expect(
-			screen.findByRole( 'button', { name: 'Try again' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Try again' } )
 		).resolves.toBeInTheDocument();
 		expect( screen.getByText( 'The activity log is unavailable.' ) ).toBeInTheDocument();
 
@@ -512,7 +511,7 @@ describe( 'A remembered place the log cannot answer for', () => {
 		activityFails = false;
 		await userEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: rowNamed( 1, 20 ) } ) ).not.toBeInTheDocument();
 
@@ -538,7 +537,7 @@ describe( 'A remembered place asked for with no connection', () => {
 
 		// The premise: paused, not failing. Nothing is sent, so nothing is learned.
 		await expect(
-			screen.findByRole( 'group', { name: 'Backup activity' }, SETTLE )
+			screen.findByRole( 'group', { name: 'Backup activity' } )
 		).resolves.toBeInTheDocument();
 		expect( activityRequests() ).toEqual( [] );
 
@@ -546,7 +545,7 @@ describe( 'A remembered place asked for with no connection', () => {
 
 		// Page 2 is what resumes, so nothing moved the reader while they were offline.
 		await expect(
-			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) }, SETTLE )
+			screen.findByRole( 'button', { name: rowNamed( 2, 20 ) } )
 		).resolves.toBeInTheDocument();
 		expect( activityRequests() ).not.toContain( '1/20' );
 
@@ -584,7 +583,7 @@ describe( 'Clearing a selection that came from memory', () => {
 
 		const view = render( <OverviewStage /> );
 		await expect(
-			screen.findByRole( 'button', { name: 'Clear selection' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Clear selection' } )
 		).resolves.toBeInTheDocument();
 		// The write-back effect puts the remembered row in the address once `<Gates>`
 		// admits the body — same trip the rest of this file waits out.

--- a/projects/packages/backup/tests/next-scheduled-backup.test.tsx
+++ b/projects/packages/backup/tests/next-scheduled-backup.test.tsx
@@ -38,10 +38,6 @@ import type { ReactNode } from 'react';
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const SITE = 'example.wordpress.com';
 
-// The route stages render behind several sequential requests and have
-// taken well over Testing Library's 1s default on a loaded runner.
-const SETTLE = { timeout: 10000 };
-
 // Everything Jest's fake timers can replace *except* `Date`. Faking the timer functions
 // too would take Testing Library's polling with it — `waitFor` switches implementation
 // the moment it sees a mocked `setTimeout` — and the suite would hang on the first
@@ -153,7 +149,7 @@ function renderStageWithProbe() {
  * @return The probe element, once it has something to show.
  */
 function scheduleIsAvailable(): Promise< HTMLElement > {
-	return screen.findByTestId( 'schedule-probe', undefined, SETTLE );
+	return screen.findByTestId( 'schedule-probe' );
 }
 
 /**
@@ -733,7 +729,7 @@ describe( 'on the Overview', () => {
 
 		render( <OverviewStage /> );
 
-		const line = await screen.findByText( /^Next full backup/, undefined, SETTLE );
+		const line = await screen.findByText( /^Next full backup/ );
 		expect( line ).toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
 
 		// Placement, not just presence: `.jpb-overview` is a two-column grid above
@@ -765,12 +761,12 @@ describe( 'on the Overview', () => {
 
 		// The running backup is reported…
 		await expect(
-			screen.findByText( 'Your backup will be ready soon', undefined, SETTLE )
+			screen.findByText( 'Your backup will be ready soon' )
 		).resolves.toBeInTheDocument();
 		// …and so is the next one.
-		await expect(
-			screen.findByText( /^Next full backup/, undefined, SETTLE )
-		).resolves.toHaveTextContent( /^Next full backup: Oct 22, 10:00-10:59 AM\.$/ );
+		await expect( screen.findByText( /^Next full backup/ ) ).resolves.toHaveTextContent(
+			/^Next full backup: Oct 22, 10:00-10:59 AM\.$/
+		);
 	} );
 
 	it( 'says nothing when the backup state could not be read', async () => {
@@ -786,7 +782,7 @@ describe( 'on the Overview', () => {
 		// Synchronized on the failure being reported *and* the schedule being
 		// available, neither of which the mutation under test removes.
 		await expect(
-			screen.findByText( "We couldn't check your site's backup status.", undefined, SETTLE )
+			screen.findByText( "We couldn't check your site's backup status." )
 		).resolves.toBeInTheDocument();
 		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
@@ -808,11 +804,7 @@ describe( 'on the Overview', () => {
 		renderStageWithProbe();
 
 		await expect(
-			screen.findByText(
-				"Your latest backup didn't complete. We'll try again shortly.",
-				undefined,
-				SETTLE
-			)
+			screen.findByText( "Your latest backup didn't complete. We'll try again shortly." )
 		).resolves.toBeInTheDocument();
 		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();
@@ -828,7 +820,7 @@ describe( 'on the Overview', () => {
 		renderStageWithProbe();
 
 		await expect(
-			screen.findByText( 'Your first cloud backup will be ready soon', undefined, SETTLE )
+			screen.findByText( 'Your first cloud backup will be ready soon' )
 		).resolves.toBeInTheDocument();
 		await expect( scheduleIsAvailable() ).resolves.toHaveTextContent( 'Oct 22' );
 		expect( screen.queryByText( /^Next full backup/ ) ).not.toBeInTheDocument();

--- a/projects/packages/backup/tests/no-plan-quiet.test.tsx
+++ b/projects/packages/backup/tests/no-plan-quiet.test.tsx
@@ -30,7 +30,6 @@ import { BACKUPS_POLL_INTERVAL_MS } from '../src/dashboard/hooks/use-backups';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const DISCONNECTED = { isRegistered: false, hasConnectedOwner: false, isUserConnected: false };
-const SETTLE = { timeout: 10000 };
 
 const NO_PLAN = "This site doesn't have an active Backup plan";
 const UPSELL_CTA = /^Get VaultPress Backup$/;
@@ -197,7 +196,7 @@ describe( 'A connected site with no Backup plan', () => {
 	it( 'asks WordPress.com only what the upsell itself can act on', async () => {
 		render( <OverviewStage /> );
 
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 		await pollTicks( 1 );
 
 		// The gate's own read: the positive that says this screen came from a real answer.
@@ -217,9 +216,7 @@ describe( 'A connected site with no Backup plan', () => {
 
 		// `/site/backup/size` is the header button's read alone, so the absence
 		// above is only meaningful next to the absence of the button.
-		await expect(
-			screen.findByRole( 'link', { name: UPSELL_CTA }, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByRole( 'link', { name: UPSELL_CTA } ) ).resolves.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'button', { name: /Back up now|Backup in progress/ } )
 		).not.toBeInTheDocument();
@@ -227,7 +224,7 @@ describe( 'A connected site with no Backup plan', () => {
 
 	it( 'never starts the backup poll', async () => {
 		render( <OverviewStage /> );
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 
 		await pollTicks( 4 );
 
@@ -244,7 +241,7 @@ describe( 'The same site once it has a plan', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: 'Backup in progress' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Backup in progress' } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
 
@@ -264,7 +261,7 @@ describe( 'The Restore screen behind the same gates', () => {
 	it( 'renders the upsell without asking what restores exist', async () => {
 		render( <RestoreStage /> );
 
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 		await pollTicks( 1 );
 
 		// The gate's own read: the positive that says this screen came from a real answer.
@@ -276,7 +273,7 @@ describe( 'The Restore screen behind the same gates', () => {
 		restoreRunning = true;
 
 		render( <RestoreStage /> );
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 
 		await pollTicks( 4 );
 
@@ -296,7 +293,7 @@ describe( 'The Restore screen behind the same gates', () => {
 
 		render( <RestoreStage /> );
 
-		await expect( screen.findByText( NOT_CONNECTED, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NOT_CONNECTED ) ).resolves.toBeInTheDocument();
 		await pollTicks( 1 );
 
 		// `useCapabilities` is disabled without a user connection, so the gate itself
@@ -333,9 +330,9 @@ describe( 'The Restore screen across a gate flip', () => {
 		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
 
 		render( <RestoreStage /> );
-		await user.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+		await user.click( await screen.findByRole( 'button', { name: /Confirm restore/ } ) );
 		await expect(
-			screen.findByText( /queued and will begin automatically/, undefined, SETTLE )
+			screen.findByText( /queued and will begin automatically/ )
 		).resolves.toBeInTheDocument();
 		const posts = () => mockApiFetch.mock.calls.filter( ( [ o ] ) => o?.method === 'POST' ).length;
 		expect( posts() ).toBe( 1 );
@@ -345,14 +342,14 @@ describe( 'The Restore screen across a gate flip', () => {
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 
 		hasBackupPlan = true;
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
 		await expect(
-			screen.findByText( /queued and will begin automatically/, undefined, SETTLE )
+			screen.findByText( /queued and will begin automatically/ )
 		).resolves.toBeInTheDocument();
 
 		expect( screen.queryByRole( 'button', { name: /Confirm restore/ } ) ).not.toBeInTheDocument();
@@ -371,7 +368,7 @@ describe( 'The Restore screen once the site has a plan', () => {
 		render( <RestoreStage /> );
 
 		await expect(
-			screen.findByRole( 'progressbar', { name: RESTORING }, SETTLE )
+			screen.findByRole( 'progressbar', { name: RESTORING } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
 
@@ -396,7 +393,7 @@ describe( 'The Download screen behind the same gates', () => {
 	it( 'renders the upsell without asking for the archive the link named', async () => {
 		render( <DownloadStage /> );
 
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 		await pollTicks( 4 );
 
 		// The gate's own read: the positive that says this screen came from a real answer.
@@ -416,7 +413,7 @@ describe( 'The Download screen behind the same gates', () => {
 
 		render( <DownloadStage /> );
 
-		await expect( screen.findByText( NOT_CONNECTED, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NOT_CONNECTED ) ).resolves.toBeInTheDocument();
 		await pollTicks( 4 );
 
 		// `useCapabilities` is disabled without a user connection, so the gate itself
@@ -439,7 +436,7 @@ describe( 'The Download screen across a gate flip', () => {
 
 		render( <DownloadStage /> );
 		await expect(
-			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+			screen.findByRole( 'progressbar', { name: PREPARING } )
 		).resolves.toBeInTheDocument();
 		expect( asked( DOWNLOAD_PATH ) ).toBe( 1 );
 
@@ -448,7 +445,7 @@ describe( 'The Download screen across a gate flip', () => {
 		await act( async () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
-		await expect( screen.findByText( NO_PLAN, {}, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_PLAN ) ).resolves.toBeInTheDocument();
 
 		// The archive is still being built, so only the hook's own gate can stop the
 		// poll: nothing about the download itself has changed.
@@ -461,7 +458,7 @@ describe( 'The Download screen across a gate flip', () => {
 			await queryClient.invalidateQueries( { queryKey: keys.capabilities() } );
 		} );
 		await expect(
-			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+			screen.findByRole( 'progressbar', { name: PREPARING } )
 		).resolves.toBeInTheDocument();
 
 		// The bar alone only proves `downloadId` survived; the count proves the poll
@@ -484,7 +481,7 @@ describe( 'The Download screen once the site has a plan', () => {
 		render( <DownloadStage /> );
 
 		await expect(
-			screen.findByRole( 'progressbar', { name: PREPARING }, SETTLE )
+			screen.findByRole( 'progressbar', { name: PREPARING } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NO_PLAN ) ).not.toBeInTheDocument();
 

--- a/projects/packages/backup/tests/overview-takeover.test.tsx
+++ b/projects/packages/backup/tests/overview-takeover.test.tsx
@@ -31,11 +31,6 @@ import { ACTIVITY_LOG_DEFAULT_PER_PAGE } from '../src/dashboard/hooks/use-activi
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-// Testing Library's default `findBy` window is one second. These stages
-// render behind several sequential requests, and a loaded CI runner under
-// coverage has taken well over that for the same work locally-green here.
-const SETTLE = { timeout: 10000 };
-
 /**
  * One rewindable-activity entry, in WPCOM's shape.
  *
@@ -204,8 +199,8 @@ describe( 'Overview takeover', () => {
 			await queryClient.invalidateQueries( { queryKey: keys.activityLogRoot() } );
 		} );
 		// The parked state reaches the observer after the invalidation settles, so
-		// asserting straight away passes without looking. Wait on the state itself,
-		// not a delay: this file's SETTLE exists because CI blows past fixed windows.
+		// asserting straight away passes without looking. Wait on the state itself
+		// rather than a fixed delay, which CI blows past.
 		await waitFor( () =>
 			expect(
 				queryClient.getQueryState(
@@ -242,7 +237,7 @@ describe( 'Overview takeover', () => {
 
 		// The activity log says what went wrong...
 		await expect(
-			screen.findByText( "We couldn't load your site's activity.", undefined, SETTLE )
+			screen.findByText( "We couldn't load your site's activity." )
 		).resolves.toBeInTheDocument();
 		// ...instead of the panel claiming a first backup is coming.
 		expect(
@@ -262,9 +257,7 @@ describe( 'Failing backups with the takeover suppressed', () => {
 		render( <OverviewStage /> );
 
 		// The list is kept...
-		await expect(
-			screen.findByText( 'Backup complete', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeInTheDocument();
 		// ...and the reader is told anyway, with a way to get help.
 		expect( screen.getByText( "We're having trouble backing up your site." ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'link', { name: /Get in touch with us/ } ) ).toBeInTheDocument();
@@ -276,7 +269,7 @@ describe( 'Failing backups with the takeover suppressed', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We're having trouble backing up your site.", undefined, SETTLE )
+			screen.findByText( "We're having trouble backing up your site." )
 		).resolves.toBeInTheDocument();
 	} );
 } );
@@ -294,7 +287,7 @@ describe( 'Backup-state read failure', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByText( "We couldn't check your site's backup status.", undefined, SETTLE )
+			screen.findByText( "We couldn't check your site's backup status." )
 		).resolves.toBeInTheDocument();
 	} );
 
@@ -307,9 +300,7 @@ describe( 'Backup-state read failure', () => {
 		// reader came for are still listed beside it. Both halves are
 		// asserted — the row alone renders on trunk too, so without the
 		// notice assertion this test would pass with the fix reverted.
-		await expect(
-			screen.findByText( 'Backup complete', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeInTheDocument();
 		expect(
 			screen.getByText( "We couldn't check your site's backup status." )
 		).toBeInTheDocument();

--- a/projects/packages/backup/tests/progress-bar-names.test.tsx
+++ b/projects/packages/backup/tests/progress-bar-names.test.tsx
@@ -44,8 +44,6 @@ const REWIND_ID = '1786663613.9425';
 const RESTORE_ID = 912682;
 const DOWNLOAD_ID = 5150;
 
-const SETTLE = { timeout: 10000 };
-
 /**
  * A restore-status payload in the shape the bridge projects.
  *
@@ -103,7 +101,7 @@ function arrange( {
  * @param name - The submit button's accessible name.
  */
 async function submit( name: RegExp ) {
-	await userEvent.click( await screen.findByRole( 'button', { name }, SETTLE ) );
+	await userEvent.click( await screen.findByRole( 'button', { name } ) );
 }
 
 /**
@@ -116,7 +114,7 @@ async function submit( name: RegExp ) {
  * @return The progress bar.
  */
 async function progressBarNamed( name: string ) {
-	return screen.findByRole( 'progressbar', { name }, SETTLE );
+	return screen.findByRole( 'progressbar', { name } );
 }
 
 beforeEach( () => {

--- a/projects/packages/backup/tests/restore-lost-track.test.tsx
+++ b/projects/packages/backup/tests/restore-lost-track.test.tsx
@@ -44,8 +44,6 @@ import { queryClient } from '../src/dashboard/data/query-client';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-const SETTLE = { timeout: 10000 };
-
 const RESTORE_ID = 912682;
 
 /**
@@ -94,7 +92,7 @@ beforeEach( () => {
  */
 async function findMessage() {
 	await expect(
-		screen.findAllByText( /We've lost track of this restore/, undefined, SETTLE )
+		screen.findAllByText( /We've lost track of this restore/ )
 	).resolves.not.toHaveLength( 0 );
 }
 
@@ -102,7 +100,7 @@ async function findMessage() {
  * Start a restore with the default six-of-six checklist.
  */
 async function startRestore() {
-	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ } ) );
 }
 
 describe( 'a restore that has gone out of sight', () => {
@@ -178,9 +176,7 @@ describe( 'a restore that definitely is not running', () => {
 
 		// `findAllBy` for the same reason as `findMessage`: `Notice` mirrors
 		// its text into the live region.
-		await expect(
-			screen.findAllByText( 'Restore aborted.', undefined, SETTLE )
-		).resolves.not.toHaveLength( 0 );
+		await expect( screen.findAllByText( 'Restore aborted.' ) ).resolves.not.toHaveLength( 0 );
 		expect( screen.getByRole( 'button', { name: /Try again/ } ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Error notice' ) ).toBeInTheDocument();
 	} );

--- a/projects/packages/backup/tests/restore-progress-message.test.tsx
+++ b/projects/packages/backup/tests/restore-progress-message.test.tsx
@@ -25,7 +25,6 @@ import { queryClient } from '../src/dashboard/data/query-client';
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 const RESTORE_ID = 912682;
 const REWIND_ID = '1786663613.9425';
-const SETTLE = { timeout: 10000 };
 
 /**
  * Answer capabilities and the initiate POST, then let the status poll
@@ -73,7 +72,7 @@ beforeEach( () => {
  * Start a restore with the default six-of-six checklist.
  */
 async function startRestore() {
-	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ }, SETTLE ) );
+	await userEvent.click( await screen.findByRole( 'button', { name: /Confirm restore/ } ) );
 }
 
 describe( 'the Restore screen during a running restore', () => {
@@ -84,7 +83,7 @@ describe( 'the Restore screen during a running restore', () => {
 		await startRestore();
 
 		await expect(
-			screen.findByText( 'Checking remote files: 22396', undefined, SETTLE )
+			screen.findByText( 'Checking remote files: 22396' )
 		).resolves.toBeInTheDocument();
 	} );
 
@@ -95,16 +94,12 @@ describe( 'the Restore screen during a running restore', () => {
 		await startRestore();
 		// Wait for the phase first: the idle branch's own `role="status"` is still
 		// mounted, empty, until the submission settles.
-		await expect(
-			screen.findByText( '0% complete', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( '0% complete' ) ).resolves.toBeInTheDocument();
 
 		// Exact, not `toHaveTextContent`: that matches a substring on any ancestor,
 		// so it passes with the role moved onto the whole block — which is the
 		// re-announce-every-poll regression this scoping exists to prevent.
-		await expect( screen.findByRole( 'status', undefined, SETTLE ) ).resolves.toHaveTextContent(
-			/^Restoring…$/
-		);
+		await expect( screen.findByRole( 'status' ) ).resolves.toHaveTextContent( /^Restoring…$/ );
 	} );
 
 	// Both figures, so a hardcoded `0%` cannot pass: the preflight pins it at
@@ -115,8 +110,6 @@ describe( 'the Restore screen during a running restore', () => {
 
 		await startRestore();
 
-		await expect(
-			screen.findByText( `${ percent }% complete`, undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( `${ percent }% complete` ) ).resolves.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
+++ b/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
@@ -135,9 +135,8 @@ function requestedPaths( fragment: string ): string[] {
 /**
  * The list's rows, in the order they are rendered.
  *
- * Awaited: DataViews' list layout commits each row's text a render before it
- * gives the row its `role`, so a synchronous read here finds no rows at all
- * for as long as that gap lasts.
+ * Awaited: the text callers wait on can render outside the list — the detail
+ * pane's heading, say — before the list has mounted any rows.
  *
  * @return Each row's text.
  */

--- a/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
+++ b/projects/packages/backup/tests/restore-rows-in-activity-list.test.tsx
@@ -24,10 +24,6 @@ import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-// Testing Library's default `findBy` window is one second, which these stages
-// have exceeded on a loaded runner under coverage.
-const SETTLE = { timeout: 10000 };
-
 const BACKUP_REWIND_ID = '1786644531.100';
 const RESTORE_ROW_ID = 'restore-912682';
 // 14:11 UTC; read as local time on the GMT-3 runner it would render three hours late.
@@ -139,10 +135,15 @@ function requestedPaths( fragment: string ): string[] {
 /**
  * The list's rows, in the order they are rendered.
  *
+ * Awaited: DataViews' list layout commits each row's text a render before it
+ * gives the row its `role`, so a synchronous read here finds no rows at all
+ * for as long as that gap lasts.
+ *
  * @return Each row's text.
  */
-function renderedRows(): string[] {
-	return screen.getAllByRole( 'row' ).map( row => row.textContent ?? '' );
+async function rowTexts(): Promise< string[] > {
+	const rows = await screen.findAllByRole( 'row' );
+	return rows.map( row => row.textContent ?? '' );
 }
 
 beforeEach( () => {
@@ -168,20 +169,17 @@ describe( 'a restore that has already ended', () => {
 
 	it( 'is reported in the list, in its place among the activity', async () => {
 		render( <OverviewStage /> );
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 
-		expect( renderedRows()[ 0 ] ).toContain( "Restore didn't finish" );
-		expect( renderedRows()[ 1 ] ).toContain( 'Backup complete' );
-		expect( renderedRows()[ 2 ] ).toContain( 'Plugin activated' );
+		const rows = await rowTexts();
+		expect( rows[ 0 ] ).toContain( "Restore didn't finish" );
+		expect( rows[ 1 ] ).toContain( 'Backup complete' );
+		expect( rows[ 2 ] ).toContain( 'Plugin activated' );
 	} );
 
 	it( "is stamped from WordPress.com's clock, not the browser's", async () => {
 		render( <OverviewStage /> );
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 
 		expect(
 			screen.getByText( RESTORE_RENDERED_AT, { selector: '.jpb-activity-list__date' } )
@@ -191,9 +189,7 @@ describe( 'a restore that has already ended', () => {
 
 	it( 'names the backup it was aiming at', async () => {
 		render( <OverviewStage /> );
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 
 		expect( screen.getByText( 'Restore to Aug 13, 2026, 6:08 PM' ) ).toBeVisible();
 	} );
@@ -202,9 +198,7 @@ describe( 'a restore that has already ended', () => {
 		render( <OverviewStage /> );
 		// Witness: the row is on screen, so the single request below is one
 		// that answered rather than one nobody made.
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 
 		expect( requestedPaths( '/jetpack/v4/restores' ) ).toHaveLength( 1 );
 	} );
@@ -212,9 +206,7 @@ describe( 'a restore that has already ended', () => {
 	it( 'still reads it once when the review prompt reads it too', async () => {
 		mockEndpoints( { restores: [ failedRestore() ], standalone: true } );
 		render( <OverviewStage /> );
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 
 		expect( requestedPaths( '/jetpack/v4/restores' ) ).toHaveLength( 1 );
 	} );
@@ -224,7 +216,7 @@ describe( 'a restore that has already ended', () => {
 		render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'heading', { name: "Restore didn't finish" }, SETTLE )
+			screen.findByRole( 'heading', { name: "Restore didn't finish" } )
 		).resolves.toBeVisible();
 		expect( screen.queryByText( NOT_ON_THIS_PAGE ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( NOT_AMONG_RECENT ) ).not.toBeInTheDocument();
@@ -241,9 +233,7 @@ describe( 'a restore still under way', () => {
 		mockEndpoints( { restores: [ failedRestore( { status: 'running' } ) ] } );
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( 'Restore in progress', undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( 'Restore in progress' ) ).resolves.toBeVisible();
 		expect( screen.queryByText( "Restore didn't finish" ) ).not.toBeInTheDocument();
 	} );
 } );
@@ -253,9 +243,7 @@ describe( 'a restore dismissed upstream', () => {
 		mockEndpoints( { restores: [ failedRestore( { dismissed: true } ) ] } );
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( "Restore didn't finish", undefined, SETTLE )
-		).resolves.toBeVisible();
+		await expect( screen.findByText( "Restore didn't finish" ) ).resolves.toBeVisible();
 	} );
 } );
 
@@ -266,10 +254,8 @@ describe( 'a collection the route could not read', () => {
 		mockEndpoints( { restores: null as unknown as unknown[] } );
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( 'Backup complete', undefined, SETTLE )
-		).resolves.toBeVisible();
-		expect( renderedRows() ).toHaveLength( 2 );
+		await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeVisible();
+		await expect( rowTexts() ).resolves.toHaveLength( 2 );
 	} );
 } );
 
@@ -281,14 +267,14 @@ describe( 'an activity feed that failed', () => {
 	it( 'still reports the failure, with restores available to fill the list', async () => {
 		render( <OverviewStage /> );
 
-		await expect( screen.findByText( ACTIVITY_FAILED, undefined, SETTLE ) ).resolves.toBeVisible();
+		await expect( screen.findByText( ACTIVITY_FAILED ) ).resolves.toBeVisible();
 		expect( screen.getByText( FAILURE_REASON ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Try again' } ) ).toBeVisible();
 	} );
 
 	it( "does not pass the restores off as the site's activity", async () => {
 		render( <OverviewStage /> );
-		await expect( screen.findByText( ACTIVITY_FAILED, undefined, SETTLE ) ).resolves.toBeVisible();
+		await expect( screen.findByText( ACTIVITY_FAILED ) ).resolves.toBeVisible();
 
 		expect( screen.queryByText( "Restore didn't finish" ) ).not.toBeInTheDocument();
 	} );
@@ -300,7 +286,7 @@ describe( 'a selected restore the collection no longer holds', () => {
 		mockEndpoints( { restores: [ failedRestore() ] } );
 		render( <OverviewStage /> );
 
-		await expect( screen.findByText( NOT_AMONG_RECENT, undefined, SETTLE ) ).resolves.toBeVisible();
+		await expect( screen.findByText( NOT_AMONG_RECENT ) ).resolves.toBeVisible();
 		expect( screen.queryByText( NOT_ON_THIS_PAGE ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Clear selection' } ) ).toBeVisible();
 	} );
@@ -319,8 +305,8 @@ describe( 'a refetch that failed with rows still on screen', () => {
 		mockEndpoints( { restores: [ failedRestore() ], activity: 'error' } );
 		render( <OverviewStage /> );
 
-		await expect( screen.findByText( ACTIVITY_FAILED, undefined, SETTLE ) ).resolves.toBeVisible();
+		await expect( screen.findByText( ACTIVITY_FAILED ) ).resolves.toBeVisible();
 		// Witness: the stale rows are on screen, so the `empty` slot never rendered.
-		expect( renderedRows()[ 0 ] ).toContain( 'Backup complete' );
+		expect( ( await rowTexts() )[ 0 ] ).toContain( 'Backup complete' );
 	} );
 } );

--- a/projects/packages/backup/tests/review-request.test.tsx
+++ b/projects/packages/backup/tests/review-request.test.tsx
@@ -41,10 +41,6 @@ import { resetPageViewForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-// These stages render behind several sequential requests; Testing
-// Library's one-second default has not been enough on a loaded runner.
-const SETTLE = { timeout: 10000 };
-
 const RESTORE_QUESTION = 'Was it easy to restore your site?';
 const BACKUPS_QUESTION = 'Do you enjoy the peace of mind of having backups?';
 // Matched loosely: `Link` appends its own "opens in a new tab" text to
@@ -233,9 +229,7 @@ function mockEndpoints( {
  */
 async function renderSettledOverview() {
 	render( <OverviewStage /> );
-	await expect(
-		screen.findByText( 'Backup complete', undefined, SETTLE )
-	).resolves.toBeInTheDocument();
+	await expect( screen.findByText( 'Backup complete' ) ).resolves.toBeInTheDocument();
 }
 
 beforeEach( () => {

--- a/projects/packages/backup/tests/stale-selection-recovery.test.tsx
+++ b/projects/packages/backup/tests/stale-selection-recovery.test.tsx
@@ -47,10 +47,6 @@ import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-// Testing Library's default `findBy` window is one second, which these stages
-// have exceeded on a loaded runner under coverage.
-const SETTLE = { timeout: 10000 };
-
 const REWIND_ID = '1786644531.100';
 const STALE_ID = '1700000000.999';
 const PAGE_TWO_ID = '1786558131.200';
@@ -220,13 +216,13 @@ describe( 'A selection the activity log cannot resolve', () => {
 
 		// The message is the positive: without it the button below could be
 		// missing because the pane never reached this branch — or threw.
-		await expect( screen.findByText( NOT_FOUND, undefined, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NOT_FOUND ) ).resolves.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: CLEAR } ) ).toBeInTheDocument();
 	} );
 
 	it( 'drops only `selected`, through the router', async () => {
 		render( <OverviewStage /> );
-		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR } ) );
 
 		expect( mockNavigate ).toHaveBeenCalledTimes( 1 );
 		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {
@@ -240,7 +236,7 @@ describe( 'A selection the activity log cannot resolve', () => {
 
 	it( 'leaves the dead end once the router applies it', async () => {
 		const { rerender } = render( <OverviewStage /> );
-		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR } ) );
 
 		// The updater's own output, not a hand-written `{}` — otherwise this asserts
 		// the fallback rather than the recovery, and passes with `selected` kept.
@@ -251,14 +247,14 @@ describe( 'A selection the activity log cannot resolve', () => {
 		rerender( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'heading', { name: 'Backup complete' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Backup complete' } )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'hands focus to the two-pane region, so the next Tab is in the list', async () => {
 		render( <OverviewStage /> );
-		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR } ) );
 
 		// The region is the positive: focus cannot be verified as "not lost"
 		// without naming where it went.
@@ -289,9 +285,7 @@ describe( 'A selection on a page nothing has loaded', () => {
 
 		// The button is the positive control: it renders in this branch either
 		// way, so a missing claim below cannot be a pane that never rendered.
-		await expect(
-			screen.findByRole( 'button', { name: CLEAR }, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByRole( 'button', { name: CLEAR } ) ).resolves.toBeInTheDocument();
 		// Page 1 answering says nothing about page 2, which holds this row and
 		// which nothing has fetched.
 		expect( screen.queryByText( GONE_CLAIM ) ).not.toBeInTheDocument();
@@ -302,16 +296,16 @@ describe( 'A selection on a page nothing has loaded', () => {
 	// checks, and would read the same way if page 2 held no such row.
 	it( 'resolves the row once the list reaches the page holding it', async () => {
 		render( <OverviewStage /> );
-		await userEvent.click( await screen.findByRole( 'button', { name: 'Next page' }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: 'Next page' } ) );
 
 		await expect(
-			screen.findByRole( 'heading', { name: 'Backup complete (page 2)' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Backup complete (page 2)' } )
 		).resolves.toBeInTheDocument();
 	} );
 
 	it( 'leaves the cleared selection on the back stack', async () => {
 		render( <OverviewStage /> );
-		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR }, SETTLE ) );
+		await userEvent.click( await screen.findByRole( 'button', { name: CLEAR } ) );
 
 		// The selection may be perfectly good, so Back has to bring it back.
 		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as { replace?: boolean };
@@ -325,9 +319,7 @@ describe( 'Choosing a row', () => {
 		mockSearch.mockReturnValue( { page: '3' } );
 
 		render( <OverviewStage /> );
-		await userEvent.click(
-			await screen.findByRole( 'button', { name: /^Post published / }, SETTLE )
-		);
+		await userEvent.click( await screen.findByRole( 'button', { name: /^Post published / } ) );
 
 		const options = mockNavigate.mock.calls[ 0 ][ 0 ] as {
 			search: ( previous: Record< string, unknown > ) => Record< string, unknown >;
@@ -346,9 +338,7 @@ describe( 'No selection yet', () => {
 
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( NO_SELECTION, undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( NO_SELECTION ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
 	} );
 } );
@@ -370,7 +360,7 @@ describe( 'A selection the activity log has not answered for', () => {
 
 		// The placeholder is the positive: "no button" passes for a pane that
 		// never rendered at all.
-		await expect( screen.findByText( LOADING, undefined, SETTLE ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( LOADING ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
 	} );
@@ -380,9 +370,7 @@ describe( 'A selection the activity log has not answered for', () => {
 
 		render( <OverviewStage /> );
 
-		await expect(
-			screen.findByText( LOAD_FAILED, undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( LOAD_FAILED ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByText( NOT_FOUND ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: CLEAR } ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
+++ b/projects/packages/backup/tests/switching-backups-resets-detail.test.tsx
@@ -46,11 +46,6 @@ import { resetListStateForTesting } from '../src/dashboard/screens/overview';
 
 const CONNECTED = { isRegistered: true, hasConnectedOwner: true, isUserConnected: true };
 
-// Testing Library's default `findBy` window is one second. These stages
-// render behind several sequential requests, and a loaded CI runner under
-// coverage has taken well over that for the same work locally-green here.
-const SETTLE = { timeout: 10000 };
-
 const REWIND_A = '1786644531.100';
 const REWIND_B = '1786644532.200';
 
@@ -146,10 +141,10 @@ describe( 'Switching between backups', () => {
 		const { rerender } = render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'heading', { name: 'Backup A complete' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Backup A complete' } )
 		).resolves.toBeInTheDocument();
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 		await userEvent.click( fileRowCheckbox() );
 
@@ -161,25 +156,23 @@ describe( 'Switching between backups', () => {
 		// deliberately constant — a restore point is restored whole, so it
 		// never counts the selection — which makes it useless as a reset
 		// signal here. Its constancy is `restore-label-scope.test.tsx`.
-		await expect(
-			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Download 1 selected item' ) ).resolves.toBeInTheDocument();
 
 		// Open the file's preview as well. A regression that cleared the
 		// selection but left `openFile` set would otherwise pass.
 		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: 'Close preview' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Close preview' } )
 		).resolves.toBeInTheDocument();
 
 		mockSearch.mockReturnValue( { selected: REWIND_B } );
 		rerender( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'heading', { name: 'Backup B complete' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Backup B complete' } )
 		).resolves.toBeInTheDocument();
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 
 		// The new backup's own file — same path, never checked here — must
@@ -201,26 +194,24 @@ describe( 'Switching between backups', () => {
 		const { rerender } = render( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'heading', { name: 'Backup A complete' }, SETTLE )
+			screen.findByRole( 'heading', { name: 'Backup A complete' } )
 		).resolves.toBeInTheDocument();
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 		await userEvent.click( fileRowCheckbox() );
-		await expect(
-			screen.findByText( 'Download 1 selected item', undefined, SETTLE )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Download 1 selected item' ) ).resolves.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'File: wp-config.php' } ) );
 		await expect(
-			screen.findByRole( 'button', { name: 'Close preview' }, SETTLE )
+			screen.findByRole( 'button', { name: 'Close preview' } )
 		).resolves.toBeInTheDocument();
 
 		// Same backup, so the key is unchanged and nothing should remount.
 		rerender( <OverviewStage /> );
 
 		await expect(
-			screen.findByRole( 'button', { name: 'File: wp-config.php' }, SETTLE )
+			screen.findByRole( 'button', { name: 'File: wp-config.php' } )
 		).resolves.toBeInTheDocument();
 		expect( fileRowCheckbox() ).toBeChecked();
 		expect( screen.getByText( 'Download 1 selected item' ) ).toBeInTheDocument();


### PR DESCRIPTION
Fixes # N/A

Trunk's **Code coverage (JS)** job has been going red on `packages/backup`, a different test each
run. Four were reported: `restore-session-recovery`, `invalid-rewind-id`, `stale-rows-feedback`
and `restore-rows-in-activity-list`. They turn out to be two causes, neither of which is what the
individual failures look like.

### Cause 1 — the async budget (3 of the 4)

`tests.yml` launches every project's test script with `&` onto one runner, each with its own jest
worker pool, and the coverage job instruments every module on top of that. Measured on an idle
6-core box under `--coverage`, these route-stage suites need **300–400ms** per `findBy*` against
Testing Library's **1000ms** default — under 3x margin before CI contention counts at all.

Seventeen test files had each grown their own `SETTLE = { timeout: 10000 }` to work around this,
plus seven copies of the comment explaining why. Three of the four failures never had it —
`invalid-rewind-id` and `stale-rows-feedback` from #51401, `restore-session-recovery` from #51440 —
because the workaround only ever spread by copy-paste, so new files are born unprotected.
`asyncUtilTimeout` now does the job once in `tests/jest.setup.js`, covering the thirty-two files
that never got the workaround and every file added from here on.

### Cause 2 — a real race (the 4th)

`restore-rows-in-activity-list` came from #51955 with `SETTLE` already in place; its failure is a
different one. `renderedRows()` read `getAllByRole( 'row' )` synchronously, one statement after
awaiting `findByText( 'Backup complete' )`. That text is also the detail pane's heading, which can
render while the activity list is still empty — and an empty DataViews list renders no grid and no
rows at all. The trunk failure's DOM dump is that state: the detail pane's `<h2>` present, and no
`grid`, `row` or `gridcell` role anywhere (the `list` and `listitem` it does show are the Jetpack
footer's menu). An idle machine mounts the rows before `findByText` returns and the synchronous
read gets away with it; a loaded one does not.

## Proposed changes

* Set `asyncUtilTimeout: 10000` once in `projects/packages/backup/tests/jest.setup.js`.
* Remove the seventeen per-file `SETTLE` constants and their 141 call-site arguments, now redundant.
* Drop `use-restore.test.ts`'s own `{ timeout: 8000 }` waits and `15000` per-test caps, which now sit
  below the package-wide budgets.
* Await the rows in `restore-rows-in-activity-list.test.tsx` (`findAllByRole` over `getAllByRole`).
* Trim the `testTimeout` comment in `tests/jest.config.js` to its constraint: it stays above the new
  global setting.

Test-only; no production code is touched.

## Related product discussion/links

* p1788970696152449-slack-C034JEXD1RD
* Failing run: https://github.com/Automattic/jetpack/actions/runs/34374049313

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change is to the test suite itself, so the suite is the test.

* Check CI is green, in particular the **Code coverage (JS)** job — that is the one that was failing.

To reproduce the original failure locally and confirm the fix addresses it:

* `cd projects/packages/backup`
* Add a setup file containing `require( '@testing-library/react' ).configure( { asyncUtilTimeout: 300 } )`
  and run the suite with `--coverage`. On `trunk` this reproduces the reported failure verbatim
  (`Restore screen — a restore already running › retires the notice once the adopted restore is
  finished`); on this branch the global 10s budget is what applies instead.
* `pnpm test` — 84 suites / 872 tests, green.

Worth confirming the budget costs nothing when tests pass: suite runtime is unchanged
(19.7s on trunk, 18.3s here). Only a *failing* wait pays the longer timeout.

I also soaked the full suite eight times under `--coverage` with the CPU oversubscribed to
imitate the shared runner — 8/8 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mq4ZnN3BHHcsYDCVVz6JMA
https://claude.ai/code/session_016xQcUXZwSKA7zhZEsSqr4N
