### PR TITLE
VideoPress: let the design system color the admin page support link

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-support-link-tokens
+++ b/projects/packages/videopress/changelog/fix-videopress-support-link-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Follow the admin color scheme for the support link.

--- a/projects/packages/videopress/src/client/components/support-link/index.tsx
+++ b/projects/packages/videopress/src/client/components/support-link/index.tsx
@@ -15,13 +15,6 @@ type Props = {
 
 const SUPPORT_POST_ID = 4458;
 
-// Holds the WordPress.com blue on every admin color scheme; the radius rounds
-// the focus ring's outline.
-const linkStyle = {
-	color: 'var(--color-link, #3858e9)',
-	borderRadius: 'var(--wpds-border-radius-sm, 2px)',
-};
-
 /**
  * Links to the VideoPress support doc. WordPress.com sites open it in the Help
  * Center; everywhere else it opens the Jetpack doc in a new tab.
@@ -48,7 +41,6 @@ export default function SupportLink( { children }: Props ) {
 					event.preventDefault();
 					setShowSupportDoc( supportUrl, SUPPORT_POST_ID );
 				} }
-				style={ linkStyle }
 			>
 				{ children }
 			</Link>
@@ -56,7 +48,7 @@ export default function SupportLink( { children }: Props ) {
 	}
 
 	return (
-		<Link openInNewTab href={ supportUrl } style={ linkStyle }>
+		<Link openInNewTab href={ supportUrl }>
 			{ children }
 		</Link>
 	);


### PR DESCRIPTION
Fixes #

## Proposed changes
* Removes the inline style overrides on the VideoPress admin page's support link, so it takes its color from the design system like every other link.
* The override pinned the link blue on every admin color scheme. The screens it was modeled on — Newsletter, My Jetpack, Jetpack AI — all follow the admin color scheme instead, so this made VideoPress the odd one out for anyone not on the default scheme.
* Also drops a border-radius that rounded the focus ring. Inline links get a rectangular one by design.

## Related product discussion/links
* Follow-up to review feedback on the PR that added the link.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Open the VideoPress admin page — Jetpack → VideoPress, or the Jetpack VideoPress plugin's own menu.
* Confirm the subtitle still ends with a working "Learn more" link, on both the modernized dashboard and a video's details screen.
* Go to Users → Profile and switch the admin color scheme to Midnight or Ocean. Reload the VideoPress page and confirm the link now matches the scheme, the same way the links on Jetpack → Newsletter do.
* Tab to the link and confirm the focus ring is rectangular, matching other inline links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
