### PR TITLE
Write: stop offering the editor once someone switches to the Block editor

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/track-block-editor-optout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/track-block-editor-optout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Write: Remember a switch to the Block editor, so the Daily Writing Prompt widget stops offering Write.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -56,6 +56,12 @@ const ANON_DRAFT_STORAGE_KEY = 'wpcom-write-anon-draft';
 // Marks the one-off "you're using Write" note as already shown in this browser.
 const EDITOR_NOTE_STORAGE_KEY = 'wpcom-write-editor-note-seen';
 
+// Marks this browser as having left Write for the Block editor. Read by the
+// Daily Writing Prompt widget, which ships from a package with no dependency
+// on this one, so the key is shared by name only.
+// See projects/packages/newsletter/src/writing-prompt/prompt-panel.jsx.
+const BLOCK_EDITOR_PREFERRED_STORAGE_KEY = 'wpcom-write-block-editor-preferred';
+
 /**
  * Whether the editor is running on a logged-out page that opts into the
  * anonymous flow by setting `window.wpcomWriteIsAnon = true` before the module
@@ -272,6 +278,17 @@ function markEditorNoteSeen() {
 		window.localStorage.setItem( EDITOR_NOTE_STORAGE_KEY, '1' );
 	} catch {
 		// No-op: worst case the note shows again on the next visit.
+	}
+}
+
+/**
+ * Record that this browser chose the Block editor over Write.
+ */
+function markBlockEditorPreferred() {
+	try {
+		window.localStorage.setItem( BLOCK_EDITOR_PREFERRED_STORAGE_KEY, '1' );
+	} catch {
+		// No-op: worst case the prompt widget keeps offering Write.
 	}
 }
 
@@ -6105,11 +6122,16 @@ const { state } = store( 'wpcom-write', {
 		 * always has. Anything already on screen — including a seeded prompt the
 		 * visitor has not touched — goes through the save, so the block editor
 		 * opens on the same words rather than on a fresh post.
+		 *
+		 * Taking either of those two ways out also stops the Daily Writing Prompt
+		 * widget offering Write, unlike the kebab's openInBlockEditor(), which is
+		 * a per-post escape hatch rather than a choice of editor.
 		 */
 		switchToBlockEditor() {
 			if ( isAnon() ) {
 				return;
 			}
+			markBlockEditorPreferred();
 			state.showHelp = false;
 			if ( ! state.editPostId && ! hasWritableContent() ) {
 				allowLeave = true;

--- a/projects/packages/newsletter/README.md
+++ b/projects/packages/newsletter/README.md
@@ -55,6 +55,12 @@ When the subscriptions module is active, a notice is added to the wp-admin **Set
 
 `Writing_Prompt_Widget::init()` registers a `Daily Writing Prompt` dashboard widget for users who can `manage_options`. The widget renders a hydration container and enqueues the `writing-prompt` build assets, which mount a React app that fetches the latest blogging prompts from `/wpcom/v3/blogging-prompts` and lets the user jump into answering one.
 
+### Where "Post your answer" goes
+
+On WordPress.com-platform sites the answer link opens the Write editor; everywhere else it opens `post-new.php`, where the `jetpack/blogging-prompt` block editor script seeds the same prompt.
+
+Write itself can send someone back the other way, from its first-visit note or its Tips panel. When it does it sets `wpcom-write-block-editor-preferred` in localStorage, and this widget stops offering Write from then on. The key is shared by name only — Write ships from `jetpack-mu-wpcom`, which this package does not depend on — so changing it means changing both sides.
+
 ### Freshly Pressed
 
 When WordPress.com is featuring posts, the widget grows a second tab listing ten of them, each linking to the post in the WordPress.com Reader.

--- a/projects/packages/newsletter/changelog/track-block-editor-optout
+++ b/projects/packages/newsletter/changelog/track-block-editor-optout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Daily Writing Prompt: Stop offering the Write editor after a switch to the Block editor.

--- a/projects/packages/newsletter/src/writing-prompt/prompt-panel.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/prompt-panel.jsx
@@ -1,11 +1,32 @@
 import analytics from '@automattic/jetpack-analytics';
 import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import { createInterpolateElement, useCallback, useState } from '@wordpress/element';
+import { createInterpolateElement, useCallback, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
 import { IconButton, Link, LinkButton, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
+
+// Set by the Write editor when someone leaves it for the Block editor. The two
+// packages ship independently, so this key is shared by name only.
+// See projects/packages/jetpack-mu-wpcom/src/features/write/view.js.
+const BLOCK_EDITOR_PREFERRED_STORAGE_KEY = 'wpcom-write-block-editor-preferred';
+
+/**
+ * Whether this browser has opted out of the Write editor.
+ *
+ * Unreadable storage counts as no opt-out, so a visitor we cannot read a
+ * preference for still gets the editor the site would otherwise offer.
+ *
+ * @return {boolean} True if Write should no longer be offered here.
+ */
+const prefersBlockEditor = () => {
+	try {
+		return window.localStorage.getItem( BLOCK_EDITOR_PREFERRED_STORAGE_KEY ) !== null;
+	} catch {
+		return false;
+	}
+};
 
 /**
  * The writing prompt view: one prompt at a time, with controls to browse the
@@ -22,14 +43,18 @@ import { addQueryArgs } from '@wordpress/url';
 const PromptPanel = ( { prompts, siteType, readerUrl, openReaderInNewTab, onReaderClick } ) => {
 	const [ index, setIndex ] = useState( 0 );
 
+	// Read once on mount: changing either half means navigating away from here.
+	const usesWriteEditor = useMemo( () => isWpcomPlatformSite() && ! prefersBlockEditor(), [] );
+
 	const goToPrevious = useCallback( () => setIndex( current => current - 1 ), [] );
 	const goToNext = useCallback( () => setIndex( current => current + 1 ), [] );
 	const recordPostAnswerClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_newsletter_writing_prompt_post_answer_click', {
 			site_type: siteType,
 			prompt_id: prompts[ index ].id,
+			editor: usesWriteEditor ? 'write' : 'block',
 		} );
-	}, [ prompts, index, siteType ] );
+	}, [ prompts, index, siteType, usesWriteEditor ] );
 	const recordViewResponsesClick = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_newsletter_writing_prompt_view_responses_click', {
 			site_type: siteType,
@@ -64,10 +89,11 @@ const PromptPanel = ( { prompts, siteType, readerUrl, openReaderInNewTab, onRead
 	const prompt = prompts[ index ];
 
 	// "Post your answer" opens the Write editor on WordPress.com-platform sites
-	// (Simple/Atomic, where Write exists); on self-hosted it falls back to the
-	// classic new-post screen, where the jetpack/blogging-prompt block editor
-	// script seeds the same prompt.
-	const postAnswerHref = isWpcomPlatformSite()
+	// (Simple/Atomic, where Write exists) unless this browser has already left
+	// Write for the Block editor. Everyone else gets the classic new-post
+	// screen, where the jetpack/blogging-prompt block editor script seeds the
+	// same prompt.
+	const postAnswerHref = usesWriteEditor
 		? addQueryArgs( 'admin.php', {
 				page: 'write',
 				answer_prompt: prompt.id,

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -432,7 +432,7 @@ describe( 'WritingPrompt widget analytics', () => {
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
 			'jetpack_newsletter_writing_prompt_post_answer_click',
-			{ site_type: 'jetpack', prompt_id: 1 }
+			{ site_type: 'jetpack', prompt_id: 1, editor: 'write' }
 		);
 	} );
 
@@ -473,6 +473,74 @@ describe( 'WritingPrompt widget analytics', () => {
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
 			'jetpack_newsletter_writing_prompt_reader_click',
 			{ site_type: 'jetpack' }
+		);
+	} );
+} );
+
+describe( 'WritingPrompt widget editor preference', () => {
+	// Written by the Write editor when someone leaves it for the Block editor.
+	// See projects/packages/jetpack-mu-wpcom/src/features/write/view.js.
+	const BLOCK_EDITOR_PREFERRED_STORAGE_KEY = 'wpcom-write-block-editor-preferred';
+
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockGetSiteData.mockReset();
+		mockGetSiteType.mockReset();
+		mockGetScriptData.mockReset();
+		mockIsWpcomPlatformSite.mockReset();
+		mockRecordEvent.mockReset();
+
+		mockApiFetch.mockResolvedValue( [ PROMPT ] );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 12345 } } );
+		mockGetSiteType.mockReturnValue( 'jetpack' );
+		mockGetScriptData.mockReturnValue( {} );
+		mockIsWpcomPlatformSite.mockReturnValue( true );
+
+		window.localStorage.clear();
+	} );
+
+	afterEach( () => {
+		window.localStorage.clear();
+		jest.restoreAllMocks();
+	} );
+
+	it( 'points Post your answer at the classic new-post screen once Write has been opted out of', async () => {
+		window.localStorage.setItem( BLOCK_EDITOR_PREFERRED_STORAGE_KEY, '1' );
+
+		render( <WritingPrompt /> );
+
+		const postAnswerLink = await screen.findByRole( 'link', { name: 'Post your answer' } );
+		expect( postAnswerLink ).toHaveAttribute( 'href', 'post-new.php?answer_prompt=1' );
+	} );
+
+	it( 'records the Block editor as the destination once Write has been opted out of', async () => {
+		window.localStorage.setItem( BLOCK_EDITOR_PREFERRED_STORAGE_KEY, '1' );
+
+		render( <WritingPrompt /> );
+
+		const postAnswerLink = await screen.findByRole( 'link', { name: 'Post your answer' } );
+		postAnswerLink.addEventListener( 'click', event => event.preventDefault() );
+		postAnswerLink.click();
+
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_newsletter_writing_prompt_post_answer_click',
+			{ site_type: 'jetpack', prompt_id: 1, editor: 'block' }
+		);
+	} );
+
+	it( 'still offers Write when localStorage cannot be read', async () => {
+		// Safari's private mode and a cookie-blocking profile both throw here,
+		// and the widget renders during the same tick that reads the flag.
+		jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'storage disabled' );
+		} );
+
+		render( <WritingPrompt /> );
+
+		const postAnswerLink = await screen.findByRole( 'link', { name: 'Post your answer' } );
+		expect( postAnswerLink ).toHaveAttribute(
+			'href',
+			'admin.php?page=write&answer_prompt=1&source=writing_prompt'
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/changelog/track-block-editor-optout
+++ b/projects/plugins/jetpack/changelog/track-block-editor-optout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Daily Writing Prompt: Stop offering the Write editor after a switch to the Block editor.

--- a/projects/plugins/wpcomsh/changelog/track-block-editor-optout
+++ b/projects/plugins/wpcomsh/changelog/track-block-editor-optout
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Write: Remember a switch to the Block editor, so the Daily Writing Prompt widget stops offering Write.


### PR DESCRIPTION
Fixes READ-720

## Proposed changes

#52094 gave Write two ways out for anyone who landed there expecting the block editor: a note on the first visit, and a line at the top of the Tips panel. Taking either one tells us the editor isn't what they wanted. And then the Daily Writing Prompt widget sent them right back to it the next day.

So Write now records that departure in `localStorage`, and the widget reads it. Once the flag is set, "Post your answer" points at the same `post-new.php?answer_prompt=` link self-hosted sites already get.

The kebab menu's "Open in Block editor" deliberately doesn't count. That one is a per-post escape hatch you reach mid-writing when a post needs blocks; it isn't a statement about which editor you want by default.

Two things to know before you review:

* **The preference lives in the browser, not on the user.** Opt out on your laptop and you'll still get the Write link on your phone. A user meta would follow you around, but that's a bigger change than this issue asks for.
* **On Atomic the two halves ship from different plugins**, the widget from the Jetpack plugin and Write from wpcomsh, so the storage key is shared by name only, with no dependency either way. Either deploy order degrades to today's behaviour: a key nobody writes reads as no opt-out, and a key nobody reads changes nothing.

## Related product discussion/links

* https://linear.app/a8c/issue/READ-720/track-editor-default-preference-change-behavior
* Follows up on #52094

## Does this pull request change what data or activity we track or use?

Yes, in two small ways:

* `jetpack_newsletter_writing_prompt_post_answer_click` gains an `editor` property, either `write` or `block`, recording where the widget sent someone. Without it the funnel would just show Write arrivals dropping, with nothing to pin it on.
* Write sets `wpcom-write-block-editor-preferred` in the browser's `localStorage`. It holds the string `1` and nothing else, no identifiers, and it never leaves the browser.

## Testing instructions

You'll need a WordPress.com-platform site (Simple or Atomic). On self-hosted the widget already points at `post-new.php`, so nothing here changes.

1. Open the dashboard and find the Daily Writing Prompt widget. "Post your answer" should point at `admin.php?page=write&answer_prompt=…&source=writing_prompt`.
2. Follow it into Write. On a first visit you'll get the introduction note; otherwise open the Tips panel (the `i` in the top bar).
3. Click "Use the Block editor" in the note, or "Block editor" in the Tips panel. You should land in the block editor.
4. Go back to the dashboard and reload. "Post your answer" now points at `post-new.php?answer_prompt=…`.
5. Check that the kebab is still exempt. Run `localStorage.removeItem( 'wpcom-write-block-editor-preferred' )` in the console, go back to Write, and leave through the ⋮ menu's "Open in Block editor". Reload the dashboard, and the widget should still offer Write.

That same `localStorage.removeItem()` call resets things at any point, which is handy since there's no UI to opt back in :)
