### PR TITLE
Goodreads: render the block when the link attribute has encoded ampersands

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-goodreads-encoded-ampersand-link
+++ b/projects/plugins/jetpack/changelog/fix-goodreads-encoded-ampersand-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Goodreads: Fix the block rendering empty on the front end of WordPress.com Simple sites.

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/render.php
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/render.php
@@ -28,7 +28,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return string Canonical URL rebuilt from the validated components, or an empty string when the URL is not allowed.
  */
 function get_validated_script_url( $url ) {
-	if ( ! is_string( $url ) || str_contains( $url, '\\' ) ) {
+	if ( ! is_string( $url ) ) {
+		return '';
+	}
+
+	// Posts saved on WordPress.com Simple store this attribute with encoded ampersands,
+	// which would otherwise parse as `amp;`-prefixed parameter names. The decode table is
+	// limited to & < > " ' and so cannot introduce a path or authority delimiter.
+	$url = wp_specialchars_decode( $url, ENT_QUOTES );
+
+	if ( str_contains( $url, '\\' ) ) {
 		return '';
 	}
 

--- a/projects/plugins/jetpack/extensions/blocks/goodreads/render.php
+++ b/projects/plugins/jetpack/extensions/blocks/goodreads/render.php
@@ -32,10 +32,10 @@ function get_validated_script_url( $url ) {
 		return '';
 	}
 
-	// Posts saved on WordPress.com Simple store this attribute with encoded ampersands,
-	// which would otherwise parse as `amp;`-prefixed parameter names. The decode table is
-	// limited to & < > " ' and so cannot introduce a path or authority delimiter.
-	$url = wp_specialchars_decode( $url, ENT_QUOTES );
+	// A link whose query separators are HTML-encoded parses as `amp;`-prefixed parameter
+	// names and fails the allowlist below. The decode table cannot produce a path or
+	// authority delimiter, so normalizing here does not widen what is accepted.
+	$url = wp_specialchars_decode( $url );
 
 	if ( str_contains( $url, '\\' ) ) {
 		return '';

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Goodreads_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Goodreads_Test.php
@@ -81,6 +81,10 @@ class Goodreads_Test extends \WP_UnitTestCase {
 				'www.goodreads.com/review/custom_widget/1176283.My%20Bookshelf?widget_id=4529663',
 				true,
 			),
+			'encoded ampersand query'    => array(
+				'https://www.goodreads.com/review/custom_widget/1176283.My%20Bookshelf?num_books=5&amp;shelf=read&amp;widget_id=4529663',
+				true,
+			),
 			'external host'              => array(
 				'https://attacker.example/review/custom_widget/1176283.My%20Bookshelf?widget_id=4529663',
 				false,


### PR DESCRIPTION
Fixes #

## Proposed changes
* The Goodreads block rendered as an empty space on the front end of WordPress.com Simple sites, while still looking correct in the editor and in Appearance → Widgets. The widget script was silently never loaded, with no error or fallback.
* The block's stored link separates its settings differently on Simple than it does elsewhere, and the render-side validation only recognised one of the two forms. This normalizes the link before validating it, so both are accepted.
* Already-published posts start rendering again without being re-saved. The allowed host, endpoint and settings are unchanged — normalization runs ahead of every existing check, so nothing new is accepted.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Automated coverage, which fails without the change:

* `jp docker phpunit jetpack -- --filter=Goodreads_Test`

On a WordPress.com Simple site:

* Add a Goodreads block to a post, enter a Goodreads user ID, pick a shelf, and publish.
* View the post on the front end. On trunk the block area is empty; with this change the bookshelf renders.
* An existing post that currently renders blank should also start rendering, without editing or re-saving it.

Check for regressions on a self-hosted or WoA site, where the block already worked:

* Add and publish a Goodreads block, then confirm it still renders on the front end.
* Try both the list and grid styles, and confirm the shelf, sort order and book count settings are still respected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
