### PR TITLE
ci: Try fixing cron issues in post-build workflow

### DIFF
--- a/.github/files/test-plugin-update/setup.sh
+++ b/.github/files/test-plugin-update/setup.sh
@@ -25,12 +25,14 @@ echo '#!/usr/bin/env bash' > /var/scripts/run-extras.sh
 echo "::endgroup::"
 
 echo "::group::Install WordPress"
-wp --allow-root core install --url="$WP_DOMAIN" --title="$WP_TITLE" --admin_user="$WP_ADMIN_USER" --admin_password="$WP_ADMIN_PASSWORD" --admin_email="$WP_ADMIN_EMAIL" --skip-email
+wp core install --url="$WP_DOMAIN" --title="$WP_TITLE" --admin_user="$WP_ADMIN_USER" --admin_password="$WP_ADMIN_PASSWORD" --admin_email="$WP_ADMIN_EMAIL" --skip-email
 rm -f index.html
 mkdir -p wp-content/mu-plugins
 cp "$GITHUB_WORKSPACE/trunk/.github/files/test-plugin-update/mu-plugin.php" wp-content/mu-plugins/hack.php
+# wp-cron's async requests sometimes wind up running during the upgrade, causing spurious fatals. Disable it.
+wp config add DISABLE_WP_CRON true --raw
 echo "::endgroup::"
 
 echo "::group::Backing up database"
-wp --allow-root db export "$GITHUB_WORKSPACE/db.sql"
+wp db export "$GITHUB_WORKSPACE/db.sql"
 echo "::endgroup::"

--- a/.github/files/test-plugin-update/test.sh
+++ b/.github/files/test-plugin-update/test.sh
@@ -39,15 +39,16 @@ for SLUG in "${SLUGS[@]}"; do
 			printf '\n\e[1mTest upgrade of %s from %s via %s\e[0m\n' "$SLUG" "$FROM" "$HOW"
 
 			echo "::group::Restoring database from backup"
-			wp --allow-root db import "$GITHUB_WORKSPACE/db.sql"
+			wp db import "$GITHUB_WORKSPACE/db.sql"
 			echo "::endgroup::"
 
 			ERRMSG=
 			echo "::group::Installing $SLUG $FROM"
 			: > /var/www/html/wp-content/debug.log
-			if ! wp --allow-root plugin install --activate "$ZIPDIR/$SLUG-$FROM.zip"; then
+			if ! wp plugin install --activate "$ZIPDIR/$SLUG-$FROM.zip"; then
 				failed "Plugin install failed for $SLUG $FROM!"
 			fi
+			wp cron event run --due-now
 			echo '== Debug log =='
 			cat /var/www/html/wp-content/debug.log
 			rm -f "/var/www/html/wp-content/plugins/$SLUG/ci-flag.txt"
@@ -58,14 +59,8 @@ for SLUG in "${SLUGS[@]}"; do
 				continue
 			fi
 
-			# Cron running asynchronously seems to like to stomp on the `jetpack_options` being set for the fake connection.
-			# Run it manually to avoid that.
-			echo "::group::Prophylactic cron run"
-			wp --allow-root cron event run --due-now
-			echo "::endgroup::"
-
 			# Mock a connection.
-			wp --allow-root eval-file - "$SLUG" <<-'EOF'
+			wp eval-file - "$SLUG" <<-'EOF'
 			<?php
 			if ( class_exists( \Jetpack_Options::class ) && class_exists( \Automattic\Jetpack\Connection\Manager::class ) ) {
 				echo "Faking connection... ";
@@ -81,12 +76,12 @@ for SLUG in "${SLUGS[@]}"; do
 
 			ERRMSG=
 			echo "::group::Upgrading $SLUG via $HOW"
-			P="$(wp --allow-root plugin path "$SLUG" | sed 's!^/var/www/html/wp-content/plugins/!!')"
-			wp --allow-root --quiet option set fake_plugin_update_plugin "$P"
-			wp --allow-root --quiet option set fake_plugin_update_url "$ZIPDIR/$SLUG-dev.zip"
+			P="$(wp plugin path "$SLUG" | sed 's!^/var/www/html/wp-content/plugins/!!')"
+			wp --quiet option set fake_plugin_update_plugin "$P"
+			wp --quiet option set fake_plugin_update_url "$ZIPDIR/$SLUG-dev.zip"
 			: > /var/www/html/wp-content/debug.log
 			if [[ "$HOW" == 'cli' ]]; then
-				if ! wp --allow-root plugin upgrade "$SLUG" 2>&1 | tee "$GITHUB_WORKSPACE/out.txt"; then
+				if ! wp plugin upgrade "$SLUG" 2>&1 | tee "$GITHUB_WORKSPACE/out.txt"; then
 					failed "CLI upgrade of $SLUG from $FROM exited with a non-zero status"
 				fi
 			else
@@ -95,6 +90,7 @@ for SLUG in "${SLUGS[@]}"; do
 				curl -v --get --url 'http://localhost/wp-admin/update.php?action=upgrade-plugin&_wpnonce=bogus' --data "plugin=$P" --output "$GITHUB_WORKSPACE/out.txt" 2>&1
 				cat "$GITHUB_WORKSPACE/out.txt"
 			fi
+			wp cron event run --due-now
 			echo '== Debug log =='
 			cat /var/www/html/wp-content/debug.log
 			echo "::endgroup::"
@@ -113,7 +109,7 @@ for SLUG in "${SLUGS[@]}"; do
 			ERRMSG=
 			echo "::group::Deactivating $SLUG"
 			: > /var/www/html/wp-content/debug.log
-			if ! wp --allow-root plugin deactivate "$SLUG"; then
+			if ! wp plugin deactivate "$SLUG"; then
 				failed "Plugin deactivate failed after $SLUG $HOW update from $FROM!"
 			fi
 			echo '== Debug log =='
@@ -126,7 +122,7 @@ for SLUG in "${SLUGS[@]}"; do
 			ERRMSG=
 			echo "::group::Uninstalling $SLUG"
 			: > /var/www/html/wp-content/debug.log
-			if ! wp --allow-root plugin uninstall "$SLUG"; then
+			if ! wp plugin uninstall "$SLUG"; then
 				failed "Plugin uninstall failed after $SLUG $HOW update from $FROM!"
 				rm -rf "/var/www/html/wp-content/plugins/$SLUG"
 			fi
@@ -137,8 +133,8 @@ for SLUG in "${SLUGS[@]}"; do
 				echo "::error::$ERRMSG"
 			fi
 
-			wp --allow-root --quiet option delete fake_plugin_update_plugin
-			wp --allow-root --quiet option delete fake_plugin_update_url
+			wp --quiet option delete fake_plugin_update_plugin
+			wp --quiet option delete fake_plugin_update_url
 
 			if [[ -z "$FAILED" ]]; then
 				echo "✅ Upgrade of $SLUG from $FROM via $HOW succeeded!" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We've been seeing occasional spurious failures in CI, where a run of `wp-cron.php` will somehow happen in the middle of the test upgrade and hit a fatal because WordPress is in the middle of updating the files.

Current theory is that 6.9 started triggering the asynchronous cron run differently (e.g. https://core.trac.wordpress.org/changeset/60925), somehow making it more likely that an in-flight async request will land mid-upgrade.

To avoid this, let's just turn off wp-cron entirely, and run `wp cron` manually post-upgrade to catch any fatals that might be due to something scheduled during the upgrade.

While I'm here, let's also remove the `--allow-root` options all over the place that are obsolete since #42007.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1788893494596319/1788893028.554009-slack-C01U2KGS2PQ
p1788183766549619/1788175406.940339-slack-C034JEXD1RD
p1787065169527839/1787063977.446829-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Merge on a fork and see how it runs?
  * [x] https://github.com/anomiex/jetpack/actions/runs/34645257269/job/103414615041