### PR TITLE
Premium Analytics: zone the clock the All-time traffic period helpers clamp at

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-period-range-zoned-now
+++ b/projects/packages/premium-analytics/changelog/fix-pa-period-range-zoned-now
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+All-time traffic: Read the clock in the site timezone when a cell opens the current month or year.

--- a/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
+++ b/projects/packages/premium-analytics/widgets/post-all-time-traffic/period-range.ts
@@ -5,6 +5,7 @@ import {
 	createTZDateFromParts,
 	drillDateRange,
 	startOfDayTZ,
+	toLocalTZ,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
 /**
@@ -42,12 +43,12 @@ function clampToLife( bucket: DateRange | null, { lifeStartsAt, timeZone }: Peri
  * @return The range to apply, or `null`.
  */
 export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | null {
-	const { timeZone, now = new Date() } = bounds;
-	// The bucket the traffic chart opens on a click, cut at the clock.
+	const { timeZone, now } = bounds;
+	// The bucket the traffic chart opens on a click, cut at the site's clock.
 	const bucket = drillDateRange(
 		createTZDateFromParts( [ key.year, key.month, 1 ], timeZone ),
 		'month',
-		now
+		toLocalTZ( now, timeZone )
 	);
 
 	return clampToLife( bucket, bounds );
@@ -61,8 +62,12 @@ export function monthRange( key: MonthKey, bounds: PeriodBounds ): DateRange | n
  * @return The range to apply, or `null`.
  */
 export function yearRange( year: number, bounds: PeriodBounds ): DateRange | null {
-	const { timeZone, now = new Date() } = bounds;
-	const bucket = drillDateRange( createTZDateFromParts( [ year, 0, 1 ], timeZone ), 'year', now );
+	const { timeZone, now } = bounds;
+	const bucket = drillDateRange(
+		createTZDateFromParts( [ year, 0, 1 ], timeZone ),
+		'year',
+		toLocalTZ( now, timeZone )
+	);
 
 	return clampToLife( bucket, bounds );
 }


### PR DESCRIPTION




## Proposed changes

Trunk's Type checking job is red since #52065 and #52137 landed back to back: #52065 narrowed `drillDateRange`'s `now` parameter to a `TZDate`, and `period-range.ts` (added in #52118, extended in #52137) still passes a plain `Date`. Each PR was green against the trunk of its time. Every PR opened since inherits the failure through the merge ref (for example #52114).

* `monthRange` and `yearRange` pass `toLocalTZ( now, timeZone )` to `drillDateRange`, so the clamp reads the clock in the site timezone the bounds already carry.
* `now` stays an optional plain `Date` on `PeriodBounds`: the helper zones it itself rather than asking every caller to pre-zone it against the same `timeZone` it also passes.

## Related product discussion/links
* #52065, #52118, #52137

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* `cd projects/packages/premium-analytics && pnpm run typecheck` passes on this branch and fails on trunk with two `TS2739` errors in `widgets/post-all-time-traffic/period-range.ts`.
* `pnpm run test-js` in the same package: the `post-all-time-traffic` suites stay green.
* The Type checking job on this PR is green.
