### PR TITLE
Premium Analytics: keep calendar dates for a 1st-of-month comparison across a leap year

### DIFF
--- a/projects/packages/premium-analytics/changelog/uni-767-yoy-leap-year-calendar-dates
+++ b/projects/packages/premium-analytics/changelog/uni-767-yoy-leap-year-calendar-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date comparison: keep the same calendar dates for a range starting on the 1st, so Year to date in a leap year compares against 1 January of the previous year rather than 31 December.

--- a/projects/packages/premium-analytics/packages/datetime/README.md
+++ b/projects/packages/premium-analytics/packages/datetime/README.md
@@ -165,12 +165,15 @@ if inputs are invalid
 - `previous-month` - Same duration, anchored one month before the reference end
 - `previous-year` - Same duration, anchored one year before the reference end
 
+A reference starting on the 1st of a month instead keeps its calendar dates for
+`previous-month` / `previous-year`, so its duration can differ: Year to date on
+1 March 2028 (61 days) compares against 1 January to 1 March 2027 (60 days).
 For whole-month references, `previous-period` steps back by the month count
 (July against June, a calendar year against the previous calendar year), and
-`previous-month` / `previous-year` stay aligned to calendar month boundaries,
-so their duration can differ. Whole months are read from the range itself, so a
-rolling window that happens to land on one (April 1-30 from "Last 30 days")
-compares against all 31 days of March.
+`previous-month` / `previous-year` stay aligned to calendar month boundaries.
+Whole months are read from the range itself, so a rolling window that happens
+to land on one (April 1-30 from "Last 30 days") compares against all 31 days of
+March.
 
 A to-date preset (`last-12-months` runs to the end of today) is measured on
 the window it covers once its running month closes, so `previous-period` steps

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/comparison-presets.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/comparison-presets.test.ts
@@ -208,6 +208,25 @@ describe( 'comparison options', () => {
 		expect( labels( pastRange ) ).toEqual( [ 'Previous 57 days', 'Same period in 2024' ] );
 	} );
 
+	it( 'names the year Year to date compares with in a leap year', () => {
+		const yearToDate2028 = daysRange( [ 2028, 0, 1 ], [ 2028, 2, 1 ] );
+		const options = getComparisonOptions( yearToDate2028, { primaryPresetId: 'year-to-date' } );
+
+		expect( options.map( option => option.label ) ).toEqual( [
+			'Previous 61 days',
+			'Same period in 2027',
+		] );
+		expect( options[ 1 ].range ).toEqual( daysRange( [ 2027, 0, 1 ], [ 2027, 2, 1 ] ) );
+	} );
+
+	it( 'folds the year option into the previous period for Last 12 months in a leap year', () => {
+		const last12Months2028 = daysRange( [ 2027, 9, 1 ], [ 2028, 8, 11 ] );
+		const options = getComparisonOptions( last12Months2028, { primaryPresetId: 'last-12-months' } );
+
+		expect( options.map( option => option.label ) ).toEqual( [ 'Previous 347 days' ] );
+		expect( options[ 0 ].range ).toEqual( daysRange( [ 2026, 9, 1 ], [ 2027, 8, 11 ] ) );
+	} );
+
 	it( 'names the month the comparison starts in across a year boundary', () => {
 		const january5 = daysRange( [ 2027, 0, 5 ], [ 2027, 0, 5 ] );
 

--- a/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/__tests__/get-comparison-range.test.ts
@@ -224,6 +224,55 @@ describe( 'getComparisonRangeFromPreset', () => {
 			} );
 		} );
 
+		/*
+		 * A range starting on the 1st compares with the same calendar dates
+		 * (UNI-767): a day-count rebuild across a leap February would start Year
+		 * to date on 31 December or 2 January instead of 1 January.
+		 */
+		it.each( [
+			[
+				'a leap year',
+				siteDate( 2028, 0, 1, 0, 0, 0, 0 ),
+				siteDate( 2028, 2, 1, 23, 59, 59, 999 ),
+				siteDate( 2027, 0, 1, 0, 0, 0, 0 ),
+				siteDate( 2027, 2, 1, 23, 59, 59, 999 ),
+			],
+			[
+				'the year after a leap year',
+				siteDate( 2029, 0, 1, 0, 0, 0, 0 ),
+				siteDate( 2029, 2, 1, 23, 59, 59, 999 ),
+				siteDate( 2028, 0, 1, 0, 0, 0, 0 ),
+				siteDate( 2028, 2, 1, 23, 59, 59, 999 ),
+			],
+			[
+				'a start on the 1st of a later month',
+				siteDate( 2028, 1, 1, 0, 0, 0, 0 ),
+				siteDate( 2028, 2, 15, 23, 59, 59, 999 ),
+				siteDate( 2027, 1, 1, 0, 0, 0, 0 ),
+				siteDate( 2027, 2, 15, 23, 59, 59, 999 ),
+			],
+		] )(
+			'keeps the calendar dates for previous-year from a 1st-of-month start in %s',
+			( _label, from, to, expectedFrom, expectedTo ) => {
+				expect( getComparisonRangeFromPreset( { from, to }, 'previous-year' ) ).toEqual( {
+					from: expectedFrom,
+					to: expectedTo,
+				} );
+			}
+		);
+
+		it( 'clamps the end of a 1st-of-month start for previous-month in a shorter month', () => {
+			const reference = {
+				from: siteDate( 2026, 2, 1, 0, 0, 0, 0 ),
+				to: siteDate( 2026, 2, 30, 23, 59, 59, 999 ),
+			};
+
+			expect( getComparisonRangeFromPreset( reference, 'previous-month' ) ).toEqual( {
+				from: siteDate( 2026, 1, 1, 0, 0, 0, 0 ),
+				to: siteDate( 2026, 1, 28, 23, 59, 59, 999 ),
+			} );
+		} );
+
 		it.each( COMPARISON_PRESETS )(
 			'covers the same number of days as the reference for %s',
 			presetId => {

--- a/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
+++ b/projects/packages/premium-analytics/packages/datetime/src/get-comparison-range.ts
@@ -13,7 +13,6 @@ import {
 	isLastDayOfMonth,
 	isSameDay,
 	startOfDay,
-	startOfMonth,
 	subDays,
 	subMilliseconds,
 	subMonths,
@@ -121,6 +120,9 @@ export type ComparisonRangeOptions = {
  *
  * - Day boundaries are resolved in the frame of the incoming dates; pass TZDate
  *   instances for site-local math.
+ * - A range starting on the 1st compares with the same calendar dates a month
+ *   or a year earlier (a whole month with the whole month before it); any
+ *   other partial-month range keeps its day count.
  * - Whole months are detected from the range shape alone, so a rolling window
  *   that happens to land on one also compares calendar-to-calendar.
  * - `previous-period` ends the day before the reference starts; a reference
@@ -222,11 +224,13 @@ export function getComparisonRangeFromPreset(
 	if ( presetId === COMPARISON_PREVIOUS_MONTH || presetId === COMPARISON_PREVIOUS_YEAR ) {
 		const shiftBack = presetId === COMPARISON_PREVIOUS_MONTH ? subMonths : subYears;
 
-		// Keep whole-month comparisons aligned to calendar boundaries.
-		if ( isFirstDayOfMonth( refFrom ) && isLastDayOfMonth( refTo ) ) {
+		// A 1st-of-month start keeps its calendar dates (whole months on month bounds):
+		// a day-count rebuild across a leap February starts Year to date on 31 December.
+		if ( isFirstDayOfMonth( refFrom ) ) {
+			const shiftedTo = shiftBack( refTo, 1 );
 			return {
-				from: clampDayBound( startOfMonth( shiftBack( refFrom, 1 ) ), 0 ),
-				to: clampDayBound( endOfMonth( shiftBack( refTo, 1 ) ), 1 ),
+				from: clampDayBound( shiftBack( refFrom, 1 ), 0 ),
+				to: clampDayBound( isLastDayOfMonth( refTo ) ? endOfMonth( shiftedTo ) : shiftedTo, 1 ),
 			};
 		}
 

--- a/projects/plugins/jetpack/changelog/uni-767-yoy-leap-year-calendar-dates
+++ b/projects/plugins/jetpack/changelog/uni-767-yoy-leap-year-calendar-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Analytics: keep the same calendar dates when comparing a range starting on the 1st with the previous year, so Year to date in a leap year starts on 1 January rather than 31 December.

--- a/projects/plugins/premium-analytics/changelog/uni-767-yoy-leap-year-calendar-dates
+++ b/projects/plugins/premium-analytics/changelog/uni-767-yoy-leap-year-calendar-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Date comparison: keep the same calendar dates for a range starting on the 1st, so Year to date in a leap year compares against 1 January of the previous year rather than 31 December.

--- a/projects/plugins/wpcomsh/changelog/uni-767-yoy-leap-year-calendar-dates
+++ b/projects/plugins/wpcomsh/changelog/uni-767-yoy-leap-year-calendar-dates
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: keep the same calendar dates when comparing a range starting on the 1st with the previous year, so Year to date in a leap year starts on 1 January rather than 31 December.


### PR DESCRIPTION
Fixes UNI-767

Year to date on 1 March 2028 compared against 31 December 2026 to 1 March 2027, and the dropdown named it "Same period in 2026"; both now read 1 January to 1 March 2027 and "Same period in 2027".

## Proposed changes

* A range starting on the 1st of a month now compares with the same calendar dates a month or a year earlier, accepting a length difference (60 days against 61) the way GA4 and Shopify do.
* Year to date in a leap year, and in the year after one, starts its previous-year comparison on 1 January instead of 31 December or 2 January.
* The year label follows, since it is read from the comparison's start.
* A whole-month range still compares with the whole month before it, and a range that does not start on the 1st keeps the day-count shift from #51469.


Out of scope: weekday-aligned comparisons and a custom comparison range (UNI-779), and calendar matching for ranges that do not start on the 1st.



## Related product discussion/links

* UNI-767, where the calendar-date option was chosen after checking GA4 and Shopify.
* #52088 added the Year to date preset that turns this into a one-click path.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Stats v2 dashboard, pick a custom range of 1 January to 1 March 2024 (a past leap year, so no clock change is needed).
* Open Compare: the year option reads "Same period in 2023" (trunk: "Same period in 2022").
* Pick it and check the URL: `compare_from` is 2023-01-01 (trunk: 2022-12-31).
* Run `jp test js packages/premium-analytics`; `get-comparison-range.test.ts` and `comparison-presets.test.ts` carry the leap-year cases.

### Before / after

Custom range 1 January to 1 March 2024 with the Compare menu open. Only the year option's label differs; "Previous 61 days" and "No comparison" are unchanged.

| Before (trunk) | After (this PR) |
| --- | --- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/uni-767-yoy-leap-year-calendar-dates/before-same-period-in-2022.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/uni-767-yoy-leap-year-calendar-dates/after-same-period-in-2023.png) |


