### PR TITLE
Contact Form: preserve nested Group wrappers

### DIFF
--- a/projects/packages/forms/changelog/fix-contact-form-nested-group-wrappers
+++ b/projects/packages/forms/changelog/fix-contact-form-nested-group-wrappers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: Preserve nested Group block layouts around form fields.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -966,7 +966,9 @@ class Contact_Form_Block {
 			}
 		}
 
-		return Contact_Form::parse( $atts, do_blocks( $content ) );
+		// Dynamic block callbacks receive content rendered by WordPress already.
+		// Rendering it again can flatten nested core/group wrappers around fields.
+		return Contact_Form::parse( $atts, $content );
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -966,8 +966,12 @@ class Contact_Form_Block {
 			}
 		}
 
-		// Dynamic block callbacks receive content rendered by WordPress already.
-		// Rendering it again can flatten nested core/group wrappers around fields.
+		// Dynamic block callbacks receive rendered content, but direct callers may
+		// legitimately provide raw serialized block content.
+		if ( has_blocks( $content ) ) {
+			$content = do_blocks( $content );
+		}
+
 		return Contact_Form::parse( $atts, $content );
 	}
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -24,6 +24,27 @@ use Jetpack;
  */
 class Contact_Form_Block {
 	/**
+	 * Whether Contact Form preserves nested core Group wrappers around fields.
+	 *
+	 * @return bool
+	 */
+	public static function supports_nested_core_group_wrappers() {
+		return true;
+	}
+
+	/**
+	 * Advertise Contact Form rendering capabilities.
+	 *
+	 * @param array<string, bool> $capabilities Rendering capabilities advertised by Forms.
+	 * @return array<string, bool>
+	 */
+	public static function add_capabilities( $capabilities ) {
+		$capabilities['nested_core_group_wrappers'] = self::supports_nested_core_group_wrappers();
+
+		return $capabilities;
+	}
+
+	/**
 	 * Register the Contact Form block.
 	 * We are core block dependent only on whether the jetpack contact form plugin
 	 * is active or not. This is allowing us to make it more discoverable

--- a/projects/packages/forms/src/contact-form/class-util.php
+++ b/projects/packages/forms/src/contact-form/class-util.php
@@ -51,6 +51,7 @@ class Util {
 		// flags stay in Contact_Form_Block::register_feature(), hooked later from
 		// Contact_Form_Block::register_block() on `init` priority 9.
 		add_filter( 'jetpack_block_editor_feature_flags', '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::register_central_form_management_default' );
+		add_filter( 'jetpack_forms_contact_form_capabilities', '\Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::add_capabilities' );
 
 		add_action( 'init', '\Automattic\Jetpack\Forms\ContactForm\Contact_Form_Plugin::init', 9 );
 		add_action( 'grunion_scheduled_delete', '\Automattic\Jetpack\Forms\ContactForm\Util::grunion_delete_old_spam' );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -828,6 +828,30 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Direct callers can provide raw serialized inner blocks rather than the
+	 * already-rendered content supplied by WordPress's block callback.
+	 */
+	public function test_gutenblock_render_form_renders_raw_inner_blocks() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$output = Contact_Form_Block::gutenblock_render_form(
+			array( 'to' => 'test@example.com' ),
+			'<!-- wp:group {"className":"outer-group"} -->' .
+			'<div class="wp-block-group outer-group">' .
+			'<!-- wp:group {"className":"inner-group"} -->' .
+			'<div class="wp-block-group inner-group">' .
+			'<!-- wp:jetpack/field-text {"label":"Name","id":"name"} /-->' .
+			'</div><!-- /wp:group -->' .
+			'</div><!-- /wp:group -->'
+		);
+
+		$this->assertStringContainsString( 'outer-group', $output );
+		$this->assertStringContainsString( 'inner-group', $output );
+		$this->assertStringContainsString( 'id="name"', $output );
+	}
+
+	/**
 	 * Group attributes are handled by core's renderer before the form consumes them.
 	 */
 	public function test_group_renderer_drops_unsupported_attributes_inside_a_contact_form_block() {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -781,4 +781,71 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		$this->assertStringContainsString( 'contact-field', do_blocks( $shown ) );
 		$this->assertStringContainsString( 'Keep me', do_blocks( $shown ) );
 	}
+
+	/**
+	 * Nested Group blocks retain their rendered hierarchy around form fields.
+	 */
+	public function test_nested_groups_are_preserved_when_rendering_a_contact_form_block() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$output = do_blocks(
+			'<!-- wp:jetpack/contact-form {"to":"test@example.com"} -->' .
+			'<!-- wp:group {"className":"outer-group","anchor":"form-section","style":{"spacing":{"padding":{"top":"1rem"}}}} -->' .
+			'<div id="form-section" class="wp-block-group outer-group" style="padding-top:1rem">' .
+			'<!-- wp:group {"className":"inner-group"} -->' .
+			'<div class="wp-block-group inner-group">' .
+			'<!-- wp:jetpack/field-text {"label":"Name","required":true} /-->' .
+			'<!-- wp:jetpack/field-email {"label":"Email","required":true} /-->' .
+			'</div><!-- /wp:group -->' .
+			'</div><!-- /wp:group -->' .
+			'<!-- /wp:jetpack/contact-form -->'
+		);
+
+		$document = new \DOMDocument();
+		$previous_libxml_errors = libxml_use_internal_errors( true );
+		$document->loadHTML( $output );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $previous_libxml_errors );
+
+		$xpath       = new \DOMXPath( $document );
+		$outer_group = $xpath->query( '//div[@id="form-section" and contains(concat(" ", normalize-space(@class), " "), " outer-group ")]' )->item( 0 );
+
+		$this->assertNotNull( $outer_group );
+		$inner_group = $xpath->query( './div[contains(concat(" ", normalize-space(@class), " "), " inner-group ")]', $outer_group )->item( 0 );
+		$this->assertNotNull( $inner_group );
+		$this->assertStringContainsString( 'padding-top:1rem', $outer_group->getAttribute( 'style' ) );
+
+		$name_input = $xpath->query( './/input[@type="text"]', $inner_group )->item( 0 );
+		$this->assertNotNull( $name_input );
+		$name_label = $xpath->query( './/label[@for="' . $name_input->getAttribute( 'id' ) . '"]', $inner_group )->item( 0 );
+		$name_error = $xpath->query( './/input[@id="' . $name_input->getAttribute( 'id' ) . '"]/following-sibling::*[1][@id="' . $name_input->getAttribute( 'id' ) . '-text-error"]', $inner_group )->item( 0 );
+
+		$this->assertNotNull( $name_label );
+		$this->assertNotNull( $name_error );
+		$this->assertStringContainsString( 'Name', $name_label->textContent );
+		$this->assertCount( 2, $xpath->query( './/input', $inner_group ) );
+	}
+
+	/**
+	 * Group attributes are handled by core's renderer before the form consumes them.
+	 */
+	public function test_group_renderer_drops_unsupported_attributes_inside_a_contact_form_block() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$output = do_blocks(
+			'<!-- wp:jetpack/contact-form {"to":"test@example.com"} -->' .
+			'<!-- wp:group {"className":"safe-group","anchor":"safe-anchor","onclick":"alert(1)","data-unsupported":"bad"} -->' .
+			'<div id="safe-anchor" class="wp-block-group safe-group">' .
+			'<!-- wp:jetpack/field-text {"label":"Name"} /-->' .
+			'</div><!-- /wp:group -->' .
+			'<!-- /wp:jetpack/contact-form -->'
+		);
+
+		$this->assertStringContainsString( 'safe-group', $output );
+		$this->assertStringContainsString( 'safe-anchor', $output );
+		$this->assertStringNotContainsString( 'onclick=', $output );
+		$this->assertStringNotContainsString( 'data-unsupported=', $output );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block;
+use Automattic\Jetpack\Forms\ContactForm\Util;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
@@ -21,6 +22,28 @@ use WP_Block_Type_Registry;
  */
 #[CoversClass( \Automattic\Jetpack\Extensions\Contact_Form\Contact_Form_Block::class )]
 class Contact_Form_Block_Test extends BaseTestCase {
+	/**
+	 * Contact Form declares support for preserving nested core Group wrappers.
+	 */
+	public function test_supports_nested_core_group_wrappers() {
+		$this->assertTrue( Contact_Form_Block::supports_nested_core_group_wrappers() );
+	}
+
+	/**
+	 * Forms advertises rendering capabilities when its runtime bootstrap loads.
+	 */
+	public function test_forms_bootstrap_advertises_contact_form_capabilities() {
+		remove_all_filters( 'jetpack_forms_contact_form_capabilities' );
+		Util::init();
+
+		$this->assertSame(
+			array( 'nested_core_group_wrappers' => true ),
+			apply_filters( 'jetpack_forms_contact_form_capabilities', array() )
+		);
+
+		remove_all_filters( 'jetpack_forms_contact_form_capabilities' );
+	}
+
 	/**
 	 * Test that ::find_nested_html_block works correctly.
 	 */


### PR DESCRIPTION
## Superseded

This PR is intentionally closed without merge.

## Root Cause
The unpatched Jetpack 16.2 runtime preserves canonical nested `core/group` saved markup around Contact Form fields, including the Group parent-child edge, field labels, errors, validation, and local submission handling. The import failure is in the Static Site Importer serializer: it emitted nested `core/group` comments without their required saved Group wrapper markup (`wrapper => "group"`), leaving no Group element for WordPress to preserve.

Jetpack therefore does not require a renderer change or an advertised capability for this issue.

## Evidence
The synthetic nested Group fixture was rendered on an isolated unpatched Jetpack 16.2 runtime. Both the normal block callback and direct raw serialized-content routes retained Group topology and supported attributes; required-field validation produced no feedback record, and a valid submission created one local feedback record with mail interception.

## Follow-up
The provider branch remains only as superseded investigation evidence. The repair belongs in Static Site Importer’s canonical Group serializer.

## AI Assistance
Used OpenCode with `openai/gpt-5.6-terra` to inspect the Jetpack and SSI rendering paths, execute isolated runtime probes, and document the root cause.