### PR TITLE
VideoPress: let the token bridge answer requests from its own window (inline player 1/5)

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-inline-player-1-token-bridge
+++ b/projects/packages/videopress/changelog/add-videopress-inline-player-1-token-bridge
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Token bridge: answer playback-token requests from the page's own window; groundwork for the inline player, no user-facing change.
+
+

--- a/projects/packages/videopress/src/client/lib/token-bridge/index.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/index.ts
@@ -88,7 +88,9 @@ export async function tokenBridgeHandler(
 		return;
 	}
 
-	if ( ! isAllowedOrigin( event.origin ) ) {
+	// An inline player (Inline_Player) runs in this very window, so its request
+	// carries the page's own origin; iframes must come from VideoPress.
+	if ( event.source !== window && ! isAllowedOrigin( event.origin ) ) {
 		debug( '(%s) Invalid origin', context );
 		return;
 	}

--- a/projects/packages/videopress/src/client/lib/token-bridge/test/index.test.ts
+++ b/projects/packages/videopress/src/client/lib/token-bridge/test/index.test.ts
@@ -98,6 +98,25 @@ describe( 'tokenBridgeHandler', () => {
 		expect( mockGetMediaToken ).not.toHaveBeenCalled();
 	} );
 
+	it( 'accepts a same-window request from an inline player on the page origin', async () => {
+		mockGetMediaToken.mockResolvedValue( { token: 'jwt-inline' } );
+		const postMessage = jest.spyOn( window, 'postMessage' ).mockImplementation( () => {} );
+		const event = createMessageEvent( {
+			data: validData,
+			origin: window.location.origin,
+			source: window as unknown as { postMessage: jest.Mock },
+		} );
+
+		await tokenBridgeHandler( event );
+
+		expect( mockGetMediaToken ).toHaveBeenCalled();
+		expect( postMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { event: 'videopress_token_received', jwt: 'jwt-inline' } ),
+			{ targetOrigin: window.location.origin }
+		);
+		postMessage.mockRestore();
+	} );
+
 	it( 'rejects messages missing guid', async () => {
 		const source = { postMessage: jest.fn() };
 		const event = createMessageEvent( {


### PR DESCRIPTION
Fixes #

Part 1 of 5 of the inline player stack that replaces #51999. Each PR is inert on its own until the last one ships the setting.

## Stack
1. #52239 (this PR) — token bridge answers same-window requests
2. #52240 — `Inline_Player` class, boot script, option getter
3. #52241 — blocks, shortcodes and embeds render it (option-gated)
4. #52242 — Jetpack plugin's in-page branch + the iframe filter
5. #52244 — the setting and its toggle

Merge in order; each PR's base is the previous branch, so GitHub retargets the next one to trunk as each merges. #52011 (poster facade) and #52052 (editor inline player) stack on #52244.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* The JWT token bridge only honoured playback-token requests posted from VideoPress origins, which is what an embed iframe sends. A player mounted in the page itself (coming in the rest of the stack) posts from the page's own origin, so requests whose `source` is this very window are now accepted. Requests from iframes keep the origin check.
* No behaviour change for anything shipping today: nothing in the page posts such a request yet.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Linear: VIDP-384

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* `jp test js packages/videopress` — the token bridge suite covers the same-window request and the unchanged rejection of foreign origins from iframes.
* On a site with a private VideoPress video embedded as an iframe: it still plays (the iframe path is untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L84aNxBedd6AWnbWFAVkq4

