### PR TITLE
PayPal Payment Buttons: write the payment with the post, not from a button

### DIFF
--- a/projects/packages/paypal-payments/changelog/update-paypal-sync-on-post-save
+++ b/projects/packages/paypal-payments/changelog/update-paypal-sync-on-post-save
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Create, update and delete the PayPal payment with the post instead of from a Create New button: the payment is written when the post is saved, and removed when the post is saved without its block and no other published post uses it.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-admin-page.php
@@ -87,9 +87,10 @@ class PayPal_Admin_Page {
 	 *
 	 * @since $$next-version$$
 	 *
+	 * @param int $exclude_post_id A post to leave out, such as the one being saved.
 	 * @return array<string,int> Post counts keyed by resource id.
 	 */
-	public static function count_published_embeds() {
+	public static function count_published_embeds( $exclude_post_id = 0 ) {
 		$posts = get_posts(
 			array(
 				'post_type'              => 'any',
@@ -105,6 +106,9 @@ class PayPal_Admin_Page {
 
 		$counts = array();
 		foreach ( $posts as $post ) {
+			if ( $exclude_post_id && (int) $post->ID === (int) $exclude_post_id ) {
+				continue;
+			}
 			if ( ! preg_match_all( '/"resourceId":"(PLB-[A-Za-z0-9]+)"/', $post->post_content, $matches ) ) {
 				continue;
 			}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/class-paypal-rest-controller.php
@@ -284,6 +284,18 @@ class PayPal_REST_Controller {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( __CLASS__, 'handle_delete_button' ),
 					'permission_callback' => array( __CLASS__, 'manage_options_permission_check' ),
+					'args'                => array(
+						'unused_only' => array(
+							'type'        => 'boolean',
+							'default'     => false,
+							'description' => __( 'Keep the payment link when another published post still embeds it.', 'jetpack-paypal-payments' ),
+						),
+						'post_id'     => array(
+							'type'        => 'integer',
+							'default'     => 0,
+							'description' => __( 'The post being saved, which does not count as still embedding the link.', 'jetpack-paypal-payments' ),
+						),
+					),
 				),
 			)
 		);
@@ -699,6 +711,32 @@ class PayPal_REST_Controller {
 	 */
 	public static function handle_delete_button( WP_REST_Request $request ) {
 		$resource_id = $request->get_param( 'resource_id' );
+
+		// The editor deletes a link when a post is saved without its block, but a
+		// link is shared by every block that points at it, on any post.
+		if ( $request->get_param( 'unused_only' ) ) {
+			$embeds = PayPal_Admin_Page::count_published_embeds( absint( $request->get_param( 'post_id' ) ) );
+			$others = $embeds[ $resource_id ] ?? 0;
+			if ( $others > 0 ) {
+				return new WP_REST_Response(
+					array(
+						'deleted'     => false,
+						'resource_id' => $resource_id,
+						'message'     => sprintf(
+							/* translators: %d: number of published posts */
+							_n(
+								'Kept the payment link: %d other published post still uses it.',
+								'Kept the payment link: %d other published posts still use it.',
+								$others,
+								'jetpack-paypal-payments'
+							),
+							$others
+						),
+					),
+					200
+				);
+			}
+		}
 
 		$result = PayPal_API_Client::delete_resource( $resource_id );
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit-api-managed.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit-api-managed.jsx
@@ -33,17 +33,12 @@ import {
 } from '@wordpress/components';
 import { useState, useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import metadata from './block.json';
 import ConfirmDialogs from './components/confirm-dialogs';
 import ConnectionWizard from './components/connection-wizard';
 import { FORMAT_OPTIONS } from './components/format-switcher';
 import LegacyBlock from './components/legacy-block';
 import PayPalButtonPreview from './components/paypal-button-preview';
-import VariantBuilder, {
-	hasVariantPricing,
-	isVariantPricingOn,
-	validateVariants,
-} from './components/variant-builder';
+import VariantBuilder, { isVariantPricingOn, validateVariants } from './components/variant-builder';
 import PayPalInspectorControls from './controls';
 import { broadcastConnectionChange, usePayPalConnection } from './hooks/use-paypal-connection';
 import { usePayPalResource } from './hooks/use-paypal-resource';
@@ -170,23 +165,10 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 	}, [] );
 
 	/**
-	 * Whether the options group carries its own per-option prices.
-	 *
-	 * PayPal rejects a request with `unit_amount` at both the product and the
-	 * variant level, so per-option prices replace the product-level price
-	 * rather than sitting alongside it.
-	 */
-	const usesVariantPricing = useMemo(
-		() => hasVariantPricing( variantsEnabled, variants ),
-		[ variantsEnabled, variants ]
-	);
-
-	/**
 	 * Whether per-variant pricing is turned on.
 	 *
 	 * The product price field goes as soon as the toggle is on, before any option price
-	 * is typed - unlike `usesVariantPricing` above, which keys on the prices themselves
-	 * because the server sanitiser reads the same thing.
+	 * is typed. The request itself keys on the prices, in utils/sync-on-save.js.
 	 */
 	const variantPricingOn = useMemo(
 		() => isVariantPricingOn( variantsEnabled, variants ),
@@ -255,23 +237,18 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 	const isFormValid = ! hasBlockingError( validationErrors ) && variantErrors.length === 0;
 
 	const {
-		isCreating,
+		isBusy,
 		error,
 		setError,
 		successMessage,
 		setSuccessMessage,
-		handleCreateButton,
-		handleUpdateButton,
 		handleDeleteButton,
 		executeDeleteButton,
 	} = usePayPalResource( {
 		attributes,
 		setAttributes,
 		isConnected,
-		usesVariantPricing,
-		isFormValid,
 		setIsEditing,
-		setTouchedFields,
 		setShowDeleteConfirm,
 	} );
 
@@ -324,6 +301,20 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 	 * Whether the block has a created button to preview.
 	 */
 	const hasButton = isApiManaged && resourceId && paymentLink;
+
+	// The payment is written with the post, so the sidebar says what the save will do.
+	let saveStatus = __(
+		'Complete the highlighted fields. Until then the button is not sent to PayPal when you save.',
+		'jetpack-paypal-payments'
+	);
+	if ( isFormValid ) {
+		saveStatus = hasButton
+			? __( 'Changes are sent to PayPal when you save the post.', 'jetpack-paypal-payments' )
+			: __(
+					'The payment button is created on PayPal when you save or publish the post.',
+					'jetpack-paypal-payments'
+			  );
+	}
 
 	/**
 	 * Whether the block is showing that button rather than the form.
@@ -418,7 +409,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 					icon="trash"
 					label={ __( 'Delete Payment Button', 'jetpack-paypal-payments' ) }
 					onClick={ handleDeleteButton }
-					disabled={ isCreating || ! isConnected }
+					disabled={ isBusy || ! isConnected }
 					isDestructive
 				/>
 			</ToolbarGroup>
@@ -435,7 +426,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 			isConnected={ isConnected }
 			environment={ environment }
 			setShowReconnect={ setShowReconnect }
-			isCreating={ isCreating }
+			isBusy={ isBusy }
 			handleDeleteButton={ handleDeleteButton }
 			handleDisconnect={ handleDisconnect }
 			hasButton={ hasButton }
@@ -571,7 +562,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						value={ productName || '' }
 						onChange={ value => setAttributes( { productName: value } ) }
 						onBlur={ () => markTouched( 'productName' ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 						placeholder={ __( 'e.g., Premium Widget', 'jetpack-paypal-payments' ) }
 						help={
 							touchedFields.productName && validationErrors.productName
@@ -598,7 +589,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 									value={ price || '' }
 									onChange={ value => setAttributes( { price: value } ) }
 									onBlur={ () => markTouched( 'price' ) }
-									disabled={ isCreating }
+									disabled={ isBusy }
 									type="number"
 									min={ priceStep }
 									step={ priceStep }
@@ -724,7 +715,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						variants={ variants }
 						currencyCode={ currencyCode || 'USD' }
 						onChange={ updates => setAttributes( updates ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 						errors={ variantErrors }
 						touched={ touchedFields }
 						// A saved button's groups came out of storage already invalid, so
@@ -745,7 +736,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						help={ adjustableQuantity ? helpQtyOn : helpQtyOff }
 						checked={ adjustableQuantity }
 						onChange={ value => setAttributes( { adjustableQuantity: value } ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 					/>
 					{ adjustableQuantity && (
 						<TextControl
@@ -755,7 +746,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 							type="number"
 							min={ 2 }
 							max={ 999 }
-							disabled={ isCreating }
+							disabled={ isBusy }
 							help={ __(
 								'Customers can select from 1 to this number.',
 								'jetpack-paypal-payments'
@@ -769,7 +760,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						help={ taxEnabled ? helpTaxOn : helpTaxOff }
 						checked={ taxEnabled }
 						onChange={ value => setAttributes( { taxEnabled: value } ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 					/>
 					{ taxEnabled && (
 						<>
@@ -787,7 +778,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 									},
 								] }
 								onChange={ value => setAttributes( { taxType: value } ) }
-								disabled={ isCreating }
+								disabled={ isBusy }
 							/>
 							{ taxIsPercentage && (
 								<TextControl
@@ -799,7 +790,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 									max="99.99"
 									step="0.01"
 									placeholder="8.25"
-									disabled={ isCreating }
+									disabled={ isBusy }
 									help={
 										validationErrors.taxValue ||
 										__( 'Percentage added to the product price.', 'jetpack-paypal-payments' )
@@ -839,7 +830,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 								setAttributes( { customerNotes: [] } );
 							}
 						} }
-						disabled={ isCreating }
+						disabled={ isBusy }
 					/>
 					{ customerNotes?.length > 0 && (
 						<div className="jetpack-paypal-payment-buttons__customer-notes">
@@ -861,7 +852,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 											setAttributes( { customerNotes: updated } );
 										} }
 										placeholder={ __( 'e.g., Gift Message', 'jetpack-paypal-payments' ) }
-										disabled={ isCreating }
+										disabled={ isBusy }
 									/>
 									<div className="jetpack-paypal-payment-buttons__customer-note-controls">
 										<ToggleControl
@@ -875,7 +866,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 												};
 												setAttributes( { customerNotes: updated } );
 											} }
-											disabled={ isCreating }
+											disabled={ isBusy }
 										/>
 										{ customerNotes.length > 1 && (
 											<Button
@@ -886,7 +877,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 													const updated = customerNotes.filter( ( _, i ) => i !== noteIndex );
 													setAttributes( { customerNotes: updated } );
 												} }
-												disabled={ isCreating }
+												disabled={ isBusy }
 												aria-label={ sprintf(
 													/* translators: %d: field number */
 													__( 'Remove field %d', 'jetpack-paypal-payments' ),
@@ -908,7 +899,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 											customerNotes: [ ...customerNotes, { label: '', required: false } ],
 										} )
 									}
-									disabled={ isCreating }
+									disabled={ isBusy }
 								>
 									{ __( 'Add field', 'jetpack-paypal-payments' ) }
 								</Button>
@@ -931,7 +922,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 							value={ returnUrl || '' }
 							onChange={ value => setAttributes( { returnUrl: value } ) }
 							required={ false }
-							disabled={ isCreating }
+							disabled={ isBusy }
 							help={
 								returnUrlError ||
 								__( 'Redirect customers here after payment.', 'jetpack-paypal-payments' )
@@ -947,7 +938,7 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						label={ __( 'Button Text', 'jetpack-paypal-payments' ) }
 						value={ buttonText || '' }
 						onChange={ value => setAttributes( { buttonText: value } ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 					/>
 					<ToggleControl
 						label={ __( 'Show QR code', 'jetpack-paypal-payments' ) }
@@ -957,62 +948,16 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 						) }
 						checked={ attributes.showQrCode !== false }
 						onChange={ value => setAttributes( { showQrCode: value } ) }
-						disabled={ isCreating }
+						disabled={ isBusy }
 					/>
 				</PanelBody>
 			</InspectorControls>
 			{ inspectorControls }
 			<InspectorControls>
 				<div className="jetpack-paypal-payment-buttons__form-actions">
-					<Button
-						variant="primary"
-						onClick={ hasButton ? handleUpdateButton : handleCreateButton }
-						isBusy={ isCreating }
-						disabled={ isCreating || ! isFormValid || ! isConnected }
-					>
-						{ isCreating && __( 'Saving…', 'jetpack-paypal-payments' ) }
-						{ ! isCreating && hasButton && __( 'Save', 'jetpack-paypal-payments' ) }
-						{ ! isCreating && ! hasButton && __( 'Create New', 'jetpack-paypal-payments' ) }
-					</Button>
-
-					<Button
-						variant="tertiary"
-						onClick={ () => {
-							if ( hasButton ) {
-								// Return to preview — discard unsaved edits.
-								setIsEditing( false );
-								setTouchedFields( {} );
-							} else {
-								// No saved button yet — reset form fields so merchant can
-								// remove the block if they want.
-								setAttributes( {
-									productName: metadata.attributes.productName.default,
-									price: metadata.attributes.price.default,
-									currencyCode: metadata.attributes.currencyCode.default,
-									productDescription: metadata.attributes.productDescription.default,
-									imageUrl: undefined,
-									imageId: undefined,
-									returnUrl: metadata.attributes.returnUrl.default,
-									variantsEnabled: metadata.attributes.variantsEnabled.default,
-									variants: undefined,
-									adjustableQuantity: metadata.attributes.adjustableQuantity.default,
-									maxQuantity: metadata.attributes.maxQuantity.default,
-									customerNotes: metadata.attributes.customerNotes.default,
-									taxEnabled: metadata.attributes.taxEnabled.default,
-									taxType: metadata.attributes.taxType.default,
-									taxName: metadata.attributes.taxName.default,
-									taxValue: metadata.attributes.taxValue.default,
-									buttonText: metadata.attributes.buttonText.default,
-									showQrCode: metadata.attributes.showQrCode.default,
-								} );
-								setTouchedFields( {} );
-								setError( null );
-							}
-						} }
-						disabled={ isCreating }
-					>
-						{ __( 'Cancel', 'jetpack-paypal-payments' ) }
-					</Button>
+					<Notice status={ isFormValid ? 'info' : 'warning' } isDismissible={ false }>
+						{ saveStatus }
+					</Notice>
 				</div>
 			</InspectorControls>
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/edit-api-managed.jsx
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/edit-api-managed.jsx
@@ -556,6 +556,13 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 		<div { ...blockProps } data-color-scheme={ colorScheme || 'auto' }>
 			{ toolbarControls }
 			<InspectorControls>
+				<div className="jetpack-paypal-payment-buttons__form-actions">
+					<Notice status={ isFormValid ? 'info' : 'warning' } isDismissible={ false }>
+						{ saveStatus }
+					</Notice>
+				</div>
+			</InspectorControls>
+			<InspectorControls>
 				<PanelBody title={ __( 'Details', 'jetpack-paypal-payments' ) } initialOpen={ true }>
 					<TextControl
 						label={ __( 'Product Name', 'jetpack-paypal-payments' ) }
@@ -953,13 +960,6 @@ export default function ApiManagedEdit( { attributes, setAttributes } ) {
 				</PanelBody>
 			</InspectorControls>
 			{ inspectorControls }
-			<InspectorControls>
-				<div className="jetpack-paypal-payment-buttons__form-actions">
-					<Notice status={ isFormValid ? 'info' : 'warning' } isDismissible={ false }>
-						{ saveStatus }
-					</Notice>
-				</div>
-			</InspectorControls>
 
 			<div className="jetpack-paypal-payment-buttons__preview">
 				<div className="jetpack-paypal-payment-buttons__preview-status">

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/editor.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/editor.js
@@ -5,11 +5,13 @@
  * `save: () => null` — the frontend markup is rendered in PHP by
  * PayPal_Payment_Buttons::render_block().
  */
+import { hasFeatureFlag } from '@automattic/jetpack-shared-extension-utils';
 import { registerJetpackBlockFromMetadata } from '../block/register-jetpack-block';
 import metadata from './block.json';
 import deprecated from './deprecated';
-import edit from './edit';
+import edit, { API_MANAGED_BUTTONS_FLAG } from './edit';
 import PayPalIcon from './icon';
+import { registerSaveSync } from './utils/register-save-sync';
 import './editor.scss';
 
 registerJetpackBlockFromMetadata( metadata, {
@@ -18,3 +20,6 @@ registerJetpackBlockFromMetadata( metadata, {
 	icon: PayPalIcon,
 	deprecated,
 } );
+
+// API-managed payments are created, updated and deleted with the post.
+registerSaveSync( () => hasFeatureFlag( API_MANAGED_BUTTONS_FLAG ) );

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/editor.scss
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/editor.scss
@@ -340,12 +340,14 @@
 // Renders as a bare child of the inspector fill rather than inside a PanelBody,
 // so it has to supply the separator and the 16px inset a panel would have given
 // it. Without them it reads as the footer of whichever panel sits above.
+// The line at the top of the sidebar saying what the save will do.
 .jetpack-paypal-payment-buttons__form-actions {
-	display: flex;
-	align-items: center;
-	gap: 12px;
 	padding: 16px;
-	border-top: 1px solid #e0e0e0;
+	border-block-end: 1px solid #e0e0e0;
+
+	.components-notice {
+		margin: 0;
+	}
 }
 
 // Image upload field in the create/edit form.

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/hooks/use-paypal-resource.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/hooks/use-paypal-resource.js
@@ -10,39 +10,32 @@ import { useDispatch } from '@wordpress/data';
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { API_BASE } from '../utils/api-base';
-import { buildRequestData, keepPayPalOnlyFields } from '../utils/request-data';
 import { getResourceAttributeUpdates } from '../utils/resource-sync';
 import { getUserFriendlyError } from '../utils/validation';
 
 /**
- * The PayPal payment resource this block points at: creating it, updating it,
- * deleting it, and reading it back.
+ * The PayPal payment resource this block points at: reading it back and
+ * deleting it. Creating and updating happen with the post save, in
+ * utils/sync-on-save.js.
  *
  * @param {object}   props                      - Hook props.
  * @param {object}   props.attributes           - Block attributes.
  * @param {Function} props.setAttributes        - Function to update block attributes.
  * @param {boolean}  props.isConnected          - Whether the site is connected to PayPal.
- * @param {boolean}  props.usesVariantPricing   - Whether the options group carries its own prices.
- * @param {boolean}  props.isFormValid          - Whether the product form has no validation errors.
  * @param {Function} props.setIsEditing         - Setter for the edit/preview mode toggle.
- * @param {Function} props.setTouchedFields     - Setter for the touched-field map.
  * @param {Function} props.setShowDeleteConfirm - Setter for the delete confirmation dialog.
- * @return {object} Resource state, its setters, and the create/update/delete handlers.
+ * @return {object} Resource state, its setters, and the delete handlers.
  */
 export function usePayPalResource( {
 	attributes,
 	setAttributes,
 	isConnected,
-	usesVariantPricing,
-	isFormValid,
 	setIsEditing,
-	setTouchedFields,
 	setShowDeleteConfirm,
 } ) {
 	const { isApiManaged, resourceId } = attributes;
 
-	// Form state.
-	const [ isCreating, setIsCreating ] = useState( false );
+	const [ isBusy, setIsBusy ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ successMessage, setSuccessMessage ] = useState( null );
 
@@ -76,7 +69,7 @@ export function usePayPalResource( {
 				__unstableMarkNextChangeAsNotPersistent?.();
 				setAttributes( updates );
 			} )
-			// A payment deleted on PayPal is re-created when the merchant next saves the block.
+			// A payment deleted on PayPal is re-created when the post is next saved.
 			.catch( () => {} );
 
 		return () => {
@@ -89,144 +82,6 @@ export function usePayPalResource( {
 		setAttributes,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
-
-	const buildRequest = useCallback(
-		() => buildRequestData( attributes, usesVariantPricing ),
-		[ attributes, usesVariantPricing ]
-	);
-
-	/**
-	 * Create a PayPal payment button via the API.
-	 */
-	const handleCreateButton = useCallback( () => {
-		// Mark all fields as touched to show any remaining errors.
-		setTouchedFields( {
-			productName: true,
-			price: true,
-			currencyCode: true,
-			productDescription: true,
-		} );
-
-		if ( ! isFormValid ) {
-			return;
-		}
-
-		setError( null );
-		setSuccessMessage( null );
-		setIsCreating( true );
-
-		apiFetch( {
-			path: `${ API_BASE }/buttons`,
-			method: 'POST',
-			data: buildRequest(),
-		} )
-			.then( response => {
-				setAttributes( {
-					isApiManaged: true,
-					resourceId: response.id,
-					paymentLink: response.payment_link,
-				} );
-				setSuccessMessage(
-					__( 'PayPal button and payment link created successfully!', 'jetpack-paypal-payments' )
-				);
-				setIsEditing( false );
-				setTouchedFields( {} );
-			} )
-			.catch( err => {
-				setError( getUserFriendlyError( err ) );
-			} )
-			.finally( () => {
-				setIsCreating( false );
-			} );
-	}, [ buildRequest, setAttributes, isFormValid, setIsEditing, setTouchedFields ] );
-
-	/**
-	 * Update an existing PayPal payment button via the API.
-	 */
-	const handleUpdateButton = useCallback( () => {
-		if ( ! resourceId ) {
-			return;
-		}
-
-		// Mark all fields as touched to show any remaining errors.
-		setTouchedFields( {
-			productName: true,
-			price: true,
-			currencyCode: true,
-			productDescription: true,
-		} );
-
-		if ( ! isFormValid ) {
-			return;
-		}
-
-		setError( null );
-		setSuccessMessage( null );
-		setIsCreating( true );
-
-		let isRecreating = false;
-
-		// Read the payment first, and let a failed read stop the save: a blind PUT
-		// would delete the fields the read was there to copy.
-		apiFetch( { path: `${ API_BASE }/buttons/${ resourceId }` } )
-			.then( resource =>
-				apiFetch( {
-					path: `${ API_BASE }/buttons/${ resourceId }`,
-					method: 'PUT',
-					data: keepPayPalOnlyFields( buildRequest(), resource ),
-				} )
-			)
-			.then( () => {
-				// An update answers 204, so the route echoes the request back and the
-				// payment link stays as it was.
-				setSuccessMessage( __( 'PayPal button updated successfully!', 'jetpack-paypal-payments' ) );
-				setIsEditing( false );
-				setTouchedFields( {} );
-			} )
-			.catch( err => {
-				// If the resource was deleted from PayPal (404 on either the read or
-				// the write), automatically re-create it as a new button with the same
-				// product data. This handles demo/playground blocks and buttons deleted
-				// outside WordPress.
-				if ( err.code === 'paypal_api_resource_not_found' || err.data?.status === 404 ) {
-					isRecreating = true;
-					apiFetch( {
-						path: `${ API_BASE }/buttons`,
-						method: 'POST',
-						data: buildRequest(),
-					} )
-						.then( response => {
-							setAttributes( {
-								isApiManaged: true,
-								resourceId: response.id,
-								paymentLink: response.payment_link,
-							} );
-							setSuccessMessage(
-								__(
-									'Button re-created on PayPal with a new payment link.',
-									'jetpack-paypal-payments'
-								)
-							);
-							setIsEditing( false );
-							setTouchedFields( {} );
-						} )
-						.catch( createErr => {
-							setError( getUserFriendlyError( createErr ) );
-						} )
-						.finally( () => {
-							setIsCreating( false );
-						} );
-					return;
-				}
-
-				setError( getUserFriendlyError( err ) );
-			} )
-			.finally( () => {
-				if ( ! isRecreating ) {
-					setIsCreating( false );
-				}
-			} );
-	}, [ resourceId, buildRequest, setAttributes, isFormValid, setIsEditing, setTouchedFields ] );
 
 	/**
 	 * Request delete confirmation via ConfirmDialog.
@@ -245,7 +100,7 @@ export function usePayPalResource( {
 	const executeDeleteButton = useCallback( () => {
 		setShowDeleteConfirm( false );
 		setError( null );
-		setIsCreating( true );
+		setIsBusy( true );
 
 		apiFetch( {
 			path: `${ API_BASE }/buttons/${ resourceId }`,
@@ -277,18 +132,16 @@ export function usePayPalResource( {
 				}
 			} )
 			.finally( () => {
-				setIsCreating( false );
+				setIsBusy( false );
 			} );
 	}, [ resourceId, setAttributes, setIsEditing, setShowDeleteConfirm ] );
 
 	return {
-		isCreating,
+		isBusy,
 		error,
 		setError,
 		successMessage,
 		setSuccessMessage,
-		handleCreateButton,
-		handleUpdateButton,
 		handleDeleteButton,
 		executeDeleteButton,
 	};

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
@@ -1,0 +1,96 @@
+/**
+ * Hook the payment sync into the post save.
+ *
+ * @package
+ */
+
+import apiFetch from '@wordpress/api-fetch'; // eslint-disable-line import/no-unresolved
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { dispatch, select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor'; // eslint-disable-line import/no-unresolved
+import { addFilter } from '@wordpress/hooks';
+import { store as noticesStore } from '@wordpress/notices'; // eslint-disable-line import/no-unresolved
+import metadata from '../block.json';
+import { API_BASE } from './api-base';
+import { deleteRemovedPayments, removedResourceIds, syncBlocksBeforeSave } from './sync-on-save';
+
+/**
+ * Every PayPal block in the post, inner blocks included.
+ *
+ * @return {Array} Blocks with clientId and attributes.
+ */
+function payPalBlocks() {
+	const store = select( blockEditorStore );
+
+	return store
+		.getClientIdsWithDescendants()
+		.map( clientId => store.getBlock( clientId ) )
+		.filter( block => block?.name === metadata.name );
+}
+
+/**
+ * Whether the site is connected to PayPal.
+ *
+ * @return {Promise<boolean>} False on any failure: no connection, nothing to sync.
+ */
+async function isConnected() {
+	try {
+		const status = await apiFetch( { path: `${ API_BASE }/connection` } );
+		return !! status?.connected;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Sync the PayPal payments before the post is saved.
+ *
+ * Runs on `editor.preSavePost`, which awaits it and saves the content it returns.
+ * The post is saved whether or not PayPal cooperated: an error is reported, and the
+ * merchant can save again.
+ *
+ * @param {Function} isEnabled - Whether API-managed buttons are on for this site.
+ */
+export function registerSaveSync( isEnabled ) {
+	addFilter(
+		'editor.preSavePost',
+		'jetpack/paypal-payment-buttons/sync-payments',
+		async ( edits, options ) => {
+			if ( options?.isAutosave || ! isEnabled() ) {
+				return edits;
+			}
+
+			const blocks = payPalBlocks();
+			const saved = select( editorStore ).getCurrentPost();
+			const savedContent = typeof saved?.content === 'string' ? saved.content : saved?.content?.raw;
+			const removed = removedResourceIds( savedContent, edits?.content );
+
+			if ( ! blocks.length && ! removed.length ) {
+				return edits;
+			}
+			if ( ! ( await isConnected() ) ) {
+				return edits;
+			}
+
+			await deleteRemovedPayments( removed, saved?.id, { request: apiFetch } );
+
+			const changed = await syncBlocksBeforeSave( blocks, {
+				request: apiFetch,
+				updateBlockAttributes: dispatch( blockEditorStore ).updateBlockAttributes,
+				reportError: message =>
+					dispatch( noticesStore ).createErrorNotice( message, { type: 'snackbar' } ),
+			} );
+
+			if ( ! changed ) {
+				return edits;
+			}
+
+			// The blocks now carry their payment ids; save that content, not the
+			// snapshot taken before this ran.
+			const content = select( editorStore ).getEditedPostContent();
+			dispatch( editorStore ).editPost( { content }, { undoIgnore: true } );
+
+			return { ...edits, content };
+		}
+	);
+}

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
@@ -43,6 +43,22 @@ async function isConnected() {
 	}
 }
 
+// How long a save notice stays on screen.
+const TOAST_MS = 5000;
+
+/**
+ * Show a short-lived snackbar, replacing an earlier one with the same id.
+ *
+ * @param {string} status  - 'error' or 'warning'.
+ * @param {string} message - What to say.
+ * @param {string} id      - Notice id, one per block and kind.
+ */
+function toast( status, message, id ) {
+	const { createNotice, removeNotice } = dispatch( noticesStore );
+	createNotice( status, message, { type: 'snackbar', id } );
+	setTimeout( () => removeNotice( id ), TOAST_MS );
+}
+
 /**
  * Sync the PayPal payments before the post is saved.
  *
@@ -78,12 +94,13 @@ export function registerSaveSync( isEnabled ) {
 			const changed = await syncBlocksBeforeSave( blocks, {
 				request: apiFetch,
 				updateBlockAttributes: dispatch( blockEditorStore ).updateBlockAttributes,
-				reportError: message =>
-					dispatch( noticesStore ).createErrorNotice( message, { type: 'snackbar' } ),
+				reportError: ( { clientId }, message ) =>
+					toast( 'error', message, `jetpack-paypal-sync-${ clientId }` ),
 				// A block the merchant left incomplete is skipped, and the only other
 				// sign is a line in the block sidebar. Say so where the save is watched.
 				reportHeldBack: ( { clientId, attributes }, reason ) =>
-					dispatch( noticesStore ).createWarningNotice(
+					toast(
+						'warning',
 						sprintf(
 							/* translators: 1: product name, 2: what to fix */
 							__(
@@ -93,7 +110,7 @@ export function registerSaveSync( isEnabled ) {
 							attributes.productName || __( 'Untitled', 'jetpack-paypal-payments' ),
 							reason
 						),
-						{ id: `jetpack-paypal-held-back-${ clientId }` }
+						`jetpack-paypal-held-back-${ clientId }`
 					),
 			} );
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/register-save-sync.js
@@ -9,6 +9,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { dispatch, select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor'; // eslint-disable-line import/no-unresolved
 import { addFilter } from '@wordpress/hooks';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices'; // eslint-disable-line import/no-unresolved
 import metadata from '../block.json';
 import { API_BASE } from './api-base';
@@ -79,6 +80,21 @@ export function registerSaveSync( isEnabled ) {
 				updateBlockAttributes: dispatch( blockEditorStore ).updateBlockAttributes,
 				reportError: message =>
 					dispatch( noticesStore ).createErrorNotice( message, { type: 'snackbar' } ),
+				// A block the merchant left incomplete is skipped, and the only other
+				// sign is a line in the block sidebar. Say so where the save is watched.
+				reportHeldBack: ( { clientId, attributes }, reason ) =>
+					dispatch( noticesStore ).createWarningNotice(
+						sprintf(
+							/* translators: 1: product name, 2: what to fix */
+							__(
+								'The PayPal button "%1$s" was not sent to PayPal: %2$s',
+								'jetpack-paypal-payments'
+							),
+							attributes.productName || __( 'Untitled', 'jetpack-paypal-payments' ),
+							reason
+						),
+						{ id: `jetpack-paypal-held-back-${ clientId }` }
+					),
 			} );
 
 			if ( ! changed ) {

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
@@ -117,7 +117,7 @@ async function createPayment( request, body ) {
  * @param {object}   deps                       - Collaborators.
  * @param {Function} deps.request               - apiFetch or a stand-in.
  * @param {Function} deps.updateBlockAttributes - Writes attributes onto a block by clientId.
- * @param {Function} deps.reportError           - Shows the merchant a message.
+ * @param {Function} deps.reportError           - Tells the merchant a block's save failed, and why.
  * @param {Function} deps.reportHeldBack        - Tells the merchant a block was not sent, and why.
  * @return {Promise<boolean>} True when the block's attributes changed.
  */
@@ -169,6 +169,7 @@ async function syncBlock(
 		lastSynced.set( clientId, key );
 	} catch ( err ) {
 		reportError(
+			{ clientId, attributes },
 			sprintf(
 				/* translators: 1: product name, 2: error message */
 				__( 'PayPal did not save "%1$s": %2$s', 'jetpack-paypal-payments' ),

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
@@ -16,7 +16,7 @@ import {
 } from '../components/variant-builder';
 import { API_BASE } from './api-base';
 import { buildRequestData, keepPayPalOnlyFields } from './request-data';
-import { getUserFriendlyError, getValidationErrors, hasBlockingError } from './validation';
+import { ADVISORY_ERROR_KEYS, getUserFriendlyError, getValidationErrors } from './validation';
 
 // The last body each block sent, so an unchanged block is not re-sent on every save.
 const lastSynced = new Map();
@@ -29,15 +29,15 @@ export function forgetSyncedRequests() {
 }
 
 /**
- * Whether a block's form is complete enough to send to PayPal.
+ * Why a block's form cannot be sent to PayPal yet, if it cannot.
  *
  * The same gate the editor shows the merchant: a blocking field error, or an
  * option group error, holds the payment back.
  *
  * @param {object} attributes - Block attributes.
- * @return {boolean} True when the payment can be created or updated.
+ * @return {string|null} The first thing to fix, or null when the payment can go.
  */
-export function isReadyForPayPal( attributes ) {
+export function heldBackReason( attributes ) {
 	const {
 		productName,
 		price,
@@ -63,10 +63,26 @@ export function isReadyForPayPal( attributes ) {
 		taxValue,
 	} );
 
-	return (
-		! hasBlockingError( errors ) &&
-		validateVariants( variantsEnabled, variants, currencyCode || 'USD' ).length === 0
+	const blocking = Object.entries( errors ).find(
+		( [ field, message ] ) => message && ! ADVISORY_ERROR_KEYS.includes( field )
 	);
+	if ( blocking ) {
+		return blocking[ 1 ];
+	}
+
+	const [ variantError ] = validateVariants( variantsEnabled, variants, currencyCode || 'USD' );
+
+	return variantError ? variantError.message : null;
+}
+
+/**
+ * Whether a block's form is complete enough to send to PayPal.
+ *
+ * @param {object} attributes - Block attributes.
+ * @return {boolean} True when the payment can be created or updated.
+ */
+export function isReadyForPayPal( attributes ) {
+	return heldBackReason( attributes ) === null;
 }
 
 /**
@@ -102,13 +118,16 @@ async function createPayment( request, body ) {
  * @param {Function} deps.request               - apiFetch or a stand-in.
  * @param {Function} deps.updateBlockAttributes - Writes attributes onto a block by clientId.
  * @param {Function} deps.reportError           - Shows the merchant a message.
+ * @param {Function} deps.reportHeldBack        - Tells the merchant a block was not sent, and why.
  * @return {Promise<boolean>} True when the block's attributes changed.
  */
 async function syncBlock(
 	{ clientId, attributes },
-	{ request, updateBlockAttributes, reportError }
+	{ request, updateBlockAttributes, reportError, reportHeldBack }
 ) {
-	if ( ! isReadyForPayPal( attributes ) ) {
+	const reason = heldBackReason( attributes );
+	if ( reason ) {
+		reportHeldBack?.( { clientId, attributes }, reason );
 		return false;
 	}
 

--- a/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
+++ b/projects/packages/paypal-payments/src/paypal-payment-buttons/utils/sync-on-save.js
@@ -1,0 +1,231 @@
+/**
+ * Keep each PayPal block's payment in step with the post it sits in.
+ *
+ * The payment is created or updated when the post is saved, and deleted when
+ * the post is saved without the block that held it.
+ *
+ * @package
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+import metadata from '../block.json';
+import {
+	hasVariantPricing,
+	isVariantPricingOn,
+	validateVariants,
+} from '../components/variant-builder';
+import { API_BASE } from './api-base';
+import { buildRequestData, keepPayPalOnlyFields } from './request-data';
+import { getUserFriendlyError, getValidationErrors, hasBlockingError } from './validation';
+
+// The last body each block sent, so an unchanged block is not re-sent on every save.
+const lastSynced = new Map();
+
+/**
+ * Forget what has been synced. Tests start clean with this.
+ */
+export function forgetSyncedRequests() {
+	lastSynced.clear();
+}
+
+/**
+ * Whether a block's form is complete enough to send to PayPal.
+ *
+ * The same gate the editor shows the merchant: a blocking field error, or an
+ * option group error, holds the payment back.
+ *
+ * @param {object} attributes - Block attributes.
+ * @return {boolean} True when the payment can be created or updated.
+ */
+export function isReadyForPayPal( attributes ) {
+	const {
+		productName,
+		price,
+		productDescription,
+		returnUrl,
+		currencyCode,
+		variantsEnabled,
+		variants,
+		taxEnabled,
+		taxType,
+		taxValue,
+	} = attributes;
+
+	const errors = getValidationErrors( {
+		productName,
+		price,
+		productDescription,
+		returnUrl,
+		currencyCode,
+		variantPricingOn: isVariantPricingOn( variantsEnabled, variants ),
+		taxEnabled,
+		taxIsPercentage: ( taxType || 'PERCENTAGE' ) === 'PERCENTAGE',
+		taxValue,
+	} );
+
+	return (
+		! hasBlockingError( errors ) &&
+		validateVariants( variantsEnabled, variants, currencyCode || 'USD' ).length === 0
+	);
+}
+
+/**
+ * Whether an API error says the payment no longer exists at PayPal.
+ *
+ * @param {object} err - The apiFetch error.
+ * @return {boolean} True for a 404.
+ */
+function isNotFound( err ) {
+	return err?.code === 'paypal_api_resource_not_found' || err?.data?.status === 404;
+}
+
+/**
+ * Create a payment and return the attributes that point the block at it.
+ *
+ * @param {Function} request - apiFetch or a stand-in.
+ * @param {object}   body    - The request body.
+ * @return {Promise<object>} Attributes to set on the block.
+ */
+async function createPayment( request, body ) {
+	const response = await request( { path: `${ API_BASE }/buttons`, method: 'POST', data: body } );
+
+	return { isApiManaged: true, resourceId: response.id, paymentLink: response.payment_link };
+}
+
+/**
+ * Create or update the payment behind one block.
+ *
+ * @param {object}   block                      - The block to sync.
+ * @param {string}   block.clientId             - The block's client id.
+ * @param {object}   block.attributes           - The block's attributes.
+ * @param {object}   deps                       - Collaborators.
+ * @param {Function} deps.request               - apiFetch or a stand-in.
+ * @param {Function} deps.updateBlockAttributes - Writes attributes onto a block by clientId.
+ * @param {Function} deps.reportError           - Shows the merchant a message.
+ * @return {Promise<boolean>} True when the block's attributes changed.
+ */
+async function syncBlock(
+	{ clientId, attributes },
+	{ request, updateBlockAttributes, reportError }
+) {
+	if ( ! isReadyForPayPal( attributes ) ) {
+		return false;
+	}
+
+	const body = buildRequestData(
+		attributes,
+		hasVariantPricing( attributes.variantsEnabled, attributes.variants )
+	);
+	const key = JSON.stringify( body );
+	const { resourceId } = attributes;
+
+	if ( resourceId && lastSynced.get( clientId ) === key ) {
+		return false;
+	}
+
+	let changed = false;
+	try {
+		if ( resourceId ) {
+			try {
+				// Read first: a PUT is a full replacement, and the payment carries
+				// fields the form has no control for.
+				const resource = await request( { path: `${ API_BASE }/buttons/${ resourceId }` } );
+				await request( {
+					path: `${ API_BASE }/buttons/${ resourceId }`,
+					method: 'PUT',
+					data: keepPayPalOnlyFields( body, resource ),
+				} );
+			} catch ( err ) {
+				if ( ! isNotFound( err ) ) {
+					throw err;
+				}
+				// Gone from PayPal, or deleted from the admin page: give the block a new one.
+				updateBlockAttributes( clientId, await createPayment( request, body ) );
+				changed = true;
+			}
+		} else {
+			updateBlockAttributes( clientId, await createPayment( request, body ) );
+			changed = true;
+		}
+		lastSynced.set( clientId, key );
+	} catch ( err ) {
+		reportError(
+			sprintf(
+				/* translators: 1: product name, 2: error message */
+				__( 'PayPal did not save "%1$s": %2$s', 'jetpack-paypal-payments' ),
+				attributes.productName,
+				getUserFriendlyError( err )
+			)
+		);
+	}
+
+	return changed;
+}
+
+/**
+ * Create or update the payment behind every PayPal block before the post is saved.
+ *
+ * @param {Array}  blocks - Blocks with clientId and attributes.
+ * @param {object} deps   - See syncBlock().
+ * @return {Promise<boolean>} True when any block's attributes changed.
+ */
+export async function syncBlocksBeforeSave( blocks, deps ) {
+	const results = await Promise.all( blocks.map( block => syncBlock( block, deps ) ) );
+
+	return results.some( Boolean );
+}
+
+const RESOURCE_ID_PATTERN = new RegExp(
+	'wp:' + metadata.name.replace( '/', '\\/' ) + ' [^\\n]*?"resourceId":"(PLB-[A-Za-z0-9]+)"',
+	'g'
+);
+
+/**
+ * The payments the PayPal blocks in some post content point at.
+ *
+ * @param {string} content - Serialized post content.
+ * @return {Set<string>} Resource ids.
+ */
+export function resourceIdsIn( content ) {
+	const ids = new Set();
+	for ( const match of String( content || '' ).matchAll( RESOURCE_ID_PATTERN ) ) {
+		ids.add( match[ 1 ] );
+	}
+
+	return ids;
+}
+
+/**
+ * The payments the saved post had that the content about to be saved no longer has.
+ *
+ * @param {string} savedContent - Content of the post as last saved.
+ * @param {string} nextContent  - Content about to be saved.
+ * @return {string[]} Resource ids the merchant removed.
+ */
+export function removedResourceIds( savedContent, nextContent ) {
+	const next = resourceIdsIn( nextContent );
+
+	return [ ...resourceIdsIn( savedContent ) ].filter( id => ! next.has( id ) );
+}
+
+/**
+ * Delete the payments behind blocks the merchant removed, unless another
+ * published post still uses them. The server does that check.
+ *
+ * @param {string[]} resourceIds  - Payments to delete.
+ * @param {number}   postId       - The post being saved, left out of the check.
+ * @param {object}   deps         - Collaborators.
+ * @param {Function} deps.request - apiFetch or a stand-in.
+ * @return {Promise<void>} Resolves once every delete has been attempted.
+ */
+export async function deleteRemovedPayments( resourceIds, postId, { request } ) {
+	await Promise.all(
+		resourceIds.map( id =>
+			request( {
+				path: `${ API_BASE }/buttons/${ id }?unused_only=1&post_id=${ Number( postId ) || 0 }`,
+				method: 'DELETE',
+				// The admin page lists what is left, so a failed delete is not worth a notice.
+			} ).catch( () => {} )
+		)
+	);
+}

--- a/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
+++ b/projects/packages/paypal-payments/tests/js/paypal-payment-buttons-block-tests/edit.test.jsx
@@ -263,6 +263,13 @@ jest.mock( '../../../src/paypal-payment-buttons/components/paypal-button-preview
 describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 	const setAttributes = jest.fn();
 
+	// The sidebar says what the post save will do with the payment.
+	const createdOnSave =
+		'The payment button is created on PayPal when you save or publish the post.';
+	const updatedOnSave = 'Changes are sent to PayPal when you save the post.';
+	const heldBack =
+		'Complete the highlighted fields. Until then the button is not sent to PayPal when you save.';
+
 	/**
 	 * An inspector panel by title. The mock renders closed panels too, so read
 	 * initialOpen off it rather than trusting that an error inside is visible.
@@ -312,17 +319,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				setAttributes={ setAttributes }
 			/>
 		);
-
-	/**
-	 * Open the block's edit form and press Save.
-	 *
-	 * @param {object} user - The userEvent instance driving the clicks.
-	 */
-	async function saveFromEditForm( user ) {
-		await expect( screen.findByTestId( 'toolbar-Edit' ) ).resolves.toBeInTheDocument();
-		await user.click( screen.getByTestId( 'toolbar-Edit' ) );
-		await user.click( screen.getByText( 'Save' ) );
-	}
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -973,7 +969,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			// The frame going away means little on its own: clearing the referral
 			// and flipping to connected each remove it. Check for the connected
 			// view itself.
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 			expect( screen.queryByTitle( 'PayPal onboarding' ) ).not.toBeInTheDocument();
 		} );
 
@@ -992,7 +988,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				window.jetpackPayPalOnboardComplete( 'AUTH_CODE_1', 'SHARED_ID_1' );
 			} );
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 
 			await user.click( screen.getByRole( 'button', { name: /Disconnect PayPal/i } ) );
 			await user.click( screen.getByTestId( 'confirm-dialog-confirm' ) );
@@ -1135,7 +1131,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			);
 
 			// Then the wizard gives way to the connected view.
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 			expect( screen.queryByTitle( 'PayPal onboarding' ) ).not.toBeInTheDocument();
 		} );
 
@@ -1436,7 +1432,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 		it( 'shows the create form when connected but no button exists', async () => {
 			render( <Edit attributes={ {} } setAttributes={ setAttributes } /> );
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 			expect( screen.getByLabelText( 'Product Name' ) ).toBeInTheDocument();
 			expect( screen.getByLabelText( 'Price' ) ).toBeInTheDocument();
 			expect( screen.getByLabelText( 'Currency' ) ).toBeInTheDocument();
@@ -1456,15 +1452,14 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			expect( setAttributes ).toHaveBeenCalledWith( { productName: 'T' } );
 		} );
 
-		it( 'disables the primary action when form is invalid', async () => {
+		it( 'holds the payment back while the form is invalid', async () => {
 			render( <Edit attributes={ {} } setAttributes={ setAttributes } /> );
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			const createButton = screen.getByText( 'Create New' );
-			expect( createButton ).toBeDisabled();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 		} );
 
-		it( 'enables the primary action when required fields are filled', async () => {
+		it( 'creates the payment on save once the required fields are filled', async () => {
 			render(
 				<Edit
 					attributes={ {
@@ -1476,12 +1471,11 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			const createButton = screen.getByText( 'Create New' );
-			expect( createButton ).toBeEnabled();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( createdOnSave ) ).toBeInTheDocument();
 		} );
 
-		it( 'disables the primary action when the description is too long', async () => {
+		it( 'holds the payment back when the description is too long', async () => {
 			render(
 				<Edit
 					attributes={ {
@@ -1494,9 +1488,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			const createButton = screen.getByText( 'Create New' );
-			expect( createButton ).toBeDisabled();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 		} );
 
 		it( 'accepts a description past the old 256 limit', async () => {
@@ -1512,56 +1505,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			expect( screen.getByText( 'Create New' ) ).toBeEnabled();
-		} );
-
-		it( 'submits create request with correct data', async () => {
-			const user = userEvent.setup();
-
-			// First call: connection check. Second call: create button.
-			apiFetch
-				.mockResolvedValueOnce( { connected: true, environment: 'sandbox' } )
-				.mockResolvedValueOnce( {
-					id: 'PLB-TEST123',
-					payment_link: 'https://www.paypal.com/paymentpage/PLB-TEST123',
-				} );
-
-			render(
-				<Edit
-					attributes={ {
-						productName: 'Test Widget',
-						price: '29.99',
-						currencyCode: 'USD',
-						collectShippingAddress: false,
-					} }
-					setAttributes={ setAttributes }
-				/>
-			);
-
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			const createButton = screen.getByText( 'Create New' );
-			await user.click( createButton );
-
-			// Should have called apiFetch with the create request.
-			expect( apiFetch ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					path: '/wpcom/v2/paypal/buttons',
-					method: 'POST',
-					data: expect.objectContaining( {
-						type: 'BUY_NOW',
-						integration_mode: 'LINK',
-						line_items: expect.arrayContaining( [
-							expect.objectContaining( {
-								name: 'Test Widget',
-								unit_amount: { currency_code: 'USD', value: '29.99' },
-								// Sent even when off: omit it and PayPal turns address collection on.
-								collect_shipping_address: false,
-							} ),
-						] ),
-					} ),
-				} )
-			);
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( createdOnSave ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -1659,7 +1604,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				<Edit
 					attributes={ {
 						productName: 'Test Widget',
-						// Invalid, and now unreachable - it must not gate the save button.
+						// Invalid, and now unreachable - it must not hold the payment back.
 						price: '0',
 						currencyCode: 'USD',
 						variantsEnabled: true,
@@ -1669,11 +1614,11 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			expect( screen.getByText( 'Create New' ) ).toBeEnabled();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
+			expect( screen.getByText( createdOnSave ) ).toBeInTheDocument();
 		} );
 
-		it( 'gates the save button on the options once their prices are cleared', async () => {
+		it( 'holds the payment back on the options once their prices are cleared', async () => {
 			const attributes = {
 				productName: 'Test Widget',
 				price: '0',
@@ -1686,7 +1631,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				<Edit attributes={ attributes } setAttributes={ setAttributes } />
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 
 			rerender(
 				<Edit
@@ -1698,7 +1643,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			// Pricing stays on, so the product price field stays away and the options
 			// themselves carry the error rather than handing it back to a hidden field.
 			expect( details().queryByLabelText( 'Price' ) ).not.toBeInTheDocument();
-			expect( screen.getByText( 'Create New' ) ).toBeDisabled();
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 			expect( screen.getAllByText( 'Price is required.' ) ).toHaveLength( 2 );
 		} );
 
@@ -1834,73 +1779,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			await expect( screen.findByLabelText( 'Option 1' ) ).resolves.toHaveValue( 'Small' );
 			expect( screen.getByLabelText( 'Option 2' ) ).toHaveValue( 'Large' );
 		} );
-
-		it( 'leaves the product amount out of the create request', async () => {
-			const user = userEvent.setup();
-
-			apiFetch
-				.mockResolvedValueOnce( { connected: true, environment: 'sandbox' } )
-				.mockResolvedValueOnce( {
-					id: 'PLB-TEST123',
-					payment_link: 'https://www.paypal.com/paymentpage/PLB-TEST123',
-				} );
-
-			render(
-				<Edit
-					attributes={ {
-						productName: 'Test Widget',
-						price: '29.99',
-						currencyCode: 'USD',
-						variantsEnabled: true,
-						variants: variantsWithPrices( [ '10.00', '20.00' ] ),
-					} }
-					setAttributes={ setAttributes }
-				/>
-			);
-
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			await user.click( screen.getByText( 'Create New' ) );
-
-			// PayPal rejects a request carrying unit_amount at both levels.
-			const [ , create ] = apiFetch.mock.calls;
-			expect( create[ 0 ].method ).toBe( 'POST' );
-			expect( create[ 0 ].data.line_items[ 0 ].name ).toBe( 'Test Widget' );
-			expect( create[ 0 ].data.line_items[ 0 ] ).not.toHaveProperty( 'unit_amount' );
-		} );
-
-		it( 'sends the option prices in the currency the product is in', async () => {
-			const user = userEvent.setup();
-
-			apiFetch
-				.mockResolvedValueOnce( { connected: true, environment: 'sandbox' } )
-				.mockResolvedValueOnce( {
-					id: 'PLB-TEST124',
-					payment_link: 'https://www.paypal.com/paymentpage/PLB-TEST124',
-				} );
-
-			render(
-				<Edit
-					attributes={ {
-						productName: 'Test Widget',
-						// The options were priced in USD and the currency changed afterwards.
-						currencyCode: 'EUR',
-						variantsEnabled: true,
-						variants: variantsWithPrices( [ '10.00', '20.00' ] ),
-					} }
-					setAttributes={ setAttributes }
-				/>
-			);
-
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
-			await user.click( screen.getByText( 'Create New' ) );
-
-			const [ , create ] = apiFetch.mock.calls;
-			const [ dimension ] = create[ 0 ].data.line_items[ 0 ].variants.dimensions;
-			expect( dimension.options.map( opt => opt.unit_amount.currency_code ) ).toEqual( [
-				'EUR',
-				'EUR',
-			] );
-		} );
 	} );
 
 	describe( 'Product option errors', () => {
@@ -2033,8 +1911,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			).resolves.toBeInTheDocument();
 			expect( screen.queryByText( 'Variant name is required.' ) ).not.toBeInTheDocument();
 			expect( screen.queryByText( 'Option name is required.' ) ).not.toBeInTheDocument();
-			// The save button is dead from the first render, with nothing on screen saying why.
-			expect( screen.getByText( 'Create New' ) ).toBeDisabled();
+			// The payment is held back from the first render, with nothing on screen saying why.
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 		} );
 
 		it( 'puts the error inside the control that caused it', async () => {
@@ -2288,7 +2166,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			);
 
 			// No link means the create form, which must not claim a shared one.
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 			expect(
 				screen.queryByText( 'Changes made will apply to all payment buttons with this link.' )
 			).not.toBeInTheDocument();
@@ -2305,7 +2183,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 				/>
 			);
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 			expect(
 				screen.queryByText( 'Changes made will apply to all payment buttons with this link.' )
 			).not.toBeInTheDocument();
@@ -2388,7 +2266,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			expect( screen.getByTestId( 'control-Tax rate (%)' ) ).toHaveClass(
 				'jetpack-paypal-payment-buttons__has-error'
 			);
-			expect( screen.getByText( 'Save' ) ).toBeDisabled();
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 			expect( panel( 'Checkout Options' ) ).toHaveAttribute( 'data-initial-open', 'true' );
 		} );
 
@@ -2467,7 +2345,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			expect( screen.getByTestId( 'control-Tax rate (%)' ) ).not.toHaveClass(
 				'jetpack-paypal-payment-buttons__has-error'
 			);
-			expect( screen.getByText( 'Save' ) ).toBeEnabled();
+			expect( screen.getByText( updatedOnSave ) ).toBeInTheDocument();
 			expect( panel( 'Checkout Options' ) ).toHaveAttribute( 'data-initial-open', 'false' );
 		} );
 
@@ -2490,91 +2368,13 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			await openEditForm( user );
 
 			expect( screen.queryByText( missingRate ) ).not.toBeInTheDocument();
-			expect( screen.getByText( 'Save' ) ).toBeEnabled();
+			expect( screen.getByText( updatedOnSave ) ).toBeInTheDocument();
 		} );
-
-		/**
-		 * The taxes the update request sent.
-		 *
-		 * @return {Array|undefined} The taxes array from the PUT.
-		 */
-		function taxesFromUpdate() {
-			const put = apiFetch.mock.calls.find( ( [ options ] ) => options.method === 'PUT' );
-			return put?.[ 0 ]?.data?.line_items?.[ 0 ]?.taxes;
-		}
 
 		// PayPal renders its own label to the buyer, so the merchant's string goes
 		// nowhere - and requiring one threw the whole tax away.
-		it( 'collects tax on a payment without a tax name', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [ { type: 'PERCENTAGE', value: '8.25' } ] )
-			);
-		} );
-
-		it( 'leaves taxes out of the request when tax collection is off', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxEnabled: false } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( apiFetch ).toHaveBeenCalledWith( expect.objectContaining( { method: 'PUT' } ) )
-			);
-			expect( taxesFromUpdate() ).toBeUndefined();
-		} );
-
-		it( 'sends PayPal’s own profile rate as PROFILE', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxType: 'PREFERENCE' } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [ { type: 'PREFERENCE', value: 'PROFILE' } ] )
-			);
-		} );
-
 		// A payment made in PayPal's dashboard can have one. Sending an empty name
 		// back would overwrite it, so the key rides along only when there is one.
-		it( 'sends a tax name the payment already has', async () => {
-			const user = userEvent.setup();
-			mockConnected();
-
-			render(
-				<Edit
-					attributes={ { ...attributes, taxName: 'ZZ Custom VAT Label' } }
-					setAttributes={ setAttributes }
-					clientId="a"
-				/>
-			);
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( taxesFromUpdate() ).toEqual( [
-					{ name: 'ZZ Custom VAT Label', type: 'PERCENTAGE', value: '8.25' },
-				] )
-			);
-		} );
 	} );
 
 	describe( 'Custom checkout fields', () => {
@@ -2813,13 +2613,13 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 		} );
 
 		// A bad URL warns, it has never blocked saving.
-		it( 'leaves Create enabled with a bad URL', async () => {
+		it( 'still sends the payment with a bad URL', async () => {
 			const user = userEvent.setup();
 			renderWith( 'http://example.com' );
 
 			await visit( user, await screen.findByLabelText( label ) );
 
-			expect( screen.getByText( 'Create New' ) ).toBeEnabled();
+			expect( screen.getByText( createdOnSave ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -2831,7 +2631,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 		const details = () => within( panel( 'Details' ) );
 
 		const formIsUp = async () => {
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 		};
 
 		it( 'shows the product name error once the field is left', async () => {
@@ -2891,7 +2691,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 		it( 'refuses to create with a currency PayPal does not take', async () => {
 			renderForm( { currencyCode: 'XYZ' } );
 
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeDisabled();
+			await expect( screen.findByText( heldBack ) ).resolves.toBeInTheDocument();
 		} );
 
 		it( 'writes the description', async () => {
@@ -3023,7 +2823,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			const { attributes, testId, visit: visitLabel } = cases[ key ];
 
 			renderForm( attributes );
-			await expect( screen.findByText( 'Create New' ) ).resolves.toBeInTheDocument();
+			await expect( screen.findByLabelText( 'Product Name' ) ).resolves.toBeInTheDocument();
 
 			if ( visitLabel ) {
 				await visit( user, within( screen.getByTestId( testId ) ).getByLabelText( visitLabel ) );
@@ -3041,7 +2841,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			const field = await showError( key );
 
 			expect( within( field ).getByText( cases[ key ].message ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Create New' ) ).toBeDisabled();
+			expect( screen.getByText( heldBack ) ).toBeInTheDocument();
 		} );
 
 		// The other half of the split: these warn and the merchant can still save.
@@ -3049,7 +2849,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 			const field = await showError( key );
 
 			expect( within( field ).getByText( cases[ key ].message ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Create New' ) ).toBeEnabled();
+			expect( screen.getByText( createdOnSave ) ).toBeInTheDocument();
 		} );
 	} );
 
@@ -3128,105 +2928,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 		} );
 	} );
 
-	describe( 'Form actions', () => {
-		beforeEach( () => {
-			apiFetch.mockResolvedValue( { connected: true, environment: 'sandbox' } );
-		} );
-
-		const savedButton = {
-			isApiManaged: true,
-			resourceId: 'PLB-CANCEL1',
-			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-CANCEL1',
-			productName: '',
-		};
-
-		/**
-		 * Open a saved button's form and leave the name field, so its error shows.
-		 *
-		 * An empty name is the only visible sign that a field was marked touched.
-		 *
-		 * @param {object} user - userEvent instance.
-		 */
-		const editWithATouchedField = async user => {
-			await user.click( await screen.findByTestId( 'toolbar-Edit' ) );
-			await visit( user, screen.getByLabelText( 'Product Name' ) );
-			expect( screen.getByText( 'Product name is required.' ) ).toBeInTheDocument();
-		};
-
-		it( 'returns a saved button to its preview on Cancel', async () => {
-			const user = userEvent.setup();
-			renderForm( savedButton );
-			await editWithATouchedField( user );
-
-			await user.click( screen.getByText( 'Cancel' ) );
-
-			expect( screen.getByTestId( 'paypal-button-preview' ) ).toBeInTheDocument();
-			// The saved button is the copy of record, so Cancel discards the edits
-			// rather than writing them back.
-			expect( setAttributes ).not.toHaveBeenCalled();
-		} );
-
-		it( 'forgets the touched fields when a saved button is cancelled', async () => {
-			const user = userEvent.setup();
-			renderForm( savedButton );
-			await editWithATouchedField( user );
-
-			await user.click( screen.getByText( 'Cancel' ) );
-			await user.click( screen.getByTestId( 'toolbar-Edit' ) );
-
-			expect( screen.queryByText( 'Product name is required.' ) ).not.toBeInTheDocument();
-		} );
-
-		// Nothing has been saved, so there is no preview to go back to - Cancel
-		// empties the form instead, leaving a block the merchant can delete. The
-		// values come from block.json, except the image and the options, which are
-		// cleared outright.
-		it( 'resets an unsaved form to the block defaults', async () => {
-			const user = userEvent.setup();
-
-			renderForm( {
-				currencyCode: 'EUR',
-				productDescription: 'A widget.',
-				imageUrl: 'https://example.com/previous.png',
-				imageId: 7,
-				returnUrl: 'https://example.com/thanks',
-				adjustableQuantity: true,
-				maxQuantity: 4,
-				customerNotes: [ { label: 'Gift message', required: false } ],
-				taxEnabled: true,
-				taxType: 'PERCENTAGE',
-				taxValue: '8.25',
-				buttonText: 'Pay up',
-				showQrCode: false,
-			} );
-
-			await user.click( await screen.findByText( 'Cancel' ) );
-
-			// toStrictEqual, so dropping the image and variant keys altogether -
-			// the bug this reset exists to prevent - is not read as a match.
-			expect( setAttributes.mock.lastCall[ 0 ] ).toStrictEqual( {
-				productName: '',
-				price: '',
-				currencyCode: 'USD',
-				productDescription: '',
-				imageUrl: undefined,
-				imageId: undefined,
-				returnUrl: '',
-				variantsEnabled: false,
-				variants: undefined,
-				adjustableQuantity: false,
-				maxQuantity: 10,
-				customerNotes: [],
-				taxEnabled: false,
-				taxType: 'PERCENTAGE',
-				taxName: 'Sales Tax',
-				taxValue: '',
-				buttonText: 'Buy Now With PayPal',
-				showQrCode: true,
-			} );
-		} );
-	} );
-
 	describe( 'Notices', () => {
 		const saved = {
 			isApiManaged: true,
@@ -3247,71 +2948,8 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 					: respond( request )
 			);
 
-		/**
-		 * The one notice a test has put on screen.
-		 *
-		 * @return {Element} The notice element.
-		 */
-		const notice = () => screen.getByTestId( 'notice' );
-
-		it( 'clears the success notice when it is dismissed', async () => {
-			const user = userEvent.setup();
-			const created = 'PayPal button and payment link created successfully!';
-			mockRoutes( () =>
-				Promise.resolve( { id: saved.resourceId, payment_link: saved.paymentLink } )
-			);
-
-			renderForm( {} );
-
-			await user.click( await screen.findByText( 'Create New' ) );
-			await expect( screen.findByText( created ) ).resolves.toBeInTheDocument();
-			expect( notice() ).toHaveAttribute( 'data-status', 'success' );
-
-			await user.click( screen.getByTestId( 'dismiss-notice' ) );
-
-			expect( screen.queryByText( created ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'clears the error notice when it is dismissed', async () => {
-			const user = userEvent.setup();
-			const refused = 'PayPal turned the payment down.';
-			mockRoutes( () => Promise.reject( { message: refused } ) );
-
-			renderForm( {} );
-
-			await user.click( await screen.findByText( 'Create New' ) );
-			await expect( screen.findByText( refused ) ).resolves.toBeInTheDocument();
-			expect( notice() ).toHaveAttribute( 'data-status', 'error' );
-
-			await user.click( screen.getByTestId( 'dismiss-notice' ) );
-
-			expect( screen.queryByText( refused ) ).not.toBeInTheDocument();
-		} );
-
 		// A save drops the merchant back on the preview, so the notice it leaves
 		// behind is a different one from the form's.
-		it( 'clears the success notice on the preview when it is dismissed', async () => {
-			const user = userEvent.setup();
-			const updated = 'PayPal button updated successfully!';
-			mockRoutes( ( { method } ) =>
-				'PUT' === method
-					? Promise.resolve( { payment_link: saved.paymentLink } )
-					: Promise.resolve( {} )
-			);
-
-			renderForm( saved );
-
-			await user.click( await screen.findByTestId( 'toolbar-Edit' ) );
-			await user.click( screen.getByText( 'Save' ) );
-
-			await expect( screen.findByText( updated ) ).resolves.toBeInTheDocument();
-			expect( screen.getByTestId( 'paypal-button-preview' ) ).toBeInTheDocument();
-
-			await user.click( screen.getByTestId( 'dismiss-notice' ) );
-
-			expect( screen.queryByText( updated ) ).not.toBeInTheDocument();
-		} );
-
 		// A delete is refused without ever leaving the preview, so its error lands
 		// there rather than on the form.
 		it( 'clears the error notice on the preview when it is dismissed', async () => {
@@ -3353,127 +2991,6 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 
 			await expect( screen.findByText( /Get Your API Credentials/ ) ).resolves.toBeInTheDocument();
 			expect( screen.queryByTestId( 'paypal-button-preview' ) ).not.toBeInTheDocument();
-		} );
-	} );
-
-	describe( 'Updating a payment', () => {
-		const attributes = {
-			isApiManaged: true,
-			resourceId: 'PLB-KEEP1',
-			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-KEEP1',
-			productName: 'Test Widget',
-			price: '29.99',
-			currencyCode: 'USD',
-			collectShippingAddress: false,
-		};
-		const resourcePath = '/wpcom/v2/paypal/buttons/PLB-KEEP1';
-
-		// A payment configured beyond what the block form covers - set in PayPal's
-		// own dashboard, or by the admin page.
-		const storedLineItem = {
-			name: 'Test Widget',
-			unit_amount: { currency_code: 'USD', value: '29.99' },
-			product_id: 'SKU-12345',
-			shipping: [ { type: 'FLAT', value: '5.00', additional_unit_value: '2.00' } ],
-			handling: [ { type: 'FLAT', value: '4.00' } ],
-			discounts: [ { type: 'FLAT', value: '2.00' } ],
-			// The block sends false, so a true in the PUT can only have come from
-			// the payment.
-			collect_shipping_address: true,
-		};
-
-		it( 'keeps the fields set outside the form', async () => {
-			const user = userEvent.setup();
-
-			apiFetch.mockImplementation( ( { path, method } ) => {
-				if ( path.endsWith( '/connection' ) ) {
-					return Promise.resolve( { connected: true, environment: 'sandbox' } );
-				}
-				if ( path === resourcePath && method === undefined ) {
-					return Promise.resolve( { id: 'PLB-KEEP1', line_items: [ storedLineItem ] } );
-				}
-				return Promise.resolve( {} );
-			} );
-
-			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( apiFetch ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						path: resourcePath,
-						method: 'PUT',
-						data: expect.objectContaining( {
-							line_items: [
-								expect.objectContaining( {
-									product_id: 'SKU-12345',
-									shipping: storedLineItem.shipping,
-									handling: storedLineItem.handling,
-									discounts: storedLineItem.discounts,
-									collect_shipping_address: true,
-								} ),
-							],
-						} ),
-					} )
-				)
-			);
-		} );
-
-		it( 'sends the form’s own values over the payment’s', async () => {
-			const user = userEvent.setup();
-
-			apiFetch.mockImplementation( ( { path, method } ) => {
-				if ( path.endsWith( '/connection' ) ) {
-					return Promise.resolve( { connected: true, environment: 'sandbox' } );
-				}
-				if ( path === resourcePath && method === undefined ) {
-					return Promise.resolve( {
-						id: 'PLB-KEEP1',
-						line_items: [ { ...storedLineItem, name: 'Stale name' } ],
-					} );
-				}
-				return Promise.resolve( {} );
-			} );
-
-			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( apiFetch ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						method: 'PUT',
-						data: expect.objectContaining( {
-							line_items: [ expect.objectContaining( { name: 'Test Widget' } ) ],
-						} ),
-					} )
-				)
-			);
-		} );
-
-		it( 're-creates a payment that has been deleted from PayPal', async () => {
-			const user = userEvent.setup();
-
-			apiFetch.mockImplementation( ( { path } ) => {
-				if ( path.endsWith( '/connection' ) ) {
-					return Promise.resolve( { connected: true, environment: 'sandbox' } );
-				}
-				if ( path === resourcePath ) {
-					return Promise.reject( { code: 'paypal_api_resource_not_found', data: { status: 404 } } );
-				}
-				return Promise.resolve( {
-					id: 'PLB-NEW1',
-					payment_link: 'https://www.paypal.com/ncp/payment/PLB-NEW1',
-				} );
-			} );
-
-			render( <Edit attributes={ attributes } setAttributes={ setAttributes } clientId="a" /> );
-			await saveFromEditForm( user );
-
-			await waitFor( () =>
-				expect( setAttributes ).toHaveBeenCalledWith(
-					expect.objectContaining( { resourceId: 'PLB-NEW1' } )
-				)
-			);
 		} );
 	} );
 
@@ -3599,7 +3116,7 @@ describe( 'PayPalPaymentButtonsEdit (V2)', () => {
 
 			// Should now show the edit form.
 			expect( screen.getByLabelText( 'Product Name' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Save' ) ).toBeInTheDocument();
+			expect( screen.getByText( updatedOnSave ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/projects/packages/paypal-payments/tests/js/request-data.test.js
+++ b/projects/packages/paypal-payments/tests/js/request-data.test.js
@@ -107,6 +107,27 @@ describe( 'buildRequestData', () => {
 
 		expect( item ).not.toHaveProperty( 'image_url' );
 	} );
+
+	// PayPal renders its own label to the buyer, so the merchant's string goes
+	// nowhere - and requiring one threw the whole tax away.
+	it( 'collects tax without a tax name', () => {
+		const [ tax ] = buildRequestData( { ...attributes, taxName: '' }, true ).line_items[ 0 ].taxes;
+
+		expect( tax ).toEqual( { type: 'PERCENTAGE', value: '7.5' } );
+	} );
+
+	it( 'leaves taxes out when tax collection is off', () => {
+		expect(
+			buildRequestData( { ...attributes, taxEnabled: false }, true ).line_items[ 0 ]
+		).not.toHaveProperty( 'taxes' );
+	} );
+
+	it( 'sends PayPal’s own profile rate as PROFILE', () => {
+		const [ tax ] = buildRequestData( { ...attributes, taxType: 'PREFERENCE', taxName: '' }, true )
+			.line_items[ 0 ].taxes;
+
+		expect( tax ).toEqual( { type: 'PREFERENCE', value: 'PROFILE' } );
+	} );
 } );
 
 describe( 'keepPayPalOnlyFields', () => {

--- a/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
+++ b/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
@@ -1,0 +1,311 @@
+/**
+ * Tests for syncing PayPal payments with the post save.
+ *
+ * @package
+ */
+
+import {
+	deleteRemovedPayments,
+	forgetSyncedRequests,
+	isReadyForPayPal,
+	removedResourceIds,
+	resourceIdsIn,
+	syncBlocksBeforeSave,
+} from '../../src/paypal-payment-buttons/utils/sync-on-save';
+
+const product = {
+	productName: 'Test Widget',
+	price: '29.99',
+	currencyCode: 'USD',
+	collectShippingAddress: false,
+};
+
+const priced = [ '10.00', '20.00' ];
+
+/**
+ * A variants structure with one primary option group.
+ *
+ * @param {Array} prices - One price per option; '' means unpriced.
+ * @return {object} Variants structure.
+ */
+const variantsWithPrices = prices => ( {
+	dimensions: [
+		{
+			name: 'Size',
+			primary: true,
+			options: prices.map( ( value, i ) => ( {
+				label: `Option ${ i + 1 }`,
+				unit_amount: { currency_code: 'USD', value },
+			} ) ),
+		},
+	],
+} );
+
+/**
+ * Collaborators the sync writes through, recorded for the assertions.
+ *
+ * @param {Function} respond - Answers each request; defaults to a created payment.
+ * @return {object} deps plus the recorded calls.
+ */
+function fakeDeps( respond ) {
+	const requests = [];
+	const request = jest.fn( options => {
+		requests.push( options );
+		return respond
+			? respond( options )
+			: Promise.resolve( {
+					id: 'PLB-NEW1',
+					payment_link: 'https://www.paypal.com/ncp/payment/PLB-NEW1',
+			  } );
+	} );
+	return {
+		requests,
+		request,
+		updateBlockAttributes: jest.fn(),
+		reportError: jest.fn(),
+	};
+}
+
+beforeEach( forgetSyncedRequests );
+
+describe( 'isReadyForPayPal', () => {
+	it( 'accepts a complete product', () => {
+		expect( isReadyForPayPal( product ) ).toBe( true );
+	} );
+
+	it( 'holds back a product with a blocking field error', () => {
+		expect( isReadyForPayPal( { ...product, productName: '' } ) ).toBe( false );
+		expect( isReadyForPayPal( { ...product, productDescription: 'x'.repeat( 2049 ) } ) ).toBe(
+			false
+		);
+	} );
+
+	// A bad URL warns, it has never blocked saving.
+	it( 'lets a bad return URL through', () => {
+		expect( isReadyForPayPal( { ...product, returnUrl: 'http://example.com' } ) ).toBe( true );
+	} );
+
+	it( 'ignores a stale product price once the options carry their own', () => {
+		expect(
+			isReadyForPayPal( {
+				...product,
+				price: '0',
+				variantsEnabled: true,
+				variants: variantsWithPrices( priced ),
+			} )
+		).toBe( true );
+	} );
+
+	it( 'holds back options that lost their prices', () => {
+		expect(
+			isReadyForPayPal( {
+				...product,
+				variantsEnabled: true,
+				variants: variantsWithPrices( [ '', '' ] ),
+			} )
+		).toBe( false );
+	} );
+} );
+
+describe( 'syncBlocksBeforeSave', () => {
+	it( 'creates the payment for a new block and points the block at it', async () => {
+		const deps = fakeDeps();
+
+		const changed = await syncBlocksBeforeSave( [ { clientId: 'a', attributes: product } ], deps );
+
+		expect( changed ).toBe( true );
+		expect( deps.requests ).toEqual( [
+			expect.objectContaining( {
+				path: '/wpcom/v2/paypal/buttons',
+				method: 'POST',
+				data: expect.objectContaining( {
+					type: 'BUY_NOW',
+					integration_mode: 'LINK',
+					line_items: [
+						expect.objectContaining( {
+							name: 'Test Widget',
+							unit_amount: { currency_code: 'USD', value: '29.99' },
+							// Sent even when off: omit it and PayPal turns address collection on.
+							collect_shipping_address: false,
+						} ),
+					],
+				} ),
+			} ),
+		] );
+		expect( deps.updateBlockAttributes ).toHaveBeenCalledWith( 'a', {
+			isApiManaged: true,
+			resourceId: 'PLB-NEW1',
+			paymentLink: 'https://www.paypal.com/ncp/payment/PLB-NEW1',
+		} );
+	} );
+
+	it( 'leaves an incomplete block alone', async () => {
+		const deps = fakeDeps();
+
+		const changed = await syncBlocksBeforeSave(
+			[ { clientId: 'a', attributes: { ...product, productName: '' } } ],
+			deps
+		);
+
+		expect( changed ).toBe( false );
+		expect( deps.request ).not.toHaveBeenCalled();
+		expect( deps.reportError ).not.toHaveBeenCalled();
+	} );
+
+	// PayPal rejects a request carrying unit_amount at both levels.
+	it( 'leaves the product amount out once the options are priced', async () => {
+		const deps = fakeDeps();
+
+		await syncBlocksBeforeSave(
+			[
+				{
+					clientId: 'a',
+					attributes: {
+						...product,
+						currencyCode: 'EUR',
+						variantsEnabled: true,
+						variants: variantsWithPrices( priced ),
+					},
+				},
+			],
+			deps
+		);
+
+		const [ item ] = deps.requests[ 0 ].data.line_items;
+		expect( item ).not.toHaveProperty( 'unit_amount' );
+		// The options were priced in USD and the currency changed afterwards.
+		expect( item.variants.dimensions[ 0 ].options.map( o => o.unit_amount.currency_code ) ).toEqual(
+			[ 'EUR', 'EUR' ]
+		);
+	} );
+
+	describe( 'a block that already has a payment', () => {
+		const saved = { ...product, isApiManaged: true, resourceId: 'PLB-KEEP1' };
+		const storedLineItem = {
+			name: 'Stale name',
+			product_id: 'SKU-12345',
+			shipping: [ { type: 'FLAT', value: '5.00' } ],
+			handling: [ { type: 'FLAT', value: '4.00' } ],
+			discounts: [ { type: 'FLAT', value: '2.00' } ],
+			// The block sends false, so a true in the PUT can only have come from the payment.
+			collect_shipping_address: true,
+		};
+
+		/**
+		 * Answer the read with the stored payment and every write with nothing.
+		 *
+		 * @param {object} options - The request.
+		 * @return {Promise<object>} The response.
+		 */
+		const stored = options =>
+			options.method === undefined
+				? Promise.resolve( { id: 'PLB-KEEP1', line_items: [ storedLineItem ] } )
+				: Promise.resolve( {} );
+
+		it( 'reads the payment and updates it, keeping the fields set outside the form', async () => {
+			const deps = fakeDeps( stored );
+
+			const changed = await syncBlocksBeforeSave( [ { clientId: 'a', attributes: saved } ], deps );
+
+			expect( changed ).toBe( false );
+			expect( deps.requests.map( r => r.method ) ).toEqual( [ undefined, 'PUT' ] );
+			const [ item ] = deps.requests[ 1 ].data.line_items;
+			expect( item ).toMatchObject( {
+				name: 'Test Widget',
+				product_id: 'SKU-12345',
+				shipping: storedLineItem.shipping,
+				handling: storedLineItem.handling,
+				discounts: storedLineItem.discounts,
+				collect_shipping_address: true,
+			} );
+			expect( deps.updateBlockAttributes ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not send an unchanged block twice', async () => {
+			const deps = fakeDeps( stored );
+
+			await syncBlocksBeforeSave( [ { clientId: 'a', attributes: saved } ], deps );
+			await syncBlocksBeforeSave( [ { clientId: 'a', attributes: saved } ], deps );
+			expect( deps.requests ).toHaveLength( 2 );
+
+			await syncBlocksBeforeSave(
+				[ { clientId: 'a', attributes: { ...saved, price: '31.00' } } ],
+				deps
+			);
+			expect( deps.requests ).toHaveLength( 4 );
+		} );
+
+		it( 're-creates a payment that has been deleted from PayPal', async () => {
+			const deps = fakeDeps( options =>
+				options.method === 'POST'
+					? Promise.resolve( {
+							id: 'PLB-NEW1',
+							payment_link: 'https://www.paypal.com/ncp/payment/PLB-NEW1',
+					  } )
+					: Promise.reject( { code: 'paypal_api_resource_not_found', data: { status: 404 } } )
+			);
+
+			const changed = await syncBlocksBeforeSave( [ { clientId: 'a', attributes: saved } ], deps );
+
+			expect( changed ).toBe( true );
+			expect( deps.updateBlockAttributes ).toHaveBeenCalledWith(
+				'a',
+				expect.objectContaining( { resourceId: 'PLB-NEW1' } )
+			);
+		} );
+
+		it( 'reports a refusal and keeps going', async () => {
+			const deps = fakeDeps( options =>
+				options.method === undefined
+					? Promise.reject( { message: 'PayPal turned the payment down.' } )
+					: Promise.resolve( {} )
+			);
+
+			const changed = await syncBlocksBeforeSave(
+				[
+					{ clientId: 'a', attributes: saved },
+					{ clientId: 'b', attributes: { ...product, productName: 'Other Widget' } },
+				],
+				deps
+			);
+
+			expect( changed ).toBe( true );
+			expect( deps.reportError ).toHaveBeenCalledWith(
+				expect.stringContaining( 'PayPal turned the payment down.' )
+			);
+			expect( deps.updateBlockAttributes ).toHaveBeenCalledWith( 'b', expect.anything() );
+		} );
+	} );
+} );
+
+describe( 'removed payments', () => {
+	const block = id =>
+		`<!-- wp:jetpack/paypal-payment-buttons {"isApiManaged":true,"resourceId":"${ id }"} /-->`;
+
+	it( 'reads the payments out of post content', () => {
+		expect( [ ...resourceIdsIn( `${ block( 'PLB-A1' ) }\n${ block( 'PLB-B2' ) }` ) ] ).toEqual( [
+			'PLB-A1',
+			'PLB-B2',
+		] );
+		expect( [ ...resourceIdsIn( '' ) ] ).toEqual( [] );
+	} );
+
+	it( 'names the payments the saved post had that the next save drops', () => {
+		const savedContent = `${ block( 'PLB-A1' ) }\n${ block( 'PLB-B2' ) }`;
+
+		expect( removedResourceIds( savedContent, block( 'PLB-B2' ) ) ).toEqual( [ 'PLB-A1' ] );
+		expect( removedResourceIds( savedContent, savedContent ) ).toEqual( [] );
+		expect( removedResourceIds( undefined, block( 'PLB-A1' ) ) ).toEqual( [] );
+	} );
+
+	it( 'asks the server to delete each one unless another post still uses it', async () => {
+		const deps = fakeDeps( () => Promise.reject( new Error( 'kept' ) ) );
+
+		await deleteRemovedPayments( [ 'PLB-A1', 'PLB-B2' ], 17, deps );
+
+		expect( deps.requests ).toEqual( [
+			{ path: '/wpcom/v2/paypal/buttons/PLB-A1?unused_only=1&post_id=17', method: 'DELETE' },
+			{ path: '/wpcom/v2/paypal/buttons/PLB-B2?unused_only=1&post_id=17', method: 'DELETE' },
+		] );
+	} );
+} );

--- a/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
+++ b/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
@@ -63,6 +63,7 @@ function fakeDeps( respond ) {
 		request,
 		updateBlockAttributes: jest.fn(),
 		reportError: jest.fn(),
+		reportHeldBack: jest.fn(),
 	};
 }
 
@@ -139,17 +140,39 @@ describe( 'syncBlocksBeforeSave', () => {
 		} );
 	} );
 
-	it( 'leaves an incomplete block alone', async () => {
+	it( 'leaves an incomplete block alone and says why', async () => {
 		const deps = fakeDeps();
 
 		const changed = await syncBlocksBeforeSave(
-			[ { clientId: 'a', attributes: { ...product, productName: '' } } ],
+			[ { clientId: 'a', attributes: { ...product, price: '' } } ],
 			deps
 		);
 
 		expect( changed ).toBe( false );
 		expect( deps.request ).not.toHaveBeenCalled();
 		expect( deps.reportError ).not.toHaveBeenCalled();
+		expect( deps.reportHeldBack ).toHaveBeenCalledWith(
+			{ clientId: 'a', attributes: { ...product, price: '' } },
+			'Price is required.'
+		);
+	} );
+
+	it( 'names an option group error as the reason', async () => {
+		const deps = fakeDeps();
+		const variants = {
+			dimensions: [ { ...variantsWithPrices( [ '1' ] ).dimensions[ 0 ], name: '' } ],
+		};
+
+		await syncBlocksBeforeSave(
+			[ { clientId: 'a', attributes: { ...product, price: '', variantsEnabled: true, variants } } ],
+			deps
+		);
+
+		expect( deps.request ).not.toHaveBeenCalled();
+		expect( deps.reportHeldBack ).toHaveBeenCalledWith(
+			expect.anything(),
+			'Variant name is required.'
+		);
 	} );
 
 	// PayPal rejects a request carrying unit_amount at both levels.

--- a/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
+++ b/projects/packages/paypal-payments/tests/js/sync-on-save.test.js
@@ -294,6 +294,7 @@ describe( 'syncBlocksBeforeSave', () => {
 
 			expect( changed ).toBe( true );
 			expect( deps.reportError ).toHaveBeenCalledWith(
+				expect.objectContaining( { clientId: 'a' } ),
 				expect.stringContaining( 'PayPal turned the payment down.' )
 			);
 			expect( deps.updateBlockAttributes ).toHaveBeenCalledWith( 'b', expect.anything() );

--- a/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_Admin_Page_Test.php
@@ -147,6 +147,34 @@ class PayPal_Admin_Page_Test extends TestCase {
 		$this->assertTrue( true );
 	}
 
+	/**
+	 * The post being saved can be left out of the count, so its own block does not
+	 * keep the link alive.
+	 */
+	public function test_count_published_embeds_can_leave_one_post_out() {
+		$post = new \WP_Post(
+			(object) array(
+				'ID'           => 1000,
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:jetpack/paypal-payment-buttons {"isApiManaged":true,"resourceId":"PLB-ABC123"} /-->',
+				'filter'       => 'raw',
+			)
+		);
+		add_filter(
+			'posts_pre_query',
+			function () use ( $post ) {
+				return array( $post );
+			}
+		);
+
+		$this->assertSame( 1, PayPal_Admin_Page::count_published_embeds()['PLB-ABC123'] );
+		$this->assertArrayNotHasKey( 'PLB-ABC123', PayPal_Admin_Page::count_published_embeds( 1000 ) );
+		$this->assertSame( 1, PayPal_Admin_Page::count_published_embeds( 999 )['PLB-ABC123'] );
+
+		remove_all_filters( 'posts_pre_query' );
+	}
+
 	// --- Delete confirmation ---
 
 	/**

--- a/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
+++ b/projects/packages/paypal-payments/tests/php/PayPal_REST_Controller_Test.php
@@ -45,6 +45,7 @@ class PayPal_REST_Controller_Test extends TestCase {
 
 		// Remove any HTTP request filters.
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'posts_pre_query' );
 
 		// Drop the REST server and its handlers so each route-registration test starts clean.
 		remove_all_actions( 'rest_api_init' );
@@ -925,6 +926,70 @@ class PayPal_REST_Controller_Test extends TestCase {
 			$sent['discounts'][0]
 		);
 		$this->assertFalse( $sent['collect_shipping_address'] );
+	}
+
+	/**
+	 * A post saved without its block asks for the link to go, but only if no other
+	 * published post still embeds it.
+	 */
+	public function test_delete_button_keeps_a_link_other_published_posts_use() {
+		$this->set_up_connected_admin_state();
+		$this->embed_in_published_post( 1000, 'PLB-42' );
+
+		$requests = array();
+		$this->mock_http_routes( array( '/v1/checkout/payment-resources' => $this->http_response( 204, array() ) ), $requests );
+
+		$request = new \WP_REST_Request( 'DELETE', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'unused_only', true );
+		$request->set_param( 'post_id', 1 );
+
+		$result = PayPal_REST_Controller::handle_delete_button( $request );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertFalse( $result->get_data()['deleted'] );
+		$this->assertStringContainsString( '1 other published post', $result->get_data()['message'] );
+		$this->assertEmpty( $requests, 'PayPal was asked to delete a link another post uses.' );
+	}
+
+	/**
+	 * The post being saved does not count: its block is the one going away.
+	 */
+	public function test_delete_button_ignores_the_post_being_saved() {
+		$this->set_up_connected_admin_state();
+		$this->embed_in_published_post( 1000, 'PLB-42' );
+
+		$requests = array();
+		$this->mock_http_routes( array( '/v1/checkout/payment-resources' => $this->http_response( 204, array() ) ), $requests );
+
+		$request = new \WP_REST_Request( 'DELETE', '/wpcom/v2/paypal/buttons/PLB-42' );
+		$request->set_param( 'resource_id', 'PLB-42' );
+		$request->set_param( 'unused_only', true );
+		$request->set_param( 'post_id', 1000 );
+
+		$result = PayPal_REST_Controller::handle_delete_button( $request );
+
+		$this->assertTrue( $result->get_data()['deleted'] );
+		$this->assertCount( 1, $requests );
+		$this->assertSame( 'DELETE', $requests[0]['args']['method'] );
+	}
+
+	/**
+	 * The delete route declares the guard the editor sends.
+	 */
+	public function test_delete_route_declares_the_unused_only_guard() {
+		$routes = $this->register_paypal_routes();
+
+		$args = null;
+		foreach ( $routes['/wpcom/v2/paypal/buttons/(?P<resource_id>PLB-[A-Za-z0-9]+)'] as $endpoint ) {
+			if ( ! empty( $endpoint['methods']['DELETE'] ) ) {
+				$args = $endpoint['args'];
+			}
+		}
+
+		$this->assertNotNull( $args, 'No DELETE endpoint registered.' );
+		$this->assertArrayHasKey( 'unused_only', $args );
+		$this->assertArrayHasKey( 'post_id', $args );
 	}
 
 	/**
@@ -1960,6 +2025,30 @@ class PayPal_REST_Controller_Test extends TestCase {
 		$this->assertNotEmpty( $requests, 'No list request was sent to PayPal.' );
 
 		return (string) $requests[0]['url'];
+	}
+
+	/**
+	 * Pretend one published post embeds a payment link.
+	 *
+	 * @param int    $post_id     The post's id.
+	 * @param string $resource_id The link it embeds.
+	 */
+	private function embed_in_published_post( $post_id, $resource_id ) {
+		$post = new \WP_Post(
+			(object) array(
+				'ID'           => $post_id,
+				'post_type'    => 'post',
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:jetpack/paypal-payment-buttons {"isApiManaged":true,"resourceId":"' . $resource_id . '"} /-->',
+				'filter'       => 'raw',
+			)
+		);
+		add_filter(
+			'posts_pre_query',
+			function () use ( $post ) {
+				return array( $post );
+			}
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/update-paypal-sync-on-post-save
+++ b/projects/plugins/jetpack/changelog/update-paypal-sync-on-post-save
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+PayPal Payment Buttons: Create and update the payment when the post is saved, and remove it when the post is saved without the block, instead of from a Create New button.

--- a/projects/plugins/paypal-payment-buttons/changelog/update-paypal-sync-on-post-save
+++ b/projects/plugins/paypal-payment-buttons/changelog/update-paypal-sync-on-post-save
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Create, update and delete the PayPal payment with the post instead of from a Create New button: the payment is written when the post is saved, and removed when the post is saved without its block and no other published post uses it.

--- a/projects/plugins/paypal-payment-buttons/tests/e2e/specs/paypal-payment-buttons.spec.js
+++ b/projects/plugins/paypal-payment-buttons/tests/e2e/specs/paypal-payment-buttons.spec.js
@@ -467,18 +467,18 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await expect( block.locator( 'text=Currency' ) ).toBeVisible();
 		} );
 
-		test( 'Create button is disabled when form is empty', async ( { page } ) => {
+		test( 'holds the payment back while the form is empty', async ( { page } ) => {
 			await setupPayPalMocks( page );
 			await goToNewPost( page );
-			const canvas = await insertPayPalBlock( page );
+			await insertPayPalBlock( page );
 
-			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			const createBtn = block.locator( 'button:text-is("Create New")' );
-
-			await expect( createBtn ).toBeDisabled();
+			// The payment is written with the post, so the sidebar says what the save will do.
+			await expect( page.locator( '.jetpack-paypal-payment-buttons__form-actions' ) ).toContainText(
+				'Complete the highlighted fields'
+			);
 		} );
 
-		test( 'creates button and shows preview after successful API call', async ( { page } ) => {
+		test( 'creates the button on save and shows the preview', async ( { page } ) => {
 			await setupPayPalMocks( page );
 			await goToNewPost( page );
 			const canvas = await insertPayPalBlock( page );
@@ -486,10 +486,12 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas, { name: 'Test Product', price: '29.99' } );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			const createBtn = block.locator( 'button:text-is("Create New")' );
+			await expect( page.locator( '.jetpack-paypal-payment-buttons__form-actions' ) ).toContainText(
+				'created on PayPal when you save'
+			);
 
-			await expect( createBtn ).toBeEnabled();
-			await createBtn.click();
+			// Saving the post creates the payment.
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -499,14 +501,14 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			);
 		} );
 
-		test( 'shows edit/preview toggle toolbar after creation', async ( { page } ) => {
+		test( 'shows edit/preview toggle toolbar after the first save', async ( { page } ) => {
 			await setupPayPalMocks( page );
 			await goToNewPost( page );
 			const canvas = await insertPayPalBlock( page );
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -527,7 +529,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas, { name: 'My Widget', price: '49.99' } );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -555,7 +557,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas, { name: 'Frontend Widget', price: '19.99' } );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -583,7 +585,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
 			} );
@@ -612,7 +614,9 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			// Fill only price, leave name empty.
 			await block.locator( 'input[placeholder="29.99"]' ).fill( '10.00' );
 
-			await expect( block.locator( 'button:text-is("Create New")' ) ).toBeDisabled();
+			await expect( page.locator( '.jetpack-paypal-payment-buttons__form-actions' ) ).toContainText(
+				'Complete the highlighted fields'
+			);
 		} );
 
 		test( 'Create button disabled when price is zero', async ( { page } ) => {
@@ -628,7 +632,9 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			// Blur the price field to trigger validation.
 			await block.locator( 'input[placeholder="e.g., Premium Widget"]' ).click();
 
-			await expect( block.locator( 'button:text-is("Create New")' ) ).toBeDisabled();
+			await expect( page.locator( '.jetpack-paypal-payment-buttons__form-actions' ) ).toContainText(
+				'Complete the highlighted fields'
+			);
 		} );
 
 		test( 'shows field validation error after blurring empty product name', async ( { page } ) => {
@@ -668,7 +674,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.components-notice.is-error' ) ).toBeVisible( {
 				timeout: 5000,
@@ -843,7 +849,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -912,7 +918,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -1243,7 +1249,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await expect( buttonOption ).toHaveAttribute( 'aria-pressed', 'true' );
 
 			// The CTA is the commit action and does not name the format.
-			await expect( block.locator( 'button:text-is("Create New")' ) ).toBeVisible();
+			await expect( page.locator( '.jetpack-paypal-payment-buttons__form-actions' ) ).toBeVisible();
 		} );
 
 		test( 'selecting Link format presses the Link option', async ( { page } ) => {
@@ -1298,7 +1304,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 				.locator( '.jetpack-paypal-payment-buttons__format-switcher button:has-text("Link")' )
 				.click();
 			await fillButtonForm( canvas, { name: 'Link Product', price: '9.99' } );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			// Preview should show format badge.
 			await expect(
@@ -1313,7 +1319,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -1342,7 +1348,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 				.locator( '.jetpack-paypal-payment-buttons__format-switcher button:has-text("Link")' )
 				.click();
 			await fillButtonForm( canvas, { name: 'Link Widget', price: '5.00' } );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -1373,7 +1379,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 				.locator( '.jetpack-paypal-payment-buttons__format-switcher button:has-text("QR Code")' )
 				.click();
 			await fillButtonForm( canvas, { name: 'QR Widget', price: '15.00' } );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,
@@ -1397,7 +1403,7 @@ test.describe( 'PayPal Payment Buttons Block', () => {
 			await fillButtonForm( canvas, { name: 'Format Switch Test', price: '25.00' } );
 
 			const block = canvas.locator( '.wp-block-jetpack-paypal-payment-buttons' );
-			await block.locator( 'button:text-is("Create New")' ).click();
+			await page.getByRole( 'button', { name: 'Save draft' } ).click();
 
 			await expect( block.locator( '.jetpack-paypal-button-preview' ) ).toBeVisible( {
 				timeout: 5000,


### PR DESCRIPTION
Fixes N/A

## Proposed changes
* Remove the Create New, Save and Cancel buttons from the block sidebar. The payment behind every PayPal block is now written with the post: an `editor.preSavePost` filter creates the payment for a new block, updates it for an existing one (reading the payment first and keeping the fields the form does not model, as the Save button did), puts the new payment id into the content being saved, and skips autosaves, unchanged blocks and blocks whose form does not pass validation. A block whose payment is gone from PayPal gets a new one.
* Delete a payment when the post is saved without the block that held it. The REST delete route gains `unused_only` and `post_id` parameters: with `unused_only`, it keeps the link when another published post still embeds it, and the post being saved does not count. Undo before saving changes nothing, and deletion is tied to the save rather than to React unmount, which also fires when the editor swaps in a template.
* Replace the buttons with a status line at the top of the sidebar saying what the next save will do: created on save, changes sent on save, or complete the highlighted fields.
* Raise a five-second snackbar on save for every block that was held back, naming the block and the first thing to fix, and for every payment PayPal refused. One notice per block and kind, so a repeat replaces rather than stacks.
* Move the request builder out of the resource hook into `utils/request-data.js` so the save hook and the tests share it.
* Update the plugin's Playwright spec, which drove the removed button, to save the draft instead. I could not run Playwright locally, so those steps are unverified.

Note: PR #52224 also introduces `utils/request-data.js`. Whichever merges second will conflict on that file, trivially; this branch's copy has no image field.

## Related product discussion/links
* Follows the WOOPTP-498 investigation; requested during testing of the API-managed buttons.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Needs a site connected to a PayPal sandbox merchant with the `paypal-payments-api-managed-buttons` feature flag on, with the package rebuilt and synced.

* Add a PayPal Payment Buttons block and fill in a name and a price. The top of the block sidebar says the button is created on PayPal when you save. There is no Create New button.
* Save the draft. The Network tab shows a request to `paypal/connection` and a `POST` to `paypal/buttons`. The code editor view shows the block with `isApiManaged`, a `resourceId` and a `paymentLink`, and the published page renders the button.
* Save again without changes: no PayPal request. Change the price and save: a `GET` then a `PUT` for the payment.
* Add a second block with a name but no price, and a third with an option group left unnamed. Save. A snackbar names each block and the reason, disappears after five seconds, and neither block gets a payment.
* Remove the first block and save. A `DELETE` for its payment is sent with `unused_only=1&post_id=<id>`, and the Payment Links admin page no longer lists it.
* Duplicate a block with a payment into a second published post, then remove it from the first post and save. The `DELETE` answers `deleted: false` and the link survives.
* Delete the payment from the Payment Links admin page, then save the post that still holds its block. The block gets a new payment.
* `pnpm jetpack test php packages/paypal-payments` and `pnpm jetpack test js packages/paypal-payments` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCqfJtcQ4f6wkbfDvgPjER
