### PR TITLE
Premium Analytics: hold back the four Insights period widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-2020-hide-insights-period-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-2020-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: Remove Total views, Total visitors, Popular days and Popular hours from the default layout, and hold the four widgets back from every widget picker for now.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -347,71 +347,41 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 5: the period totals and the weekday and hour-of-day
-			// distributions.
-			get_dashboard_default_widget_instance(
-				'default-total-views-widget-instance',
-				'jpa/total-views',
-				7,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-total-visitors-widget-instance',
-				'jpa/total-visitors',
-				8,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-popular-days-widget-instance',
-				'jpa/popular-days',
-				9,
-				1,
-				1
-			),
-			get_dashboard_default_widget_instance(
-				'default-popular-hours-widget-instance',
-				'jpa/popular-hours',
-				10,
-				1,
-				1
-			),
-			// Row 6: daily views heatmap. Two rows tall, as in the prototype: cells are sized
+			// Row 5: daily views heatmap. Two rows tall, as in the prototype: cells are sized
 			// from the tile's height, and only here do they fit each day's view count.
 			get_dashboard_default_widget_instance(
 				'default-traffic-views-activity-widget-instance',
 				'jpa/traffic-views-activity',
-				11,
+				7,
 				4,
 				2
 			),
-			// Row 7: the comment leaderboards, shares, and tags.
+			// Row 6: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				12,
+				8,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				13,
+				9,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				14,
+				10,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				15,
+				11,
 				1,
 				2
 			),

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -35,6 +35,16 @@ const PLAN_USAGE_WIDGET_TYPES = array(
 );
 
 /**
+ * Period widgets whose sparkline reads the section's date range.
+ */
+const PERIOD_WIDGET_TYPES = array(
+	'jpa/total-views',
+	'jpa/total-visitors',
+	'jpa/popular-days',
+	'jpa/popular-hours',
+);
+
+/**
  * Returns the current widget support context.
  *
  * @return array{is_wpcom_simple:bool,has_videopress:bool} Widget support context.
@@ -56,6 +66,10 @@ function get_unsupported_widget_types( $context ) {
 	// Usage and upgrade UX stays out of Stats v2 on every site until the paid plan is
 	// settled (STATS-459); it returns through the configurations drawer (WOOA7S-2037).
 	$unsupported = PLAN_USAGE_WIDGET_TYPES;
+
+	// Temporary: the period widgets are held back on every site until product decides
+	// whether they return or go (WOOA7S-2020). Their code stays.
+	$unsupported = array_merge( $unsupported, PERIOD_WIDGET_TYPES );
 
 	// File download tracking is served only on WPCOM Simple. Calypso applies
 	// the same boundary, which excludes self-hosted Jetpack and Atomic sites.

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -433,15 +433,11 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 4 ),
 			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 5 ),
 			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 6 ),
-			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 7 ),
-			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 8 ),
-			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 9 ),
-			'default-popular-hours-widget-instance'        => array( 'jpa/popular-hours', 1, 1, 10 ),
-			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 11 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 12 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 13 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 14 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 15 ),
+			'default-traffic-views-activity-widget-instance' => array( 'jpa/traffic-views-activity', 4, 2, 7 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 8 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 9 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 10 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 11 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
@@ -467,6 +463,11 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$this->assertNotContains( 'jpa/stats-emails', $layout_types );
 		// The Comments module ships as two focused widgets, not one toggled widget.
 		$this->assertNotContains( 'jpa/comments', $layout_types );
+		// The period widgets are held back while their return is decided (WOOA7S-2020).
+		$this->assertNotContains( 'jpa/total-views', $layout_types );
+		$this->assertNotContains( 'jpa/total-visitors', $layout_types );
+		$this->assertNotContains( 'jpa/popular-days', $layout_types );
+		$this->assertNotContains( 'jpa/popular-hours', $layout_types );
 
 		// Highlights falls back to the widget's own default metric list.
 		$this->assertArrayNotHasKey(

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -91,6 +91,22 @@ class Widget_Availability_Test extends BaseTestCase {
 				'category' => 'stats',
 			),
 			array(
+				'name'     => 'jpa/total-views',
+				'category' => 'stats',
+			),
+			array(
+				'name'     => 'jpa/total-visitors',
+				'category' => 'stats',
+			),
+			array(
+				'name'     => 'jpa/popular-days',
+				'category' => 'stats',
+			),
+			array(
+				'name'     => 'jpa/popular-hours',
+				'category' => 'stats',
+			),
+			array(
 				'name'     => 'jpa/hello-world',
 				'category' => 'demo',
 			),
@@ -192,6 +208,19 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The period widgets are held back regardless of host or features (WOOA7S-2020).
+	 */
+	public function test_type_policy_removes_period_widgets_everywhere() {
+		$period = array( 'jpa/total-views', 'jpa/total-visitors', 'jpa/popular-days', 'jpa/popular-hours' );
+
+		foreach ( $period as $name ) {
+			$this->assertNotContains( $name, $this->available_names( false, false ), $name );
+			$this->assertNotContains( $name, $this->available_names( true, true ), $name );
+		}
+		$this->assertContains( 'jpa/hello-world', $this->available_names( false, false ) );
+	}
+
+	/**
 	 * Without VideoPress, every gated video widget is unavailable.
 	 */
 	public function test_type_policy_removes_video_widgets_without_videopress() {
@@ -289,6 +318,17 @@ class Widget_Availability_Test extends BaseTestCase {
 		$names = $this->manifest_widget_names();
 
 		foreach ( PLAN_USAGE_WIDGET_TYPES as $held ) {
+			$this->assertContains( $held, $names, "$held is held back but no manifest declares it." );
+		}
+	}
+
+	/**
+	 * Same guard for the held period widgets: each names a real manifest.
+	 */
+	public function test_period_widget_types_match_the_manifest() {
+		$names = $this->manifest_widget_names();
+
+		foreach ( PERIOD_WIDGET_TYPES as $held ) {
 			$this->assertContains( $held, $names, "$held is held back but no manifest declares it." );
 		}
 	}

--- a/projects/plugins/jetpack/changelog/wooa7s-2020-hide-insights-period-widgets
+++ b/projects/plugins/jetpack/changelog/wooa7s-2020-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Premium Analytics: Remove Total views, Total visitors, Popular days and Popular hours from the default Insights layout and from the widget picker for now.

--- a/projects/plugins/premium-analytics/changelog/wooa7s-2020-hide-insights-period-widgets
+++ b/projects/plugins/premium-analytics/changelog/wooa7s-2020-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: Remove Total views, Total visitors, Popular days and Popular hours from the default layout, and hold the four widgets back from every widget picker for now.

--- a/projects/plugins/wpcomsh/changelog/wooa7s-2020-hide-insights-period-widgets
+++ b/projects/plugins/wpcomsh/changelog/wooa7s-2020-hide-insights-period-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: Remove Total views, Total visitors, Popular days and Popular hours from the default Insights layout and from the widget picker for now.


### PR DESCRIPTION
Fixes WOOA7S-2020

Insights showed Total views, Total visitors, Popular days, and Popular hours for “the selected period,” but the tab has had no date control since WOOA7S-2012. Customer interviews questioned these visuals, so we’re temporarily hiding them and keeping the code until we decide whether to bring them back or remove them.

## Proposed changes
* Hold the four back from the widget registry on every host, as `jpa/plan-usage` already is: they leave every tab's "Add widget" picker and the `/widget-modules` record set (50 records to 46 on a test site).
* Drop the four from the Insights default layout; the heatmap and the leaderboards move up to orders 7 to 11 with no gap.
* A reader who already placed one keeps their layout; the tile renders as the host's "Missing widget" placeholder. Removing it needs the dashboard-composition flag (off by default), so on an internal site it stays until the flag is on or the layout is reset. Preview customers only see Traffic, so none carries one.


## Related product discussion/links
* WOOA7S-2008 (parent): the four were asked to leave the widget picker as well as the default layout.
* #51637, the closed earlier attempt: per-section scoping, plus two of the widgets seeded into Traffic.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Needs Insights visible (`jetpack_premium_analytics_enabled` option unset, Premium Analytics enabled through the filter) and the `premium-analytics-dashboard-composition` flag on.

* Stats v2, Insights, Reset to default from the page menu: no Total views, Total visitors, Popular days or Popular hours tile; Traffic views activity sits right under the post spotlights.
* Customize, Add widget, search `Total v`: No results. Search `Popular`: no Popular days or Popular hours. Same on Traffic.
* Persisted layout: on trunk, move any Insights tile and press Done, then switch to this branch and reload. The four slots read "Widget is no longer available."; Remove works, and Reset to default clears them.
* Dispatch `/wpcom/v2/widget-modules` with `wp eval`: none of the four names is in the record set.

### Screenshots

Same persisted Insights layout, same scroll position. Only the four period tiles change; the tiles around them do not.

| Before (trunk) | After (this PR) |
| --- | --- |
| <img width="1047" height="796" alt="Screenshot 2026-09-11 at 2 41 15 PM" src="https://github.com/user-attachments/assets/06f738f5-4740-49fc-a848-03175cf1323d" /> | <img width="1048" height="786" alt="Screenshot 2026-09-11 at 2 41 20 PM" src="https://github.com/user-attachments/assets/4e95db86-2fd3-46a3-95fc-3096748b257c" /> |

Insights "Add widget" picker, searching `Total v`:

| Before (trunk) | After (this PR) |
| --- | --- |
| <img width="620" src="https://raw.githubusercontent.com/Automattic/jetpack/90003f74f9cdc071fc236352e7abc396bb99670f/before-insights-picker-total-v-lists-two.png" /> | <img width="620" src="https://raw.githubusercontent.com/Automattic/jetpack/90003f74f9cdc071fc236352e7abc396bb99670f/after-insights-picker-total-v-no-results.png" /> |

<img width="2560" height="897" alt="Screenshot 2026-09-11 at 2 45 26 PM" src="https://github.com/user-attachments/assets/cf74230f-52ce-4673-968b-e0a29d9476da" />
