### PR TITLE
Jetpack: restore site verification validation safely

### DIFF
--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -19,6 +19,8 @@ $config = make_phan_config(
 			'tests/php/_inc/lib/mocks/simplepie.php',
 			// Standalone compatibility fixture that intentionally redefines a WordPress function.
 			'tests/php/fixtures/random-redirect-existing-function.php',
+			// Standalone compatibility fixture that intentionally redefines Jetpack symbols.
+			'tests/php/json-api/fixtures/site-settings-mixed-version-bootstrap.php',
 			// Mocks of wpcom classes and functions.
 			'tests/php/lib/class-wpcom-features.php',
 			'tests/php/lib/class-email-verification.php',

--- a/projects/plugins/jetpack/_inc/client/traffic/test/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/test/verification-services.jsx
@@ -1,0 +1,27 @@
+import { VerificationServicesComponent } from '../verification-services';
+
+describe( 'Site verification meta tag formatting', () => {
+	const component = new VerificationServicesComponent( {} );
+
+	it( 'wraps verification codes containing safe punctuation', () => {
+		expect( component.getMetaTag( 'google', '+token.value/with=safe:@~characters' ) ).toBe(
+			'<meta name="google-site-verification" content="+token.value/with=safe:@~characters" />'
+		);
+	} );
+
+	it( 'does not wrap values containing attribute delimiters', () => {
+		expect( component.getMetaTag( 'google', 'unsafe"attribute' ) ).toBe( 'unsafe"attribute' );
+	} );
+
+	it( 'escapes ampersands when formatting the meta tag', () => {
+		expect( component.getMetaTag( 'bing', 'token&value' ) ).toBe(
+			'<meta name="msvalidate.01" content="token&amp;value" />'
+		);
+	} );
+
+	it( 'does not double-escape stored HTML entities', () => {
+		expect( component.getMetaTag( 'bing', 'token&amp;value' ) ).toBe(
+			'<meta name="msvalidate.01" content="token&amp;value" />'
+		);
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
+++ b/projects/plugins/jetpack/_inc/client/traffic/verification-services.jsx
@@ -12,7 +12,7 @@ import SettingsGroup from 'components/settings-group';
 import TextInput from 'components/text-input';
 import GoogleVerificationService from './verification-services/google';
 
-class VerificationServicesComponent extends Component {
+export class VerificationServicesComponent extends Component {
 	static serviceIds = {
 		google: 'google-site-verification',
 		bing: 'msvalidate.01',
@@ -26,7 +26,7 @@ class VerificationServicesComponent extends Component {
 			return '';
 		}
 
-		if ( ! /^[a-z0-9_-]+$/i.test( content ) ) {
+		if ( ! /^(?!.*[<>"'])[!-~]+$/.test( content ) ) {
 			// User is probably editing the content
 			return content;
 		}
@@ -36,9 +36,11 @@ class VerificationServicesComponent extends Component {
 			return content;
 		}
 
+		const escapedContent = content.replace( /&(?!(?:#\d+|#x[\da-f]+|[a-z][\da-z]*);)/gi, '&amp;' );
+
 		return `<meta name="${
 			VerificationServicesComponent.serviceIds?.[ serviceName ] ?? ''
-		}" content="${ content }" />`;
+		}" content="${ escapedContent }" />`;
 	}
 
 	getSiteVerificationValue( service ) {

--- a/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php
@@ -3160,12 +3160,12 @@ class Jetpack_Core_Json_Api_Endpoints {
 	 * @return bool|WP_Error
 	 */
 	public static function validate_verification_service( $value, $request, $param ) {
-		if ( ! empty( $value ) && ! ( is_string( $value ) && ( preg_match( '/^[a-z0-9_-]+$/i', $value ) || jetpack_verification_get_code( $value ) !== false ) ) ) {
+		if ( ! empty( $value ) && ( ! is_string( $value ) || false === jetpack_verification_validate_code( $value ) ) ) {
 			return new WP_Error(
 				'invalid_param',
 				sprintf(
 					/* Translators: Placeholder is a verification string used to verify a service like Google Webmaster Console. */
-					esc_html__( '%s must be an alphanumeric string or a verification tag.', 'jetpack' ),
+					esc_html__( '%s must be a valid verification code or verification tag.', 'jetpack' ),
 					$param
 				)
 			);

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -816,12 +816,13 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 					$grouped_options_current = (array) get_option( 'verification_services_codes' );
 					$grouped_options         = $grouped_options_current;
 
-					// Extracts the content attribute from the HTML meta tag if needed.
-					if ( preg_match( '#.*<meta name="(?:[^"]+)" content="([^"]+)" />.*#i', $value, $matches ) ) {
-						$grouped_options[ $option ] = $matches[1];
-					} else {
-						$grouped_options[ $option ] = $value;
+					$validated_code = jetpack_verification_validate_code( $value );
+					if ( false === $validated_code ) {
+						$error = esc_html__( 'The site verification code is invalid.', 'jetpack' );
+						break;
 					}
+
+					$grouped_options[ $option ] = $validated_code;
 
 					// If option value was the same, consider it done.
 					$updated = $grouped_options_current !== $grouped_options

--- a/projects/plugins/jetpack/changelog/dsgcom-534-validate-site-verification-codes
+++ b/projects/plugins/jetpack/changelog/dsgcom-534-validate-site-verification-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Site Verification: Reject invalid verification codes instead of reporting a successful save.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
+require_once dirname( __DIR__ ) . '/modules/verification-tools/verification-tools-utils.php';
+
 new WPCOM_JSON_API_Site_Settings_Endpoint(
 	array(
 		'description'      => 'Get detailed settings information about a site.',
@@ -1234,6 +1236,20 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					break;
 
 				case 'verification_services_codes':
+					foreach ( $value as $raw_code ) {
+						if ( '' === $raw_code || null === $raw_code || false === $raw_code ) {
+							continue;
+						}
+
+						if ( false === jetpack_verification_validate_code( $raw_code ) ) {
+							return new WP_Error(
+								'invalid_input',
+								__( 'Invalid site verification code. Enter a verification code or verification tag.', 'jetpack' ),
+								400
+							);
+						}
+					}
+
 					$verification_codes = jetpack_verification_validate( $value );
 
 					if ( update_option( 'verification_services_codes', $verification_codes ) ) {

--- a/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
+++ b/projects/plugins/jetpack/modules/verification-tools/verification-tools-utils.php
@@ -6,6 +6,42 @@
  * @package jetpack
  */
 
+if ( ! function_exists( 'jetpack_verification_validate_code' ) ) {
+	/**
+	 * Validate and normalize a site verification code.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed $code Verification code or meta tag.
+	 * @return string|false Normalized code, or false when invalid.
+	 */
+	function jetpack_verification_validate_code( $code ) {
+		if ( ! is_scalar( $code ) ) {
+			return false;
+		}
+
+		// Allow printable ASCII except characters that can delimit HTML attributes or tags.
+		$code_pattern = '/^(?!.*[<>"\'])[!-~]+$/';
+		$code         = trim( (string) $code );
+
+		if ( '' === $code ) {
+			return '';
+		}
+
+		// Parse html meta tag if it does not look like a valid code.
+		if ( ! preg_match( $code_pattern, $code ) ) {
+			$code = jetpack_verification_get_code( $code );
+		}
+
+		$code = trim( (string) $code );
+		if ( '' === $code || ! preg_match( $code_pattern, $code ) ) {
+			return false;
+		}
+
+		return substr( $code, 0, 100 );
+	}
+}
+
 if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	/**
 	 * Validate jetpack verification codes.
@@ -14,15 +50,8 @@ if ( ! function_exists( 'jetpack_verification_validate' ) ) {
 	 */
 	function jetpack_verification_validate( $verification_services_codes ) {
 		foreach ( $verification_services_codes as $key => $code ) {
-			// Parse html meta tag if it does not look like a valid code.
-			if ( ! preg_match( '/^[a-z0-9_-]+$/i', $code ) ) {
-				$code = jetpack_verification_get_code( $code );
-			}
-
-			$code = esc_attr( trim( $code ) );
-
-			// limit length to 100 chars.
-			$code = substr( $code, 0, 100 );
+			$code = jetpack_verification_validate_code( $code );
+			$code = false === $code ? '' : $code;
 
 			/**
 			 * Fire after each Verification code was validated.
@@ -52,7 +81,7 @@ if ( ! function_exists( 'jetpack_verification_get_code' ) ) {
 		$pattern = '/content=["\']?([^"\' ]*)["\' ]/is';
 		preg_match( $pattern, $code, $match );
 		if ( $match ) {
-			return urldecode( $match[1] );
+			return rawurldecode( $match[1] );
 		} else {
 			return false;
 		}

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -18,6 +18,7 @@ module.exports = {
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/ai/test/tracks.js',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',
+		'<rootDir>/_inc/client/traffic/test/verification-services.jsx',
 	],
 	setupFilesAfterEnv: [ ...baseConfig.setupFilesAfterEnv, '<rootDir>/tests/jest-globals.gui.js' ],
 	coverageDirectory: baseConfig.coverageDirectory + '/gui',

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_REST_API_endpoints_Test.php
@@ -188,6 +188,73 @@ class Jetpack_REST_API_endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test verification service validation.
+	 *
+	 * @dataProvider verification_service_provider
+	 *
+	 * @param string $value    Verification value.
+	 * @param bool   $expected Expected validation result.
+	 */
+	#[DataProvider( 'verification_service_provider' )]
+	public function test_validate_verification_service( $value, $expected ) {
+		$this->load_rest_endpoints_direct();
+		$validation_actions = 0;
+		$action_callback    = static function () use ( &$validation_actions ) {
+			++$validation_actions;
+		};
+		add_action( 'jetpack_site_verification_validate', $action_callback );
+
+		$result = Jetpack_Core_Json_Api_Endpoints::validate_verification_service( $value, new WP_REST_Request(), 'google' );
+		remove_action( 'jetpack_site_verification_validate', $action_callback );
+
+		if ( $expected ) {
+			$this->assertTrue( $result );
+		} else {
+			$this->assertWPError( $result );
+		}
+		$this->assertSame( 0, $validation_actions );
+	}
+
+	/**
+	 * Provide safe and unsafe verification values.
+	 *
+	 * @return array
+	 */
+	public static function verification_service_provider() {
+		return array(
+			'printable punctuation' => array( 'verification.Code_123-+/=:@~', true ),
+			'google meta tag'       => array( '<meta name="google-site-verification" content="+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=" />', true ),
+			'angle bracket'         => array( 'unsafe<script', false ),
+			'quote'                 => array( 'unsafe"attribute', false ),
+			'whitespace'            => array( "unsafe\nvalue", false ),
+		);
+	}
+
+	/**
+	 * Updating a verification code normalizes and stores it through the complete REST path.
+	 */
+	public function test_update_verification_service_stores_normalized_code() {
+		$this->load_rest_endpoints_direct();
+		require_once JETPACK__PLUGIN_DIR . 'modules/verification-tools/blog-verification-tools.php';
+		jetpack_verification_options_init();
+
+		$user = $this->create_and_get_user( 'administrator' );
+		$user->add_cap( 'jetpack_configure_modules' );
+		wp_set_current_user( $user->ID );
+		Jetpack::update_active_modules( array( 'verification-tools' ) );
+
+		$response = $this->create_and_get_request(
+			'module/verification-tools',
+			array( 'google' => '+token.value/with=safe:@~characters' ),
+			'POST'
+		);
+
+		$this->assertResponseStatus( 200, $response );
+		$stored_codes = get_option( 'verification_services_codes' );
+		$this->assertSame( '+token.value/with=safe:@~characters', $stored_codes['google'] );
+	}
+
+	/**
 	 * Test permission to see if users can view Jetpack admin screen.
 	 *
 	 * @since 4.4.0

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -182,6 +182,107 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The endpoint loads the matching verification helper in a mixed-version bootstrap.
+	 */
+	public function test_loads_site_verification_helper_in_mixed_version_bootstrap() {
+		$script = __DIR__ . '/fixtures/site-settings-mixed-version-bootstrap.php';
+
+		$output    = array();
+		$exit_code = 0;
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- A separate process is required to simulate a partial legacy bootstrap.
+		exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script ) . ' 2>&1', $output, $exit_code );
+
+		$this->assertSame(
+			0,
+			$exit_code,
+			"Mixed-version bootstrap failed:\n" . implode( "\n", $output )
+		);
+		$this->assertSame( array( 'OK' ), $output );
+	}
+
+	/**
+	 * Invalid site verification codes return an actionable client error and are not saved.
+	 */
+	public function test_post_rejects_invalid_site_verification_code() {
+		$existing_codes = array( 'bing' => 'existing-code' );
+		update_option( 'verification_services_codes', $existing_codes );
+
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'bing' => 'not a valid token' ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'invalid_input', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data() );
+		$this->assertSame( $existing_codes, get_option( 'verification_services_codes' ) );
+	}
+
+	/**
+	 * A valid site verification meta tag is reduced to its content value and saved.
+	 */
+	public function test_post_saves_site_verification_code_from_meta_tag() {
+		$setting = wp_json_encode(
+			array(
+				'verification_services_codes' => array(
+					'bing' => '<meta name="msvalidate.01" content="12C1203B5086AECE94EB3A3D9830B2E" />',
+				),
+			),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame(
+			array( 'bing' => '12C1203B5086AECE94EB3A3D9830B2E' ),
+			$response['updated']['verification_services_codes']
+		);
+		$this->assertSame(
+			array( 'bing' => '12C1203B5086AECE94EB3A3D9830B2E' ),
+			get_option( 'verification_services_codes' )
+		);
+	}
+
+	/**
+	 * A boolean false remains a supported way to clear a verification code.
+	 */
+	public function test_post_clears_site_verification_code_with_false() {
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'google' => false ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame(
+			array( 'google' => '' ),
+			$response['updated']['verification_services_codes']
+		);
+		$this->assertSame( array( 'google' => '' ), get_option( 'verification_services_codes' ) );
+	}
+
+	/**
+	 * A non-scalar verification code is rejected without clearing the stored value.
+	 */
+	public function test_post_rejects_non_scalar_site_verification_code() {
+		$existing_codes = array( 'google' => 'existing-code' );
+		update_option( 'verification_services_codes', $existing_codes );
+
+		$setting = wp_json_encode(
+			array( 'verification_services_codes' => array( 'google' => array() ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+
+		$response = $this->make_post_request( $setting );
+
+		$this->assertWPError( $response );
+		$this->assertSame( 'invalid_input', $response->get_error_code() );
+		$this->assertSame( $existing_codes, get_option( 'verification_services_codes' ) );
+	}
+
+	/**
 	 * The free tier description is capped to 500 characters to match the
 	 * paid-tier description field.
 	 */

--- a/projects/plugins/jetpack/tests/php/json-api/fixtures/site-settings-mixed-version-bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/json-api/fixtures/site-settings-mixed-version-bootstrap.php
@@ -1,0 +1,69 @@
+<?php
+// phpcs:ignoreFile -- This standalone fixture must stub the partially loaded runtime.
+/**
+ * Loads the site settings endpoint with legacy verification helpers present.
+ *
+ * @package automattic/jetpack
+ */
+
+define( 'ABSPATH', __DIR__ );
+
+/**
+ * Minimal endpoint stub.
+ */
+class WPCOM_JSON_API_Endpoint {
+	/**
+	 * Accept endpoint registration arguments.
+	 *
+	 * @param array $args Endpoint arguments.
+	 */
+	public function __construct( $args ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	}
+}
+
+/**
+ * Minimal SEO utility stub.
+ */
+class Jetpack_SEO_Utils {
+	const FRONT_PAGE_META_OPTION = 'advanced_seo_front_page_description';
+}
+
+/**
+ * Minimal SEO titles stub.
+ */
+class Jetpack_SEO_Titles {
+	const TITLE_FORMATS_OPTION = 'jetpack_seo_titles';
+}
+
+/**
+ * Simulate the legacy helper loaded from the active deployment tree.
+ *
+ * @param array $codes Verification codes.
+ * @return array
+ */
+function jetpack_verification_validate( $codes ) {
+	return $codes;
+}
+
+/**
+ * Simulate the legacy tag parser loaded from the active deployment tree.
+ *
+ * @param string $code Verification code.
+ * @return string
+ */
+function jetpack_verification_get_code( $code ) {
+	return $code;
+}
+
+$plugin_dir = dirname( __DIR__, 4 );
+require $plugin_dir . '/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php';
+
+if ( ! function_exists( 'jetpack_verification_validate_code' ) ) {
+	throw new RuntimeException( 'The site settings endpoint did not load its verification helper.' );
+}
+
+if ( 'verification-code' !== jetpack_verification_validate_code( 'verification-code' ) ) {
+	throw new RuntimeException( 'The site verification helper did not validate a code.' );
+}
+
+echo "OK\n";

--- a/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/verification-tools/Jetpack_Verification_Tools_Utils_Test.php
@@ -1,12 +1,15 @@
 <?php
 
 use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 require __DIR__ . '/../../../../modules/verification-tools/verification-tools-utils.php';
 
 /**
  * @covers ::jetpack_verification_validate
+ * @covers ::jetpack_verification_validate_code
  */
 #[CoversFunction( 'jetpack_verification_validate' )]
+#[CoversFunction( 'jetpack_verification_validate_code' )]
 class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
@@ -16,9 +19,9 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test_jetpack_verification_validate_google_raw_code() {
 		$this->assertEquals(
-			array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ),
-			jetpack_verification_validate( array( 'google' => 'W2gxpExLATRT5c0dgRjlJsXRnrLE7vpr_1YtYxEnDIzn9ylj7C' ) ),
-			'raw code should be accepeted'
+			array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			jetpack_verification_validate( array( 'google' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ) ),
+			'raw code should be accepted'
 		);
 	}
 
@@ -28,8 +31,8 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test_jetpack_verification_validate_google_code_in_meta_double_quotes() {
 		$this->assertEquals(
-			array( 'test' => 'bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr' ),
-			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content="bX1szG_kxD6O0CGSVgS8m4F5gKvgUPMdo96McTiJ7pZ5Ax7mQr" />' ) ),
+			array( 'test' => '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content="+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=" />' ) ),
 			'google-style meta tag with double quotes should be accepeted'
 		);
 	}
@@ -43,6 +46,87 @@ class Jetpack_Verification_Tools_Utils_Test extends WP_UnitTestCase {
 			array( 'test' => 'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub' ),
 			jetpack_verification_validate( array( 'test' => '<meta name="google-site-verification" content=\'jLjbTBvtuQepL3eR09id83p4q_w8JBStrB5DKCunOX7kK1XKub\' />' ) ),
 			'google-style meta tag with single quotes should be accepeted'
+		);
+	}
+
+	/**
+	 * Verification codes with valid characters are accepted for every service.
+	 *
+	 * @dataProvider valid_verification_code_provider
+	 *
+	 * @param string $service Verification service key.
+	 * @param string $code    Verification code.
+	 */
+	#[DataProvider( 'valid_verification_code_provider' )]
+	public function test_valid_code_is_accepted_for_every_service( $service, $code ) {
+		$this->assertSame(
+			array( $service => $code ),
+			jetpack_verification_validate( array( $service => $code ) )
+		);
+	}
+
+	/**
+	 * Verification codes with invalid characters are rejected for every service.
+	 *
+	 * @dataProvider invalid_verification_code_provider
+	 *
+	 * @param string $service Verification service key.
+	 * @param string $code    Verification code.
+	 */
+	#[DataProvider( 'invalid_verification_code_provider' )]
+	public function test_invalid_code_is_rejected_for_every_service( $service, $code ) {
+		$this->assertSame(
+			array( $service => '' ),
+			jetpack_verification_validate( array( $service => $code ) )
+		);
+	}
+
+	/**
+	 * The validation action receives the same canonical code that is returned for storage.
+	 */
+	public function test_validation_action_receives_canonical_code() {
+		$action_code = null;
+		$callback    = static function ( $service, $code ) use ( &$action_code ) {
+			$action_code = $code;
+		};
+		add_action( 'jetpack_site_verification_validate', $callback, 10, 2 );
+
+		$validated = jetpack_verification_validate( array( 'google' => 'verification&Code' ) );
+
+		remove_action( 'jetpack_site_verification_validate', $callback, 10 );
+		$this->assertSame( $validated['google'], $action_code );
+	}
+
+	/**
+	 * Provide valid verification codes.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public static function valid_verification_code_provider() {
+		return array(
+			'google'           => array( 'google', '+nxGUDJ4QpAZ5l9Bsjdi102tLVC21AIh5d1Nl23908vVuFHs34=' ),
+			'bing'             => array( 'bing', '12C1203B5086AECE94EB3A3D9830B2E' ),
+			'pinterest'        => array( 'pinterest', 'f100679e6048d45e4a0b0b92dce1efce' ),
+			'yandex'           => array( 'yandex', '44d68e1216009f40' ),
+			'facebook'         => array( 'facebook', 'rvv8b23jxlp1lq41I9rwsvpzncy1fd' ),
+			'safe punctuation' => array( 'google', 'verification.Code_123-+/=:@~' ),
+			'ampersand'        => array( 'bing', 'verification&Code' ),
+		);
+	}
+
+	/**
+	 * Provide invalid verification codes.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public static function invalid_verification_code_provider() {
+		return array(
+			'opening angle bracket'        => array( 'google', 'invalid<script' ),
+			'closing angle bracket'        => array( 'bing', 'invalid>script' ),
+			'double quote'                 => array( 'pinterest', 'invalid"code' ),
+			'single quote'                 => array( 'yandex', "invalid'code" ),
+			'control character'            => array( 'facebook', "invalid\ncode" ),
+			'unsafe character after limit' => array( 'google', '<meta name="google-site-verification" content="' . str_repeat( 'a', 100 ) . '<" />' ),
 		);
 	}
 }


### PR DESCRIPTION
Fixes DSGCOM-534

## Proposed changes

* Restore the site verification validation introduced in #52091 after its emergency revert in #52209.
* Accept printable ASCII verification-code characters while excluding whitespace and characters that can delimit HTML attributes or tags.
* Continue accepting a full verification meta tag by extracting and validating its `content` value without converting literal `+` characters to spaces.
* Introduce collision-free canonical helpers for extracting and validating codes, while retaining the legacy public functions as compatibility wrappers.
* Use the canonical helpers in the WordPress.com settings endpoint and load them explicitly from the endpoint's selected deployment tree.
* Return an HTTP 400 response when a supplied code is invalid, without replacing the stored value.
* Document WordPress.com's partial Jetpack bootstrap in `AGENTS.md` so endpoint dependencies and host-defined globals are considered in future changes.
* Add a regression fixture that reproduces the partial WordPress.com bootstrap with its legacy `urldecode()` parser, alongside utility, endpoint, REST write-path, and UI coverage.

## Related product discussion/links

* DSGCOM-534
* #52091
* #52209
* p1789082379200519-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `CI=1 jp build plugins/jetpack --deps` and confirm the build succeeds.
* Run `CI=1 jp test js plugins/jetpack` and confirm the JavaScript suite succeeds.
* Set up the Jetpack Docker test environment and run `CI=1 jp docker phpunit jetpack -- --filter='(Jetpack_Verification_Tools_Utils_Test|Jetpack_REST_API_endpoints_Test|WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test)'`.
* Confirm all 135 focused PHP tests pass, including `test_loads_site_verification_helpers_in_partial_wpcom_bootstrap`.
* Save a provider verification token containing `+`, `.`, `/`, `=`, `:`, `@`, or `~`; reload the settings page and confirm it is displayed as the provider's complete meta tag.
* Confirm the generated front-end meta tag contains the original verification value.
* Submit a value containing `<`, `>`, a quote, whitespace, or a control character and confirm the request returns an error without changing the stored value.
