### PR TITLE
Add jetpack-ui-hero skill for building product hero animations

### DIFF
--- a/.agents/skills/jetpack-ui-hero.md
+++ b/.agents/skills/jetpack-ui-hero.md
@@ -1,0 +1,152 @@
+---
+description: >
+  Builds landing-page hero animations of real Jetpack/WordPress admin UI — CSS keyframe timelines
+  layered over screenshots of a live site, published as one self-contained HTML showcase page with
+  real selectable text. Use when asked for a hero animation, product or marketing animation,
+  animated screenshot, animated demo, showcase page, or landing-page motion for any Jetpack
+  product surface, for jetpack.com, a release or P2 post, or a design review; also for "something
+  like the Jetpack AI heroes". Use it too when the request says "video", "GIF", "screen recording"
+  or "loom" of product UI, since this skill produces the CSS-animated alternative to those. Do not
+  use for ordinary Jetpack development — bug fixes, PR review, changelog entries, tests, or taking
+  verification screenshots of a Jurassic Ninja site — nor for adding animation to shipping product
+  code.
+---
+
+# Jetpack UI hero animations
+
+Produce a hero animation of real product UI: a screenshot of the parts that never move, with
+everything that changes redrawn on top as DOM or as slices of a second screenshot, driven by CSS
+keyframes. The result is one self-contained HTML file.
+
+## Before you start
+
+Needs Playwright (a Jetpack monorepo checkout, or `PLAYWRIGHT_ROOT` pointing at one) and Python
+with Pillow. Check both, and set the two paths every command below uses:
+
+```bash
+SKILL=.agents/skills/jetpack-ui-hero   # from the monorepo root
+export PLAYWRIGHT_ROOT=~/a8c/jetpack          # absolute; a relative path hangs the resolver
+python3 -c 'import PIL' || python3 -m pip install --user Pillow
+```
+
+Exporting to MP4 or GIF additionally needs `ffmpeg` (`brew install ffmpeg`); nothing else does.
+
+Pick a working directory for the build and stay in it — steps 3 to 6 all use the same one.
+
+## Workflow
+
+### 1. Agree the piece before capturing
+
+Settle three things with the user, because each changes what to capture:
+
+- **Which moment.** The payoff or the differentiator, not a feature list. See
+  `references/composition.md` for choosing, for how long and how big a piece should be, and for the
+  motion shapes the Jetpack AI set already uses — do not repeat them.
+- **Persona and site identity**, if this is a set of two or more — one name and one site across all
+  of them. See "Continuity across a set" in the same file before inventing a name.
+- **Whether the feature ships.** Flag-gated UI can be captured but must be labelled.
+
+Sketch the beats as a list of times before writing any CSS.
+
+### 2. Set up a capture site
+
+**One site per set, not per piece.** Provision a Jurassic Ninja site, connect Jetpack, and log in
+with `login()` from the capture kit. Rename the site and the admin user to the persona through
+Settings → General and Users → Profile in the same Playwright session — there is no CLI route that
+does not need the password. Seed realistic data through the real UI.
+
+Read **`references/capture-traps.md` before this step** — sessions, rate limits, module activation,
+the display-name two-step, and seeding.
+
+### 3. Capture layers
+
+Write `<dir>/capture.mjs` importing `$SKILL/scripts/capture-kit.mjs`. You will re-run it, and step
+6 keeps it. Exports: `preflight`, `login`, `open`, `settle`, `dismissModals`, `hidePage`,
+`hideInFrame`, `frameOffset`, `stampId`, `measure`, `measureAll`, `crop`, `toWebp`, `sleep`.
+
+Produce:
+
+- **`geometry.json`** — every rect and computed style you will redraw. Measure, never eyeball.
+- **A clean plate** — the full frame with everything that changes blanked out.
+- **Crops** — one per element that appears, moves, or swaps as a unit.
+
+Convert to lossless WebP with `toWebp()`.
+
+`references/capture-traps.md` is the whole value of this step — sessions, clean plates, measuring,
+unstable class names, React screens that are not settled, the block-editor iframe, DataViews
+tables, front-end pages, seeding, feature flags.
+
+### 4. Build the scene
+
+Generate the CSS from `geometry.json` rather than typing coordinates. Patterns for slices, typing,
+counters, cursors, signals, sequential animations and reduced motion are in
+`references/scene-patterns.md` — read it before writing scene CSS; it also lists what the shell
+already provides, so you never need to open `assets/`.
+
+Lay the working directory out like this:
+
+```
+<dir>/
+├── pieces.json          manifest — copy assets/pieces.example.json and edit
+├── capture.mjs          your capture script, kept
+├── piece-<id>.css       one per piece
+├── piece-<id>.html      one per piece: layers ONLY — the builder adds the
+│                        stage/box/scene wrappers. {{asset:name}} becomes a data URI
+└── *.webp               plates and crops
+```
+
+`shell.css` and `stage.js` are taken from the skill unless you drop your own copy in `<dir>`.
+Then:
+
+```bash
+python3 "$SKILL"/scripts/build-page.py <dir>
+```
+
+It inlines every asset once, emits each scene's size and timing variables, computes per-piece
+weights, and writes `index.html`. Heed its warnings — they catch an asset referenced from both the
+stylesheet and the markup, which inlines it twice.
+
+Do not set `width`/`height` on `#<id>-scene` yourself; the builder emits them from the manifest.
+
+### 5. Verify by scrubbing
+
+Do not watch the animation. Seek it — **once per piece**:
+
+```bash
+node "$SKILL"/scripts/scrub.mjs <dir>/index.html <id>-box 0.5,2.4,5.7,8.5
+```
+
+Pick a time either side of every beat plus one after the last; the defaults assume a ~9s piece.
+It writes a frame per time and a full-page shot, checks that reduced motion matches the final
+frame, checks phone width, and exits non-zero on failure.
+
+`index.html` is generated. Fix the piece CSS or markup and rebuild — never hand-edit it.
+
+Then look at the frames, and check:
+
+- every count consistent across the frame at every moment
+- nothing clipped mid-word at a crop edge
+- the last beat still in frame after everything has grown
+- no stale value showing through from the plate
+- `page.png` — the shell, spec table and footer, which the box frames do not show
+
+### 6. Publish, deliver and report
+
+Publish `index.html` with whatever artifact or hosting tool is available; if there is none, hand
+over the absolute path, since the file is self-contained and opens from `file://`. Copy the working
+directory to `~/a8c/plans/<topic>/` — planning artifacts live outside the repo.
+
+Ask where the piece is actually going, and read `references/output.md`: a WordPress page wants
+`build-page.py --embed`, which writes a style-isolated fragment per piece; a deck or a P2 wants
+`scripts/export.mjs`, which renders MP4/WebM/GIF by seeking the timeline.
+
+**Delete `state.json` from the copy.** It holds live session cookies for the capture site.
+
+State plainly what was verified and what was not: headless rendering is not the same as having
+seen it in a real browser, and say so.
+
+## The rule that matters most
+
+**Anything that changes during the animation must be blanked in the plate and redrawn.** A count in
+a sidebar badge, a title echoed in a toolbar, a status pill — leave one baked in and it contradicts
+the animation on screen. This is the most common defect in these pieces.

--- a/.agents/skills/jetpack-ui-hero/assets/pieces.example.json
+++ b/.agents/skills/jetpack-ui-hero/assets/pieces.example.json
@@ -1,0 +1,53 @@
+{
+	"title": "Jetpack Forms Heroes",
+	"h1": "Jetpack Forms heroes",
+	"lede": "One sentence on what this set is and how it is built.",
+	"footer": "One sentence under the last piece. Press R to replay the nearest one.",
+	"date": "September 2026",
+	"fonts": "family=Inter:wght@400;500;600",
+
+	"pieces": [
+		{
+			"id": "fr",
+			"name": "Response lands",
+			"lede": "What the piece shows, and why it is shaped this way.",
+
+			"width": 1280,
+			"height": 820,
+
+			"css": "piece-fr.css",
+			"markup": "piece-fr.html",
+
+			"vars": {
+				"t-open": "0.35s",
+				"t-press": "4.6s",
+				"t-land": "5.75s"
+			},
+
+			"assets": { "plate": "plate.webp" },
+			"weight": [ "plate.webp" ],
+
+			"spec": [
+				{
+					"dt": "Beats",
+					"beats": [
+						[ "0.35s", "the card rises" ],
+						[ "4.6s", "cursor presses Send" ],
+						[ "5.75s", "the row lands" ]
+					]
+				},
+				{ "dt": "Weight", "dd": "{weight}", "small": "one WebP; everything else is DOM and CSS" },
+				{
+					"dt": "Made of",
+					"dd": "HTML + CSS keyframes",
+					"small": "live text, no JS in the animation"
+				},
+				{
+					"dt": "Source",
+					"dd": "A live Jetpack site",
+					"small": "the real dashboard; only the rows are redrawn"
+				}
+			]
+		}
+	]
+}

--- a/.agents/skills/jetpack-ui-hero/assets/shell.css
+++ b/.agents/skills/jetpack-ui-hero/assets/shell.css
@@ -1,0 +1,314 @@
+/* Page chrome for a hero showcase, carried over from the Jetpack AI heroes page
+		so a new set sits beside it: green-40 identity, green-50 on white. */
+:root {
+	--ground: #fff;
+	--surface: #f6f7f7;
+	--rule: #dcdcde;
+	--ink: #101517;
+	--ink-strong: #101517;
+	--muted: #646970;
+	--accent: #069e08;
+	--accent-ink: #008710;
+	--accent-pressed: #005b18;
+	--stage: #fff;
+	--stage-dot: #dcdcde;
+	--sans:
+		"Inter",
+		-apple-system,
+		BlinkMacSystemFont,
+		"Segoe UI",
+		"Roboto",
+		sans-serif;
+	--mono: "Menlo", "Consolas", monaco, monospace;
+
+	/* wp-admin's own stack, so redrawn UI matches the plate underneath it */
+	--wp:
+		-apple-system,
+		system-ui,
+		"Segoe UI",
+		Roboto,
+		Oxygen-Sans,
+		Ubuntu,
+		Cantarell,
+		"Helvetica Neue",
+		sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+
+	:root:not([data-theme="light"]) {
+		--ground: #101517;
+		--surface: #1d2327;
+		--rule: #2c3338;
+		--ink: #e7e8ea;
+		--ink-strong: #fff;
+		--muted: #a7aaad;
+		--accent-ink: #64ca43;
+	}
+}
+
+:root[data-theme="dark"] {
+	--ground: #101517;
+	--surface: #1d2327;
+	--rule: #2c3338;
+	--ink: #e7e8ea;
+	--ink-strong: #fff;
+	--muted: #a7aaad;
+	--accent-ink: #64ca43;
+}
+
+body {
+	margin: 0;
+	background: var(--ground);
+	color: var(--ink);
+	font: 15px/1.6 var(--sans);
+	-webkit-font-smoothing: antialiased;
+	text-wrap: pretty;
+}
+
+main {
+	max-width: 1040px;
+	margin: 0 auto;
+	padding: 56px 24px 96px;
+}
+
+header {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 24px;
+	align-items: end;
+	padding-bottom: 28px;
+	border-bottom: 1px solid var(--rule);
+}
+
+.brand {
+	display: block;
+	height: 40px;
+	margin: -8px 0 20px -8px;
+}
+
+.brand img {
+	height: 100%;
+	width: auto;
+	display: block;
+}
+
+.brand .dark {
+	display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+
+	:root:not([data-theme="light"]) .brand .light {
+		display: none;
+	}
+
+	:root:not([data-theme="light"]) .brand .dark {
+		display: block;
+	}
+}
+
+:root[data-theme="dark"] .brand .light {
+	display: none;
+}
+
+:root[data-theme="dark"] .brand .dark {
+	display: block;
+}
+
+header h1 {
+	font: 600 44px/1.1 var(--sans);
+	color: var(--ink-strong);
+	margin: 0;
+	letter-spacing: -0.02em;
+	text-wrap: balance;
+}
+
+header p {
+	margin: 8px 0 0;
+	color: var(--muted);
+	max-width: 58ch;
+}
+
+.meta {
+	font-size: 12px;
+	color: var(--muted);
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
+.meta b {
+	color: var(--ink);
+	font-weight: 600;
+}
+
+section.piece {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: 20px;
+	padding: 48px 0;
+	border-bottom: 1px solid var(--rule);
+}
+
+.piece h2 {
+	font: 600 30px/1.2 var(--sans);
+	color: var(--ink-strong);
+	margin: 0;
+	letter-spacing: -0.01em;
+	text-wrap: balance;
+}
+
+.piece .lede {
+	margin: 6px 0 0;
+	color: var(--muted);
+	max-width: 62ch;
+}
+
+.head {
+	display: flex;
+	justify-content: space-between;
+	align-items: end;
+	gap: 24px;
+	flex-wrap: wrap;
+}
+
+.head button {
+	font: 600 14px var(--sans);
+	color: #fff;
+	background: var(--accent-ink);
+	border: 0;
+	border-radius: 4px;
+	padding: 10px 16px;
+	cursor: pointer;
+	display: inline-flex;
+	gap: 8px;
+	align-items: center;
+	transition: background-color 100ms cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+
+.head button:hover {
+	background: var(--accent-pressed);
+}
+
+.head button:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.head button kbd {
+	font: 500 11px var(--sans);
+	color: #fff;
+	border: 1px solid rgba(255, 255, 255, 0.45);
+	border-radius: 2px;
+	padding: 0 5px;
+}
+
+@media (prefers-color-scheme: dark) {
+
+	:root:not([data-theme="light"]) .head button {
+		background: var(--accent);
+	}
+}
+
+:root[data-theme="dark"] .head button {
+	background: var(--accent);
+}
+
+.stage {
+	background: var(--stage);
+	border: 1px solid var(--rule);
+	border-radius: 8px;
+	padding: clamp(12px, 3vw, 40px);
+	overflow: hidden;
+	background-image: radial-gradient(var(--stage-dot) 0.6px, transparent 0.7px);
+	background-size: 14px 14px;
+}
+
+.stage.is-idle .scene,
+.stage.is-idle .scene * {
+	animation-play-state: paused !important;
+}
+
+/* A centred grid item makes width:min(100%,…) resolve against an indefinite
+		track; one block wrapper centred by margin is unambiguous. */
+.stage > div {
+	width: 100%;
+	max-width: 1280px;
+	margin-inline: auto;
+	position: relative;
+}
+
+.stage > div > .scene {
+	position: absolute;
+	inset: 0 auto auto 0;
+	transform-origin: 0 0;
+}
+
+.stage > div > .scene > * {
+	position: absolute;
+}
+
+dl.spec {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+	gap: 16px 28px;
+	margin: 4px 0 0;
+}
+
+dl.spec div {
+	border-top: 2px solid var(--accent);
+	padding-top: 10px;
+}
+
+dl.spec dt {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--muted);
+	margin: 0 0 4px;
+}
+
+dl.spec dd {
+	margin: 0;
+	font-variant-numeric: tabular-nums;
+}
+
+dl.spec dd small {
+	display: block;
+	color: var(--muted);
+}
+
+ol.beats {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+	gap: 8px 20px;
+	font-size: 13px;
+}
+
+ol.beats li {
+	display: grid;
+	grid-template-columns: 48px 1fr;
+	gap: 8px;
+}
+
+ol.beats li span {
+	color: var(--muted);
+	font-variant-numeric: tabular-nums;
+}
+
+footer {
+	padding-top: 28px;
+	color: var(--muted);
+	font-size: 13px;
+	max-width: 70ch;
+}
+
+footer code {
+	font: 12px var(--mono);
+	background: var(--surface);
+	border: 1px solid var(--rule);
+	border-radius: 2px;
+	padding: 1px 5px;
+}

--- a/.agents/skills/jetpack-ui-hero/assets/stage.js
+++ b/.agents/skills/jetpack-ui-hero/assets/stage.js
@@ -1,0 +1,51 @@
+( function () {
+	// Each scene is authored at its capture size and scaled to the width it gets.
+	for ( const scene of document.querySelectorAll( '.scene' ) ) {
+		const box = scene.parentElement;
+		const fit = () => {
+			scene.style.transform = 'scale(' + box.clientWidth / scene.offsetWidth + ')';
+		};
+		new ResizeObserver( fit ).observe( box );
+		fit();
+	}
+
+	const replay = stage => {
+		stage.classList.remove( 'is-idle' );
+		stage.getAnimations( { subtree: true } ).forEach( a => {
+			a.cancel();
+			a.play();
+		} );
+	};
+	const stages = [ ...document.querySelectorAll( '.stage' ) ];
+
+	// Start the first time half of it is on screen; replay if it comes back after
+	// leaving. A hero nobody sees the start of explains nothing.
+	const seen = new WeakSet();
+	const io = new IntersectionObserver(
+		es =>
+			es.forEach( e => {
+				if ( e.intersectionRatio >= 0.5 ) {
+					if ( seen.has( e.target ) ) replay( e.target );
+					else {
+						seen.add( e.target );
+						e.target.classList.remove( 'is-idle' );
+					}
+				}
+			} ),
+		{ threshold: [ 0.5 ] }
+	);
+	stages.forEach( s => io.observe( s ) );
+
+	document
+		.querySelectorAll( '[data-replay]' )
+		.forEach( b =>
+			b.addEventListener( 'click', () => replay( document.getElementById( b.dataset.replay ) ) )
+		);
+	document.addEventListener( 'keydown', e => {
+		if ( e.key.toLowerCase() !== 'r' || e.target.matches( 'input,textarea' ) ) return;
+		const top = stages
+			.map( s => ( { s, d: Math.abs( s.getBoundingClientRect().top ) } ) )
+			.sort( ( a, b ) => a.d - b.d )[ 0 ];
+		if ( top ) replay( top.s );
+	} );
+} )();

--- a/.agents/skills/jetpack-ui-hero/references/capture-traps.md
+++ b/.agents/skills/jetpack-ui-hero/references/capture-traps.md
@@ -1,0 +1,210 @@
+# Capture traps
+
+Every entry here is a failure that produced a *plausible-looking wrong capture* rather than an
+error. Read before capturing; re-read when a frame looks subtly off.
+
+- [Getting a session](#getting-a-session)
+- [React admin screens](#react-admin-screens)
+- [Selectors you can rely on](#selectors-you-can-rely-on)
+- [Playwright in the monorepo](#playwright-in-the-monorepo)
+- [The clean plate](#the-clean-plate)
+- [Measuring](#measuring)
+- [The block editor canvas](#the-block-editor-canvas)
+- [DataViews tables](#dataviews-tables)
+- [Front-end pages](#front-end-pages)
+- [Images](#images)
+- [Seeding data](#seeding-data)
+- [Feature-flagged UI](#feature-flagged-ui)
+
+## Getting a session
+
+Provision a throwaway site with the `jurassic-ninja` provider (`context-a8c` MCP): `provision-site`
+with `{"jetpack":"true"}`, poll `list-sites` until `status` is `2`, then `connect-jetpack`.
+
+Log in with `login()` from the capture kit, which drives `?auto_login` and saves `storageState`.
+That link is **one-shot** — do not `curl` it, do not let a link preview touch it. If it is already
+consumed, a fresh site is cheaper than repairing one; but use **one site per set**, or the pieces
+disagree about whose site they are showing.
+
+**`storageState` is a credential.** It holds live session cookies. Keep it in the working
+directory, and delete it before copying that directory anywhere.
+
+Renaming the admin user takes **two saves**: WordPress builds the `display_name` dropdown from the
+*saved* name, so the new option does not exist on the page you are submitting. Save first/last
+name, reload, select the new display name, save again — otherwise the admin bar still reads
+"Howdy, demo".
+
+**Never put the JN password on a command line.** The sandbox blocks it as credential
+materialisation, and you do not need it: the browser session covers everything below.
+
+Many Jetpack features need a connection, and an inactive module looks exactly like broken block
+markup: an empty wrapper `<div>` with no `<form>` inside. **The two are indistinguishable by
+symptom** — connecting Jetpack may not fix it, because stale markup produces the same empty
+wrapper. Check both before concluding either.
+
+JN rate-limits: a burst of requests returns a **429 HTML page**, which surfaces as apiFetch's "The
+response is not a valid JSON response." Back off ~75s rather than debugging the call.
+
+## Playwright in the monorepo
+
+`import 'playwright'` fails everywhere — it is hoisted into pnpm's store and no package the scripts
+run from depends on it. Use `playwright()` from `scripts/capture-kit.mjs`, and run from inside the
+monorepo or set `PLAYWRIGHT_ROOT`. It is CommonJS, so a direct import needs `.default`.
+
+Capture at `deviceScaleFactor: 2` and place the image at logical size in the scene.
+
+`toWebp()` shells out to Python **Pillow**. Call `preflight()` at the top of a capture script so a
+missing dependency fails before a run that has already spent a site.
+
+## The clean plate
+
+The rule is in SKILL.md. What is easy to get wrong is the list.
+
+Blank, at minimum: every count and badge, the document title wherever it is echoed, any status
+pill or button whose label changes, and any row list you intend to animate.
+
+Two that are easy to miss because they are far from the thing you are animating:
+
+- A **count repeated in several places** — a WP admin sidebar badge, a tab badge, a filter pill and
+  a table footer can all show the same number. Blank and animate all of them together.
+- The **document bar title** in the block editor, which echoes the post title you are typing into
+  the canvas.
+
+Transient chrome lands on top of clipped crops. Hide `.components-snackbar-list` (the "New form
+created." toast) before any crop, and call `dismissModals()` — an open modal does **not** break DOM
+queries inside an iframe, so measurements look correct while every crop captures the modal.
+
+## React admin screens
+
+"Network idle" is not "finished rendering". My Jetpack will happily screenshot with a spinner
+inside every product card. Call `settle()` before any capture; it waits for `.components-spinner`
+and `[aria-busy="true"]` to clear and throws rather than let you capture a loading state.
+
+## Selectors you can rely on
+
+Jetpack admin screens ship CSS-module class names like `J94mUfxvLuP1Gu8JjQdO` that change on every
+build. Never build a selector from one.
+
+Anchor on something stable — an ARIA label — walk to the element you actually want, and stamp your
+own id on it with `stampId()`, so every later `measure`, `crop` and `hidePage` call uses a selector
+you control:
+
+```js
+await stampId(page, 'input[aria-label="Toggle Downtime Monitor module"]', 'hero-toggle', 'td')
+```
+
+Some hidden inputs share a rect with the visible control they drive (a `components-form-toggle`
+input and its span), so measuring the input works — but confirm it rather than assume it.
+
+Scanning `querySelectorAll('*')` to find text to blank — the clean-plate idiom below — **throws on
+SVG elements**, whose `innerText` is `undefined`. Guard every such scan with `(el.innerText || '')`.
+
+## Measuring
+
+**Before capturing a two-state control, diff the whole frame, not the control.** Flipping a toggle
+can move a count, a filter pill or a row height somewhere else entirely. Measure everything in both
+states and compare; the blanking rule tells you what to do about a change, not how to find it.
+
+Never eyeball a coordinate. Read `getBoundingClientRect()` and `getComputedStyle()` for every
+element you will redraw, dump to a JSON file, and generate the CSS from it.
+
+Copy the real values: font shorthand, colour, border-radius, and the row pitch (measure it as
+`row[1].y - row[0].y`, do not assume it equals the row height).
+
+**Hiding anything can move everything.** After injecting CSS that hides an element, re-measure —
+do not reuse rects taken before the injection.
+
+Sample real colours out of the PNG rather than guessing them. Avatar and status-pill colours are
+generated, not from a palette you can look up.
+
+**Read the computed font of any text you redraw, and load it.** A theme may set the post title in
+Cardo; the builder's default font list is Inter only, so redrawn text silently falls back and the
+overlay stops matching the plate. Add the family to the manifest's `fonts` key.
+
+Row pitch is `measureAll()[1].y - [0].y`, not a row's height — the two differ whenever rows have
+gaps or borders.
+
+## The block editor canvas
+
+The canvas is an **iframe**. Rects measured inside it are relative to the iframe, so add the
+iframe's page offset (`frameOffset()`); it is typically 96px down.
+
+Inject CSS into the iframe's own document (`hideInFrame()`), not the page.
+
+The **starter-pattern modal** ("Choose a pattern") opens on every new page and covers everything.
+The `enableChoosePatternModal` preference does not reliably persist — dismiss it in the same run as
+the capture and assert it is gone.
+
+`wp.data` is the reliable way to drive the editor: `insertBlocks`, `updateBlockAttributes`,
+`clearSelectedBlock`, `savePost`. Real clicks fail on variation tiles because a hover preview modal
+intercepts pointer events — find the `<button>` inside the `<li>` and call `.click()` on it.
+
+To capture a "nothing selected" state, `clearSelectedBlock()` and hide
+`.block-editor-block-list__block::after`, which draws the selection outline.
+
+## DataViews tables
+
+Do **not** delete a `<th>` to drop a column: the fixed layout redistributes the widths into
+nonsense, and forcing widths back is fought by the component. Use the table's own settings gear →
+Properties to hide the field. That preference **does not survive a reload**, so toggle it in the
+same run as the capture.
+
+If a column cannot be hidden, crop the frame so it falls outside, and fade the cut edge.
+
+DataViews gives the primary title cell no class of its own; identify cells positionally.
+
+## Front-end pages
+
+**Do not scroll before capturing.** A short page clamps `scrollTo`, so the content lands somewhere
+you did not ask for and every measurement shifts silently. Capture the page whole in a tall
+viewport and slide the plate up inside the scene (`inset: -180px auto auto 0`) to frame it.
+
+Hiding the site footer to keep it out of frame shortens the page — which is exactly what causes the
+clamp above. Expect it, and re-measure.
+
+Native `<select>` dropdowns are drawn by the OS, so assume they cannot be screenshotted. Elide the
+dropdown: show the cursor click and the value change with a focus ring.
+
+`#wpfooter` is the WordPress admin footer, not the app footer a Jetpack screen renders. Check what
+you actually hid.
+
+## Images
+
+**Lossless WebP beats lossy for UI screenshots** — smaller *and* crisp. Flat UI compresses better
+losslessly than a photograph does. Use `toWebp()`; it keeps alpha when the source has it, which
+matters for any crop taken with `omitBackground`.
+
+## Seeding data
+
+Submit real forms through the front end rather than inserting rows. The submission path fills in
+fields you would otherwise get wrong.
+
+Deactivate **Akismet** first: test submissions have been reported landing in a custom `spam` status
+that the dashboard hides and `wp post list` does not show. Cheap insurance, not verified here.
+
+Getting an authenticated REST session: `wpApiSettings.nonce` is often **missing** on Jetpack admin
+screens. The route that works is to navigate to a block-editor page and use `wp.apiFetch`, which
+carries its own nonce.
+
+Posting block markup through the REST API is unreliable for Jetpack Forms: flat field markup is
+stored as-is, and the front end renders an empty wrapper. Opening the post in the editor upgrades
+it to the current nested shape — so **open it in the editor and re-save** before it will render.
+Some attributes (`conditionalLogic`) are dropped by the parse entirely and must be written with
+`updateBlockAttributes`.
+
+**Reading an attribute back is not proof it took effect.** A default object like
+`{enabled:false,…}` is truthy, so every field reports "set". The only real check is behavioural:
+load the front end and confirm the thing actually happens.
+
+Vary the seeded timestamps. Real seeding produces rows all within the same minute, which looks
+fake; since rows are usually redrawn as DOM, write plausible dates there instead.
+
+## Feature-flagged UI
+
+Jetpack feature flags are **filter-only** (`jetpack_feature_flag_enabled_{slug}`) — there is no
+option to set and no admin toggle. To capture flagged UI, upload a one-line plugin through
+Plugins → Add New → Upload with Playwright's `setInputFiles`; that needs no SSH and is trivially
+reversible.
+
+A piece built this way **depicts something users cannot see**. Say so on the page itself — a
+`Status` row in the spec table — and say so to whoever asked for it.

--- a/.agents/skills/jetpack-ui-hero/references/composition.md
+++ b/.agents/skills/jetpack-ui-hero/references/composition.md
@@ -1,0 +1,84 @@
+# Composition and art direction
+
+## House rules
+
+Inherited from the Jetpack AI heroes page (`jetpack-ai-heroes.adamjfpickering.workers.dev`,
+source `github.com/adampickering/jetpack-ai-heroes`), so a new set sits beside it rather than
+beneath it:
+
+- **No video, no GIF.** DOM or SVG plus CSS keyframes.
+- **Real text.** Anything a reader could read is text, so it stays selectable and translatable.
+- Starts when scrolled into view, replays on re-entry, plus a Replay button and the `R` key.
+- `prefers-reduced-motion` lands on the final frame.
+- Each piece ships a spec table. Beats, Weight and Made of are fixed; the fourth slot is
+  discretionary — *Source* usually, *Status* for a flag-gated piece, or whatever the piece earns.
+- One self-contained HTML file, every asset inlined.
+
+## How long, how big
+
+**Length: 8–9 seconds**, with the last beat landing around 6 and the rest held. Long enough to read,
+short enough to loop on a replay without tedium. A simple piece can run 3–4 seconds; nothing needs
+more than 10.
+
+**Canvas: the capture viewport**, authored 1:1 and scaled to fit. 1280×820 to 1280×950 has worked
+for admin screens; the block editor wanted 900 of height and a front-end page 950. Pick the size
+that frames the content with the whole timeline in mind, then capture at exactly that.
+
+Beats want ~0.4–0.6s between related events and a visible pause before a new idea. Cascades read
+well at 0.25s apart, and at 0.55s when each item is its own beat.
+
+## Choosing what to animate
+
+Pick the moment that carries the claim, not the feature list. Strong candidates:
+
+- **The payoff** — the thing the user installs the product to get.
+- **The differentiator** — what this does that a competitor's version does not.
+- **The mechanism**, but only when the mechanism *is* the pitch (it is blocks; it is a rule).
+
+A feature that only makes sense after two other explanations is not a hero.
+
+## Don't repeat the set's shapes
+
+The AI set already spends two of its four pieces on *things arriving around a centre* — provider
+bubbles orbiting a toggle, site pills popping in around a hub. A third radial arrival stops reading
+as a house style and starts reading as a tic.
+
+Before committing, ask what the motion's **shape** is — radial, linear, cascading, assembling,
+adapting — and pick one the set does not already lean on. When the obvious treatment for a subject
+is a fan-out, a vertical list of the same information usually says it just as clearly.
+
+Give each piece its own signature move. If one piece's is typing, the next one's should not be.
+
+## Framing
+
+- **Include the chrome that carries the claim.** The wp-admin sidebar is what says "this is in your
+  WordPress", so a dashboard piece keeps it.
+- **Crop on a column boundary, never through content.** A card that clips "Book a shoot" to "B"
+  reads as a bug; the same card starting exactly at the column edge reads as depth.
+- **Give a floating card a device frame** when it belongs to a different surface than what is
+  behind it — a small browser window over an admin screen says "visitor" instantly.
+- Soften a deliberate cut with an edge fade rather than a hard clip.
+- Check the whole timeline for fit, not just the first frame: a piece that grows (a field appearing,
+  a row pushing a list down) can push its own call-to-action out of frame at the end.
+- Clip a list you animate to the region it really occupies, or a pushed row escapes past the footer.
+
+## Honesty
+
+These end up in front of customers, so:
+
+- Screenshot the real product. Redraw for motion, never to improve the design.
+- Do not show a state the product cannot produce. Hiding a column is fine — the settings gear does
+  it. Inventing a status pill is not.
+- No real IP addresses, no real personal data, no real customer names.
+- Flag-gated UI must be labelled as such, on the page and to whoever asked for it.
+
+## Continuity across a set
+
+Only relevant once there are two or more pieces — skip it for a one-off.
+
+Keep one persona and one site identity across every piece, and capture them all from **one** site.
+Rename the site and the admin user before the first capture, so the admin bar does not say
+"Vocational Manatee" and "Howdy, demo".
+
+Invented names are a liability: once a name appears in four pieces, changing it is four
+re-captures. Ask whether marketing has a persona sheet before the second piece.

--- a/.agents/skills/jetpack-ui-hero/references/output.md
+++ b/.agents/skills/jetpack-ui-hero/references/output.md
@@ -1,0 +1,70 @@
+# Getting a piece in front of people
+
+- [What the built page is](#what-the-built-page-is)
+- [Embedding in WordPress](#embedding-in-wordpress)
+- [Exporting MP4 or GIF](#exporting-mp4-or-gif)
+- [Which to use where](#which-to-use-where)
+
+## What the built page is
+
+`index.html` is one self-contained file — every image inlined, no external requests except
+Google Fonts. It opens from `file://`, publishes as an artifact, and drops into a worker or any
+static host unchanged. That page is the *showcase*: header, pieces, spec tables, footer.
+
+For putting a single piece inside something else, build the embed fragments instead:
+
+```bash
+python3 "$SKILL"/scripts/build-page.py <dir> --embed
+```
+
+That writes `embed-<id>.html` per piece — the scene, its CSS and a small script, and nothing
+else. It is style-isolated in **both** directions: no element selectors reach out into the host,
+and a `:where()` guard stops a host theme's `img { border }` or `p { margin }` reaching in. It
+scales to whatever width it is given and replays on click.
+
+## Embedding in WordPress
+
+**A Custom HTML block** is the direct route: paste the whole of `embed-<id>.html` in. It needs the
+inline `<script>` to survive, which means the editing user must have `unfiltered_html` —
+self-hosted and Atomic admins do; **WordPress.com Simple and non-super-admins on multisite do
+not**, and the script is silently stripped, leaving a static first frame. Check the saved page,
+not the editor preview.
+
+**An iframe** is the fallback when scripts are stripped or the theme is hostile. Host the built
+`index.html` (or a single-piece build of it) anywhere static and iframe it at the scene's aspect
+ratio. Note the media library rejects `.html` uploads by default, so it needs real hosting.
+
+**A video block** always works and never breaks — see below for the trade.
+
+Whichever route, check it on the published page at phone width. The fragment has no minimum width,
+but a theme's content column can be narrower than the text in the screenshot stays legible at.
+
+## Exporting MP4 or GIF
+
+```bash
+node "$SKILL"/scripts/export.mjs <dir>/index.html <id>-box \
+  --duration 9 --format mp4,gif --width 1000 --out response-lands
+```
+
+Frames are captured by **seeking**, not by screen-recording, so the output is deterministic — the
+same bytes on a slow machine as a fast one. Needs `ffmpeg` (`brew install ffmpeg`).
+
+Real numbers for a 9s 1280×820 piece exported at 1000px wide: **MP4 174 KB, GIF 767 KB.** The GIF
+uses one shared palette (`palettegen stats_mode=diff`) with bayer dithering, which keeps flat UI
+from crawling between frames and keeps small text readable.
+
+`--format` takes `mp4`, `webm`, `gif`. GIF defaults to 15fps when exported alone, since it is the
+format that suffers most from frame count.
+
+## Which to use where
+
+| Destination | Use | Why |
+|---|---|---|
+| jetpack.com, a WP page | `embed-<id>.html` | Text stays text: selectable, translatable, and reduced-motion still lands on the final frame |
+| Design review, sharing a set | the published artifact | Spec tables and beats come with it |
+| Slide deck, Figma, Slack | `.mp4` | Smallest, best quality, plays everywhere |
+| GitHub comment, a P2, docs | `.gif` | The only thing that reliably auto-plays inline |
+| Anywhere scripts are stripped | `.mp4` in a video block | Needs `muted playsinline autoplay loop` to start on its own |
+
+Export loses three things the animation has: real text, `prefers-reduced-motion`, and the weight
+advantage. Prefer the embed on the web and export only for destinations that cannot take HTML.

--- a/.agents/skills/jetpack-ui-hero/references/scene-patterns.md
+++ b/.agents/skills/jetpack-ui-hero/references/scene-patterns.md
@@ -1,0 +1,175 @@
+# Scene patterns
+
+CSS for the layer techniques.
+
+- [What the shell already gives you](#what-the-shell-already-gives-you)
+- [Layer budget](#layer-budget)
+- [Timing](#timing)
+- [Sequential animations on one property](#sequential-animations-on-one-property)
+- [Image slices](#image-slices)
+- [Typing](#typing)
+- [Counters and label swaps](#counters-and-label-swaps)
+- [Cursor](#cursor)
+- [Signals between regions](#signals-between-regions)
+- [Reduced motion](#reduced-motion)
+- [Specificity](#specificity)
+
+## What the shell already gives you
+
+`build-page.py` wraps each piece in `#<id>-stage > #<id>-box > #<id>-scene.scene` and emits the
+scene's `width`/`height` from the manifest. `assets/shell.css` and `assets/stage.js` then handle:
+
+- **Sizing.** `#<id>-box` carries the aspect ratio; `stage.js` scales the scene to the box.
+  **Never set `width`/`height` on `#<id>-scene` yourself** — and never set `position` on it either
+  (see [Specificity](#specificity)). A scene with no size collapses to zero, `stage.js` computes
+  `scale(Infinity)`, CSS drops the invalid transform, and the page renders at 1:1 clipped to a
+  corner with no error anywhere.
+- **Positioning.** Every direct child of `.scene` is already `position:absolute`, so a layer needs
+  only `left`/`top`. Grandchildren are normal flow.
+- **Playback.** `.is-idle` pauses everything until scrolled into view; `data-replay` and the `R`
+  key restart it.
+- **Fonts.** `--wp` is wp-admin's own stack, for redrawn UI that must match the plate. It matches
+  exactly on the machine that captured the plate and approximates elsewhere — a Mac capture bakes
+  SF while a Windows viewer renders Segoe UI. Acceptable for admin chrome; check it for large text.
+
+Your piece stylesheet supplies the layers and the keyframes, nothing else.
+
+## Layer budget
+
+**Default to slices.** A slice is pixel-exact, weighs almost nothing, and cannot drift from the
+product. Redrawing costs a handful of style values copied by hand and carries the font risk above.
+
+Decide per element: **plate** (never changes), **image slice** (changes as a unit, pixels must be
+the product's), or **DOM** (text that must stay real, or geometry that must move freely).
+
+Redraw as DOM only when the text must be selectable and translatable, or when items reflow — table
+rows, counts, a form the visitor types into. Use a slice for anything that appears or moves as a
+block: a built form, a picker card, a settings panel.
+
+## Timing
+
+Put every beat in a custom property on the scene root and reference it everywhere. Retiming is then
+editing a list of numbers, not hunting through rules. `build-page.py` emits this block from the
+manifest's `vars`.
+
+```css
+#xx-scene { --t-open: 0.35s; --t-press: 4.6s; --t-land: 5.75s; }
+.xx-card { animation: xx-rise .62s cubic-bezier(.22,1,.36,1) var(--t-open) both; }
+```
+
+Each beat should be *caused* by the one before it. Crossfading states reads as a slideshow.
+
+## Sequential animations on one property
+
+Two animations on the same property fight over the backwards fill: the later one's implicit `from`
+applies from time zero and clobbers the earlier one. **Nest instead** — transforms compose and
+opacities multiply.
+
+```css
+/* in at one beat, out at a later one */
+.thing        { animation: in  .44s cubic-bezier(.22,1,.36,1) var(--t-a) both; }
+.thing > span { animation: out .26s ease-in var(--t-b) both; }
+
+/* two different shifts of the same element */
+.below        { animation: down1 .5s cubic-bezier(.22,1,.36,1) var(--t-a) both; }  /* +134px */
+.below > span { animation: down2 .42s cubic-bezier(.22,1,.36,1) var(--t-b) both; } /* -24.6px */
+```
+
+Give every keyframe set an explicit `from` — implicit ones resolve against the underlying value and
+misbehave under fill.
+
+## Image slices
+
+Reveal parts of one screenshot in turn: one image, N positioned windows onto it.
+
+```css
+.field { left:330px; width:620px; background-image:var(--form);
+  background-size:620px 528.3px; background-repeat:no-repeat;
+  animation:drop .44s cubic-bezier(.22,1,.36,1) calc(var(--t-build) + var(--i) * .25s) both; }
+```
+
+Each slice sets `top: <formY + relY>px`, `height: <relH>px`, `background-position: 0 -<relY>px`.
+Generate them from the measured geometry.
+
+Slices of *different* states go at the same slot with only one visible at a time — but check their
+heights, because different fields shift what follows by different amounts.
+
+**Clipping a list changes its coordinate origin.** Wrapping animated rows in an `overflow:hidden`
+container so a pushed row cannot escape means their `top` is now relative to that container, not to
+the scene. Re-derive the offsets; reusing the scene-absolute ones is a silent few-hundred-pixel
+error.
+
+## Typing
+
+Per-character reveal where untyped characters collapse to zero width, so a trailing caret sits
+where the text really ends.
+
+```css
+.typed span { font-size:0; animation:key 1ms var(--d) both; }
+@keyframes key { to { font-size:var(--fs) } }
+.caret { display:inline-block; width:1.5px; height:1em; background:#111;
+  animation:blink .9s steps(1,end) var(--t-type) 3, hide 1ms var(--t-done) forwards; }
+```
+
+Emit `<span style="--d:0.055s">c</span>` per character, `&nbsp;` for spaces, and add the beat with
+`animation-delay: calc(var(--t-type) + var(--d))`.
+
+Hand focus rings off between fields — two lit at once reads as a bug.
+
+## Counters and label swaps
+
+Stack the old and new glyphs in one grid cell so the change is a swap, not a reflow.
+
+```css
+.count { display:grid; place-items:center; }
+.count b, .count i { grid-area:1/1; font:inherit; font-style:normal; }
+.count b { animation:out .28s ease-out var(--t-count) both; }
+.count i { animation:in  .28s cubic-bezier(.34,1.56,.64,1) var(--t-count) both; }
+```
+
+## Cursor
+
+One 20×24 SVG arrow whose *tip* — not its box — lands on the target. Nest for multiple taps.
+
+```css
+.cursor { animation:move 1.5s cubic-bezier(.3,0,.2,1) var(--t-in) both,
+                     away .7s ease-in calc(var(--t-out) + .3s) both; }
+@keyframes move { from { transform:translate(1340px,960px) } to { transform:translate(396px,418px) } }
+.tap-1 { display:block; animation:tap .34s ease-out var(--t-a) both; }  /* nested per tap */
+@keyframes tap { 0%,100% { scale:1 } 34% { scale:.86 } }
+```
+
+## Signals between regions
+
+Draw a curve, then wipe it. Compute the path length for the dash rather than guessing — an
+over-long `dasharray` makes the last part of the animation do nothing.
+
+```css
+.trail path { stroke-dasharray:var(--len); stroke-dashoffset:var(--len);
+  animation:draw .52s cubic-bezier(.4,0,.2,1) var(--t) both,
+            wipe .34s ease-in calc(var(--t) + .5s) both; }
+.spark { offset-path:var(--path); animation:fly .52s cubic-bezier(.4,0,.2,1) var(--t) both; }
+```
+
+Order the spark before the card it leaves, so it emerges from behind it.
+
+## Reduced motion
+
+Every animation uses `both` fill, so collapsing durations lands the whole scene on its final frame.
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  #xx-scene, #xx-scene * { animation-duration:1ms !important; animation-delay:0ms !important;
+    animation-iteration-count:1 !important; }
+  .caret { display:none; }   /* infinite blinks would flicker */
+}
+```
+
+Verify it: `scrub.mjs` renders the reduced-motion frame, which must match the last scrubbed time.
+
+## Specificity
+
+`assets/shell.css` positions scenes with a class selector. An id-level rule in a piece stylesheet
+(`#xx-scene { position:relative }`) **beats it**, and the scene silently falls out of its scaled
+box. Do not set `position` in a piece stylesheet — the shell's `absolute` is also the positioning
+context its children need.

--- a/.agents/skills/jetpack-ui-hero/scripts/build-page.py
+++ b/.agents/skills/jetpack-ui-hero/scripts/build-page.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Assemble a hero showcase into one self-contained HTML file.
+
+Every image is inlined as a data URI, so the result is a single file that can be
+published as an Artifact or dropped into a worker unchanged.
+
+Usage:  build-page.py <dir>            # <dir> holds pieces.json and everything it names
+        build-page.py <dir> --embed    # also write embed-<id>.html per piece
+
+`--embed` writes one standalone fragment per piece, scoped so it cannot leak styles
+into a host page: paste it straight into a WordPress Custom HTML block. Nothing in it
+touches `body`, `main` or any element selector.
+
+pieces.json:
+{
+  "title":  "Jetpack Forms Heroes",        # <title>, and the artifact's name
+  "h1":     "Jetpack Forms heroes",
+  "lede":   "One sentence under the h1.",
+  "footer": "One sentence under the last piece.",
+  "logo":   { "light": "logo-light.svg", "dark": "logo-dark.svg" },   # optional
+  "pieces": [{
+    "id":     "fr",                        # scene id prefix: #fr-scene, #fr-box, #fr-stage
+    "name":   "Response lands",
+    "lede":   "What the piece shows, and why it is shaped this way.",
+    "width":  1280, "height": 820,         # the capture size the scene is authored at
+    "css":    "piece-fr.css",
+    "markup": "piece-fr.html",             # {{asset:plate}} -> data URI
+    "vars":   { "t-card": "0.35s" },       # -> --t-card on #fr-scene
+    "assets": { "plate": "plate.webp" },   # -> {{asset:plate}} and --plate
+    "weight": ["plate.webp"],              # KB shown in the spec table
+    "spec": [
+      { "dt": "Beats", "beats": [["0.35s", "the card rises"], ["4.6s", "press"]] },
+      { "dt": "Weight", "dd": "{weight}", "small": "one WebP; the rest is DOM" },
+      { "dt": "Made of", "dd": "HTML + CSS keyframes", "small": "live text, no JS in the animation" }
+    ]
+  }]
+}
+"""
+import base64, html, json, mimetypes, sys
+from pathlib import Path
+
+SKILL_ASSETS = Path(__file__).resolve().parent.parent / 'assets'
+
+esc = html.escape
+
+MIME = {'.webp': 'image/webp', '.png': 'image/png', '.svg': 'image/svg+xml',
+        '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.avif': 'image/avif'}
+
+
+def data_uri(path: Path) -> str:
+    mime = MIME.get(path.suffix.lower()) or mimetypes.guess_type(path.name)[0] or 'application/octet-stream'
+    return f'data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}'
+
+
+def read(root: Path, name: str, why: str) -> str:
+    p = root / name
+    if not p.exists():
+        sys.exit(f'{name}: no such file in {root} (named by {why})')
+    return p.read_text(encoding='utf-8')
+
+
+def shared(root: Path, name: str) -> str:
+    """Prefer a local override, fall back to the skill's own copy."""
+    local = root / name
+    return (local if local.exists() else SKILL_ASSETS / name).read_text()
+
+
+def kb(root: Path, names) -> int:
+    for n in names:
+        if not (root / n).exists():
+            sys.exit(f'{n}: no such file in {root} (named by a piece\'s "weight")')
+    return round(sum((root / n).stat().st_size for n in names) / 1024)
+
+
+def spec_html(rows, weight):
+    """Spec rows. Values may carry inline markup on purpose (<code>, <br>), so they
+    are not escaped; keep them authored, not user-supplied."""
+    out = []
+    for row in rows:
+        dt = html.escape(str(row['dt']))
+        if 'beats' in row:
+            items = ''.join(f'<li><span>{t}</span>{d}</li>' for t, d in row['beats'])
+            out.append(f'<div><dt>{dt}</dt><dd><ol class="beats">{items}</ol></dd></div>')
+        else:
+            sub = lambda v: str(v).replace('{weight}', f'{weight} KB')
+            small = f'<small>{sub(row["small"])}</small>' if row.get('small') else ''
+            out.append(f'<div><dt>{dt}</dt><dd>{sub(row.get("dd", ""))}{small}</dd></div>')
+    return '\n    '.join(out)
+
+
+EMBED = """<div class="jph jph-{pid} is-idle" id="jph-{pid}">
+  <div class="jph-box"><div class="jph-scene" id="{pid}-scene">
+{markup}
+  </div></div>
+</div>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?{fonts}&display=swap">
+<style>
+/* Scoped to .jph-{pid}: no element selectors, nothing that can reach the host page. */
+.jph-{pid} {{
+  --sans:"Inter",-apple-system,BlinkMacSystemFont,"Segoe UI","Roboto",sans-serif;
+  --wp:-apple-system,system-ui,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+  --accent:#069e08; --accent-ink:#008710; --accent-pressed:#005b18;
+  display:block; width:100%; max-width:{w}px; margin-inline:auto;
+}}
+/* Inbound guard. A host theme styling `img`, `svg` or `p` would otherwise reach in —
+   a themed `img {{ border }}` puts a border round the plate. :where() keeps this at
+   zero specificity, so the piece's own rules below still win on source order. */
+.jph-{pid} .jph-scene :where(img, svg, div, span, p, b, i, u, em, ol, ul, li, figure) {{
+  margin:0; padding:0; border:0; border-radius:0; background:transparent; box-shadow:none;
+  max-width:none; min-width:0; max-height:none; outline:0; float:none; list-style:none;
+  text-transform:none; text-decoration:none; letter-spacing:normal; vertical-align:baseline;
+  box-sizing:border-box;
+}}
+.jph-{pid} .jph-box {{ position:relative; width:100%; aspect-ratio:{w}/{h}; }}
+.jph-{pid} .jph-scene {{ position:absolute; inset:0 auto auto 0; transform-origin:0 0; }}
+.jph-{pid} .jph-scene > * {{ position:absolute; }}
+.jph-{pid}.is-idle .jph-scene, .jph-{pid}.is-idle .jph-scene * {{ animation-play-state:paused !important; }}
+#{pid}-scene {{
+  {decls}
+}}
+{css}
+</style>
+<script>
+(function () {{
+  var wrap = document.getElementById('jph-{pid}')
+  if (!wrap || wrap.dataset.jph) return
+  wrap.dataset.jph = '1'
+  var box = wrap.querySelector('.jph-box'), scene = wrap.querySelector('.jph-scene')
+  function fit() {{ if (scene.offsetWidth) scene.style.transform = 'scale(' + (box.clientWidth / scene.offsetWidth) + ')' }}
+  new ResizeObserver(fit).observe(box); fit()
+  function replay() {{
+    wrap.classList.remove('is-idle')
+    wrap.getAnimations({{ subtree: true }}).forEach(function (a) {{ a.cancel(); a.play() }})
+  }}
+  var seen = false
+  new IntersectionObserver(function (es) {{
+    es.forEach(function (e) {{
+      if (e.intersectionRatio < 0.5) return
+      if (seen) replay(); else {{ seen = true; wrap.classList.remove('is-idle') }}
+    }})
+  }}, {{ threshold: [0.5] }}).observe(wrap)
+  wrap.addEventListener('click', replay)
+}})()
+</script>
+"""
+
+
+def build_embeds(root: Path, cfg: dict, pieces: list) -> list:
+    """One standalone, style-scoped fragment per piece."""
+    written = []
+    for p, piece_css, markup in pieces:
+        pid = p['id']
+        decls = '\n  '.join(
+            [f'width:{p["width"]}px;', f'height:{p["height"]}px;']
+            + [f'--{k}: {v};' for k, v in p.get('vars', {}).items()]
+            + [f'--{k}: url("{u}");' for k, u in p['_assets'].items() if f'var(--{k})' in piece_css]
+        )
+        out = root / f'embed-{pid}.html'
+        out.write_text(EMBED.format(pid=pid, w=p['width'], h=p['height'], markup=markup,
+                                    decls=decls, css=piece_css,
+                                    fonts=cfg.get('fonts', 'family=Inter:wght@400;500;600')),
+                       encoding='utf-8')
+        written.append(out)
+    return written
+
+
+def build(root: Path, embed: bool = False) -> Path:
+    manifest = root / 'pieces.json'
+    if not manifest.exists():
+        sys.exit(f'no pieces.json in {root} — see this script\'s docstring for the schema')
+    cfg = json.loads(manifest.read_text(encoding='utf-8'))
+    for key in ('title', 'h1', 'lede', 'footer', 'pieces'):
+        if key not in cfg:
+            sys.exit(f'pieces.json is missing required key: {key}')
+    shell = shared(root, 'shell.css')
+    stage = shared(root, 'stage.js')
+
+    styles, sections, boxes, collected = [], [], [], []
+    for p in cfg['pieces']:
+        pid, w, h = p['id'], p['width'], p['height']
+        assets = {k: data_uri(root / v) for k, v in p.get('assets', {}).items()}
+        piece_css = read(root, p['css'], f'piece {pid}.css')
+
+        # Inline each asset once, where it is actually referenced: as a CSS custom
+        # property only if the stylesheet reads var(--name), and in the markup only
+        # if it carries the placeholder. Emitting both doubles the page weight.
+        # The scene MUST have explicit dimensions. Its children are all absolutely
+        # positioned, so without these it shrink-to-fits to zero, stage.js computes
+        # scale(Infinity), CSS drops the invalid transform, and the page renders at
+        # 1:1 clipped to a corner — with no error anywhere.
+        decls = [f'width:{w}px;', f'height:{h}px;']
+        decls += [f'--{k}: {v};' for k, v in p.get('vars', {}).items()]
+        decls += [f'--{k}: url("{uri}");' for k, uri in assets.items() if f'var(--{k})' in piece_css]
+        styles.append(f'#{pid}-scene {{\n  ' + '\n  '.join(decls) + '\n}\n' + piece_css)
+        boxes.append(f'#{pid}-box {{ aspect-ratio:{w}/{h}; }}')
+
+        raw = read(root, p['markup'], f'piece {pid}.markup')
+        markup = raw
+        for k, uri in assets.items():
+            markup = markup.replace('{{asset:' + k + '}}', uri)
+        for k in assets:
+            in_css, in_markup = f'var(--{k})' in piece_css, '{{asset:' + k + '}}' in raw
+            if in_css and in_markup:
+                print(f'  warning: piece {pid} asset "{k}" is referenced from BOTH the '
+                      f'stylesheet and the markup, so it is inlined twice; pick one')
+            elif not in_css and not in_markup:
+                print(f'  warning: piece {pid} declares asset "{k}" that nothing references')
+
+        p['_assets'] = assets
+        collected.append((p, piece_css, markup))
+        sections.append(f'''
+<section class="piece" id="piece-{pid}">
+  <div class="head">
+    <div><h2>{esc(p["name"])}</h2><p class="lede">{esc(p["lede"])}</p></div>
+    <button type="button" data-replay="{pid}-stage">Replay <kbd>R</kbd></button>
+  </div>
+
+  <div class="stage is-idle" id="{pid}-stage"><div id="{pid}-box"><div id="{pid}-scene" class="scene">
+{markup}
+  </div></div></div>
+
+  <dl class="spec">
+    {spec_html(p.get('spec', []), kb(root, p.get('weight', [])))}
+  </dl>
+</section>''')
+
+    logo = ''
+    if cfg.get('logo'):
+        for side in ('light', 'dark'):
+            if side not in cfg['logo']:
+                sys.exit(f'pieces.json "logo" needs both light and dark; missing: {side}')
+        light, dark = data_uri(root / cfg['logo']['light']), data_uri(root / cfg['logo']['dark'])
+        logo = (f'<a class="brand" href="https://jetpack.com" aria-label="Jetpack">'
+                f'<img class="light" src="{light}" alt="Jetpack"><img class="dark" src="{dark}" alt=""></a>')
+
+    n = len(cfg['pieces'])
+    page = f'''<meta charset="utf-8">
+<title>{esc(cfg["title"])}</title>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?{cfg.get("fonts", "family=Inter:wght@400;500;600")}&display=swap">
+<style>
+{shell}
+{chr(10).join(boxes)}
+{chr(10).join(styles)}
+</style>
+
+<main>
+<header>
+  <div>
+    {logo}
+    <h1>{esc(cfg["h1"])}</h1>
+    <p>{esc(cfg["lede"])}</p>
+  </div>
+  <div class="meta"><b>{n}</b> piece{"s" if n != 1 else ""} · <b>\x00SIZE\x00 KB</b> total · {cfg.get("date", "")}</div>
+</header>
+{"".join(sections)}
+<footer>{esc(cfg["footer"])}</footer>
+</main>
+
+<script>
+{stage}
+</script>
+'''
+    if embed:
+        for e in build_embeds(root, cfg, collected):
+            print(f'wrote {e}')
+
+    out = root / 'index.html'
+    # Measure after substituting, or the reported total undercounts itself.
+    size = round((len(page.encode()) + 4) / 1024)
+    out.write_text(page.replace('\x00SIZE\x00', str(size), 1), encoding='utf-8')
+    return out
+
+
+if __name__ == '__main__':
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    root = Path(args[0] if args else '.').resolve()
+    path = build(root, embed='--embed' in sys.argv)
+    print(f'wrote {path} — {round(path.stat().st_size / 1024)} KB')

--- a/.agents/skills/jetpack-ui-hero/scripts/capture-kit.mjs
+++ b/.agents/skills/jetpack-ui-hero/scripts/capture-kit.mjs
@@ -1,0 +1,510 @@
+/* global process */
+/*
+ * Helpers for capturing a piece of WordPress admin UI as hero-animation layers.
+ *
+ * Import from a per-task capture script; every function here exists because the
+ * naive version of it silently produced a wrong capture. See
+ * references/capture-traps.md for why each one is shaped the way it is.
+ */
+import { execFileSync } from 'node:child_process';
+import { readdirSync, existsSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Pause for a number of milliseconds.
+ *
+ * @param {number} ms - How long to wait.
+ * @return {Promise<void>} Resolves when the time has passed.
+ */
+export const sleep = ms => new Promise( r => setTimeout( r, ms ) );
+
+/*
+ * The monorepo hoists playwright into pnpm's store, so `import 'playwright'`
+ * fails from anywhere outside a package that depends on it. Find it on disk.
+ * @param from
+ */
+/**
+ * Resolve Playwright, which the monorepo hoists into pnpm's store where a bare
+ * `import 'playwright'` cannot see it.
+ *
+ * @param {string} [from] - Directory to search upwards from.
+ * @return {Promise<object>} The Playwright module namespace.
+ */
+export async function playwright( from = process.cwd() ) {
+	try {
+		// eslint-disable-next-line import/no-unresolved -- optional; found in the pnpm store below
+		return await import( 'playwright' );
+	} catch {
+		/* fall through */
+	}
+	const roots = [ process.env.PLAYWRIGHT_ROOT, from ]
+		.filter( Boolean )
+		.map( r => resolve( r.replace( /^~(?=$|\/)/, process.env.HOME || '~' ) ) );
+	for ( const root of roots ) {
+		// Walk until dirname stops changing. A relative path or an unexpanded "~"
+		// never reaches '/', and the loop blocks the event loop hard enough that a
+		// watchdog timer never fires.
+		for ( let dir = root, prev; dir !== prev; prev = dir, dir = dirname( dir ) ) {
+			const store = join( dir, 'node_modules/.pnpm' );
+			if ( ! existsSync( store ) ) continue;
+			const hit = readdirSync( store )
+				.filter( d => d.startsWith( 'playwright@' ) )
+				.sort( ( a, b ) => a.localeCompare( b, undefined, { numeric: true } ) )
+				.pop();
+			if ( ! hit ) continue;
+			// It is CommonJS, so the namespace lands on `.default`.
+			const mod = await import(
+				pathToFileURL( join( store, hit, 'node_modules/playwright/index.js' ) ).href
+			);
+			return mod.default ?? mod;
+		}
+	}
+	throw new Error(
+		'playwright not found. Run this from inside the Jetpack monorepo, or set ' +
+			'PLAYWRIGHT_ROOT to a checkout that has it installed:\n' +
+			'  PLAYWRIGHT_ROOT=~/a8c/jetpack node <script>'
+	);
+}
+
+/*
+ * Sign in through the one-shot `?auto_login` link and save the session.
+ *
+ * That link works exactly once. Never curl it, never paste it anywhere a preview
+ * might fetch it — a fresh site is cheaper than repairing a consumed one.
+ * @param page
+ * @param domain
+ * @param statePath
+ */
+/**
+ * Sign in through the one-shot `?auto_login` link and save the session.
+ *
+ * That link works exactly once. Never curl it, and never paste it anywhere a link
+ * preview might fetch it.
+ *
+ * @param {object} page      - Playwright page.
+ * @param {string} domain    - Site domain, with or without a scheme.
+ * @param {string} statePath - Where to write the storage state.
+ * @return {Promise<string>} The path the state was written to.
+ */
+export async function login( page, domain, statePath ) {
+	const site = domain.startsWith( 'http' ) ? domain : `https://${ domain }`;
+	await page.goto( `${ site }/?auto_login`, { waitUntil: 'domcontentloaded', timeout: 90000 } );
+	await sleep( 2500 );
+	if ( ( await page.locator( '#wpadminbar' ).count() ) === 0 ) {
+		throw new Error(
+			`?auto_login did not sign in at ${ site } — the link was probably already consumed`
+		);
+	}
+	await page.context().storageState( { path: statePath } );
+	return statePath;
+}
+
+/*
+ * Wait for a React admin screen to finish rendering. "Network idle" is not the
+ * same thing: My Jetpack will happily screenshot with a spinner in every card.
+ * @param page
+ * @param root0
+ * @param root0.timeout
+ */
+/**
+ * Wait for a React admin screen to finish rendering. "Network idle" is not the same
+ * thing: My Jetpack will happily screenshot with a spinner in every card.
+ *
+ * @param {object} page              - Playwright page.
+ * @param {object} [options]         - Options.
+ * @param {number} [options.timeout] - How long to wait, in ms.
+ * @return {Promise<void>} Resolves once nothing is loading.
+ */
+export async function settle( page, { timeout = 20000 } = {} ) {
+	await page
+		.waitForFunction(
+			() => ! document.querySelector( '.components-spinner, [aria-busy="true"], .is-loading' ),
+			null,
+			{ timeout }
+		)
+		.catch( () => {
+			throw new Error( 'page still shows a spinner or aria-busy after waiting; do not capture it' );
+		} );
+	await sleep( 600 );
+}
+
+/*
+ *
+ * @param root0
+ * @param root0.storageState
+ * @param root0.width
+ * @param root0.height
+ * @param root0.scale
+ */
+/**
+ * Launch a browser and page set up for capture.
+ *
+ * @param {object} [options]              - Options.
+ * @param {string} [options.storageState] - Saved session to restore.
+ * @param {number} [options.width]        - Viewport width.
+ * @param {number} [options.height]       - Viewport height.
+ * @param {number} [options.scale]        - Device scale factor.
+ * @return {Promise<object>} `{ browser, ctx, page, errors }`.
+ */
+export async function open( { storageState, width = 1280, height = 900, scale = 2 } = {} ) {
+	const { chromium } = await playwright();
+	const browser = await chromium.launch();
+	const ctx = await browser.newContext( {
+		...( storageState ? { storageState } : {} ),
+		viewport: { width, height },
+		deviceScaleFactor: scale,
+	} );
+	const page = await ctx.newPage();
+	const errors = [];
+	page.on( 'pageerror', e => errors.push( String( e.message ) ) );
+	return { browser, ctx, page, errors };
+}
+
+/*
+ * Close any modal overlay and prove it is gone. An open modal does not break
+ * DOM queries inside an iframe, so measurements look fine while every clipped
+ * screenshot silently captures the modal instead.
+ * @param page
+ * @param tries
+ */
+/**
+ * Close any modal overlay and prove it is gone.
+ *
+ * An open modal does not break DOM queries inside an iframe, so measurements look
+ * correct while every clipped screenshot silently captures the modal instead.
+ *
+ * @param {object} page    - Playwright page.
+ * @param {number} [tries] - How many times to try.
+ * @return {Promise<void>} Resolves when no overlay remains.
+ */
+export async function dismissModals( page, tries = 6 ) {
+	for ( let i = 0; i < tries; i++ ) {
+		if ( ( await page.locator( '.components-modal__screen-overlay' ).count() ) === 0 ) return;
+		await page.keyboard.press( 'Escape' );
+		await sleep( 300 );
+		if ( ( await page.locator( '.components-modal__screen-overlay' ).count() ) === 0 ) return;
+		// Scope to the overlay: an unscoped aria-label="Close" plus force:true will
+		// happily click a dismissible admin notice earlier in the DOM instead.
+		const x = page
+			.locator( '.components-modal__screen-overlay' )
+			.locator( '.components-modal__header button, button[aria-label="Close"]' )
+			.first();
+		if ( await x.count() ) await x.click( { force: true } ).catch( () => {} );
+		await sleep( 700 );
+	}
+	if ( await page.locator( '.components-modal__screen-overlay' ).count() ) {
+		throw new Error( 'a modal overlay is still up; captures would be covered' );
+	}
+}
+
+/*
+ * Inject (or replace) a stylesheet in the page.
+ * @param page
+ * @param css
+ */
+/**
+ * Inject or replace a stylesheet in the page.
+ *
+ * @param {object} page - Playwright page.
+ * @param {string} css  - Stylesheet text.
+ * @return {Promise<void>} Resolves once applied.
+ */
+export const hidePage = ( page, css ) =>
+	page.evaluate( c => {
+		let s = document.getElementById( 'hero-hide-page' );
+		if ( ! s ) {
+			s = document.createElement( 'style' );
+			s.id = 'hero-hide-page';
+			document.head.appendChild( s );
+		}
+		s.textContent = c;
+	}, css );
+
+/*
+ * Inject (or replace) a stylesheet inside the block-editor canvas iframe.
+ * @param page
+ * @param css
+ * @param name
+ */
+/**
+ * Inject or replace a stylesheet inside the block-editor canvas iframe.
+ *
+ * @param {object} page   - Playwright page.
+ * @param {string} css    - Stylesheet text.
+ * @param {string} [name] - Iframe name attribute.
+ * @return {Promise<void>} Resolves once applied.
+ */
+export const hideInFrame = ( page, css, name = 'editor-canvas' ) =>
+	page.evaluate(
+		( [ c, n ] ) => {
+			const d = document.querySelector( `iframe[name="${ n }"]` ).contentDocument;
+			let s = d.getElementById( 'hero-hide' );
+			if ( ! s ) {
+				s = d.createElement( 'style' );
+				s.id = 'hero-hide';
+				d.head.appendChild( s );
+			}
+			s.textContent = c;
+		},
+		[ css, name ]
+	);
+
+/*
+ * Offset of the editor canvas iframe, which every rect measured inside it needs.
+ * @param page
+ * @param name
+ */
+/**
+ * Offset of the editor canvas iframe, which every rect measured inside it needs.
+ *
+ * @param {object} page   - Playwright page.
+ * @param {string} [name] - Iframe name attribute.
+ * @return {Promise<object>} `{ x, y }` in page coordinates.
+ */
+export const frameOffset = ( page, name = 'editor-canvas' ) =>
+	page.evaluate( n => {
+		const f = document.querySelector( `iframe[name="${ n }"]` );
+		// Returning {0,0} here would be a plausible-looking wrong answer: every rect
+		// measured inside the frame would come out short by the frame's offset.
+		if ( ! f ) throw new Error( `no iframe[name="${ n }"] on this page` );
+		const r = f.getBoundingClientRect();
+		return { x: +r.x.toFixed( 1 ), y: +r.y.toFixed( 1 ) };
+	}, name );
+
+/*
+ * Measure named selectors. Pass `frame` to look inside the canvas iframe, and
+ * `offset` (from frameOffset) to convert to page coordinates.
+ *
+ * @param          page
+ * @param {object} map          - name -> CSS selector
+ * @param {object} opts         - { frame, offset, styles }
+ * @param          root0
+ * @param          root0.frame
+ * @param          opts.frame
+ * @param          root0.offset
+ * @param          opts.offset
+ * @param          root0.styles
+ * @param          opts.styles
+ */
+/**
+ * Measure named selectors, one element each.
+ *
+ * @param {object}  page             - Playwright page.
+ * @param {object}  map              - Map of name to CSS selector.
+ * @param {object}  [options]        - Options.
+ * @param {string}  [options.frame]  - Iframe name to look inside.
+ * @param {object}  [options.offset] - Offset to add, from `frameOffset`.
+ * @param {boolean} [options.styles] - Include computed styles.
+ * @return {Promise<object>} Map of name to rect, or null where the selector missed.
+ */
+export function measure(
+	page,
+	map,
+	{ frame = null, offset = { x: 0, y: 0 }, styles = true } = {}
+) {
+	return page.evaluate(
+		( [ m, f, off, wantStyles ] ) => {
+			const root = f ? document.querySelector( `iframe[name="${ f }"]` ).contentDocument : document;
+			const out = {};
+			for ( const [ name, sel ] of Object.entries( m ) ) {
+				const el = root.querySelector( sel );
+				if ( ! el ) {
+					out[ name ] = null;
+					continue;
+				}
+				const r = el.getBoundingClientRect();
+				const rect = {
+					x: +( r.x + off.x ).toFixed( 1 ),
+					y: +( r.y + off.y ).toFixed( 1 ),
+					w: +r.width.toFixed( 1 ),
+					h: +r.height.toFixed( 1 ),
+				};
+				if ( wantStyles ) {
+					const s = getComputedStyle( el );
+					Object.assign( rect, {
+						font: s.font,
+						color: s.color,
+						bg: s.backgroundColor,
+						radius: s.borderRadius,
+					} );
+				}
+				rect.text = ( el.innerText || '' ).replace( /\s+/g, ' ' ).trim().slice( 0, 80 );
+				out[ name ] = rect;
+			}
+			return out;
+		},
+		[ map, frame, offset, styles ]
+	);
+}
+
+/*
+ * Screenshot a measured rect. Playwright wants width/height, not w/h.
+ * @param page
+ * @param rect
+ * @param path
+ */
+/**
+ * Screenshot a measured rect.
+ *
+ * @param {object} page - Playwright page.
+ * @param {object} rect - Rect from `measure`.
+ * @param {string} path - Where to write the PNG.
+ * @return {Promise<object>} The screenshot buffer.
+ */
+export const crop = ( page, rect, path ) => {
+	if ( ! rect )
+		throw new Error(
+			`crop(${ path }): no rect — the selector that should have produced it missed`
+		);
+	return page.screenshot( { path, clip: { x: rect.x, y: rect.y, width: rect.w, height: rect.h } } );
+};
+
+/*
+ * Measure every match of one selector — needed for row pitch, which is
+ * `rows[1].y - rows[0].y` and is NOT the same as a row's height.
+ * @param page
+ * @param selector
+ * @param root0
+ * @param root0.frame
+ * @param root0.offset
+ */
+/**
+ * Measure every match of one selector.
+ *
+ * Needed for row pitch, which is `rows[1].y - rows[0].y` and is not the same as a
+ * row's height.
+ *
+ * @param {object} page             - Playwright page.
+ * @param {string} selector         - CSS selector.
+ * @param {object} [options]        - Options.
+ * @param {string} [options.frame]  - Iframe name to look inside.
+ * @param {object} [options.offset] - Offset to add, from `frameOffset`.
+ * @return {Promise<Array>} One rect per match, in document order.
+ */
+export function measureAll( page, selector, { frame = null, offset = { x: 0, y: 0 } } = {} ) {
+	return page.evaluate(
+		( [ sel, f, off ] ) => {
+			const root = f ? document.querySelector( `iframe[name="${ f }"]` ).contentDocument : document;
+			return [ ...root.querySelectorAll( sel ) ].map( el => {
+				const r = el.getBoundingClientRect();
+				return {
+					x: +( r.x + off.x ).toFixed( 1 ),
+					y: +( r.y + off.y ).toFixed( 1 ),
+					w: +r.width.toFixed( 1 ),
+					h: +r.height.toFixed( 1 ),
+					text: ( el.innerText || '' ).replace( /\s+/g, ' ' ).trim().slice( 0, 60 ),
+				};
+			} );
+		},
+		[ selector, frame, offset ]
+	);
+}
+
+/*
+ * Give an element an id of your own before measuring it.
+ *
+ * Jetpack admin screens ship CSS-module class names like `J94mUfxvLuP1Gu8JjQdO`
+ * that change on every build. Anchor on something stable (an ARIA label), walk to
+ * the element you actually want, stamp an id, and use that id everywhere after.
+ * @param page
+ * @param selector
+ * @param id
+ * @param climb
+ */
+/**
+ * Give an element an id of your own before measuring it.
+ *
+ * Jetpack admin screens ship CSS-module class names that change on every build.
+ * Anchor on something stable, walk to the element you want, and stamp an id.
+ *
+ * @param {object} page     - Playwright page.
+ * @param {string} selector - Stable selector to anchor on.
+ * @param {string} id       - Id to assign.
+ * @param {string} [climb]  - Optional ancestor selector to walk up to first.
+ * @return {Promise<boolean>} True once stamped.
+ */
+export const stampId = ( page, selector, id, climb = null ) =>
+	page.evaluate(
+		( [ sel, newId, up ] ) => {
+			const found = document.querySelector( sel );
+			if ( ! found ) throw new Error( `stampId: nothing matches ${ sel }` );
+			const el = up ? found.closest( up ) : found;
+			if ( ! el ) throw new Error( `stampId: ${ sel } has no ancestor matching ${ up }` );
+			el.id = newId;
+			return true;
+		},
+		[ selector, id, climb ]
+	);
+
+/*
+ * PNG -> lossless WebP. Lossless beats lossy for flat UI: smaller AND crisp.
+ * @param png
+ * @param webp
+ * @param root0
+ * @param root0.alpha
+ */
+/**
+ * Convert a PNG to lossless WebP, which is both smaller and crisper than lossy for
+ * flat UI.
+ *
+ * @param {string}         png             - Source PNG path.
+ * @param {string}         webp            - Destination WebP path.
+ * @param {object}         [options]       - Options.
+ * @param {boolean|string} [options.alpha] - `auto` keeps alpha when the source has it.
+ * @return {string} The destination path.
+ */
+export function toWebp( png, webp, { alpha = 'auto' } = {} ) {
+	// RGB by default: crops are opaque. Pass { alpha: true } for anything captured
+	// with omitBackground, or the transparency silently becomes a black box.
+	// `auto` keeps alpha only when the source has it. Flattening a transparent crop
+	// silently produces an opaque rectangle that covers the plate underneath.
+	let mode = 'RGB';
+	if ( alpha === 'auto' ) {
+		mode = null;
+	} else if ( alpha ) {
+		mode = 'RGBA';
+	}
+	try {
+		execFileSync(
+			'python3',
+			[
+				'-c',
+				`
+from PIL import Image
+im = Image.open(${ JSON.stringify( png ) })
+mode = ${
+					mode === null
+						? "('RGBA' if im.mode in ('RGBA', 'LA', 'P') else 'RGB')"
+						: JSON.stringify( mode )
+				}
+im.convert(mode).save(${ JSON.stringify( webp ) }, 'WEBP', lossless=True, quality=100, method=6)
+`,
+			],
+			{ stdio: [ 'ignore', 'ignore', 'pipe' ] }
+		);
+	} catch ( e ) {
+		const err = String( e.stderr || '' );
+		if ( /No module named .PIL./.test( err ) ) {
+			throw new Error( 'toWebp needs Python Pillow: python3 -m pip install --user Pillow', {
+				cause: e,
+			} );
+		}
+		throw new Error( `toWebp failed for ${ png }: ${ err.trim() || e.message }`, { cause: e } );
+	}
+	return webp;
+}
+
+/* Check the tools this kit shells out to, before a capture run spends a JN site. */
+/**
+ * Check the tools this kit shells out to, before a capture run spends a site.
+ *
+ * @return {void}
+ */
+export function preflight() {
+	try {
+		execFileSync( 'python3', [ '-c', 'import PIL' ], { stdio: 'ignore' } );
+	} catch {
+		throw new Error( 'Python Pillow is missing: python3 -m pip install --user Pillow' );
+	}
+}

--- a/.agents/skills/jetpack-ui-hero/scripts/export.mjs
+++ b/.agents/skills/jetpack-ui-hero/scripts/export.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/* global process */
+/* eslint-disable no-console, n/no-process-exit -- a CLI: stdout is the interface and the exit code is the result. */
+/*
+ * Export a built hero piece to MP4 / WebM / GIF.
+ *
+ * The animation stays the deliverable for the web — it is text, it is 20-90 KB, and
+ * it respects reduced motion. Export when the destination cannot take HTML: a deck,
+ * a Slack post, a GitHub comment.
+ *
+ * Frames are captured by SEEKING, not by recording, so the output is identical on
+ * any machine regardless of how fast it renders.
+ *
+ * Usage:
+ *   export.mjs <index.html> [box-id] [options]
+ *     --all               export every piece on the page (default when no box-id)
+ *     --duration 9        seconds (default: measured from the timeline + --hold)
+ *     --hold 2.5          seconds to sit on the final frame (default 2.5)
+ *     --fps 25            frames per second (default 25; GIF alone forces 15)
+ *     --width 1280        output width in px (default: the scene's own width)
+ *     --format mp4,gif    comma-separated: mp4, webm, gif (default mp4)
+ *     --out hero          basename, or prefix when exporting several
+ *     --outDir .          where to write (default: alongside index.html)
+ *     --keep-frames       leave the PNG frames behind for inspection
+ *
+ * MP4 is the default because it is 4-8x smaller than the same piece as a GIF and
+ * holds full colour. Ask for gif only where the destination cannot play video.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { open, sleep } from './capture-kit.mjs';
+
+// Parse properly: naively filtering out `--x` leaves each flag's VALUE looking
+// like a positional, so `--format mp4` was being read as the box id.
+const BOOLEAN = new Set( [ 'all', 'keep-frames' ] );
+const argv = process.argv.slice( 2 );
+const opts = {};
+const positional = [];
+for ( let i = 0; i < argv.length; i++ ) {
+	const a = argv[ i ];
+	if ( ! a.startsWith( '--' ) ) {
+		positional.push( a );
+		continue;
+	}
+	const name = a.slice( 2 );
+	if ( BOOLEAN.has( name ) ) {
+		opts[ name ] = true;
+		continue;
+	}
+	const next = argv[ i + 1 ];
+	if ( next === undefined || next.startsWith( '--' ) ) {
+		opts[ name ] = true;
+		continue;
+	}
+	opts[ name ] = next;
+	i++;
+}
+const [ file, box ] = positional;
+const flag = ( name, fallback ) => ( name in opts ? opts[ name ] : fallback );
+if ( ! file ) {
+	console.error(
+		'usage: export.mjs <index.html> [box-id] [--all] [--format mp4,gif] [--width 1280] [--out name]'
+	);
+	process.exit( 1 );
+}
+if ( ! existsSync( file ) ) {
+	console.error( `no such file: ${ file }` );
+	process.exit( 1 );
+}
+try {
+	execFileSync( 'ffmpeg', [ '-version' ], { stdio: 'ignore' } );
+} catch {
+	console.error( 'ffmpeg is not installed: brew install ffmpeg' );
+	process.exit( 1 );
+}
+
+const durationFlag = flag( 'duration', null );
+const hold = Number( flag( 'hold', 2.5 ) );
+const formats = String( flag( 'format', 'mp4' ) )
+	.split( ',' )
+	.map( s => s.trim() )
+	.filter( Boolean );
+const base = flag( 'out', null );
+const outDir = resolve( String( flag( 'outDir', dirname( resolve( file ) ) ) ) );
+const keep = !! flag( 'keep-frames', false );
+mkdirSync( outDir, { recursive: true } );
+
+const url = pathToFileURL( resolve( file ) ).href;
+const frameDir = mkdtempSync( join( tmpdir(), 'hero-frames-' ) );
+
+const { browser, page } = await open( { width: 1600, height: 1400, scale: 2 } );
+const outputs = [];
+try {
+	await page.goto( url, { waitUntil: 'networkidle' } );
+	await sleep( 1500 );
+	await page.evaluate( () =>
+		document.querySelectorAll( '.stage, .jph' ).forEach( s => s.classList.remove( 'is-idle' ) )
+	);
+	await sleep( 300 );
+
+	// Which pieces to export, and what to call each file.
+	const pieces = await page.evaluate( wanted => {
+		const slug = s =>
+			s
+				.toLowerCase()
+				.replace( /[^a-z0-9]+/g, '-' )
+				.replace( /^-|-$/g, '' );
+		const boxes = [ ...document.querySelectorAll( '[id$="-box"]' ) ].filter( b =>
+			b.querySelector( '.scene, .jph-scene' )
+		);
+		return boxes
+			.filter( b => ! wanted || b.id === wanted )
+			.map( b => {
+				const scene = b.querySelector( '.scene, .jph-scene' );
+				const heading = b.closest( 'section' )?.querySelector( 'h2' )?.textContent?.trim();
+				return {
+					box: b.id,
+					name: heading ? slug( heading ) : b.id.replace( /-box$/, '' ),
+					w: scene.offsetWidth,
+				};
+			} );
+	}, box || null );
+
+	if ( ! pieces.length ) {
+		const ids = await page.evaluate( () =>
+			[ ...document.querySelectorAll( '[id$="-box"]' ) ].map( b => b.id )
+		);
+		console.error( box ? `no element #${ box }.` : 'no pieces found on this page.' );
+		console.error( `Boxes on this page: ${ ids.join( ', ' ) || '(none)' }` );
+		process.exit( 1 );
+	}
+	const bad = pieces.find( p => ! p.w );
+	if ( bad ) {
+		console.error( `#${ bad.box }: the scene has no width — run scrub.mjs` );
+		process.exit( 1 );
+	}
+
+	const gifOnly = formats.length === 1 && formats[ 0 ] === 'gif';
+	const fps = Number( flag( 'fps', gifOnly ? 15 : 25 ) );
+	const run = args =>
+		execFileSync( 'ffmpeg', [ '-y', '-hide_banner', '-loglevel', 'error', ...args ], {
+			stdio: 'inherit',
+		} );
+
+	for ( const piece of pieces ) {
+		// How long the piece actually runs: the last beat to finish, plus a hold.
+		// Guessing this is the most common way an export ends up truncated.
+		const measured = await page.evaluate( id => {
+			const root = document.getElementById( id );
+			let end = 0;
+			for ( const a of document.getAnimations() ) {
+				const target = a.effect?.target;
+				if ( ! target || ! root.contains( target ) ) continue;
+				const t = a.effect.getComputedTiming();
+				if ( ! Number.isFinite( t.iterations ) ) continue; // skip infinite blinks
+				const finish = ( t.delay || 0 ) + ( t.activeDuration || 0 );
+				if ( Number.isFinite( finish ) ) end = Math.max( end, finish );
+			}
+			return end / 1000;
+		}, piece.box );
+		const duration =
+			durationFlag !== null ? Number( durationFlag ) : Math.max( measured + hold, 2 );
+		const width = Math.round( Number( flag( 'width', piece.w ) ) / 2 ) * 2; // h264 needs even dimensions
+		const total = Math.round( duration * fps );
+		let stem = piece.name;
+		if ( base ) {
+			stem = pieces.length > 1 ? `${ base }-${ piece.name }` : String( base );
+		}
+
+		console.log(
+			`${ piece.name }: ${ duration.toFixed( 1 ) }s (last beat ${ measured.toFixed(
+				1
+			) }s + ${ hold }s hold), ` +
+				`${ total } frames at ${ fps }fps, ${ piece.w }px -> ${ width }px`
+		);
+
+		rmSync( frameDir, { recursive: true, force: true } );
+		mkdirSync( frameDir, { recursive: true } );
+		const loc = page.locator( '#' + piece.box );
+		for ( let i = 0; i < total; i++ ) {
+			await page.evaluate(
+				ms =>
+					document.getAnimations().forEach( a => {
+						a.pause();
+						a.currentTime = ms;
+					} ),
+				( i / fps ) * 1000
+			);
+			await loc.screenshot( {
+				path: join( frameDir, `f_${ String( i ).padStart( 5, '0' ) }.png` ),
+			} );
+		}
+
+		const input = [ '-framerate', String( fps ), '-i', join( frameDir, 'f_%05d.png' ) ];
+		for ( const fmt of formats ) {
+			const out = join( outDir, `${ stem }.${ fmt }` );
+			if ( fmt === 'mp4' ) {
+				run( [
+					...input,
+					'-vf',
+					`scale=${ width }:-2:flags=lanczos`,
+					'-c:v',
+					'libx264',
+					'-pix_fmt',
+					'yuv420p',
+					'-crf',
+					'20',
+					'-movflags',
+					'+faststart',
+					out,
+				] );
+			} else if ( fmt === 'webm' ) {
+				run( [
+					...input,
+					'-vf',
+					`scale=${ width }:-2:flags=lanczos`,
+					'-c:v',
+					'libvpx-vp9',
+					'-crf',
+					'32',
+					'-b:v',
+					'0',
+					'-row-mt',
+					'1',
+					out,
+				] );
+			} else if ( fmt === 'gif' ) {
+				// One shared palette beats per-frame quantisation on flat UI, and bayer
+				// dithering keeps large flat areas from crawling between frames.
+				run( [
+					...input,
+					'-vf',
+					`scale=${ width }:-2:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=192:stats_mode=diff[p];[s1][p]paletteuse=dither=bayer:bayer_scale=3`,
+					'-loop',
+					'0',
+					out,
+				] );
+			} else {
+				console.error( `unknown format: ${ fmt }` );
+				continue;
+			}
+			outputs.push( out );
+		}
+	}
+} finally {
+	await browser.close();
+	if ( keep ) console.log( `frames kept in ${ frameDir }` );
+	else rmSync( frameDir, { recursive: true, force: true } );
+}
+
+const { statSync } = await import( 'node:fs' );
+for ( const o of outputs )
+	console.log( `${ o } — ${ Math.round( statSync( o ).size / 1024 ) } KB` );
+if ( outputs.some( o => o.endsWith( '.gif' ) ) ) {
+	console.log(
+		'note: GIF is 256 colours and has no alpha; prefer mp4 wherever the destination allows it'
+	);
+}

--- a/.agents/skills/jetpack-ui-hero/scripts/scrub.mjs
+++ b/.agents/skills/jetpack-ui-hero/scripts/scrub.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/* global process */
+/* eslint-disable no-console, n/no-process-exit -- a CLI verifier: stdout is the interface and the exit code is the result. */
+/*
+ * Verify a built hero page by scrubbing its timeline, instead of watching it.
+ *
+ * Pauses every animation, seeks to each time and screenshots the scene box; also
+ * renders the whole page (so the shell, spec table and footer get looked at), the
+ * reduced-motion state — which MUST match the final frame — and phone width.
+ *
+ * Usage: scrub.mjs <index.html> <box-id> [times] [outDir]
+ *        scrub.mjs build/index.html fr-box 0.5,2.4,5.7,8.5 frames
+ *
+ * Run it once per piece. Pick times either side of every beat, plus one after the
+ * last, rather than reusing the defaults — they assume a ~9s piece.
+ */
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { sleep, playwright } from './capture-kit.mjs';
+
+const [ file, box, timesArg = '0.5,3,6,8.5', outDir = 'frames' ] = process.argv.slice( 2 );
+if ( ! file || ! box ) {
+	console.error( 'usage: scrub.mjs <index.html> <box-id> [times] [outDir]' );
+	process.exit( 1 );
+}
+const times = timesArg.split( ',' ).map( t => Number( String( t ).trim().replace( /s$/, '' ) ) );
+if ( ! times.length || ! times.every( Number.isFinite ) ) {
+	console.error( `bad times: "${ timesArg }" — comma-separated seconds, e.g. 0.5,2.4,5.7` );
+	process.exit( 1 );
+}
+// A '#' in the path becomes a fragment if the URL is built by concatenation.
+const url = pathToFileURL( resolve( file ) ).href;
+mkdirSync( outDir, { recursive: true } );
+
+const seek = ( page, ms ) =>
+	page.evaluate(
+		t =>
+			document.getAnimations().forEach( a => {
+				a.pause();
+				a.currentTime = t;
+			} ),
+		ms
+	);
+const start = page =>
+	page.evaluate( () =>
+		document.querySelectorAll( '.stage' ).forEach( s => s.classList.remove( 'is-idle' ) )
+	);
+
+const errors = [];
+const watch = ( page, label ) => {
+	page.on( 'pageerror', e => errors.push( `${ label }: ${ e.message }` ) );
+	return page;
+};
+
+const { chromium } = await playwright();
+const browser = await chromium.launch();
+let failed = false;
+try {
+	const ctx = await browser.newContext( {
+		viewport: { width: 1400, height: 1300 },
+		deviceScaleFactor: 2,
+	} );
+	const page = watch( await ctx.newPage(), 'timeline' );
+	await page.goto( url, { waitUntil: 'networkidle' } );
+	await sleep( 1800 );
+	await start( page );
+	await sleep( 300 );
+
+	const scenes = await page.evaluate( () =>
+		[ ...document.querySelectorAll( '.scene' ) ].map( s => s.id )
+	);
+	console.log( 'scenes:', scenes );
+	if ( ( await page.locator( '#' + box ).count() ) === 0 ) {
+		console.error(
+			`no element #${ box }. Scenes on this page: ${ scenes.join( ', ' ) || '(none)' }`
+		);
+		console.error( 'the box id is the scene id with -scene swapped for -box' );
+		process.exit( 1 );
+	}
+
+	// A scene with no width scales to Infinity, which CSS drops silently; the page
+	// then renders at 1:1 in a corner and every frame below looks merely wrong.
+	const sized = await page.evaluate( id => {
+		const b = document.getElementById( id ),
+			s = b.querySelector( '.scene' );
+		return { w: s.offsetWidth, h: s.offsetHeight, transform: getComputedStyle( s ).transform };
+	}, box );
+	if ( ! sized.w || ! sized.h || sized.transform === 'none' ) {
+		console.error(
+			`#${ box }: scene measures ${ sized.w }x${ sized.h }, transform "${ sized.transform }".`
+		);
+		console.error( 'The scene needs explicit width/height. build-page.py emits them from the' );
+		console.error(
+			'manifest width/height — check those are set and that no piece CSS overrides them.'
+		);
+		failed = true;
+	}
+
+	let finalFrame = null;
+	for ( const t of times ) {
+		await seek( page, t * 1000 );
+		await sleep( 220 );
+		const shot = await page
+			.locator( '#' + box )
+			.screenshot( { path: `${ outDir }/${ box }-${ String( t ).replace( '.', '_' ) }.png` } );
+		if ( t === Math.max( ...times ) ) finalFrame = shot;
+	}
+	// the whole page once, so the shell is actually looked at
+	await page.screenshot( { path: `${ outDir }/page.png`, fullPage: true } );
+
+	// reduced motion must land on the final frame, not somewhere mid-timeline
+	const rmCtx = await browser.newContext( {
+		viewport: { width: 1400, height: 1300 },
+		deviceScaleFactor: 2,
+		reducedMotion: 'reduce',
+	} );
+	const rm = watch( await rmCtx.newPage(), 'reduced-motion' );
+	await rm.goto( url, { waitUntil: 'networkidle' } );
+	await start( rm );
+	await sleep( 1200 );
+	const rmFrame = await rm
+		.locator( '#' + box )
+		.screenshot( { path: `${ outDir }/${ box }-reduced-motion.png` } );
+
+	// The invariant, actually checked: reduced motion must land on the final frame.
+	// If it does not, some animation is missing `both` fill or runs infinitely.
+	if ( finalFrame && ! rmFrame.equals( finalFrame ) ) {
+		console.error( `reduced motion does NOT match the last frame (t=${ Math.max( ...times ) }).` );
+		console.error(
+			`compare ${ outDir }/${ box }-reduced-motion.png against ${ outDir }/${ box }-${ String(
+				Math.max( ...times )
+			).replace( '.', '_' ) }.png`
+		);
+		console.error(
+			'usual cause: an animation without `both` fill, or an infinite one that needs disabling'
+		);
+		failed = true;
+	} else if ( finalFrame ) {
+		console.log( 'reduced motion matches the final frame' );
+	}
+
+	// phone width: nothing may scroll sideways
+	const mob = await browser.newContext( {
+		viewport: { width: 390, height: 900 },
+		deviceScaleFactor: 2,
+	} );
+	const mp = watch( await mob.newPage(), 'phone' );
+	await mp.goto( url, { waitUntil: 'networkidle' } );
+	await sleep( 1200 );
+	const over = await mp.evaluate( () => ( {
+		doc: document.documentElement.scrollWidth,
+		win: innerWidth,
+	} ) );
+	const ok = over.doc <= over.win;
+	console.log( 'phone width:', JSON.stringify( over ), ok ? 'OK' : 'OVERFLOWS' );
+	if ( ! ok ) failed = true;
+
+	console.log( 'errors:', errors.length ? errors.slice( 0, 6 ) : 'none' );
+	if ( errors.length ) failed = true;
+	console.log( `frames in ${ outDir }/ — look at page.png for the shell, spec table and footer` );
+} finally {
+	await browser.close();
+}
+process.exit( failed ? 1 : 0 );

--- a/.claude/skills/jetpack-ui-hero/SKILL.md
+++ b/.claude/skills/jetpack-ui-hero/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agents/skills/jetpack-ui-hero.md


### PR DESCRIPTION
## Proposed changes

Adds `jetpack-ui-hero`, a skill for building **landing-page hero animations of real Jetpack admin UI** — the kind used on jetpack.com, in release posts and in design reviews.

The technique: screenshot the parts of a screen that never move, redraw only the parts that change as DOM or as slices of a second screenshot, and drive it with CSS keyframes. The output is one self-contained HTML file. No video and no GIF on the page itself, which means the text stays real text (selectable, translatable), a piece weighs 20–90 KB instead of megabytes, and `prefers-reduced-motion` can land on a meaningful final frame.

```
.agents/skills/jetpack-ui-hero.md          the workflow
.agents/skills/jetpack-ui-hero/
├── references/  capture-traps, scene-patterns, composition, output
├── scripts/     capture-kit.mjs, build-page.py, scrub.mjs, export.mjs
└── assets/      shell.css, stage.js, pieces.example.json
.claude/skills/jetpack-ui-hero/SKILL.md    symlink, matching the other skills here
```

Most of the value is in `references/capture-traps.md`. Every entry there is a failure that produced a *plausible-looking wrong capture rather than an error* — the block-editor canvas iframe's 96px offset, the starter-pattern modal that covers clipped screenshots while DOM queries keep working, DataViews column widths collapsing if you delete a `<th>`, `scrollTo` silently clamping on a short page, and `innerText` being undefined on SVG elements.

Verification is by scrubbing rather than watching: `scrub.mjs` pauses every animation, seeks to given times, asserts that the reduced-motion render matches the final frame, checks phone width, and exits non-zero.

The skill was reviewed by four independent agents before this PR, including one that built a My Jetpack piece from the skill alone with no other context. That run found the defect worth knowing about: a scene with no explicit width collapses to zero, `stage.js` computes `scale(Infinity)`, CSS silently drops the invalid transform, and the page renders at 1:1 clipped to a corner — with no error from the build, the browser or the verifier. The builder now emits the size and the verifier asserts it.

## Related product discussion/links

Built while producing a set of hero animations for Jetpack Forms; the four below are that set. Modelled on the existing Jetpack AI heroes page, and follows its house rules so a new set sits beside it.

## Does this pull request change what data or activity we track or use?

No. Tooling only — nothing ships to users, and no plugin or package code is touched.

## Testing instructions

No changelog entry: the diff only touches `.agents/` and `.claude/`, both outside `/projects`.

1. Confirm the skill is discoverable — `.claude/skills/jetpack-ui-hero/SKILL.md` should resolve through the symlink to `.agents/skills/jetpack-ui-hero.md`.
2. Lint is clean: `pnpm exec eslint .agents/skills/jetpack-ui-hero/` and `pnpm exec stylelint .agents/skills/jetpack-ui-hero/assets/shell.css` both report zero problems.
3. To exercise it end to end, ask an agent for a hero animation of any Jetpack screen. It provisions its own Jurassic Ninja site, captures, builds and scrubs. Needs Python Pillow; `ffmpeg` is needed only for the MP4/GIF export. Playwright comes from the monorepo's own `node_modules`.

Nothing depends on where your checkout lives: the scripts locate the monorepo from their own path, and a hero's working files go in a folder **beside** the repo — `python3 .agents/skills/jetpack-ui-hero/scripts/build-page.py --where forms` prints exactly where, and the builder warns if you build inside the repo by mistake. Captures are large binaries that should never be committed.

### The four pieces this was built from

Recorded straight out of the tool with `export.mjs --all`. Durations are measured from each timeline rather than guessed.

**Response lands** — a visitor presses Send and the enquiry lands in the Forms inbox, three counts ticking 8 → 9. MP4 [153 KB](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/response-lands.mp4)

![Response lands](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/response-lands.gif)

**Build a form** — `/form` names the block, seven templates are offered, and the fields assemble. MP4 [77 KB](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/build-a-form.mp4)

![Build a form](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/build-a-form.gif)

**The form adapts** — pick Wedding and it asks for a date; switch to Portrait and it asks how many people. Conditional logic is **behind a feature flag and does not ship to users yet**; this was captured with the flag forced on. MP4 [43 KB](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/the-form-adapts.mp4)

![The form adapts](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/the-form-adapts.gif)

**Where the answers go** — the integrations panel connecting in turn. MP4 [97 KB](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/where-the-answers-go.mp4)

![Where the answers go](https://github.com/Automattic/jetpack/raw/screenshots/add/jetpack-ui-hero-skill/where-the-answers-go.gif)

The MP4s are 3–5x smaller than the GIFs and are the better file for a deck or Figma, but GitHub strips `<video>` from PR descriptions and renders an `.mp4` in image syntax as a broken image, so the GIFs are what can actually play here. Both formats live on `refs/heads/screenshots/add/jetpack-ui-hero-skill` so no binaries enter this branch's history.

