### PR TITLE
mu-wpcom: Record a server-side wpcom_admin_screen Tracks event for every admin screen

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-admin-screen-tracks-event
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-wpcom-admin-screen-tracks-event
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+wp-admin: Record a server-side wpcom_admin_screen Tracks event for every admin screen, to audit page view coverage.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Wpadmin_Page_View;
 
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 use WPCOMSH_Support_Session_Detect;
 
 /**
@@ -65,6 +66,91 @@ function wpcom_nosara_track_admin_page_views() {
 	<?php
 }
 add_action( 'admin_footer', __NAMESPACE__ . '\wpcom_nosara_track_admin_page_views' );
+
+/**
+ * Build the properties for the server-side `wpcom_admin_screen` Tracks event.
+ *
+ * The event is recorded for every admin screen from PHP, so it does not depend on the
+ * client-side beacon in `wpcom_nosara_track_admin_page_views()`. Comparing the two events
+ * measures how many admin page views the client event misses.
+ *
+ * @param mixed $screen The screen passed to the `current_screen` action.
+ * @return array|null Event properties, or null when the request should not be tracked.
+ */
+function wpcom_get_admin_screen_event_props( $screen ) {
+	if ( ! $screen instanceof \WP_Screen || wp_doing_ajax() || ! is_user_logged_in() ) {
+		return null;
+	}
+
+	if ( do_not_track_a11ns() ) {
+		return null;
+	}
+
+	/**
+	 * Allow disabling the server-side `wpcom_admin_screen` event without a deploy.
+	 *
+	 * @param bool $enabled Whether the event is recorded. Default true.
+	 */
+	if ( ! apply_filters( 'wpcom_admin_screen_tracking_enabled', true ) ) {
+		return null;
+	}
+
+	$is_simple_site = defined( 'IS_WPCOM' ) && IS_WPCOM;
+
+	return array(
+		'screen_id'       => $screen->id,
+		'is_block_editor' => $screen->is_block_editor ? 'true' : 'false',
+		'platform'        => $is_simple_site ? 'simple' : 'atomic',
+		'blog_id'         => (string) wpcom_get_admin_screen_blog_id( $is_simple_site ),
+		'source'          => 'wp-admin',
+	);
+}
+
+/**
+ * Get the blog ID to attach to the `wpcom_admin_screen` event.
+ *
+ * @param bool $is_simple_site Whether this is a Simple site.
+ * @return int|null
+ */
+function wpcom_get_admin_screen_blog_id( $is_simple_site ) {
+	if ( $is_simple_site ) {
+		global $current_blog;
+
+		return $current_blog instanceof \WP_Site ? (int) $current_blog->blog_id : null;
+	}
+
+	return function_exists( '_wpcom_get_current_blog_id' ) ? (int) _wpcom_get_current_blog_id() : null;
+}
+
+/**
+ * Remember the admin screen that is rendering, and record it once the response is complete.
+ *
+ * Recording happens on `shutdown` so the Tracks request never delays the admin page. On
+ * Atomic, `fastcgi_finish_request()` closes the connection to the browser first; Simple
+ * sites keep their own request lifecycle.
+ *
+ * @param mixed $screen The screen passed to the `current_screen` action.
+ */
+function wpcom_capture_admin_screen( $screen ) {
+	$props = wpcom_get_admin_screen_event_props( $screen );
+
+	if ( null === $props ) {
+		return;
+	}
+
+	add_action(
+		'shutdown',
+		function () use ( $props ) {
+			if ( 'atomic' === $props['platform'] && function_exists( 'fastcgi_finish_request' ) ) {
+				fastcgi_finish_request();
+			}
+
+			Common\wpcom_record_tracks_event( 'wpcom_admin_screen', $props );
+		},
+		PHP_INT_MAX
+	);
+}
+add_action( 'current_screen', __NAMESPACE__ . '\wpcom_capture_admin_screen' );
 
 /**
  * Track non-calypso Customizer views if the user is linked from the frontend.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php
@@ -53,6 +53,7 @@ function wpcom_nosara_track_admin_page_views() {
 		var _admin_pv_props = {
 			from_page: '<?php echo esc_js( $current_screen->id ); ?>',
 			is_block_editor: '<?php echo $current_screen->is_block_editor ? 'true' : 'false'; ?>',
+			platform: '<?php echo $is_simple_site ? 'simple' : 'atomic'; ?>',
 			source: 'wp-admin',
 			blog_id: '<?php echo esc_js( (string) $blog_id ); ?>',
 			user_type: '<?php echo esc_js( implode( ',', $user_types ) ); ?>'

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Screen_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Screen_Test.php
@@ -55,6 +55,7 @@ class WPCOM_WPAdmin_Screen_Test extends \WorDBless\BaseTestCase {
 
 		$props = wpcom_get_admin_screen_event_props( $this->login_and_set_screen( 'edit-post' ) );
 
+		$this->assertIsArray( $props );
 		$this->assertSame( 'edit-post', $props['screen_id'] );
 		$this->assertSame( 'false', $props['is_block_editor'] );
 		$this->assertSame( 'simple', $props['platform'] );
@@ -72,6 +73,7 @@ class WPCOM_WPAdmin_Screen_Test extends \WorDBless\BaseTestCase {
 
 		$props = wpcom_get_admin_screen_event_props( $this->login_and_set_screen() );
 
+		$this->assertIsArray( $props );
 		$this->assertSame( 'dashboard', $props['screen_id'] );
 		$this->assertSame( 'atomic', $props['platform'] );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Screen_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-wpadmin-page-view/WPCOM_WPAdmin_Screen_Test.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for the server-side wpcom_admin_screen Tracks event.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom\Wpcom_Wpadmin_Page_View;
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+// Needed to load Class "WPCOMSH_Support_Session_Detect"
+require_once Jetpack_Mu_Wpcom::PKG_DIR . '../../plugins/wpcomsh/support-session.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-wpadmin-page-view/wpcom-wpadmin-page-view.php';
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class WPCOM_WPAdmin_Screen_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Set up a logged-in user and the dashboard screen.
+	 */
+	private function login_and_set_screen( $screen_id = 'dashboard' ) {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'test_user_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'test@example.com',
+			)
+		);
+		wp_set_current_user( $user_id );
+		set_current_screen( $screen_id );
+
+		return get_current_screen();
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_builds_props_for_a_simple_site_screen() {
+		define( 'IS_WPCOM', true );
+		define( 'WP_NETWORK_ADMIN', false );
+		Functions\stubs( array( 'is_automattician' => false ) );
+
+		$props = wpcom_get_admin_screen_event_props( $this->login_and_set_screen( 'edit-post' ) );
+
+		$this->assertSame( 'edit-post', $props['screen_id'] );
+		$this->assertSame( 'false', $props['is_block_editor'] );
+		$this->assertSame( 'simple', $props['platform'] );
+		$this->assertSame( 'wp-admin', $props['source'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_builds_props_for_an_atomic_site_screen() {
+		define( 'IS_WPCOM', false );
+
+		$props = wpcom_get_admin_screen_event_props( $this->login_and_set_screen() );
+
+		$this->assertSame( 'dashboard', $props['screen_id'] );
+		$this->assertSame( 'atomic', $props['platform'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_does_not_track_automatticians() {
+		define( 'IS_WPCOM', true );
+		define( 'WP_NETWORK_ADMIN', false );
+		Functions\stubs( array( 'is_automattician' => true ) );
+
+		$this->assertNull( wpcom_get_admin_screen_event_props( $this->login_and_set_screen() ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_does_not_track_logged_out_requests() {
+		define( 'IS_WPCOM', false );
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
+		$this->assertNull( wpcom_get_admin_screen_event_props( get_current_screen() ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_does_not_track_without_a_screen() {
+		define( 'IS_WPCOM', false );
+
+		$this->assertNull( wpcom_get_admin_screen_event_props( null ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_can_be_disabled_with_a_filter() {
+		define( 'IS_WPCOM', false );
+		add_filter( 'wpcom_admin_screen_tracking_enabled', '__return_false' );
+
+		$this->assertNull( wpcom_get_admin_screen_event_props( $this->login_and_set_screen() ) );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_capture_defers_recording_to_shutdown() {
+		define( 'IS_WPCOM', false );
+
+		wpcom_capture_admin_screen( $this->login_and_set_screen() );
+
+		$this->assertNotFalse( has_action( 'shutdown' ) );
+	}
+}


### PR DESCRIPTION
Part of MARTECH-3065 and MARTECH-3071 (Step 1, Part A of the page view logging project).

## Proposed changes

* Add a `wpcom_admin_screen` Tracks event that is recorded from PHP for every wp-admin screen, on Simple and Atomic sites. It hooks `current_screen`, so it fires even when the page redirects or the client-side beacon never runs.
* Properties: `screen_id`, `is_block_editor`, `platform` (`simple` or `atomic`), `blog_id`, `source: 'wp-admin'`.
* Exclusions match the existing client event: Automatticians (and network admin on Simple), plus AJAX requests and logged-out requests.
* Delivery happens on `shutdown` at the lowest priority so the Tracks request never delays the page. On Atomic, `fastcgi_finish_request()` closes the connection to the browser before the event is sent.
* A `wpcom_admin_screen_tracking_enabled` filter turns the event off without a deploy.
* Add `platform` to the existing client-side `wpcom_admin_page_view` event so the two can be compared per platform.

This event is temporary. It exists to be compared against `wpcom_admin_page_view` for about a week. Whether server-side delivery becomes the permanent mechanism is a Part B decision.

## Related product discussion/links

* Linear: MARTECH-3071 (Step 1), MARTECH-3065 (Part A instrumentation)
* Slack: #proj-pageview-tracking

## Does this pull request change what data or activity we track or use?

Yes. It adds a new event, `wpcom_admin_screen`, recorded server side for every wp-admin screen load. It records the screen id, whether the block editor is active, the platform, and the blog id, tied to the current user like the existing `wpcom_admin_page_view` event. It records no data the existing event does not already record, and it honours the same Automattician exclusion. Adding the "[Status] Needs Privacy Updates" label. Note: This is temporary. We'll likely remove it once the audit is over.

## Testing instructions

1. On a Simple sandbox and on an Atomic site running this branch, log in as a non-Automattician user (or a support session on Atomic) and load a few wp-admin screens, including the post editor.
2. Check Tracks for `wpcom_admin_screen` events: one per screen load, with `screen_id`, `platform`, and `blog_id` set.
3. Load the same screens as an Automattician and confirm no `wpcom_admin_screen` event is recorded.
4. Add `add_filter( 'wpcom_admin_screen_tracking_enabled', '__return_false' );` and confirm the event stops.
5. Confirm the existing `wpcom_admin_page_view` event now carries `platform`.
6. Check that admin page load time is unchanged. On Atomic, the Tracks request goes out after the response is finished.
7. Run `jetpack test php packages/jetpack-mu-wpcom -- --filter WPCOM_WPAdmin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
